### PR TITLE
docs: add WRITING_VOICE.md and wire it into guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,12 @@ curl -X POST \
 
 ---
 
+## Writing Voice
+
+When editing, creating, or rewriting any article under `content/blog/`, read `WRITING_VOICE.md` first. It defines Isaac's voice, hard formatting rules, and the condensing philosophy used across all 22 articles. Non-conforming articles should be rewritten to match it, not patched around it.
+
+---
+
 ## Source Of Truth Docs
 
 - `README.md`
@@ -254,6 +260,7 @@ curl -X POST \
 - `DEVELOPMENT.md`
 - `TESTING.md`
 - `STYLING.md`
+- `WRITING_VOICE.md`
 - `docs/README.md`
 
 Older plans, redesign notes, and summary docs are kept for history. Check `docs/README.md` before treating a markdown file as current.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ This is intentional to avoid stacked closing CTAs.
 - Posts live in `content/blog/`
 - `src/lib/blog.ts` reads frontmatter and converts markdown/MDX to HTML using `remark`
 - `/writing` and `/writing/[slug]` are the live surfaced routes
+- All articles must follow the voice and formatting rules in `WRITING_VOICE.md` — read it before editing or creating any post
 
 ### Investments
 
@@ -255,6 +256,7 @@ Treat the following as current source of truth:
 - `DEVELOPMENT.md`
 - `TESTING.md`
 - `STYLING.md`
+- `WRITING_VOICE.md`
 - `docs/README.md`
 - `docs/ai-context/*`
 

--- a/WRITING_VOICE.md
+++ b/WRITING_VOICE.md
@@ -1,0 +1,58 @@
+# Writing Voice
+
+**Last updated:** 2026-04-03
+
+This document governs all writing under `content/blog/`. Any agent or collaborator editing, creating, or rewriting articles must follow these rules exactly.
+
+---
+
+## What the Voice Sounds Like
+
+Isaac's writing is first-person, direct, and opinion-forward. It reads like a senior practitioner explaining something they've actually worked through — not a thought-leadership summary, not a tutorial, not a blog post trying to rank.
+
+Specific characteristics:
+
+- First person used naturally and frequently: "I think," "I would argue," "I believe," "In my mind," "What I found," "I built this because"
+- States opinions directly without corporate hedging
+- Rhetorical questions to pivot between ideas: "But what actually changes this?" "So where does that leave you?"
+- Flowing prose paragraphs — related points strung together in sentences, not converted into bullets
+- Acknowledges multiple perspectives before landing on a clear position
+- Conversational asides: "What's interesting here is..." "What makes this worth paying attention to..."
+- Data and specifics woven naturally into sentences, not isolated in callouts
+- Section headers only where a long article genuinely needs navigation
+
+---
+
+## Hard Rules
+
+Never use these patterns, regardless of topic:
+
+- No em dashes as stylistic devices
+- No colons as sentence connectors — "The problem: X" must become "The problem is X"
+- No nested bullet lists with bold labels — always convert to prose
+- No Tables of Contents
+- No corporate or MBA framework names as section headers (Porter's Five Forces, Kotter's Model, McKinsey 7S, etc.)
+- No "comprehensive guide" or "complete guide" openers that set up a listicle structure
+- No generic restating "Conclusion" sections
+- No "Next Steps" bullet lists at the end
+- No "About the Author" sections
+
+---
+
+## Condensing Philosophy
+
+- Cut anything that pads with generic advice or restates what the article already said
+- Keep only what is actually worth saying
+- Fantasy football and QA articles especially tend to be padded — cut aggressively
+- A good article says one thing clearly, not seven things vaguely
+
+---
+
+## Examples in the Codebase
+
+The articles below demonstrate the voice correctly. Read them before editing or creating new content:
+
+- `content/blog/rb-vs-wr-draft-strategy-modeling-positional-value.mdx` — data woven into prose, clear positional argument
+- `content/blog/building-an-investment-research-platform.mdx` — product rationale in first person, restraint as a feature
+
+All 22 articles in `content/blog/` were rewritten to this voice in April 2026 and can be used as references.


### PR DESCRIPTION
## Changes

- Created `WRITING_VOICE.md` to document Isaac's writing style, hard formatting rules, and condensing philosophy for all blog articles
- Added references to `WRITING_VOICE.md` in `AGENTS.md` and `CLAUDE.md` as a source-of-truth document
- Included guidance that all articles under `content/blog/` must conform to the defined voice and formatting rules

## Key Guidance

The writing voice is:
- First-person, direct, and opinion-forward
- Conversational with flowing prose (no nested bullets or tables)
- Clear on perspective without corporate hedging
- Data and specifics woven naturally into sentences

Hard rules include restrictions on em dashes, colons as connectors, TOCs, frameworks as headers, and generic conclusion sections.