### PR TITLE
Add Fantasy Football Analytics case study with coming soon state

### DIFF
--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { Heading } from "@/components/ui/Heading";
 import { WarmCard } from "@/components/ui/WarmCard";
-import { IconArrowRight, IconExternalLink } from "@tabler/icons-react";
+import { IconArrowRight, IconExternalLink, IconClock } from "@tabler/icons-react";
 import { caseStudiesData } from "@/constants/caseStudies";
 
 export const metadata: Metadata = {
@@ -100,17 +100,24 @@ export default function PortfolioPage() {
               More Work
             </h2>
             <div className="grid md:grid-cols-2 gap-6">
-              {otherCaseStudies.map((study) => (
-                <Link key={study.slug} href={`/portfolio/${study.slug}`}>
+              {otherCaseStudies.map((study) =>
+                study.comingSoon ? (
                   <WarmCard
+                    key={study.slug}
                     padding="lg"
-                    hover={true}
-                    className="h-full group"
+                    hover={false}
+                    className="h-full"
                   >
                     <div className="space-y-4">
-                      <h3 className="font-bold text-lg text-[var(--text-primary)] group-hover:text-[var(--color-primary)] transition-colors">
-                        {study.title}
-                      </h3>
+                      <div className="flex items-start justify-between gap-3">
+                        <h3 className="font-bold text-lg text-[var(--text-primary)]">
+                          {study.title}
+                        </h3>
+                        <span className="shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-[var(--color-warning)]/15 text-[var(--color-warning)] border border-[var(--color-warning)]/30">
+                          <IconClock className="h-3 w-3" />
+                          Coming Soon
+                        </span>
+                      </div>
 
                       <p className="text-sm text-[var(--text-secondary)]">
                         {study.description}
@@ -124,14 +131,70 @@ export default function PortfolioPage() {
                         {study.metrics}
                       </p>
 
-                      <div className="flex items-center gap-2 text-sm font-medium text-[var(--text-primary)] group-hover:text-[var(--color-primary)] transition-colors pt-2">
-                        View Case Study
-                        <IconArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
+                      <div className="flex flex-wrap gap-2">
+                        {study.tools.slice(0, 4).map((tool) => (
+                          <span
+                            key={tool}
+                            className="px-2 py-1 text-xs font-medium rounded-full bg-[var(--surface-secondary)] text-[var(--text-secondary)]"
+                          >
+                            {tool}
+                          </span>
+                        ))}
+                        {study.tools.length > 4 && (
+                          <span className="px-2 py-1 text-xs font-medium rounded-full bg-[var(--surface-secondary)] text-[var(--text-secondary)]">
+                            +{study.tools.length - 4}
+                          </span>
+                        )}
                       </div>
+
+                      <p className="text-xs text-[var(--text-tertiary)] italic">
+                        2026 NFL season updates coming soon — expanded analytics and user personalization in progress.
+                      </p>
+
+                      {study.link && (
+                        <Link
+                          href={study.link}
+                          className="inline-flex items-center gap-2 text-sm font-medium text-[var(--color-primary)] hover:underline pt-1"
+                        >
+                          View Live Platform
+                          <IconArrowRight className="h-4 w-4" />
+                        </Link>
+                      )}
                     </div>
                   </WarmCard>
-                </Link>
-              ))}
+                ) : (
+                  <Link key={study.slug} href={`/portfolio/${study.slug}`}>
+                    <WarmCard
+                      padding="lg"
+                      hover={true}
+                      className="h-full group"
+                    >
+                      <div className="space-y-4">
+                        <h3 className="font-bold text-lg text-[var(--text-primary)] group-hover:text-[var(--color-primary)] transition-colors">
+                          {study.title}
+                        </h3>
+
+                        <p className="text-sm text-[var(--text-secondary)]">
+                          {study.description}
+                        </p>
+
+                        <p className="text-xs font-medium text-[var(--text-tertiary)]">
+                          {study.role} · {study.timeline}
+                        </p>
+
+                        <p className="text-xs font-semibold text-[var(--color-primary)]">
+                          {study.metrics}
+                        </p>
+
+                        <div className="flex items-center gap-2 text-sm font-medium text-[var(--text-primary)] group-hover:text-[var(--color-primary)] transition-colors pt-2">
+                          View Case Study
+                          <IconArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
+                        </div>
+                      </div>
+                    </WarmCard>
+                  </Link>
+                )
+              )}
             </div>
           </div>
         )}

--- a/src/constants/caseStudies.ts
+++ b/src/constants/caseStudies.ts
@@ -9,6 +9,7 @@ export interface CaseStudyData {
   github?: string | null;
   link?: string | null;
   featured?: boolean;
+  comingSoon?: boolean;
 
   overview: {
     summary: string;
@@ -610,6 +611,116 @@ export const caseStudiesData: Record<string, CaseStudyData> = {
     retrospective:
       "I'd define SLOs (Service Level Objectives) before building dashboards. We ended up with great visibility but no shared definition of 'good enough' performance, which made prioritization debates harder.",
     pmFramework: "SLO-based prioritization",
+  },
+
+  "fantasy-football-analytics": {
+    slug: "fantasy-football-analytics",
+    title: "Fantasy Football Analytics Platform",
+    description:
+      "Built a full-stack fantasy football analytics platform with live positional tier rankings (QB/RB/WR/TE/K/DST/Flex), automated FantasyPros data integration, D3-powered tier visualizations, a draft tracker, and a statistically-grounded player clustering system.",
+    role: "Solo Product Builder & Engineer",
+    timeline: "2024–2025",
+    tools: ["Next.js", "D3.js", "TypeScript", "SQLite", "FantasyPros API"],
+    metrics: "Live platform · 2026 season coming soon",
+    github: "https://github.com/IsaacAVazquez",
+    link: "/fantasy-football",
+    featured: false,
+    comingSoon: true,
+
+    overview: {
+      summary:
+        "Designed and built a fantasy football analytics platform from scratch — covering live positional tier rankings for all 7 NFL positions, an automated FantasyPros data pipeline, D3-powered visualizations, a draft tracker, and a Gaussian mixture model clustering system for statistically-grounded tier groupings.",
+      impact:
+        "Platform is live at isaacavazquez.com/fantasy-football. Full 2026 season tier updates and expanded analytics features are coming soon.",
+    },
+
+    problem: {
+      context:
+        "Existing fantasy football tools are paywalled, ad-heavy, or present tier data without statistical grounding — leaving players making draft decisions on poorly structured rankings.",
+      painPoints: [
+        "No clean, free visualization for all-position tier rankings in one place",
+        "FantasyPros tier data behind session-authenticated login walls with no public API",
+        "Player images served from inconsistent, third-party sources with poor coverage",
+        "Competitor tier groupings are arbitrary manual cutoffs, not statistically driven",
+      ],
+      stakes:
+        "Fantasy players make high-stakes draft decisions in seconds — poor data presentation and arbitrary tier boundaries directly lead to suboptimal picks.",
+    },
+
+    process: {
+      approach:
+        "Built an end-to-end data pipeline: FantasyPros session authentication → player data scraping → Gaussian mixture model clustering → SQLite persistence → D3 tier chart rendering.",
+      methodology: [
+        "Reverse-engineered FantasyPros session authentication to enable programmatic data access",
+        "Implemented Gaussian mixture model clustering for statistically-grounded, defensible tier boundaries",
+        "Built a unified cache layer and SQLite-backed pipeline for efficient data updates and build-time persistence",
+        "Scraped and served player headshots via a custom image pipeline covering all active NFL players",
+        "Shipped a draft tracker for in-draft player management with position filtering",
+      ],
+      decisions: [
+        "Chose D3.js over charting libraries for full control over tier chart layout and player positioning",
+        "Used SQLite (better-sqlite3) for zero-infrastructure persistence compatible with Netlify's static-first deployment",
+        "Chose Gaussian mixture models over k-means for more natural, data-driven tier boundaries",
+        "Built a unified cache abstraction to decouple data freshness logic from API and DB layers",
+      ],
+      collaboration:
+        "Solo project — product vision, data engineering, API design, and frontend built end-to-end.",
+    },
+
+    result: {
+      outcomes: [
+        "Live tier rankings for 7 positions (QB/RB/WR/TE/K/DST/Flex) at isaacavazquez.com/fantasy-football",
+        "Automated FantasyPros data pipeline with scheduled updates and freshness indicators",
+        "D3-powered tier visualizations with expert consensus signals and player headshots",
+        "Draft tracker tool for real-time in-draft player management",
+        "Full 2026 season data refresh and expanded analytics features coming soon",
+      ],
+      lessonsLearned: [
+        "A fantasy analytics product is 60% data pipeline and 40% UI — underestimating the pipeline is the #1 mistake",
+        "Gaussian mixture models require careful initialization; k-means++ seeding significantly improved cluster stability",
+        "Scraping fragility demands robust session management, fallback data strategies, and graceful degradation",
+      ],
+    },
+
+    detailedMetrics: [
+      { label: "Positions Covered", value: "7", improvement: "QB/RB/WR/TE/K/DST/Flex" },
+      { label: "Data Pipeline", value: "Automated", improvement: "Scheduled FantasyPros updates" },
+      { label: "Tier Algorithm", value: "GMM Clustering", improvement: "vs. manual cutoffs" },
+      { label: "2026 Season", value: "Coming Soon", improvement: "Expanded analytics" },
+    ],
+
+    userSegments: [
+      "Competitive fantasy players preparing for snake and auction drafts",
+      "Casual players wanting fast, clean all-position tier rankings",
+      "Analytics-minded players who want statistically grounded, defensible tiers",
+    ],
+    northStarMetric: "Active users during NFL draft season",
+    tradeoffs: [
+      {
+        decision: "Tier calculation algorithm",
+        optionChosen: "Gaussian mixture models",
+        optionRejected: "Manual tier breakpoints",
+        reasoning:
+          "Gaussian mixture models produce statistically defensible tier boundaries rather than arbitrary cutoffs, increasing user trust and reducing the need for manual maintenance each week.",
+      },
+      {
+        decision: "Data persistence layer",
+        optionChosen: "SQLite (better-sqlite3)",
+        optionRejected: "Hosted PostgreSQL",
+        reasoning:
+          "SQLite allows zero-infrastructure deployment with pre-built data at build time — perfectly suited for Netlify's static-first architecture without added operational overhead.",
+      },
+      {
+        decision: "Chart rendering",
+        optionChosen: "D3.js with custom layout",
+        optionRejected: "Recharts / Chart.js",
+        reasoning:
+          "The tier chart requires precise player positioning across a 2D projection space. Off-the-shelf charting libraries don't support this layout; D3 gives full control over element placement and interaction.",
+      },
+    ],
+    retrospective:
+      "The data pipeline proved significantly more complex than the UI. FantasyPros session scraping is fragile — for the 2026 season, I'd prioritize a more resilient data source and add user-level personalization (custom scoring, watchlists) to increase retention beyond draft day.",
+    pmFramework: "Jobs to Be Done",
   },
 };
 


### PR DESCRIPTION
## Summary
Added a new "Fantasy Football Analytics Platform" case study to the portfolio with a "coming soon" status indicator. This includes a new `comingSoon` field in the case study data structure and updated the portfolio page to render coming soon projects differently from completed case studies.

## Key Changes

- **New Case Study Data**: Added comprehensive `fantasy-football-analytics` case study covering a full-stack fantasy football platform with tier rankings, FantasyPros integration, D3 visualizations, and a draft tracker
- **Data Structure Enhancement**: Added optional `comingSoon?: boolean` field to `CaseStudyData` interface to support projects in progress
- **Portfolio Page UI Updates**:
  - Imported `IconClock` from Tabler Icons for visual indicator
  - Conditional rendering: coming soon projects display as non-interactive cards with a "Coming Soon" badge
  - Completed projects remain as clickable links with hover effects
  - Coming soon cards show:
    - Warning-colored "Coming Soon" badge with clock icon
    - Tool tags (first 4 with "+X more" overflow)
    - Status message about 2026 season updates
    - Direct link to live platform (if available) instead of full case study
  - Removed hover state and navigation link for coming soon items

## Implementation Details

- The coming soon card maintains the same visual hierarchy and spacing as regular case study cards but with disabled interactivity
- Tools are displayed as tags with overflow handling for projects with many technologies
- The "Coming Soon" badge uses the warning color scheme to distinguish it from completed work
- Coming soon projects can still link to live platforms/demos via the `link` field while deferring full case study documentation

https://claude.ai/code/session_019eqiWgzXqTaGVRTnogG5nD