### PR TITLE
Add four April 2026 hot-topic deep dives

### DIFF
--- a/content/blog/ai-coding-tools-developer-displacement-2026.mdx
+++ b/content/blog/ai-coding-tools-developer-displacement-2026.mdx
@@ -1,0 +1,61 @@
+---
+title: "Developer Displacement Is Not Uniform, and That's the Whole Story"
+excerpt: "AI coding tools are reshaping software hiring, but not the way the headlines frame it. The displacement is hitting specific roles and tasks while creating leverage for others, and that asymmetry is what anyone trying to read the market should actually understand."
+publishedAt: "2026-04-21"
+category: "Agentic AI"
+tags: ["AI", "Software Engineering", "Developer Tools", "Career", "Labor Market", "Cursor", "GitHub Copilot", "Agentic AI"]
+featured: false
+author: "Isaac Vazquez"
+seo:
+  title: "AI Coding Tools and Developer Displacement: What's Actually Happening in 2026"
+  description: "The real story of AI coding tools in 2026 is not that developers are being replaced. It is that displacement is hitting specific roles while creating leverage for others. Here is what that split looks like and why it matters."
+  keywords: ["AI coding tools", "developer displacement", "software engineering jobs", "Cursor", "GitHub Copilot", "junior developer hiring", "AI agents", "engineering productivity"]
+---
+
+# Developer Displacement Is Not Uniform, and That's the Whole Story
+
+The discourse around AI coding tools has been stuck in a binary for about two years now. One camp says developers are being replaced. The other says developers are being augmented. I think both framings miss what's actually happening, because both of them treat software engineering as a single homogeneous job. It isn't. It never was. And when you look at what AI coding tools have actually displaced so far, the pattern is not "some of developers' work" in any uniform way. It's specific tasks, specific roles, and specific parts of the industry taking disproportionate hits while other parts are gaining serious leverage.
+
+That asymmetry is the story worth telling, because it's the one that tells you where to position yourself.
+
+## What actually got displaced first
+
+If you want to know where AI coding tools are biting, don't look at the hiring announcements from AI-native startups. Look at the places that aren't hiring anymore. Over the past twelve months the clearest signal has been the collapse in demand for offshore code farms, the body shops that staffed large numbers of engineers against feature tickets for enterprise clients. That business was priced on headcount arbitrage. When a mid-size enterprise can get comparable ticket throughput by pairing one onshore senior with Cursor and a small agent fleet, the economic case for the body shop evaporates. Several of the largest Indian IT services firms have quietly started restructuring toward higher-value consulting and platform work because the commodity delivery business is being eaten from underneath.
+
+The second cohort taking visible hits is junior developer hiring at U.S. companies that aren't hypergrowth. Not across the board, and not at AI-native companies where junior roles are still meaningful because they're training the next generation of builders of the core product. But at established software companies that do a lot of maintenance and feature work on mature codebases, junior headcount has compressed. The math is straightforward. A senior engineer with a good agent loop can close more well-specified tickets in a day than they used to close in a week. The company still needs senior engineers. It needs fewer of the people whose main output was ticket closure.
+
+The third cohort, and this one is underreported, is traditional QA. I wrote about this at length in the QA guide and the testing AI systems piece, but the short version is that the scripted-test-case writer role is functionally gone at any company that has moved to modern tooling. That work was already being automated before the current generation of AI coding tools. What's finished it is agents that can read a PR, generate the tests, run them, and iterate on failures without human involvement. Exploratory QA is still valuable. The "translate the requirements doc into a test plan" role is not.
+
+## What gained leverage
+
+The other half of the story, which gets less airtime because it doesn't make for punchy headlines, is that a meaningful number of roles have become much more powerful.
+
+Senior engineers who can specify work precisely and evaluate output critically have gotten dramatically more productive. I know individual engineers shipping the equivalent of a small team's monthly output because they've developed the muscle for decomposing work into agent-tractable pieces, supervising the agent's execution, and stitching the results into coherent systems. That's not hypothetical. Walk into any AI-native product company in San Francisco or New York and the principal engineers will tell you, without being asked, that their ratio of ideas-shipped-to-time-spent has changed by an order of magnitude in the past year.
+
+Product managers who can write specifications that a coding agent can actually execute against have become unusually valuable. This is a skill most PMs underdeveloped because for years the interface to engineering was conversational and iterative. Now the interface to a meaningful chunk of engineering output is a specification document, and PMs who can write tight, unambiguous requirements with clear acceptance criteria have leverage they didn't have two years ago. I think this is why the better PMs at AI-native companies are getting outsized comp bumps right now. The role has shifted toward something closer to a staff-level individual contributor, and the people who can operate there are still rare.
+
+The third group gaining leverage is a category that didn't really exist before, which I'll call the AI-native tech lead. These are people who can do everything a senior engineer does, everything a PM does, and also design the agent workflows themselves. They're thinking about how to set up repos so that agents can navigate them, how to structure the test suite so that autonomous fixes converge, how to manage context windows across long-running agent tasks. Companies that have figured out they need this role are hiring for it aggressively. Companies that haven't figured it out yet will eventually, and they'll be behind.
+
+## Why the headline "developers are being replaced" is misleading
+
+The thing that frustrates me about the replacement narrative is that it obscures the actual dynamic. No software engineer with genuine systems thinking, product judgment, or the ability to architect for nonobvious failure modes is getting replaced by an AI agent in 2026. What's getting replaced is a specific bundle of tasks: writing scoped feature code from well-defined tickets, fixing straightforward bugs, generating standard test coverage, translating requirements into boilerplate. If a role was primarily composed of those tasks, that role is in trouble. If a role was composed of those tasks plus other, harder things, the role is fine, and probably more valuable than before.
+
+The framing issue matters because it's misleading people about what to do about it. If you believe developers are being replaced, the advice is to leave software. If you believe what's actually happening, the advice is to shift the composition of your work toward the tasks AI agents don't do well yet, and to develop the skills to direct and evaluate the agents that do the rest. Those are very different strategies, and only one of them is going to work out.
+
+## What this means if you're entering the field
+
+This is the part I get asked about most, and my honest answer is that the path in is harder than it was three years ago, but the ceiling is higher. Entry-level jobs that existed to give people reps on ticket work are compressing. That was a big part of how people used to build the muscle for more complex engineering. The pipeline problem is real, and I don't think the industry has solved it.
+
+What seems to work for people breaking in now is some combination of building real things in public that demonstrate they can direct agents well, developing taste for which AI outputs are actually correct versus plausibly wrong, and being able to work across the stack in a way that pure bootcamp graduates historically didn't. The floor on what a new hire is expected to do has risen. You're not being evaluated against a junior of five years ago. You're being evaluated against what a senior with an agent fleet can produce.
+
+If you're in school now and worried about this, the best preparation is not more leetcode. It's spending serious time working with agents, building meaningful systems, and developing judgment about when the agent is producing something good versus something that looks good. That judgment is the thing companies actually need, and it's the thing you can't easily fake.
+
+## Where I think this goes
+
+I've argued in other pieces that the slope of the improvement curve matters more than today's capability, and I still believe that. The fraction of engineering work that's agent-tractable is going to keep growing. The roles that are safe today at the bottom of the stack will not all be safe in two years. The roles that are gaining leverage today will gain more.
+
+What I don't think happens is that software engineering disappears. There's too much work, too many systems that need to be built and maintained, and too many decisions that require human judgment. What happens instead is a sharper bifurcation: the top half of the profession gets more productive and better compensated, and the bottom half, as it's currently structured, compresses hard. Where you sit in that bifurcation in two or three years will depend almost entirely on what you're doing with your time right now.
+
+That's the honest version of the story, and it's also the useful one.
+
+For more on how to position for this shift, I wrote about [the new baseline of AI skills for PM internships](/writing/ai-skills-pm-internship-2026) and what the [week-of-April-6 signals looked like](/writing/2026-week-april-6-ai-coding-tools-developer-displacement) from the broader tech news cycle.

