### PR TITLE
Configure TailwindCSS v4 with Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## Personal Website
 
-This is my personal site built with Next.js and Tailwind CSS.
+This is my personal site built with Next.js and Tailwind CSS v4. The project also
+includes Vite scripts which can be used if you prefer a Vite based workflow.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "vite:dev": "vite dev",
+    "vite:build": "vite build",
+    "vite:preview": "vite preview"
   },
   "dependencies": {
     "@mapbox/rehype-prism": "^0.9.0",
     "@mdx-js/loader": "^3.1.0",
     "@next/mdx": "^15.3.4",
     "@tabler/icons-react": "^3.34.0",
-    "@tailwindcss/postcss": "^4.1.0",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.10",
     "@types/node": "24.0.3",
@@ -35,6 +37,8 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.10"
+    "tailwindcss": "^4.1.10",
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.1"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+});


### PR DESCRIPTION
## Summary
- add Vite configuration for TailwindCSS v4
- expose optional Vite scripts
- document Vite support

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a67fa5388325b1d6a33531ece2d2