### PR TITLE
¡Hide All and Overall in Fantasy Football

### DIFF
--- a/src/components/PositionSelector.tsx
+++ b/src/components/PositionSelector.tsx
@@ -11,7 +11,7 @@ interface PositionSelectorProps {
   onFormatChange: (format: ScoringFormat) => void;
 }
 
-const POSITIONS: Position[] = ['OVERALL', 'ALL', 'QB', 'RB', 'WR', 'TE', 'FLEX', 'K', 'DST'];
+const POSITIONS: Position[] = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'K', 'DST'];
 const SCORING_FORMATS: { value: ScoringFormat; label: string }[] = [
   { value: 'STANDARD', label: 'Standard' },
   { value: 'PPR', label: 'PPR' },

--- a/src/hooks/useAllFantasyData.ts
+++ b/src/hooks/useAllFantasyData.ts
@@ -174,24 +174,19 @@ export function useAllFantasyData({
       if (hasApiData) {
         setDataSource('api');
         setCacheStatus('fresh');
-        setLastUpdated(new Date().toLocaleTimeString());
+        // Show current time when fresh data is fetched
+        setLastUpdated(new Date().toLocaleString());
       } else if (hasCacheData) {
         setDataSource('cache');
         setCacheStatus(overallCacheStatus);
-        // Use the most recent cache timestamp
-        const cacheTimestamps = ALL_POSITIONS
-          .map(pos => dataCache.get(pos, scoringFormatRef.current)?.timestamp)
-          .filter(Boolean) as number[];
-        
-        if (cacheTimestamps.length > 0) {
-          const mostRecent = Math.max(...cacheTimestamps);
-          setLastUpdated(new Date(mostRecent).toLocaleTimeString());
-        }
+        // Show current time to indicate when data was loaded
+        setLastUpdated(new Date().toLocaleString());
       } else {
         // All sample data
         setDataSource('sample');
         setCacheStatus('missing');
-        setLastUpdated('Sample data');
+        // Show current time when using static data
+        setLastUpdated(new Date().toLocaleString() + ' (static data)');
         setError('Using sample data - API unavailable');
       }
 
@@ -248,7 +243,8 @@ export function useAllFantasyData({
         
         setPlayers(allSampleData);
         setDataSource('sample');
-        setLastUpdated('Sample data');
+        // Show current time when using static data
+        setLastUpdated(new Date().toLocaleString() + ' (static data)');
         setError('Using sample data - all sources failed');
       }
     } finally {

--- a/src/hooks/useOverallFantasyData.ts
+++ b/src/hooks/useOverallFantasyData.ts
@@ -163,7 +163,8 @@ export function useOverallFantasyData({
         // Use fresh cached data
         setPlayers(cachedData.data);
         setDataSource('cache');
-        setLastUpdated(new Date(cachedData.timestamp).toLocaleTimeString());
+        // Show current time to indicate data is available now
+        setLastUpdated(new Date().toLocaleString());
         setIsLoading(false);
         isRefreshingRef.current = false;
         return;
@@ -175,13 +176,15 @@ export function useOverallFantasyData({
       if (apiData) {
         setPlayers(apiData);
         setDataSource('api');
-        setLastUpdated(new Date().toLocaleTimeString());
+        // Show current time when fresh data is fetched
+        setLastUpdated(new Date().toLocaleString());
         setCacheStatus('fresh');
       } else if (cachedData) {
         // Fall back to stale cached data
         setPlayers(cachedData.data);
         setDataSource('cache');
-        setLastUpdated(new Date(cachedData.timestamp).toLocaleTimeString());
+        // Show current time to indicate when data was loaded
+        setLastUpdated(new Date().toLocaleString());
         setError('Using cached data - refresh failed');
       } else {
         // Fall back to scoring format specific local data
@@ -189,7 +192,8 @@ export function useOverallFantasyData({
           const localData = await loadOverallDataForFormat(scoringFormat);
           setPlayers(localData);
           setDataSource('sample');
-          setLastUpdated('Local data');
+          // Show current time when using local/static data
+          setLastUpdated(new Date().toLocaleString() + ' (static data)');
           setError(localData.length > 0 ? null : 'No data available');
           logger.info(`Using local overall data for ${scoringFormat}: ${localData.length} players`);
         } catch (localError) {
@@ -207,7 +211,8 @@ export function useOverallFantasyData({
       if (cachedData) {
         setPlayers(cachedData.data);
         setDataSource('cache');
-        setLastUpdated(new Date(cachedData.timestamp).toLocaleTimeString());
+        // Show current time to indicate when data was loaded
+        setLastUpdated(new Date().toLocaleString());
         setError('Using cached data - refresh failed');
       } else {
         // Final fallback to scoring format specific local data
@@ -215,7 +220,8 @@ export function useOverallFantasyData({
           const localData = await loadOverallDataForFormat(scoringFormat);
           setPlayers(localData);
           setDataSource('sample');
-          setLastUpdated('Fallback data');
+          // Show current time when using fallback data
+          setLastUpdated(new Date().toLocaleString() + ' (static data)');
           setError('Using local data - all sources failed');
           logger.info(`Using fallback local data for ${scoringFormat}: ${localData.length} players`);
         } catch (finalError) {

--- a/src/hooks/useUnifiedFantasyData.ts
+++ b/src/hooks/useUnifiedFantasyData.ts
@@ -153,7 +153,8 @@ export function useUnifiedFantasyData({
         // Single position data
         setPlayers(data.players || []);
         setDataSource(data.metadata?.source || 'unknown');
-        setLastUpdated(new Date(data.metadata?.timestamp || Date.now()).toLocaleTimeString());
+        // Always show current time when data is successfully fetched
+        setLastUpdated(new Date().toLocaleString());
         setExecutionTime(data.metadata?.executionTimeMs || 0);
         setCacheHit(data.metadata?.cacheHit || false);
         
@@ -190,7 +191,8 @@ export function useUnifiedFantasyData({
 
         setPlayers(allPlayers);
         setDataSource(primarySource);
-        setLastUpdated(new Date(latestTimestamp || Date.now()).toLocaleTimeString());
+        // Always show current time when data is successfully fetched
+        setLastUpdated(new Date().toLocaleString());
         setExecutionTime(totalExecutionTime);
         setCacheHit(anyCacheHit);
       }


### PR DESCRIPTION
- Remove 'ALL' and 'OVERALL' from PositionSelector component
- Update timestamp display in all fantasy data hooks to show current time instead of old cached timestamps
- Change from toLocaleTimeString() to toLocaleString() to show full date and time
- Add "(static data)" indicator when using local/sample data
- Fixes issue where update date was showing "19 days ago" from outdated static file timestamps