### PR TITLE
[codex] Harden search hydration and RSS coverage

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Search", () => {
+  test("hydrates deep-linked search state and clears back to the canonical URL", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/search?q=fantasy&type=project&category=Fantasy%20Football%20Analytics"
+    );
+    await page.waitForLoadState("networkidle");
+
+    const input = page.getByRole("textbox", { name: /search content/i });
+
+    await expect(input).toHaveValue("fantasy");
+    await expect(page.getByRole("heading", { name: /search results/i })).toBeVisible();
+    await expect(page.getByText("Fantasy Football Analytics Platform")).toBeVisible();
+    await expect(page.getByText("Type: project")).toBeVisible();
+    await expect(page.getByText("Category: Fantasy Football Analytics")).toBeVisible();
+
+    await page.getByRole("button", { name: /show filters|hide filters/i }).click();
+    await page.getByRole("button", { name: /clear all filters/i }).click();
+
+    await expect(page).toHaveURL(/\/search\?q=fantasy$/);
+
+    await page.getByRole("button", { name: /clear search/i }).click();
+
+    await expect(input).toHaveValue("");
+    await expect(page).toHaveURL(/\/search$/);
+    await expect(page.getByText(/search tips/i)).toBeVisible();
+  });
+});

--- a/src/app/api/rss/__tests__/route.test.ts
+++ b/src/app/api/rss/__tests__/route.test.ts
@@ -15,6 +15,7 @@ const mockGetAllBlogPosts = getAllBlogPosts as jest.MockedFunction<
 describe("GET /api/rss", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    delete process.env.SITE_URL;
   });
 
   it("builds RSS items from blog frontmatter", async () => {
@@ -67,5 +68,72 @@ describe("GET /api/rss", () => {
     const body = await response.text();
 
     expect(body).toContain("<description>It&#039;s all in the excerpt</description>");
+  });
+
+  it("filters invalid posts and falls back to the title when no description fields exist", async () => {
+    mockGetAllBlogPosts.mockResolvedValue([
+      {
+        slug: "invalid-title",
+        title: "   ",
+        excerpt: "Ignored",
+        publishedAt: "2026-04-02",
+      },
+      {
+        slug: "invalid-date",
+        title: "Invalid Date",
+        excerpt: "Ignored",
+        publishedAt: "not-a-date",
+      },
+      {
+        slug: "title-fallback",
+        title: "Title Fallback",
+        excerpt: "",
+        publishedAt: "2026-04-02",
+      },
+    ]);
+
+    const response = await GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("<title>Title Fallback</title>");
+    expect(body).toContain("<description>Title Fallback</description>");
+    expect(body).not.toContain("invalid-title");
+    expect(body).not.toContain("invalid-date");
+    expect(body.match(/<item>/g)).toHaveLength(1);
+  });
+
+  it("uses the most recent updatedAt value for lastBuildDate and trims custom SITE_URL values", async () => {
+    process.env.SITE_URL = "https://preview.isaacavazquez.com/";
+    mockGetAllBlogPosts.mockResolvedValue([
+      {
+        slug: "newer-published",
+        title: "Newer Published",
+        excerpt: "Latest by publish date",
+        content: "<p>Latest by publish date</p>",
+        publishedAt: "2026-04-02T00:00:00.000Z",
+      },
+      {
+        slug: "older-but-updated",
+        title: "Older but updated",
+        excerpt: "Updated later",
+        content: "<p>Updated later</p>",
+        publishedAt: "2026-03-17T00:00:00.000Z",
+        updatedAt: "2026-04-03T12:34:56.000Z",
+      },
+    ]);
+
+    const response = await GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("<lastBuildDate>Fri, 03 Apr 2026 12:34:56 GMT</lastBuildDate>");
+    expect(body).toContain("<link>https://preview.isaacavazquez.com</link>");
+    expect(body).toContain(
+      "<atom:link href=\"https://preview.isaacavazquez.com/api/rss\" rel=\"self\" type=\"application/rss+xml\"/>"
+    );
+    expect(body).toContain(
+      "<guid isPermaLink=\"true\">https://preview.isaacavazquez.com/writing/older-but-updated</guid>"
+    );
   });
 });

--- a/src/app/api/rss/route.ts
+++ b/src/app/api/rss/route.ts
@@ -14,8 +14,12 @@ export async function GET() {
 
     return true;
   });