--- a/content/blog/mcp-winning-integration-war-enterprise-default.mdx
+++ b/content/blog/mcp-winning-integration-war-enterprise-default.mdx
@@ -1,0 +1,55 @@
+---
+title: "MCP Has Already Won the Integration War. Most People Haven't Noticed Yet."
+excerpt: "The Model Context Protocol moved from interesting standard to default integration layer faster than most people tracking enterprise software realized. Here is why that happened, what it displaces, and what builders should be doing about it now."
+publishedAt: "2026-04-21"
+category: "Agentic AI"
+tags: ["AI", "MCP", "Model Context Protocol", "Integration", "Enterprise Software", "Agentic AI", "API", "Platform Strategy"]
+featured: false
+author: "Isaac Vazquez"
+seo:
+  title: "MCP Is Winning the AI Integration War: What It Means for Enterprise Software"
+  description: "The Model Context Protocol has quietly become the default integration layer for AI agents. Here is why enterprise adoption accelerated, what it displaces, and how builders should respond."
+  keywords: ["MCP", "Model Context Protocol", "AI integration", "enterprise AI", "agentic AI", "iPaaS", "Zapier", "MuleSoft", "AI agents", "integration layer"]
+---
+
+# MCP Has Already Won the Integration War. Most People Haven't Noticed Yet.
+
+About a year ago I wrote a piece arguing that MCP was becoming the default integration layer for AI agents. At the time that was a forward-looking claim with genuine counterfactual scenarios attached to it. Anthropic had published the protocol, a handful of early adopters had built servers, and the open question was whether the ecosystem would converge on MCP or fragment across vendor-specific approaches. A year on, that question has been answered, and it's not close.
+
+MCP has won. Not in the sense that every integration in the world runs through it, which it doesn't and won't. But in the sense that when a builder sits down to figure out how an AI agent will talk to their product, MCP is now the default answer and everything else is an exception. That shift happened faster than I expected, and the implications for the integration layer of the enterprise software stack are larger than I think most people have priced in.
+
+## What convergence actually looked like
+
+The thing that made MCP's adoption curve unusual is that it didn't follow the typical protocol-war pattern. Most of those, whether you're looking at SOAP versus REST or the early smart-contract standards, went through a long period of competing standards, market confusion, and eventual consolidation driven by the dominant platform vendor. MCP compressed that timeline dramatically because the market conditions were unusual. Every AI company and every enterprise software vendor had the same problem at the same time, which was that their users wanted AI agents that could act across systems, and building that one vendor at a time was going to be a losing game. When Anthropic published a reasonable open standard, the incentive for everyone else to adopt it rather than write their own was unusually strong.
+
+What tipped the ecosystem was not a single vendor announcement. It was the first wave of enterprises that started building their internal platforms around MCP. Once the agent-facing interface of an enterprise's internal tools was MCP, the cost calculus for every external vendor flipped. Supporting MCP natively became the obvious path, because any vendor that didn't was going to be harder to integrate into that enterprise's agent workflows than a vendor that did. That's how a standard goes from "worth considering" to "assumed" in a remarkably short period.
+
+By early 2026 the major cloud providers were all shipping native MCP support. The large developer tooling companies had MCP-first agent integrations. And most revealing, the CRM and ERP vendors, which are usually the slowest to adopt anything new because their enterprise customers move glacially, started announcing MCP roadmaps. When Salesforce, ServiceNow, and SAP all signal movement in the same direction within a quarter of each other, the standard has won.
+
+## What this displaces
+
+The interesting question now isn't whether MCP succeeds, which is settled, but what the success of MCP changes about the software stack. I think the answer is larger than the current conversation suggests.
+
+The most obvious place this creates pressure is the integration middleware space. Zapier, Workato, MuleSoft, Boomi, and the broader iPaaS category have existed because moving data between enterprise systems was hard and every pair of systems needed a custom connector. In a world where every major SaaS product exposes its data and actions through MCP, and every AI agent speaks MCP natively, the core value proposition of the iPaaS layer compresses. You still need workflow orchestration, state management, and governance for complex multi-step automations. But the "translation layer between systems" part of the value prop, which was a big share of what customers were paying for, gets absorbed into the protocol itself.
+
+I don't think this means iPaaS companies disappear. The smart ones are already pivoting to orchestration, observability, and governance of agentic workflows, which are real and underserved problems. Zapier's agent platform is a clear example of this. But the simple "connect these two apps" business is getting commoditized, and the companies that were built around that as their primary wedge are going to have a harder time than their market caps currently suggest.
+
+A less obvious place MCP creates pressure is in how enterprise software gets bought. The historical buying pattern was that you evaluated a tool largely on its own merits, possibly with some attention to integration capabilities. When agents become the primary way people interact with enterprise systems, which I think happens for a meaningful chunk of knowledge work within two years, the evaluation criteria shift. "How well does your tool surface through MCP" becomes a first-class question. Vendors that can't answer it credibly will lose deals they would have otherwise won. This is already showing up in enterprise procurement conversations in late 2026.
+
+## What builders should be doing now
+
+If you're building a product that has any business exposing itself to AI agents, which in practice means almost any SaaS product, the question isn't whether to build an MCP server. It's how to build one that's actually useful rather than box-checking.
+
+The box-checking version is what I see most teams shipping right now. They take their existing REST API and generate an MCP wrapper that exposes each endpoint as a tool. That's technically compliant and technically unhelpful. The problem is that a REST API was designed for developers who are reading documentation and composing calls. An agent is a probabilistic system trying to infer which tool to use from descriptions, and the granularity, naming, and documentation that made a REST API good make an MCP server mediocre. The agents can't disambiguate, they call the wrong tools, and the resulting agent experience is worse than no integration at all.
+
+The version that works looks different. Tool definitions are higher-level and task-oriented rather than CRUD-oriented, descriptions include the kind of context an agent needs to choose correctly, and the surface area is deliberately smaller than your full API. It looks more like designing a good command-line interface than wrapping an HTTP API. That's the craft that distinguishes the MCP servers that actually work from the ones that exist. Most vendors haven't learned this yet. The ones that figure it out first will have a noticeable edge in how well their products work inside agent workflows.
+
+The second thing builders should be doing is thinking carefully about the trust boundary. Every MCP server you expose is a potential pivot point for a compromised agent context. Least privilege, audit logging, and human-in-the-loop checkpoints for destructive actions are not optional. I wrote about the agentic attack surface in the cybersecurity piece, and nothing I've seen since then has made me less worried about it.
+
+## Where I think the integration layer sits in three years
+
+My best guess is that the integration layer of the enterprise software stack looks meaningfully different in 2029 than it does today. MCP or its direct descendants become the assumed protocol for how AI-mediated work moves across systems. The iPaaS category consolidates, with the survivors having moved up the stack into orchestration, governance, and agent lifecycle management. The CRM, ERP, and HRIS vendors invest heavily in making their MCP surfaces the best in the industry because they recognize that's where competitive differentiation lives now. And a new category of companies emerges around observability, security, and reliability for agent-mediated workflows, which will be where much of the interesting infrastructure investment goes.
+
+What does not happen is that MCP ends. Standards like this, once adopted at this scale, tend to persist longer than anyone expects. TCP/IP is still how the internet runs. SQL is still how most databases get queried. MCP doesn't need to be perfect to be durable. It just needs to be the thing everyone agreed on, and it already is.
+
+For the broader context of why this matters for build-vs-buy decisions in agentic AI, I wrote about that tradeoff [here](/writing/build-vs-buy-agentic-ai-platform). For the original framing of what MCP is and why it matters, the earlier piece is [here](/writing/mcp-integration-layer-what-it-means).

