### PR TITLE
Reduce spacing on home page layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1468,21 +1468,21 @@ textarea:valid:not(:placeholder-shown) {
 
 /* Premium Spacing System - Generous whitespace for editorial feel */
 .pentagram-section {
-  padding-top: 5rem;    /* 80px */
-  padding-bottom: 5rem;
+  padding-top: 3rem;    /* 48px */
+  padding-bottom: 3rem;
 }
 
 @media (min-width: 768px) {
   .pentagram-section {
-    padding-top: 7rem;  /* 112px */
-    padding-bottom: 7rem;
+    padding-top: 4rem;  /* 64px */
+    padding-bottom: 4rem;
   }
 }
 
 @media (min-width: 1280px) {
   .pentagram-section {
-    padding-top: 10rem;  /* 160px */
-    padding-bottom: 10rem;
+    padding-top: 5rem;  /* 80px */
+    padding-bottom: 5rem;
   }
 }
 
@@ -1492,7 +1492,7 @@ textarea:valid:not(:placeholder-shown) {
   font-weight: 700;              /* Bold, not black */
   line-height: 1;                /* Very tight */
   letter-spacing: -0.04em;       /* Tight grotesk tracking */
-  margin-bottom: 2rem;           /* Generous spacing */
+  margin-bottom: 1rem;           /* Generous spacing */
 }
 
 .editorial-subheading {
@@ -1500,7 +1500,7 @@ textarea:valid:not(:placeholder-shown) {
   font-weight: 600;              /* Semibold */
   line-height: 1.2;              /* Tight but readable */
   letter-spacing: -0.03em;       /* Tight tracking */
-  margin-bottom: 1.5rem;         /* Generous spacing */
+  margin-bottom: 1rem;           /* Generous spacing */
 }
 
 .editorial-body {
@@ -1524,18 +1524,18 @@ textarea:valid:not(:placeholder-shown) {
 /* Structured Grid System - Clean, modular layouts */
 .pentagram-grid {
   display: grid;
-  gap: 2rem;
+  gap: 1.5rem;
 }
 
 @media (min-width: 768px) {
   .pentagram-grid {
-    gap: 3rem;
+    gap: 2rem;
   }
 }
 
 @media (min-width: 1024px) {
   .pentagram-grid {
-    gap: 4rem;
+    gap: 2.5rem;
   }
 }
 
@@ -1569,7 +1569,7 @@ textarea:valid:not(:placeholder-shown) {
 .pentagram-card {
   background: white;
   border: 1px solid rgba(0, 0, 0, 0.08);
-  padding: 2.5rem;
+  padding: 1.5rem;
   transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
@@ -1591,13 +1591,13 @@ textarea:valid:not(:placeholder-shown) {
 
 @media (min-width: 768px) {
   .pentagram-card {
-    padding: 3.5rem;
+    padding: 2rem;
   }
 }
 
 @media (min-width: 1280px) {
   .pentagram-card {
-    padding: 4rem;
+    padding: 2.5rem;
   }
 }
 
@@ -1606,7 +1606,7 @@ textarea:valid:not(:placeholder-shown) {
   width: 100%;
   height: 1px;
   background: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.1), transparent);
-  margin: 4rem 0;
+  margin: 2rem 0;
 }
 
 .dark .pentagram-divider {
@@ -1615,13 +1615,13 @@ textarea:valid:not(:placeholder-shown) {
 
 @media (min-width: 768px) {
   .pentagram-divider {
-    margin: 6rem 0;
+    margin: 3rem 0;
   }
 }
 
 @media (min-width: 1280px) {
   .pentagram-divider {
-    margin: 8rem 0;
+    margin: 4rem 0;
   }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ const TimelineItem = ({ item, index }: { item: typeof personalMetrics.careerTime
       className="pentagram-card pentagram-card-hover group"
     >
       {/* Header Section */}
-      <div className="flex items-start justify-between gap-6 mb-6">
+      <div className="flex items-start justify-between gap-6 mb-4">
         <div className="flex-1">
           <h3 className="text-2xl md:text-3xl font-bold text-[#2D1B12] dark:text-[#FFFCF7] mb-2 leading-tight">
             {item.role}
@@ -40,12 +40,12 @@ const TimelineItem = ({ item, index }: { item: typeof personalMetrics.careerTime
       </div>
 
       {/* Year */}
-      <p className="editorial-caption mb-4 text-[#6B4F3D] dark:text-[#9C7A5F] font-mono">
+      <p className="editorial-caption mb-3 text-[#6B4F3D] dark:text-[#9C7A5F] font-mono">
         {item.year}
       </p>
 
       {/* Description */}
-      <p className="editorial-body text-[#4A3426] dark:text-[#D4A88E] mb-6">
+      <p className="editorial-body text-[#4A3426] dark:text-[#D4A88E] mb-4">
         {item.description}
       </p>
 
@@ -94,24 +94,24 @@ export default function Home() {
             className="max-w-6xl mx-auto"
           >
             {/* Section Header */}
-            <h2 className="editorial-heading text-[#2D1B12] dark:text-[#FFFCF7] mb-12">
+            <h2 className="editorial-heading text-[#2D1B12] dark:text-[#FFFCF7] mb-6">
               Overview
             </h2>
 
             {/* Content Grid */}
-            <div className="space-y-8">
+            <div className="space-y-5">
               <p className="editorial-body text-[#4A3426] dark:text-[#D4A88E]">
                 Product-focused technologist transitioning into product management, bringing 6+ years of experience in quality assurance, data analytics, and technology. At Civitech, I've led testing initiatives for voter engagement platforms, bridging technical execution with strategic product outcomes.
               </p>
 
               {/* Core Competencies */}
               <div className="pentagram-card">
-                <h3 className="editorial-subheading text-[#2D1B12] dark:text-[#FFFCF7] mb-6">
+                <h3 className="editorial-subheading text-[#2D1B12] dark:text-[#FFFCF7] mb-4">
                   Core Competencies
                 </h3>
                 <div className="pentagram-grid pentagram-grid-2">
                   <div>
-                    <h4 className="text-lg font-bold text-[#FF6B35] dark:text-[#FF8E53] mb-3">
+                    <h4 className="text-lg font-bold text-[#FF6B35] dark:text-[#FF8E53] mb-2">
                       Product & Strategy
                     </h4>
                     <p className="text-base text-[#4A3426] dark:text-[#D4A88E] leading-relaxed">
@@ -119,7 +119,7 @@ export default function Home() {
                     </p>
                   </div>
                   <div>
-                    <h4 className="text-lg font-bold text-[#FF6B35] dark:text-[#FF8E53] mb-3">
+                    <h4 className="text-lg font-bold text-[#FF6B35] dark:text-[#FF8E53] mb-2">
                       Technical
                     </h4>
                     <p className="text-base text-[#4A3426] dark:text-[#D4A88E] leading-relaxed">
@@ -127,7 +127,7 @@ export default function Home() {
                     </p>
                   </div>
                   <div>
-                    <h4 className="text-lg font-bold text-[#FF6B35] dark:text-[#FF8E53] mb-3">
+                    <h4 className="text-lg font-bold text-[#FF6B35] dark:text-[#FF8E53] mb-2">
                       Analytics
                     </h4>
                     <p className="text-base text-[#4A3426] dark:text-[#D4A88E] leading-relaxed">
@@ -135,7 +135,7 @@ export default function Home() {
                     </p>
                   </div>
                   <div>
-                    <h4 className="text-lg font-bold text-[#FF6B35] dark:text-[#FF8E53] mb-3">
+                    <h4 className="text-lg font-bold text-[#FF6B35] dark:text-[#FF8E53] mb-2">
                       Leadership
                     </h4>
                     <p className="text-base text-[#4A3426] dark:text-[#D4A88E] leading-relaxed">
@@ -153,7 +153,7 @@ export default function Home() {
                 Currently pursuing an MBA at UC Berkeley Haas to deepen my product management expertise and explore venture capital opportunities in civic tech, SaaS, and mission-driven startups. Passionate about leveraging technology to create social impact and democratize access to essential services.
               </p>
 
-              <p className="text-xl md:text-2xl text-[#2D1B12] dark:text-[#FFFCF7] font-semibold mt-12">
+              <p className="text-xl md:text-2xl text-[#2D1B12] dark:text-[#FFFCF7] font-semibold mt-6">
                 Let's connect if you're interested in technology, product strategy, or social impact.
               </p>
             </div>
@@ -175,8 +175,8 @@ export default function Home() {
             className="max-w-6xl mx-auto"
           >
             {/* Section Header */}
-            <div className="mb-16">
-              <h2 className="editorial-heading text-[#2D1B12] dark:text-[#FFFCF7] mb-6">
+            <div className="mb-8">
+              <h2 className="editorial-heading text-[#2D1B12] dark:text-[#FFFCF7] mb-4">
                 Career Journey
               </h2>
               <p className="editorial-body text-[#4A3426] dark:text-[#D4A88E] max-w-4xl">
@@ -199,7 +199,7 @@ export default function Home() {
       </section>
 
       {/* Bottom Spacing */}
-      <div className="h-20" aria-hidden="true" />
+      <div className="h-8" aria-hidden="true" />
     </div>
   );
 }

--- a/src/components/ModernHero.tsx
+++ b/src/components/ModernHero.tsx
@@ -33,7 +33,7 @@ export function ModernHero() {
 
   return (
     <section
-      className="relative min-h-screen flex items-center overflow-hidden bg-white dark:bg-black"
+      className="relative min-h-[600px] md:min-h-[700px] flex items-center overflow-hidden bg-white dark:bg-black py-16 md:py-20"
       role="main"
       aria-label="Isaac Vazquez - Technical Product Manager and UC Berkeley Haas MBA Candidate"
     >
@@ -47,22 +47,22 @@ export function ModernHero() {
       />
 
       <motion.div
-        className="relative z-10 w-full container-wide pentagram-section"
+        className="relative z-10 w-full container-wide"
         variants={containerVariants}
         initial="hidden"
         animate="visible"
       >
         {/* Mouthwash Studio layout - generous whitespace */}
-        <div className="max-w-[90rem] mx-auto grid grid-cols-1 lg:grid-cols-[1.2fr_1fr] gap-16 lg:gap-24 items-start">
+        <div className="max-w-[90rem] mx-auto grid grid-cols-1 lg:grid-cols-[1.2fr_1fr] gap-8 lg:gap-12 items-start">
 
           {/* Left Column - Bold Monochrome Typography */}
-          <div className="space-y-12 lg:space-y-16">
+          <div className="space-y-6 lg:space-y-8">
             {/* Oversized Grotesk Heading - Pure Black */}
             <motion.div variants={itemVariants}>
               <h1 className="editorial-heading text-black dark:text-white">
                 Isaac Vazquez
               </h1>
-              <p className="editorial-subheading text-neutral-500 dark:text-neutral-400 mt-6">
+              <p className="editorial-subheading text-neutral-500 dark:text-neutral-400 mt-3">
                 Technical Product Manager & UC Berkeley Haas MBA Candidate
               </p>
             </motion.div>
@@ -94,7 +94,7 @@ export function ModernHero() {
             {/* Minimal Monochrome CTAs */}
             <motion.div
               variants={itemVariants}
-              className="flex flex-wrap gap-4 pt-6"
+              className="flex flex-wrap gap-4 pt-2"
             >
               <Link href="/resume">
                 <ModernButton variant="primary" size="lg">
@@ -127,7 +127,7 @@ export function ModernHero() {
             </div>
 
             {/* Minimal Caption - Mid Grey */}
-            <p className="editorial-caption mt-6 text-neutral-500 dark:text-neutral-400">
+            <p className="editorial-caption mt-3 text-neutral-500 dark:text-neutral-400">
               Isaac Vazquez, MBA Candidate at UC Berkeley Haas School of Business
             </p>
           </motion.div>


### PR DESCRIPTION
Comprehensive spacing reduction across home page components:

- ModernHero: Changed from full viewport to fixed heights (600px/700px)
- ModernHero: Reduced internal spacing (space-y from 12/16 to 6/8)
- ModernHero: Reduced grid gaps (from 16/24 to 8/12)
- Section padding: Reduced pentagram-section from 5/7/10rem to 3/4/5rem
- Dividers: Reduced pentagram-divider margins from 4/6/8rem to 2/3/4rem
- Grid gaps: Reduced pentagram-grid from 2/3/4rem to 1.5/2/2.5rem
- Card padding: Reduced pentagram-card from 2.5/3.5/4rem to 1.5/2/2.5rem
- Typography: Reduced editorial-heading/subheading margins from 2/1.5rem to 1rem
- Content spacing: Reduced various mb/mt values throughout page
- Timeline items: Reduced spacing between elements
- Bottom spacing: Reduced from h-20 to h-8

This creates a more compact, efficient layout while maintaining readability and the clean editorial aesthetic.