### PR TITLE
Prioritize homepage featured projects to top three

### DIFF
--- a/src/constants/caseStudies.ts
+++ b/src/constants/caseStudies.ts
@@ -644,8 +644,7 @@ export const caseStudiesData: Record<string, CaseStudyData> = {
 
 const HOMEPAGE_FEATURED_SLUGS = [
   "investment-analytics-platform",
-  "data-analytics-dashboard",
-  "civic-engagement-platform",
+  "news-pulse-dashboard",
   "spacex-mission-control",
 ] as const;
 


### PR DESCRIPTION
### Motivation
- Ensure the homepage surfaces the highest-priority projects (Investment, News Pulse, and SpaceX) so visitors see the most important work first.

### Description
- Updated `HOMEPAGE_FEATURED_SLUGS` in `src/constants/caseStudies.ts` to list `investment-analytics-platform`, `news-pulse-dashboard`, and `spacex-mission-control`, replacing the previous middle entries.

### Testing
- Ran `npx eslint src/constants/caseStudies.ts`, which failed in this environment due to a missing dependency (`@eslint/js`); no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf1267a94c8325baca8ce9243cb07a)