### PR TITLE
Fix PostCSS config for Next.js

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,5 @@
-export default {
+/** @type {import('postcss').Config} */
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
## Summary
- export a CommonJS PostCSS config

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854a83a47488325949b7da1d28756b1