--- a/content/blog/new-model-economics-tier-collapse-2026.mdx
+++ b/content/blog/new-model-economics-tier-collapse-2026.mdx
@@ -1,0 +1,65 @@
+---
+title: "Which Model to Use Is Now an Architecture Question, Not a Budget Question"
+excerpt: "Model pricing has collapsed fast enough that the old decision framework for choosing an AI model is obsolete. What replaces it is closer to system design than cost optimization, and builders who still treat this as a budget exercise are leaving a lot of value on the table."
+publishedAt: "2026-04-21"
+category: "Agentic AI"
+tags: ["AI", "Model Economics", "Reasoning Models", "Product Strategy", "AI Architecture", "Claude", "GPT", "Gemini", "Agentic AI"]
+featured: false
+author: "Isaac Vazquez"
+seo:
+  title: "The New Model Economics: Choosing AI Models in 2026"
+  description: "Model pricing has collapsed dramatically. Choosing between frontier, mid-tier, and fast models is now an architecture question. Here is how to think about it, where reasoning models earn their premium, and what commoditization of mid-tier changes for builders."
+  keywords: ["AI model economics", "reasoning models", "model pricing", "Claude", "GPT", "Gemini", "AI architecture", "cost optimization", "frontier models"]
+---
+
+# Which Model to Use Is Now an Architecture Question, Not a Budget Question
+
+Eighteen months ago I was in a lot of conversations with product teams where the question of which AI model to use was, functionally, a cost question. The shape of the conversation was always the same. Here's what the ideal model would do for this workflow. Here's what it would cost at our projected volume. Now let's figure out which worse-and-cheaper model we can degrade to in order to hit a viable unit economics target. That was the dominant decision framework for most builders, and it was a sensible one given where pricing sat.
+
+It's also completely the wrong framework now. Model costs have collapsed so quickly in the past year that in most categories of use, the decision is no longer driven by unit economics. It's driven by what architectural pattern produces the best product, and that's a much more interesting question than the one teams were asking before.
+
+I still see teams optimizing for the old problem. I'd argue that's now where the clearer wins are being left on the table.
+
+## The shape of the cost collapse
+
+The numbers on this are worth stating clearly. Frontier reasoning models that cost $15 to $60 per million output tokens eighteen months ago are now in the $3 to $10 range for equivalent or better capability. Mid-tier models that were the default choice at around $3 to $5 are now sitting below $1 for most workloads, and the gap between mid-tier quality and frontier quality has narrowed more than it has widened on the tasks most products actually care about. The fast-and-cheap tier, which is where a lot of production inference was being routed for cost reasons, has gotten dramatically cheaper too, but that's the less interesting part of the story.
+
+The interesting part is that the ratio between frontier and mid-tier pricing matters less than it used to because the absolute numbers are small enough to stop being the binding constraint for most product decisions. When frontier inference costs were eating 60% of your unit economics, of course you were routing aggressively to cheaper models. When it's eating 8% of unit economics, the question shifts to where that 8% is buying you the most marginal product quality.
+
+## Why this turns it into an architecture question
+
+The old model-choice decision was mostly scalar. You were picking a point on a quality-cost curve. The new decision is structural because you're designing a system with multiple models handling different roles.
+
+Every interesting AI product I've looked at recently has stopped being a single-model system. It's a pipeline. Light models handle input parsing, classification, and routing. A frontier model gets called for the specific sub-tasks where its reasoning earns the extra latency and cost. A separate model might handle tool selection. Another might validate the output. The architecture of the product is about how these models are composed, what hands off to what, and where the quality bottlenecks live.
+
+This shift has a few consequences worth thinking about. The first is that evaluating models head-to-head on benchmarks is less informative than it used to be, because the relevant question is rarely "which model is best overall." It's "for this specific role in my pipeline, which model has the right combination of capability, latency, and cost." A model that's mediocre at everything but excellent at one specific thing can be the right call for a sub-step that a frontier model would over-serve.
+
+The second is that the pattern of a product being built on a single model provider is looking less defensible. Multi-provider architectures are becoming the norm not because builders have strong loyalty to a second provider, but because the best model for each role in the pipeline tends not to all come from the same lab. Teams that are still committed to a single-provider story are usually making a procurement decision that doesn't match where the quality gains are.
+
+## Where reasoning models actually earn their premium
+
+The cost collapse hasn't eliminated the premium on reasoning models, it's just changed where that premium is worth paying. A reasoning model earns its cost when the task is one where carefully thinking through intermediate steps produces materially better output than pattern matching. That's a narrower category than the current discourse suggests.
+
+Where I've consistently seen the premium justified is in tasks where the cost of a wrong answer is asymmetrically high. Contract analysis is an obvious example. The cost of a reasoning model getting a clause interpretation right, when a faster model would have missed a nuance that blows up later, is several orders of magnitude larger than the inference cost difference. Similar for medical decision support, structured financial analysis, and complex code review of systems where bugs are expensive. In these, the reasoning premium is not a luxury. It's the only economically correct choice.
+
+Where the reasoning premium is rarely worth it is on tasks with low asymmetry of error costs and high volume. Routine customer support responses, content moderation at scale, straightforward summarization, classification tasks where "mostly right" is the requirement. A fast mid-tier model gets you 95% of the quality at 10% of the cost, and the 5% quality gap is not worth paying for because the downside of the marginal wrong answer is small. Teams that route these workloads through reasoning models anyway, because they're building against "always use the best," are burning budget without product benefit.
+
+The practical framework I use when designing these systems is something like: What does it cost me if this model gets this wrong? How often does it get wrong? What's the alternative model's quality for this specific task? Almost every workload sorts itself into reasoning-worthwhile or not-reasoning-worthwhile once you answer those three questions honestly.
+
+## What commoditization of mid-tier changes for builders
+
+The thing that gets less coverage but matters the most for product decisions is what's happening at the mid-tier. Mid-tier models have gotten good enough at most tasks, cheap enough to deploy casually, and fast enough to respond in real time that they're becoming what I'd call the default substrate for AI-powered products. They're where most of the inference is going to happen in practice, and frontier models are going to be used more surgically.
+
+This has a few implications. One is that being opinionated about the mid-tier matters a lot. The quality differences between mid-tier options from different labs are real and matter for specific tasks. Teams that haven't tested rigorously against their own workloads are leaving quality on the table. Another is that the platform layer you build on top of the mid-tier starts mattering more than the model choice. Evaluation infrastructure, prompt management, context engineering, the whole scaffolding of how the model gets used reliably in production. The model is the commodity. The system around it is the product.
+
+The third implication, which I think is underweighted, is that the advantage for companies that have built strong evaluation and iteration loops compounds faster now. When the model is cheap, you can run more evaluations, iterate more prompts, try more architectures. The teams that figured out how to evaluate rigorously two years ago, when it was expensive, have a meaningful lead over teams that are now trying to build that muscle because it's finally affordable.
+
+## What I'd watch next
+
+The trajectory that interests me most is where the cost curve flattens. We've had a year of roughly 5x price reductions per year on frontier capability, but that can't continue indefinitely. When it flattens, probably within the next twelve months, the interesting question will be what the steady-state ratios are between tiers and how product architectures settle around those ratios.
+
+My guess is that we end up in a world where frontier reasoning inference costs something like $2 to $5 per million output tokens, mid-tier costs something under $0.50, and fast/cheap costs under $0.10. At those numbers, the architecture question becomes: how many fast calls can you run to preprocess and route to a single frontier call that does the hard thinking? The answer is "a lot," and that answer shapes the product.
+
+Builders who start architecting for that world now will have a meaningful head start on those who wait for pricing to settle. The patterns you develop for multi-model pipelines are going to matter more over time, not less.
+
+For the earlier version of this argument, and more on the category of tasks where reasoning models justify their cost, I wrote about that [here](/writing/reasoning-model-economics-when-to-use-which). For the build-vs-buy framing of how this interacts with platform decisions, [this piece](/writing/build-vs-buy-agentic-ai-platform) has more.

