### PR TITLE
Improve dark mode support

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,6 +51,21 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="scroll-smooth">
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+              try {
+                const theme = localStorage.getItem('theme');
+                const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                if (theme === 'dark' || (!theme && prefersDark)) {
+                  document.documentElement.classList.add('dark');
+                }
+              } catch (_) {}
+            })();`,
+          }}
+        />
+      </head>
       <body
         className={twMerge(
           inter.className,

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -3,56 +3,58 @@ import { Paragraph } from "@/components/Paragraph";
 
 export default function About() {
   return (
-    <section className="relative z-10 flex flex-col items-center py-20 px-6 md:px-0 bg-gradient-to-br from-gray-950/90 via-gray-900/80 to-gray-950/90 min-h-screen rounded-3xl shadow-2xl">
+    <section
+      className="relative z-10 flex flex-col items-center py-20 px-6 md:px-0 bg-gradient-to-br from-neutral-50 via-white to-neutral-200 dark:from-gray-950/90 dark:via-gray-900/80 dark:to-gray-950/90 min-h-screen rounded-3xl shadow-2xl"
+    >
       <div className="max-w-3xl w-full text-center md:text-left">
         <h2 className="text-4xl md:text-5xl font-extrabold tracking-tight mb-6 bg-gradient-to-r from-sky-400 to-purple-600 bg-clip-text text-transparent animate-fade-in">
           About Me
         </h2>
 
-        <Paragraph className="text-lg md:text-xl mb-6 text-gray-300">
+        <Paragraph className="text-lg md:text-xl mb-6 text-gray-700 dark:text-gray-300">
           Hi, I’m Isaac. I build reliable, impactful software at the intersection of tech and democracy.
         </Paragraph>
 
-        <Paragraph className="mb-6 text-gray-400">
+        <Paragraph className="mb-6 text-gray-600 dark:text-gray-400">
           My journey started in political organizing and grew into a passion for civic technology. As a QA Engineer and product builder, I obsess over every detail—because building trustworthy tools isn’t just about code, it’s about empowering real people.
         </Paragraph>
 
-        <Paragraph className="mb-6 text-gray-400">
+        <Paragraph className="mb-6 text-gray-600 dark:text-gray-400">
           Whether I’m leading cross-functional QA efforts at a political tech startup or collaborating on data-driven product launches, I focus on clarity, accessibility, and creative problem-solving. My career is defined by my commitment to making complex systems understandable and impactful for the communities they serve.
         </Paragraph>
 
-        <Paragraph className="mb-6 text-gray-400">
+        <Paragraph className="mb-6 text-gray-600 dark:text-gray-400">
           Outside of work, you’ll find me cooking up new recipes, hiking Texas trails, or volunteering to help organize local elections. I believe in technology’s power to build stronger, more representative communities—and I’m just getting started.
         </Paragraph>
 
         {/* Animated dividers for a high-tech feel */}
         <div className="my-10 flex flex-col gap-6 md:gap-12">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-6 animate-fade-in-up border border-gray-800">
+            <div className="bg-white/60 dark:bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-6 animate-fade-in-up border border-neutral-200 dark:border-gray-800">
               <h3 className="text-xl font-bold mb-2 text-sky-400">Education</h3>
-              <p className="text-gray-300">
+              <p className="text-gray-700 dark:text-gray-300">
                 B.A., Political Science & International Affairs<br />
                 <span className="text-gray-500 text-sm">Florida State University, magna cum laude, Phi Beta Kappa</span>
               </p>
             </div>
-            <div className="bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-6 animate-fade-in-up border border-gray-800">
+            <div className="bg-white/60 dark:bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-6 animate-fade-in-up border border-neutral-200 dark:border-gray-800">
               <h3 className="text-xl font-bold mb-2 text-purple-400">Experience</h3>
-              <p className="text-gray-300">
+              <p className="text-gray-700 dark:text-gray-300">
                 6+ years in QA, analytics, and civic tech.<br />
                 Led automation, data validation, and release quality at high-growth startups.
               </p>
             </div>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-6 animate-fade-in-up border border-gray-800">
+            <div className="bg-white/60 dark:bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-6 animate-fade-in-up border border-neutral-200 dark:border-gray-800">
               <h3 className="text-xl font-bold mb-2 text-pink-400">Skills</h3>
-              <p className="text-gray-300">
+              <p className="text-gray-700 dark:text-gray-300">
                 QA, Automation, T-SQL, MySQL, NoSQL, Data Analysis, Product Collaboration
               </p>
             </div>
-            <div className="bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-6 animate-fade-in-up border border-gray-800">
+            <div className="bg-white/60 dark:bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-6 animate-fade-in-up border border-neutral-200 dark:border-gray-800">
               <h3 className="text-xl font-bold mb-2 text-teal-400">Focus Areas</h3>
-              <p className="text-gray-300">
+              <p className="text-gray-700 dark:text-gray-300">
                 Product Quality, Civic Tech, Data-Driven Impact, Empowering Representation
               </p>
             </div>

--- a/src/components/Highlight.tsx
+++ b/src/components/Highlight.tsx
@@ -10,7 +10,12 @@ export const Highlight = ({
   children: React.ReactNode;
 }) => {
   return (
-    <span className={twMerge("bg-neutral-100 px-1 py-0.5", className)}>
+    <span
+      className={twMerge(
+        "bg-neutral-100 dark:bg-neutral-800 text-neutral-800 dark:text-neutral-100 px-1 py-0.5",
+        className
+      )}
+    >
       {children}
     </span>
   );

--- a/src/components/Prose.tsx
+++ b/src/components/Prose.tsx
@@ -11,7 +11,7 @@ export function Prose({
     <div
       className={clsx(
         className,
-        "prose prose-sm prose-blue max-w-none prose-p:text-secondary prose-headings:text-primary"
+        "prose prose-sm prose-blue max-w-none prose-p:text-secondary prose-headings:text-primary dark:prose-invert"
       )}
     >
       {children}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -65,7 +65,7 @@ export const Navigation = ({
           href={link.href}
           onClick={() => isMobile() && setOpen(false)}
           className={twMerge(
-            "group relative text-secondary hover:text-primary transition duration-200 flex items-center space-x-2 py-2 px-2 rounded-md text-[1rem] font-medium dark:hover:bg-neutral-700/30 overflow-hidden focus:outline-none focus:ring-2 focus:ring-sky-400",
+            "group relative text-secondary dark:text-gray-300 hover:text-primary dark:hover:text-cyan-200 transition duration-200 flex items-center space-x-2 py-2 px-2 rounded-md text-[1rem] font-medium dark:hover:bg-neutral-700/30 overflow-hidden focus:outline-none focus:ring-2 focus:ring-sky-400",
             isActive(link.href) &&
               "bg-white/90 dark:bg-neutral-700/70 shadow-lg text-sky-600 dark:text-cyan-300"
           )}
@@ -83,7 +83,9 @@ export const Navigation = ({
             <link.icon
               className={twMerge(
                 "h-5 w-5 flex-shrink-0 group-hover:scale-110 transition-transform",
-                isActive(link.href) && "text-sky-500 dark:text-cyan-300"
+                isActive(link.href)
+                  ? "text-sky-500 dark:text-cyan-300"
+                  : "dark:text-gray-300"
               )}
             />
           ) : null}
@@ -91,7 +93,7 @@ export const Navigation = ({
         </Link>
       ))}
 
-      <Heading as="p" className="text-sm pt-10 px-2 text-secondary font-semibold tracking-wider opacity-70">
+      <Heading as="p" className="text-sm pt-10 px-2 text-secondary dark:text-gray-400 font-semibold tracking-wider opacity-70">
         Socials
       </Heading>
       <div className="flex flex-wrap gap-2 mt-1 px-2">


### PR DESCRIPTION
## Summary
- initialize theme early to avoid flash of incorrect theme
- adjust About page to support light & dark modes
- make Highlight component responsive to theme
- invert prose colors for dark mode
- improve sidebar text/icon styles for dark backgrounds

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ec53eda0832599f4f661c7707ab8