### PR TITLE
Fix Netlify build plugin error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  NETLIFY_NEXT_PLUGIN_SKIP = "true"


### PR DESCRIPTION
## Summary
- skip the Netlify Next.js plugin since this is a Vite project

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532c3698148325abb14b300fee3913