-  const lastBuildDate = posts[0]
-    ? new Date(posts[0].updatedAt || posts[0].publishedAt).toUTCString()
+  const lastBuildTimestamp = posts.reduce((latest, post) => {
+    const candidate = new Date(post.updatedAt || post.publishedAt).getTime();
+    return Number.isNaN(candidate) ? latest : Math.max(latest, candidate);
+  }, 0);
+  const lastBuildDate = lastBuildTimestamp > 0
+    ? new Date(lastBuildTimestamp).toUTCString()
     : new Date().toUTCString();
 
   const rss = `<?xml version="1.0" encoding="UTF-8"?>

--- a/src/components/search/SearchInterface.client.tsx
+++ b/src/components/search/SearchInterface.client.tsx
@@ -9,15 +9,32 @@ const SearchInterfaceNoSSR = dynamic(
   { ssr: false }
 );
 
+function resolveInitialSearchState(searchParams: ReturnType<typeof useSearchParams>) {
+  if (!searchParams.toString()) {
+    return {
+      initialQuery: "",
+      initialType: "all",
+      initialCategory: "all",
+    };
+  }
+
+  return {
+    initialQuery: searchParams.get("q") ?? "",
+    initialType: searchParams.get("type") ?? "all",
+    initialCategory: searchParams.get("category") ?? "all",
+  };
+}
+
 export function SearchInterfaceClient(props: SearchInterfaceProps) {
   const searchParams = useSearchParams();
+  const initialState = resolveInitialSearchState(searchParams);
 
   return (
     <SearchInterfaceNoSSR
       {...props}
-      initialQuery={searchParams.get("q") ?? props.initialQuery}
-      initialType={searchParams.get("type") ?? props.initialType}
-      initialCategory={searchParams.get("category") ?? props.initialCategory}
+      initialQuery={initialState.initialQuery}
+      initialType={initialState.initialType}
+      initialCategory={initialState.initialCategory}
     />
   );
 }

--- a/src/components/search/SearchInterface.tsx
+++ b/src/components/search/SearchInterface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Heading } from "@/components/ui/Heading";
 import { Paragraph } from "@/components/ui/Paragraph";
@@ -41,6 +41,10 @@ export interface SearchState {
   searchTime: number;
 }
 
+function getSearchStateKey(query: string, type: string, category: string) {
+  return JSON.stringify([query, type, category]);
+}
+
 function readSeededSearchState(fallbacks: Pick<SearchState, "query" | "type" | "category">) {
   if (typeof window === "undefined") {
     return fallbacks;
@@ -61,6 +65,7 @@ export function SearchInterface({
   initialCategory = "all"
 }: SearchInterfaceProps) {
   const router = useRouter();
+  const pendingUrlSyncKeyRef = useRef<string | null>(null);
   const seededState = readSeededSearchState({
     query: initialQuery,
     type: initialType,
@@ -80,6 +85,7 @@ export function SearchInterface({
 
   const [showFilters, setShowFilters] = useState(false);
   const debouncedQuery = useDebounce(searchState.query, 300);
+  const effectiveQuery = searchState.query === "" ? "" : debouncedQuery;
 
   useEffect(() => {
     const nextSeededState = readSeededSearchState({
@@ -108,6 +114,7 @@ export function SearchInterface({
 
   // Update URL when search parameters change
   const updateURL = useCallback((query: string, type: string, category: string) => {
+    pendingUrlSyncKeyRef.current = getSearchStateKey(query, type, category);
     const params = new URLSearchParams();
     if (query) params.set('q', query);
     if (type !== 'all') params.set('type', type);
@@ -170,15 +177,15 @@ export function SearchInterface({
   // Effect for debounced search
   useEffect(() => {
     if (
-      debouncedQuery !== initialQuery ||
+      effectiveQuery !== initialQuery ||
       searchState.type !== initialType ||
       searchState.category !== initialCategory
     ) {
-      performSearch(debouncedQuery, searchState.type, searchState.category);
-      updateURL(debouncedQuery, searchState.type, searchState.category);
+      performSearch(effectiveQuery, searchState.type, searchState.category);
+      updateURL(effectiveQuery, searchState.type, searchState.category);
     }
   }, [
-    debouncedQuery,
+    effectiveQuery,
     searchState.type,
     searchState.category,
     performSearch,
@@ -190,9 +197,26 @@ export function SearchInterface({
 
   // Initial search if query is provided
   useEffect(() => {
+    const nextSearchKey = getSearchStateKey(initialQuery, initialType, initialCategory);
+
+    if (pendingUrlSyncKeyRef.current === nextSearchKey) {
+      pendingUrlSyncKeyRef.current = null;
+      return;
+    }
+
     if (initialQuery) {
       performSearch(initialQuery, initialType, initialCategory);
+      return;
     }
+
+    setSearchState((prev) => ({
+      ...prev,
+      results: [],
+      isLoading: false,
+      hasSearched: false,
+      totalResults: 0,
+      searchTime: 0,
+    }));
   }, [performSearch, initialCategory, initialQuery, initialType]);
 
   const handleQueryChange = (query: string) => {
@@ -211,6 +235,8 @@ export function SearchInterface({
     setSearchState(prev => ({
       ...prev,
       query: "",
+      type: "all",
+      category: "all",
       results: [],
       hasSearched: false,
       totalResults: 0,
@@ -255,11 +281,13 @@ export function SearchInterface({
                   value={searchState.query}
                   onChange={(e) => handleQueryChange(e.target.value)}
                   placeholder="Search for content..."
+                  aria-label="Search content"
                   className="w-full pl-12 pr-12 py-4 bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-all duration-200 text-slate-900 dark:text-slate-100"
                 />
                 {searchState.query && (
                   <button
                     onClick={clearSearch}
+                    aria-label="Clear search"
                     className="absolute right-4 top-1/2 transform -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
                   >
                     <IconX className="w-5 h-5" />
@@ -269,6 +297,7 @@ export function SearchInterface({
               
               <button
                 onClick={() => setShowFilters(!showFilters)}
+                aria-label={showFilters ? "Hide filters" : "Show filters"}
                 className={`ml-4 p-4 rounded-lg border transition-all duration-200 ${
                   showFilters || searchState.type !== 'all' || searchState.category !== 'all'
                     ? 'bg-primary text-white border-primary' 

--- a/src/components/search/__tests__/SearchInterface.client.test.tsx
+++ b/src/components/search/__tests__/SearchInterface.client.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { SearchInterfaceClient } from "../SearchInterface.client";
+
+type SearchInterfaceProps = {
+  initialQuery?: string;
+  initialType?: string;
+  initialCategory?: string;
+};
+
+const mockRenderedSearchInterface = jest.fn<void, [SearchInterfaceProps]>();
+const mockGet = jest.fn();
+const mockToString = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => ({
+    get: mockGet,
+    toString: mockToString,
+  }),
+}));
+
+jest.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => {
+    return (props: SearchInterfaceProps) => {
+      mockRenderedSearchInterface(props);
+      return <div data-testid="search-interface" />;
+    };
+  },
+}));
+
+describe("SearchInterfaceClient", () => {
+  beforeEach(() => {
+    mockRenderedSearchInterface.mockReset();
+    mockGet.mockReset();
+    mockToString.mockReset();
+  });
+
+  it("prefers live URL params over seeded server props", () => {
+    mockToString.mockReturnValue(
+      "q=fantasy&type=project&category=Fantasy%20Football%20Analytics"
+    );
+    mockGet.mockImplementation((key: string) => {
+      const values: Record<string, string> = {
+        q: "fantasy",
+        type: "project",
+        category: "Fantasy Football Analytics",
+      };
+
+      return values[key] ?? null;
+    });
+
+    render(
+      <SearchInterfaceClient
+        initialQuery="resume"
+        initialType="page"
+        initialCategory="Career Playbooks"
+      />
+    );
+
+    expect(screen.getByTestId("search-interface")).toBeVisible();
+    expect(mockRenderedSearchInterface).toHaveBeenCalledWith({
+      initialQuery: "fantasy",
+      initialType: "project",
+      initialCategory: "Fantasy Football Analytics",
+    });
+  });
+
+  it("resets to clean defaults after the URL params are cleared", () => {
+    mockToString.mockReturnValue("");
+    mockGet.mockReturnValue(null);
+
+    render(
+      <SearchInterfaceClient
+        initialQuery="resume"
+        initialType="page"
+        initialCategory="Career Playbooks"
+      />
+    );
+
+    expect(mockRenderedSearchInterface).toHaveBeenCalledWith({
+      initialQuery: "",
+      initialType: "all",
+      initialCategory: "all",
+    });
+  });
+});

