### PR TITLE
Add Artemis II blog post about crewed lunar flyby mission

### DIFF
--- a/content/blog/artemis-ii-first-crewed-lunar-mission.mdx
+++ b/content/blog/artemis-ii-first-crewed-lunar-mission.mdx
@@ -1,0 +1,61 @@
+---
+title: "Artemis II: What It Actually Means to Send Humans Back to the Moon"
+excerpt: "For the first time in 50 years, humans are traveling beyond Earth orbit. Artemis II is not just a milestone — it's a stress test of everything NASA has been building toward, and it's happening right now."
+publishedAt: "2026-04-07"
+category: "Space Exploration"
+tags: ["Space Exploration", "NASA", "Artemis", "Moon", "Orion", "Space Launch System", "Human Spaceflight"]
+featured: false
+author: "Isaac Vazquez"
+seo:
+  title: "Artemis II: What It Means to Send Humans Back to the Moon"
+  description: "Artemis II launched April 1, 2026, sending four astronauts on a 10-day lunar flyby — the first crewed journey beyond Earth orbit in 50 years. Here's what it means and why it matters."
+  keywords: ["artemis ii", "nasa moon mission 2026", "crewed lunar flyby", "orion spacecraft", "space launch system", "first crewed moon mission 50 years", "reid wiseman", "victor glover", "christina koch", "jeremy hansen"]
+---
+
+# Artemis II: What It Actually Means to Send Humans Back to the Moon
+
+On April 1, 2026, four people left Earth orbit for the first time in half a century. That sentence deserves a moment. The last time humans traveled beyond low Earth orbit was December 1972, when Gene Cernan stepped off the lunar surface and climbed back into the Apollo 17 ascent module. Nobody has gone farther than a few hundred miles above the planet since. Artemis II changes that.
+
+I've followed the Artemis program closely, and I think the tendency is to either oversell it as humanity's triumphant return to the Moon or to dismiss it as an overpriced proof of concept that took too long to arrive. Both reactions miss what's actually interesting. Artemis II is a genuine inflection point — not because the mission itself is going to the Moon's surface, but because it's the crewed test that has to succeed before any of the more ambitious stuff is even possible.
+
+## What the Mission Is Actually Doing
+
+Artemis II is a lunar flyby, not a landing. Commander Reid Wiseman, pilot Victor Glover, mission specialist Christina Koch, and Canadian Space Agency astronaut Jeremy Hansen launched aboard the Orion spacecraft on April 1 and flew a 10-day trajectory that brought them around the Moon before returning home, with splashdown scheduled off the coast of San Diego on April 10.
+
+On April 6, the crew reached their closest approach at about 4,070 miles above the lunar surface. During the flyby, Orion passed behind the Moon entirely, cutting off all communication with Earth for about 40 minutes. What I find genuinely striking is what happened during that blackout window: the crew witnessed Earthrise from deep space, something fewer than two dozen humans have ever seen with their own eyes.
+
+More concretely, this mission broke records. The maximum distance from Earth reached approximately 252,760 miles — surpassing Apollo 13's 1970 distance record by over 4,000 miles. That's not a symbolic achievement. It means Orion's navigation, communication, and life-support systems functioned correctly at a distance that no crewed spacecraft had previously survived under operational conditions with a live crew aboard.
+
+The mission has five core objectives that go beyond just "fly around the Moon": demonstrating the crew can be sustained in deep space, validating the systems essential for future crewed lunar campaigns, testing emergency abort capabilities, retrieving flight hardware for post-mission analysis, and completing a series of subsystem verification data points that Artemis I — the uncrewed test flight in 2022 — couldn't gather with actual humans in the loop. Every one of those objectives has a direct line to Artemis III, which is targeting a crewed lunar landing.
+
+## The Spacecraft Behind the Mission
+
+I want to spend a minute on the hardware because it's easy to gloss over and the details matter. The Space Launch System — the rocket — stands 322 feet tall and generates 8.8 million pounds of thrust at liftoff, which is about 15 percent more than the Saturn V produced. That's not trivial. Getting mass to deep space is hard, and the SLS's capacity is what enables the Orion capsule's mass and the mission duration.
+
+Orion itself carries the crew module designated CM-003, named Integrity. Its heat shield is 16.5 feet in diameter, the largest ever built, and it needs to handle reentry temperatures up to 5,000 degrees Fahrenheit at speeds approaching 25,000 miles per hour. One of the reasons this mission took longer than originally planned is that after Artemis I, engineers discovered heat shield damage during reentry that required investigation and design analysis. That kind of conservative response is frustrating from a schedule perspective, but it's exactly right from a risk management perspective when you're about to put four people in the thing.
+
+The launch pad itself carries a footnote worth noting: Launch Complex 39B at Kennedy Space Center hadn't seen a crewed mission since Space Shuttle STS-116 in 2006. There's something strange about that number. Twenty years of a launch complex sitting dark between crewed flights tells you something about the gap in political will and funding that preceded this program.
+
+## The Crew and What They Represent
+
+Reid Wiseman has logged time on the International Space Station and now commands the first crewed deep space mission in a generation. Victor Glover flew to the ISS on Crew Dragon in 2020, but Artemis II puts him farther from Earth than any human since the Apollo era. Christina Koch holds the record for the longest single spaceflight by a woman — 328 days on ISS — and is now the first woman to travel to the Moon. Jeremy Hansen becomes the first Canadian to venture beyond Earth orbit.
+
+I think the composition of this crew matters beyond the symbolic. Deep space introduces risk profiles that ISS missions don't have. The radiation environment beyond the protection of Earth's magnetic field is substantially more intense. Emergency abort options that exist in low Earth orbit don't exist at 250,000 miles from home. The psychological and physiological demands are different. This crew's ability to perform under those conditions is itself part of what the mission is testing, and the data collected on crew health and performance throughout the flight will directly inform how NASA prepares for the longer durations required by actual lunar surface missions.
+
+## Why It Matters That This Is a Flyby, Not a Landing
+
+Some people have expressed impatience that Artemis II doesn't land on the Moon. I understand the reaction, but I think it gets the engineering logic backwards. A crewed lunar flyby is enormously harder than a crewed ISS mission and substantially less risky than a crewed landing. That ordering is intentional.
+
+Orion has never carried a crew. The abort system has never been tested with humans aboard in a real deep-space environment. The communication protocols between the crew and mission control have never been exercised at 250,000 miles of lag. Life support behaves differently when actual metabolic loads and psychological stress are in play versus a simulator. You do not discover any of those failure modes for the first time when you're trying to land on the Moon. You discover them on a flyby that gives you a survivable return path at every stage.
+
+What Artemis II is really doing is validating the stack. If Orion holds together, if the crew stays healthy, if splashdown goes as planned — then the engineering argument for proceeding to Artemis III, which targets a landing near the lunar south pole, is on solid ground. If something breaks, you have learned something critical at a cost that is recoverable. That's the correct risk ladder for a program this consequential.
+
+## What Comes After
+
+Artemis III is targeting a mid-2027 landing, and the stakes are different in a way that I think people underestimate. The landing zone — the lunar south pole region — matters because of permanently shadowed craters that are believed to hold water ice. Water ice means oxygen for life support and hydrogen for fuel. The ability to use in-situ resources is what eventually makes sustained lunar presence economically and logistically viable rather than a series of extremely expensive flags-and-footprints visits.
+
+Whether you believe the current timeline is credible depends on how much credit you give NASA's ability to hold a schedule, which historically is a fraught question. But the technical progression is coherent. Artemis I proved the rocket and spacecraft could survive an uncrewed lunar mission. Artemis II is proving the same with a crew in the loop. Artemis III needs a human landing system — SpaceX's Starship HLS in its current plan — and a crewed surface sortie. Each step depends on the previous one working.
+
+I find the current moment genuinely exciting in a way I haven't felt about NASA programs in a long time. That's partly because the mission is actually happening right now — four humans are out there past the Moon, heading home — and partly because the follow-on rationale is cleaner than it's been since Apollo. The goal is not purely national prestige this time, even if that's part of it. The goal is establishing infrastructure for a sustained human presence in deep space, with water ice and fuel production as the economic logic. That's a coherent long-term objective, not just a destination.
+
+The crew lands in four days. I'll be watching the splashdown.


