### PR TITLE
Add blog post: The SpaceX IPO Question analysis

### DIFF
--- a/content/blog/spacex-ipo-case-for-going-public.mdx
+++ b/content/blog/spacex-ipo-case-for-going-public.mdx
@@ -1,0 +1,67 @@
+---
+title: "The SpaceX IPO Question Is More Interesting Than It Looks"
+excerpt: "SpaceX is one of the most valuable companies ever built without ever touching the public markets. Whether that changes, and when, is a decision that will reshape how retail investors think about the space economy."
+publishedAt: "2026-04-07"
+category: "Investing"
+tags: ["SpaceX", "IPO", "Investing", "Space Economy", "Starlink", "Elon Musk", "Private Markets"]
+featured: false
+author: "Isaac Vazquez"
+seo:
+  title: "The SpaceX IPO: What Public Markets Would Be Getting Into"
+  description: "SpaceX remains one of the most valuable private companies in the world. I look at what a potential IPO would actually mean for investors, what makes the business unusual, and why Musk's hesitation is probably more rational than it sounds."
+  keywords: ["SpaceX IPO", "SpaceX valuation", "Starlink IPO", "space economy investing", "private company IPO", "Elon Musk SpaceX public", "space stocks"]
+---
+
+# The SpaceX IPO Question Is More Interesting Than It Looks
+
+SpaceX has spent two decades becoming one of the most consequential companies in the world without once giving retail investors a way to own a piece of it. That is not an accident. It is a deliberate product of how Elon Musk thinks about capital, control, and operational tempo. But it is also a tension that grows more visible every time the company raises at a valuation the public markets would scramble to price.
+
+The company was valued at roughly $350 billion in its most recent secondary tender round, making it one of the most valuable private companies ever built. To put that in context, that figure puts SpaceX in the same tier as major financial institutions and established industrial giants that have been publicly traded for decades. The difference is that SpaceX got there without quarterly earnings calls, shareholder letters, or SEC filings explaining why a rocket exploded.
+
+I think the IPO question is worth taking seriously not because it's imminent, but because understanding why SpaceX has stayed private this long tells you something important about what kind of company it actually is. And understanding what would change if it went public tells you something important about what you'd actually be buying.
+
+## Why the company has stayed private
+
+The most common explanation is control. Musk has been explicit about this in interviews over the years. Taking a company public means accepting a set of institutional obligations that can conflict with the kind of long-cycle decision-making that gets rockets to orbit. Public shareholders optimize for quarterly results. Building a fully reusable heavy-lift launch system and simultaneously deploying a global satellite internet constellation are decade-length bets that generate enormous costs long before they generate commensurate returns.
+
+That explanation is real, but I think it undersells a second factor, which is that SpaceX has never needed the capital. Going public is fundamentally a financing mechanism. It converts equity into cash that the company can use to grow. But SpaceX has had access to enormous pools of private capital, substantial government contracts through NASA and the Department of Defense, and increasingly, Starlink subscription revenue that funds operations from the inside. When your funding problem is already solved, the costs of going public start to look like they outweigh the benefits.
+
+There is also a national security dimension that does not get discussed enough in financial media. A significant portion of SpaceX's revenue comes from classified or sensitive government programs. The level of operational transparency that public company status requires sits awkwardly against the kind of disclosure restrictions that come with those contracts. That tension does not make an IPO impossible, but it adds a layer of complexity that does not apply to most technology companies.
+
+## What the business actually looks like
+
+The reason the IPO conversation keeps coming back is that SpaceX's underlying business has matured in ways that make it look increasingly like a durable public company rather than a moonshot venture.
+
+Starlink is the clearest part of that story. The service has grown from a niche product for rural broadband to a business operating across consumer, enterprise, maritime, aviation, and military segments, with millions of subscribers globally. Recurring subscription revenue at that scale is the kind of thing public market investors pay significant multiples for. It is not speculative. It is infrastructure with a payment attached.
+
+The launch business has similarly matured. Falcon 9 has a reliability record that makes it the default choice for most commercial satellite operators, and SpaceX's cost structure, built around vertical integration and reusability, is structurally lower than legacy competitors. The company has effectively become the supply chain backbone of the global satellite industry. That kind of market position does not come and go.
+
+Starship adds a different kind of optionality. If Starship delivers on its design objectives, which include full reusability and payload capacity far beyond anything currently operational, the economics of access to orbit change at an order-of-magnitude level. That would unlock markets, including lunar logistics, large-scale satellite constellations, and eventually point-to-point cargo, that do not meaningfully exist yet. I would not price Starship into a valuation model today. But I would not ignore it either.
+
+## What the IPO structure would probably look like
+
+The assumption that SpaceX itself goes public in one clean offering is probably wrong. The more likely path, and the one that has been floated by people close to the company for years, is a Starlink IPO first. That structure makes sense for a few reasons.
+
+Starlink has the financial profile that most comfortably translates into a public company narrative. Recurring revenue, a large addressable market, visible subscriber growth, and a relatively clear competitive moat. It is also easier to value than SpaceX as a whole. SpaceX consolidated includes the launch business, Starship development costs, Starlink, and a collection of government programs, some of which carry classification constraints. Separating Starlink creates a cleaner story.
+
+Musk has confirmed in multiple public appearances that a Starlink IPO is something the company has considered. The framing has consistently been "when Starlink's revenue growth is predictable enough," which is the kind of benchmark that is genuinely hard to argue with. Predictable enough is not a date, it is a condition. And conditions can be pushed out indefinitely if the motivation to stay private remains stronger than the motivation to access public capital.
+
+## Why retail investors should think carefully about what they're buying
+
+Assume for a moment that some form of SpaceX or Starlink equity does become publicly available. The first question I would ask is not about the valuation multiple. It is about what version of the company you are actually getting.
+
+The history of founder-led companies going public teaches a consistent lesson: the public market captures a business that has already de-risked significantly from what made it exceptional. The period where SpaceX was landing orbital rocket boosters for the first time, proving out Starlink's physics, and building manufacturing and launch infrastructure at unprecedented scale, is largely behind it. What's left is a more mature operating business inside a much larger and more complicated regulatory, geopolitical, and competitive environment.
+
+That is not a reason to avoid it. Mature operating businesses can be great investments. But the psychological frame that this is still the same SpaceX that was betting on the edge of bankruptcy in the early Falcon 1 days is the wrong frame. By the time public investors get access, they are buying into a company whose biggest innovations are probably upstream of the offering date.
+
+I also think the Musk control premium deserves serious attention. SpaceX's trajectory has been built around Musk's willingness to make concentrated, unconventional bets and then hold them through enormous uncertainty. That capacity for risk tolerance is not separable from his control over the company. If an IPO structure creates meaningful dilution of that control, or introduces the institutional pressures that public markets inevitably create, the dynamic that built this company changes. That is not obviously bad. But it is different.
+
+## Where I land on this
+
+I think some form of SpaceX equity becomes publicly accessible within the next several years. The business is too large, too cash-generative, and too strategically important to stay private indefinitely. The pressure on early investors and employees to get liquidity grows every year, and secondary markets only partially solve that problem.
+
+What I would watch is Starlink's revenue trajectory and the degree to which Musk's attention and capital allocation shifts focus between his various projects. If Starlink hits a subscriber growth plateau, the logic for keeping it private gets weaker because the story that justifies a massive private valuation becomes harder to sustain without public market discipline. If Starship development hits meaningful milestones on reusability, the strategic optionality argument for SpaceX as a combined entity gets stronger and the Starlink separation becomes more attractive as a way to surface value without giving up control of the core launch infrastructure.
+
+The company I would actually want to own long-term is SpaceX consolidated, with Starship in the picture. But that is also the version of the company that is least likely to be offered in a form that retail investors can access cleanly.
+
+That tension is what makes this more interesting than most IPO conversations. You are not just waiting for a price. You are waiting to find out which version of the company goes public, under what structure, with what kind of governance, and whether any of that matches the version of SpaceX that made the question worth asking in the first place.


### PR DESCRIPTION
## Summary
Added a new blog post analyzing SpaceX's IPO prospects, examining why the company has remained private, its current business maturity, and what a potential public offering might look like for retail investors.

## Changes
- **New blog post**: `content/blog/spacex-ipo-case-for-going-public.mdx`
  - Comprehensive analysis of SpaceX's private company status and IPO considerations
  - Covers the company's valuation ($350B), business segments (Starlink, Falcon 9, Starship), and strategic rationale for staying private
  - Discusses potential IPO structure (likely Starlink-first approach) and implications for public market investors
  - Includes SEO metadata and categorization under "Investing" with relevant tags
  - Author: Isaac Vazquez
  - Published date: April 7, 2026

## Notable Details
- Post explores non-obvious factors beyond control, including capital availability, government contracts, and national security considerations
- Analyzes the maturation of SpaceX's business segments and their public market readiness
- Provides thoughtful perspective on what retail investors should consider if SpaceX equity becomes publicly available
- Structured with clear sections examining historical context, current business state, and future implications

https://claude.ai/code/session_01WMEaVQqcorNfuzaspjKHSt