--- a/src/components/search/__tests__/SearchInterface.test.tsx
+++ b/src/components/search/__tests__/SearchInterface.test.tsx
@@ -1,0 +1,192 @@
+import React from "react";
+import { act } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SearchInterface } from "../SearchInterface";
+
+const mockPush = jest.fn();
+const mockFetch = jest.fn();
+const originalFetch = global.fetch;
+let syncUrlState = (_url: string) => {};
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: (url: string, options: { scroll: boolean }) => {
+      mockPush(url, options);
+      syncUrlState(url);
+    },
+  }),
+}));
+
+function buildSearchResponse(query: string) {
+  return Promise.resolve({
+    json: async () => ({
+      results: query
+        ? [
+            {
+              id: `${query}-result`,
+              title: `${query} result`,
+              excerpt: `${query} excerpt`,
+              url: "/writing",
+              type: "page",
+              relevanceScore: 42,
+            },
+          ]
+        : [],
+      total: query ? 1 : 0,
+      query,
+      filters: {
+        type: "all",
+        category: "all",
+      },
+    }),
+  });
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function SearchHarness() {
+  const [, forceSync] = React.useReducer((count) => count + 1, 0);
+
+  React.useEffect(() => {
+    syncUrlState = (url: string) => {
+      window.history.replaceState({}, "", url);
+      forceSync();
+    };
+
+    return () => {
+      syncUrlState = () => {};
+    };
+  }, []);
+
+  const params = new URLSearchParams(window.location.search);
+
+  return (
+    <SearchInterface
+      initialQuery={params.get("q") ?? ""}
+      initialType={params.get("type") ?? "all"}
+      initialCategory={params.get("category") ?? "all"}
+    />
+  );
+}
+
+describe("SearchInterface", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockPush.mockReset();
+    mockFetch.mockReset();
+    syncUrlState = () => {};
+    global.fetch = mockFetch as unknown as typeof fetch;
+    window.history.replaceState({}, "", "/search");
+    mockFetch.mockImplementation((input: RequestInfo | URL) => {
+      const url = new URL(String(input), "http://localhost");
+      const query = url.searchParams.get("q") ?? "";
+
+      return buildSearchResponse(query);
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("does not duplicate the initial fetch when hydrated state already matches the URL", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/search?q=resume&type=page&category=Fantasy%20Football%20Analytics"
+    );
+
+    render(<SearchHarness />);
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    expect(String(mockFetch.mock.calls[0]?.[0])).toContain("q=resume");
+    expect(String(mockFetch.mock.calls[0]?.[0])).toContain("type=page");
+    expect(String(mockFetch.mock.calls[0]?.[0])).toContain(
+      "category=Fantasy+Football+Analytics"
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    await flushPromises();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(screen.getByText(/1 result found/i)).toBeVisible();
+  });
+
+  it("syncs debounced searches and filter changes into the URL, then clears back to /search", async () => {
+    const user = userEvent.setup({
+      advanceTimers: jest.advanceTimersByTime,
+    });
+
+    render(<SearchHarness />);
+
+    const input = screen.getByRole("textbox", { name: /search content/i });
+    await user.type(input, "fantasy");
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    expect(mockPush).toHaveBeenLastCalledWith("/search?q=fantasy", {
+      scroll: false,
+    });
+
+    await user.click(screen.getByRole("button", { name: /show filters/i }));
+    await user.click(screen.getByRole("button", { name: /^projects$/i }));
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenLastCalledWith("/search?q=fantasy&type=project", {
+        scroll: false,
+      })
+    );
+
+    await user.click(screen.getByRole("button", { name: /fantasy football/i }));
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenLastCalledWith(
+        "/search?q=fantasy&type=project&category=Fantasy+Football+Analytics",
+        { scroll: false }
+      )
+    );
+
+    await user.click(screen.getByRole("button", { name: /clear all filters/i }));
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenLastCalledWith("/search?q=fantasy", {
+        scroll: false,
+      })
+    );
+
+    const fetchCallsBeforeClear = mockFetch.mock.calls.length;
+
+    await user.click(screen.getByRole("button", { name: /clear search/i }));
+
+    expect(input).toHaveValue("");
+    expect(screen.queryByText(/active filters:/i)).not.toBeInTheDocument();
+    expect(mockPush).toHaveBeenLastCalledWith("/search", {
+      scroll: false,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    await flushPromises();
+
+    expect(mockFetch).toHaveBeenCalledTimes(fetchCallsBeforeClear);
+    expect(screen.getByText(/search tips/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- harden search hydration around URL-seeded state, clear/reset flows, and accessible search controls
- add component-level Jest coverage for `SearchInterfaceClient` and `SearchInterface`
- expand RSS route coverage for invalid post filtering, title fallback, `updatedAt` precedence, and custom `SITE_URL` handling

## Why
Recent April 2 changes fixed search hydration and moved RSS generation onto blog frontmatter, but the regression coverage was still concentrated on happy-path rendering. This follow-up locks the state-sync and feed edge cases that were still untested.

## Validation
- `npm test -- --runInBand --runTestsByPath src/app/search/__tests__/page.test.tsx src/components/search/__tests__/SearchInterface.client.test.tsx src/components/search/__tests__/SearchInterface.test.tsx src/app/api/rss/__tests__/route.test.ts`
- `npx playwright test e2e/search.spec.ts --project=chromium`