### PR DESCRIPTION
## Summary
Added a comprehensive blog post analyzing NASA's Artemis II mission, the first crewed lunar flyby in 50 years that launched on April 1, 2026.

## Changes
- **New blog post**: `content/blog/artemis-ii-first-crewed-lunar-mission.mdx`
  - Detailed analysis of the Artemis II mission objectives and achievements
  - Technical breakdown of the Space Launch System rocket and Orion spacecraft
  - Overview of the four-person crew and their significance
  - Explanation of why a flyby precedes a landing in the mission sequence
  - Context for future Artemis III lunar landing mission
  - Includes comprehensive SEO metadata and frontmatter

## Notable Details
- Published date: April 7, 2026 (6 days after mission launch)
- Covers mission specifics: 10-day trajectory, 4,070-mile lunar approach, 252,760-mile distance record
- Discusses crew composition: Reid Wiseman (commander), Victor Glover (pilot), Christina Koch (mission specialist), Jeremy Hansen (Canadian Space Agency)
- Emphasizes the engineering rationale for testing with a crewed flyby before attempting a landing
- Provides context on hardware: SLS rocket (322 ft, 8.8M lbs thrust), Orion CM-003 "Integrity" with 16.5 ft heat shield
- Authored by Isaac Vazquez with category "Space Exploration"

https://claude.ai/code/session_01Cm5BoE8yehNAk2RubbAHY5