--- a/content/blog/tech-job-market-splitting-2026-macro-backdrop.mdx
+++ b/content/blog/tech-job-market-splitting-2026-macro-backdrop.mdx
@@ -1,0 +1,65 @@
+---
+title: "The Tech Job Market Is Splitting in Two, and the Split Is Bigger Than Anyone Admits"
+excerpt: "Rates, VC slowdown, and AI tooling are not separate forces acting on tech employment. They are one compounding pressure that is creating two very different labor markets inside what used to be one. Here is what the split looks like in mid-2026 and how to position for the right side of it."
+publishedAt: "2026-04-21"
+category: "Product Management"
+tags: ["Career", "Labor Market", "Tech Jobs", "Product Management", "AI", "Macro", "Venture Capital", "Software Engineering"]
+featured: false
+author: "Isaac Vazquez"
+seo:
+  title: "The Tech Job Market in 2026 Is Splitting in Two. Here Is What It Means."
+  description: "Higher rates, slower VC, and AI tooling are compounding into a bifurcated tech labor market. Here is what the split looks like in mid-2026 and what positioning for the right half requires."
+  keywords: ["tech job market 2026", "tech labor market", "AI jobs", "product manager career", "venture capital slowdown", "tech layoffs", "software engineering careers"]
+---
+
+# The Tech Job Market Is Splitting in Two, and the Split Is Bigger Than Anyone Admits
+
+I've been watching the conversation about the tech job market for the past year and I think most of it is miscalibrated. Some of it is too pessimistic, treating the layoff headlines as evidence that the whole industry is contracting in a durable way. Some of it is too optimistic, pointing at AI-native companies' hiring frenzies as evidence that everything is fine if you just know where to look. Both of these are describing the same market from different ends of it, and the actual story is that it's not a single market anymore. It has split, and the split is widening fast.
+
+What I want to walk through is how the split happened, what it looks like in practice in mid-2026, and what it implies about positioning yourself for the half of the market that has the wind at its back instead of the half that's getting pressure from every direction.
+
+## The forces that compounded
+
+This isn't a single-cause story. The distortion happening in the tech labor market right now is the result of three forces arriving at roughly the same time and amplifying each other.
+
+The first is the rate environment. We spent the better part of a decade in a ZIRP era that was uniquely favorable to venture-backed tech employment. Companies raised huge rounds, hired aggressively on the assumption that revenue would catch up, and the industry built an entire compensation and headcount model around the idea that growth could be bought at a very high multiple. When rates normalized, that math stopped working. It's still not working in 2026. VC deployment into early-stage companies is down materially from the 2021 peak, and the companies that did raise are running tighter.
+
+The second is that even the companies doing well are choosing to hire fewer people. This is not the story that gets told most often, because it's less dramatic than layoffs, but I think it matters more. When public tech companies tell their investors they're expecting revenue per employee to grow materially, that's a directional commitment to headcount restraint. That commitment has been made widely across the public tech sector over the past two years. The industry has quietly reset its expectations for how much headcount is required to produce a given amount of software output.
+
+The third force is the one I've been writing about at length, which is AI tooling shrinking the headcount required for categories of work that used to be labor-intensive. I covered this in the developer displacement piece and won't rehash it here, but the compounding effect is real. Fewer engineers can ship more, fewer QA engineers can cover more test surface, fewer PMs can manage more product area if they're operating well with AI tools. That's deflationary for aggregate headcount demand in a way that wasn't true three years ago.
+
+Each of these forces on its own would be manageable. The combination of them has created something qualitatively different from the labor market most people entered the industry planning around.
+
+## What the split actually looks like
+
+The easiest way to see the bifurcation is to look at where hiring is happening and where it isn't.
+
+On one side, you have the AI-native companies and a specific cohort of product companies that have figured out how to use AI leverage aggressively. These companies are hiring, and their hiring is concentrated in senior roles where the ability to direct AI tools and set strategic direction is the core competency. Comp at these companies has continued to rise, particularly for senior engineers, staff-level ICs, and experienced product managers who can operate independently. If you're reading the market through the lens of friends at OpenAI, Anthropic, Cursor, Vercel, or a handful of AI-leveraged incumbents, you're seeing what looks like an ongoing boom.
+
+On the other side, you have everything else. Established enterprise software companies, mid-size product companies that haven't found AI-native product-market fit, early-stage startups outside the AI wedge, and a long tail of consulting and services firms. In this segment, hiring has slowed dramatically. Junior hiring has compressed even more. Comp has stayed flat or drifted down in real terms. If you're reading the market from the middle of this segment, the industry feels like it's contracting, because for you it is.
+
+The bifurcation is also showing up in where people are actually moving. The labor flows in 2026 look less like the traditional "talent moves from big incumbents to hot startups" pattern and more like "talent moves from the slow side of the market to the fast side." Senior engineers leaving Google for AI-native startups. Product managers leaving traditional SaaS companies for companies building AI-native products. The talent market for people who can credibly claim AI fluency is tight and price-sensitive. The market for people whose experience is in pre-AI product work is much softer.
+
+The part of this that's uncomfortable to say clearly is that the gap is widening rather than closing. The fast side is hiring aggressively from the slow side, which is both relieving pressure on the slow side's headcount problems and pulling its most capable people into the fast side. If you're managing a team at a traditional company in 2026, the hardest problem you have is not finding budget to hire. It's that the best people you want to hire are getting recruited into AI-native roles, and the people still applying to your openings are, on average, not as strong as they would have been three years ago.
+
+## What positioning for the right half looks like
+
+I want to be careful here because the advice "get a job at an AI company" is both true and unhelpful. Most people can't rotate into an AI-native role on a whim, and even if they could, the category is already competitive enough that it's not a frictionless move.
+
+What I'd argue is that positioning for the right half of this market is less about changing employers and more about changing the composition of your work wherever you are. The common thread across the roles that are benefiting from the current labor dynamics is that they combine domain depth with the ability to direct AI tools effectively. You don't have to work at an AI company to do that. You have to structure your current work around it.
+
+For engineers, this means developing the muscle for working with agents on real production work, not toy problems. Learning how to specify tasks tightly, how to evaluate agent output critically, how to compose agent work into larger systems. For PMs, it means getting genuinely fluent at writing specifications that agents can execute against, running product discovery with AI tooling in the loop, and being the person in your org who's figuring out how AI-native product patterns apply to your domain. For anyone in a role adjacent to either of those, it means developing the AI literacy that lets you be a credible hire for a company that's operating on the other side of the split.
+
+The second thing that matters is compounding. The skill premium for AI fluency is high right now and has been rising for two years. If you start building that muscle seriously in 2026, you'll be meaningfully differentiated by 2027. If you start in 2027, you'll be behind a much larger cohort that started earlier. The earlier you commit, the more of the upside curve you capture. That's true in any skill that's becoming newly valuable, but the steepness of the current curve makes it matter more than usual.
+
+The third thing, and this one is more strategic than tactical, is being honest about which side of the market your current trajectory is on. If you're at a company that's investing seriously in AI-leveraged product work, your internal options for moving into the right half of the market might be better than you realize. If you're at a company that's treating AI as a checkbox rather than a core capability, your internal options are probably constrained and you'll have to make the move externally. That's a hard assessment to make about your own employer, but making it honestly is more valuable than almost any other career decision you'll make in the next two years.
+
+## Where this goes
+
+I don't think the split resolves back into a single market anytime soon. The forces that created it are structural, not cyclical, and several of them are accelerating rather than stabilizing. The compensation gap between the two sides is going to keep widening, the skill requirements for the right side are going to keep rising, and the slow-side companies are going to increasingly have to choose between bending their hiring and product strategy toward the AI-native model or accepting a slower-growth future.
+
+The uncomfortable implication is that where you are in 2028 is going to be determined more by the choices you make in the next eighteen months than by almost anything you did before this point. That's not how most people are used to thinking about career planning, and it creates a kind of urgency that tech workers haven't felt in a decade.
+
+If you're tracking this clearly, that urgency is the useful signal. It's telling you that the cost of drifting is higher than it used to be, and the return on intentional positioning is higher than it used to be too. Both of those things are true at the same time, and acting on them is the most consequential thing you can do right now.
+
+For more on what this looks like on the engineering side, I wrote about [developer displacement](/writing/ai-coding-tools-developer-displacement-2026). For the PM-specific version of the positioning question, [this piece on AI skills for 2026 internships](/writing/ai-skills-pm-internship-2026) and [this one on how MBAs should and shouldn't use AI](/writing/mba-ai-misuse-how-to-stand-out) get into the specifics.

--- a/docs/superpowers/specs/2026-04-21-hot-topic-articles-design.md
+++ b/docs/superpowers/specs/2026-04-21-hot-topic-articles-design.md
@@ -1,0 +1,100 @@
+# Hot Topic Articles — April 2026 Batch
+
+**Date:** 2026-04-21
+**Type:** Content / Writing
+
+## Context
+
+Isaac's blog has 51 published articles. The most recent cluster includes "Week in Tech" dispatches on AI coding tools, tariffs, and the agentic AI infrastructure race. This batch extends that momentum with four longer, standalone deep-dive articles on topics that are genuinely hot right now in AI/tech and the tech labor market. Each article targets ~2000 words, adheres to `WRITING_VOICE.md`, and slots into an existing category — no new taxonomy.
+
+These are standalone pieces (Option A from brainstorming). Light cross-links where natural; no series framing.
+
+## The Four Articles
+
+### 1. AI Coding Tools and Developer Displacement
+- **Slug:** `ai-coding-tools-developer-displacement-2026`
+- **Category:** Agentic AI
+- **Angle:** Not "will AI replace developers" — "what does the shift actually look like, and who feels it first." Displacement is non-uniform: juniors, QA, offshore code farms are affected; senior engineers and precise PMs are gaining leverage.
+- **Evidence to weave in:** Copilot/Cursor adoption trends, layoff patterns at dev shops, the shift in junior hiring signals.
+- **Closing move:** What this means for someone entering the field in 2026.
+- **Cross-links:** `2026-week-april-6-ai-coding-tools-developer-displacement`, `ai-skills-pm-internship-2026`.
+
+### 2. MCP Is Winning the Integration War
+- **Slug:** `mcp-winning-integration-war-enterprise-default`
+- **Category:** Agentic AI
+- **Angle:** Past "what is MCP" (covered by `mcp-integration-layer-what-it-means`) to "why it has already won." Network effects of a shared protocol, enterprise adoption, what it means for iPaaS/middleware (Zapier, MuleSoft), and what builders should be doing before it becomes assumed infrastructure.
+- **Closing move:** A clear position on where the integration layer sits in three years.
+- **Cross-links:** `mcp-integration-layer-what-it-means`, `build-vs-buy-agentic-ai-platform`.
+
+### 3. The New Model Economics
+- **Slug:** `new-model-economics-tier-collapse-2026`
+- **Category:** Agentic AI
+- **Angle:** Cost has collapsed fast enough that "which model should I use" is now a product architecture question, not a budget question. Covers the tier structure (frontier / mid-tier / fast-cheap), where reasoning models earn their premium vs. where they are overkill, and what commoditization of mid-tier changes for builders.
+- **Constraint:** Decision framework woven into prose — no comparison tables.
+- **Cross-links:** `reasoning-model-economics-when-to-use-which`, `build-vs-buy-agentic-ai-platform`.
+
+### 4. The Tech Job Market Is Splitting in Two
+- **Slug:** `tech-job-market-splitting-2026-macro-backdrop`
+- **Category:** Product Management
+- **Angle:** Rate environment slowing VC → fewer early-stage jobs → compression toward profitable companies → AI tooling shrinking headcount at mid-size firms → two markets emerging (high-leverage roles at AI-native companies vs. contracting work everywhere else). Honest, not doom-and-gloom.
+- **Closing move:** What "positioning for the right half" actually looks like for someone mid-career.
+- **Cross-links:** `ai-skills-pm-internship-2026`, `mba-ai-misuse-how-to-stand-out`, article #1 above.
+
+## Voice and Format Rules (from WRITING_VOICE.md)
+
+- First-person, opinion-forward, prose-heavy. State position early.
+- No em dashes as stylistic devices. No colons as sentence connectors.
+- No nested bullet lists with bold labels — convert to prose.
+- No TOC, no "Conclusion" section, no "Next Steps" list, no "About the Author."
+- No "comprehensive guide" / "complete guide" openers.
+- No MBA framework names as section headers (Porter, Kotter, McKinsey 7S, etc.).
+- Section headers only when a long article genuinely needs navigation. 4–7 H2s max.
+- Data woven into prose sentences, not isolated callouts.
+- Rhetorical pivots allowed: "But what actually changes this?" "What makes this worth paying attention to..."
+
+## Frontmatter Conventions
+
+Each article uses the standard frontmatter pattern observed in recent posts:
+
+```yaml
+---
+title: "..."
+excerpt: "1-2 concrete sentences."
+publishedAt: "2026-04-21"
+category: "Agentic AI" | "Product Management"
+tags: [5-8 specific tags]
+featured: false
+author: "Isaac Vazquez"
+seo:
+  title: "..."
+  description: "..."
+  keywords: [...]
+---
+```
+
+## Files to Create
+
+- `content/blog/ai-coding-tools-developer-displacement-2026.mdx`
+- `content/blog/mcp-winning-integration-war-enterprise-default.mdx`
+- `content/blog/new-model-economics-tier-collapse-2026.mdx`
+- `content/blog/tech-job-market-splitting-2026-macro-backdrop.mdx`
+
+## Reference Examples (voice models)
+
+- `content/blog/rb-vs-wr-draft-strategy-modeling-positional-value.mdx` — data in prose, decisive argument
+- `content/blog/building-an-investment-research-platform.mdx` — first-person rationale, restraint as a feature
+- `content/blog/2026-week-april-6-ai-coding-tools-developer-displacement.mdx` — closest topical precedent for article #1
+
+## Verification
+
+- Run `npm run build` (or at least `next build` on the writing routes) to confirm MDX parses and frontmatter is valid.
+- Spot-check each article renders at `/writing/<slug>` in `npm run dev`.
+- Confirm each article appears in `/writing` index and is indexed by `src/lib/blog.ts`.
+- Voice check: read each article top-to-bottom against `WRITING_VOICE.md` hard rules before committing.
+
+## Out of Scope
+
+- No changes to `/writing` route logic or `src/lib/blog.ts`.
+- No new categories or tag taxonomy.
+- No cover images (optional frontmatter field, skipped for this batch).
+- No CTA to live products unless the article naturally warrants one.


### PR DESCRIPTION
## Summary

Adds four standalone long-form articles extending the recent weekly-dispatch momentum into deeper analysis on hot topics in AI and tech labor:

- **Developer Displacement Is Not Uniform, and That's the Whole Story** (`ai-coding-tools-developer-displacement-2026`) — why AI coding tools are hitting specific roles and tasks, not engineering as a whole
- **MCP Has Already Won the Integration War** (`mcp-winning-integration-war-enterprise-default`) — how the Model Context Protocol went from interesting standard to assumed infrastructure, and what it does to the iPaaS category
- **Which Model to Use Is Now an Architecture Question, Not a Budget Question** (`new-model-economics-tier-collapse-2026`) — how model-choice has shifted from unit economics to pipeline design
- **The Tech Job Market Is Splitting in Two** (`tech-job-market-splitting-2026-macro-backdrop`) — rates, VC slowdown, and AI tooling compounding into a bifurcated labor market, and how to position for the right side

All four follow `WRITING_VOICE.md`: first-person, prose-forward, no em dashes, no nested bold-label bullets, no TOC / Conclusion / Next Steps / About the Author sections. Internal cross-links to adjacent articles where natural. Each lands in an existing category — no new taxonomy.

Design spec committed at `docs/superpowers/specs/2026-04-21-hot-topic-articles-design.md`.

## Test plan

- [ ] `npm run dev` and confirm each slug renders: `/writing/ai-coding-tools-developer-displacement-2026`, `/writing/mcp-winning-integration-war-enterprise-default`, `/writing/new-model-economics-tier-collapse-2026`, `/writing/tech-job-market-splitting-2026-macro-backdrop`
- [ ] Confirm all four appear on `/writing` index
- [ ] Spot-check internal cross-links resolve to existing posts
- [ ] `npm run build` passes