### PR TITLE
style: fix dark-mode elevation and touch-target compliance

### DIFF
--- a/src/app/accessibility/page.tsx
+++ b/src/app/accessibility/page.tsx
@@ -183,7 +183,7 @@ export default function AccessibilityPage() {
                   <dd
                     className="mb-0 rounded-md px-3 py-1 font-mono text-sm"
                     style={{
-                      background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+                      background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
                       color: "var(--home-ink)",
                       border: "1px solid var(--home-rule)",
                     }}

--- a/src/app/decision-lab/decision-lab-client.tsx
+++ b/src/app/decision-lab/decision-lab-client.tsx
@@ -79,7 +79,7 @@ const recommendationCopy: Record<DecisionRecommendation, string> = {
 
 function getPanelStyle(): CSSProperties {
   return {
-    background: "color-mix(in srgb, var(--home-paper-alt) 74%, white)",
+    background: "color-mix(in srgb, var(--home-paper-alt) 74%, var(--home-elev-mix))",
     border: "1px solid var(--home-rule)",
     boxShadow: "var(--shadow-sm)",
   };
@@ -128,7 +128,7 @@ function DecisionMatrix({ state }: { state: DecisionLabState }) {
             width={size}
             height={size}
             rx={18}
-            fill="color-mix(in srgb, var(--home-paper) 82%, white)"
+            fill="color-mix(in srgb, var(--home-paper) 82%, var(--home-elev-mix))"
             stroke="var(--home-rule)"
           />
 
@@ -143,7 +143,7 @@ function DecisionMatrix({ state }: { state: DecisionLabState }) {
                   y1={padding}
                   x2={x}
                   y2={padding + size}
-                  stroke="color-mix(in srgb, var(--home-rule) 75%, white)"
+                  stroke="color-mix(in srgb, var(--home-rule) 75%, var(--home-elev-mix))"
                   strokeDasharray="3 5"
                 />
                 <line
@@ -151,7 +151,7 @@ function DecisionMatrix({ state }: { state: DecisionLabState }) {
                   y1={y}
                   x2={padding + size}
                   y2={y}
-                  stroke="color-mix(in srgb, var(--home-rule) 75%, white)"
+                  stroke="color-mix(in srgb, var(--home-rule) 75%, var(--home-elev-mix))"
                   strokeDasharray="3 5"
                 />
               </g>
@@ -380,7 +380,7 @@ function MetricSlider({
                   : `color-mix(in srgb, ${accent} 22%, var(--home-rule))`,
               background:
                 delta === 0
-                  ? "color-mix(in srgb, var(--home-paper) 92%, white)"
+                  ? "color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))"
                   : `color-mix(in srgb, ${accent} 12%, var(--home-paper))`,
             }}
           >
@@ -581,7 +581,7 @@ function DecisionLabWorkbench({
                           ...getPanelStyle(),
                           background: isActive
                             ? "color-mix(in srgb, var(--home-haze) 13%, var(--home-paper))"
-                            : "color-mix(in srgb, var(--home-paper-alt) 68%, white)",
+                            : "color-mix(in srgb, var(--home-paper-alt) 68%, var(--home-elev-mix))",
                           borderColor: isActive
                             ? "color-mix(in srgb, var(--home-haze) 35%, var(--home-rule))"
                             : "var(--home-rule)",

--- a/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
@@ -76,7 +76,7 @@ function getFilterStyle(active: boolean): CSSProperties {
 
   return {
     borderColor: "var(--home-rule)",
-    background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
     color: "var(--home-ink)",
   };
 }
@@ -115,7 +115,7 @@ function getPositionTone(position: string): CSSProperties {
       };
     default:
       return {
-        background: "color-mix(in srgb, var(--home-paper-alt) 90%, white)",
+        background: "color-mix(in srgb, var(--home-paper-alt) 90%, var(--home-elev-mix))",
         borderColor: "var(--home-rule)",
       };
   }
@@ -193,7 +193,7 @@ export function DraftBoard({
             className="rounded-full border px-3 py-1.5 text-sm font-medium"
             style={{
               borderColor: "var(--home-rule)",
-              background: "color-mix(in srgb, var(--home-paper-alt) 52%, white)",
+              background: "color-mix(in srgb, var(--home-paper-alt) 52%, var(--home-elev-mix))",
             }}
           >
             {isUserPick ? "Your pick is live" : "Log the room's next selection"}
@@ -230,7 +230,7 @@ export function DraftBoard({
               className="min-h-[48px] rounded-[1.2rem] border px-4 text-sm transition-[background-color,border-color,box-shadow] duration-200"
               style={{
                 borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
                 color: "var(--home-ink)",
               }}
             />
@@ -259,7 +259,7 @@ export function DraftBoard({
                 className="rounded-[1.5rem] border px-5 py-12 text-center"
                 style={{
                   borderColor: "var(--home-rule)",
-                  background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                  background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                 }}
               >
                 <p className="text-lg font-semibold">Draft complete.</p>
@@ -272,7 +272,7 @@ export function DraftBoard({
                 className="rounded-[1.5rem] border px-5 py-12 text-center"
                 style={{
                   borderColor: "var(--home-rule)",
-                  background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                  background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                 }}
               >
                 <p className="text-lg font-semibold">No players match that filter.</p>
@@ -290,7 +290,7 @@ export function DraftBoard({
                     className="grid gap-4 rounded-[1.5rem] border px-4 py-4 sm:grid-cols-[72px_minmax(0,1.45fr)_110px_140px_auto] sm:items-center"
                     style={{
                       borderColor: "var(--home-rule)",
-                      background: "color-mix(in srgb, var(--home-paper-alt) 42%, white)",
+                      background: "color-mix(in srgb, var(--home-paper-alt) 42%, var(--home-elev-mix))",
                     }}
                   >
                     <div>
@@ -361,7 +361,7 @@ export function DraftBoard({
             className="rounded-[1.5rem] border p-4"
             style={{
               borderColor: "var(--home-rule)",
-              background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+              background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
             }}
           >
             <p className="home-kicker mb-1">Available pool</p>
@@ -375,7 +375,7 @@ export function DraftBoard({
             className="rounded-[1.5rem] border p-4"
             style={{
               borderColor: "var(--home-rule)",
-              background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+              background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
             }}
           >
             <p className="home-kicker mb-1">Roster pressure</p>

--- a/src/app/fantasy-football/draft-tracker/components/DraftSetup.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftSetup.tsx
@@ -26,7 +26,7 @@ function getOptionStyle(active: boolean): CSSProperties {
 
   return {
     borderColor: "var(--home-rule)",
-    background: "color-mix(in srgb, var(--home-paper-alt) 52%, white)",
+    background: "color-mix(in srgb, var(--home-paper-alt) 52%, var(--home-elev-mix))",
     color: "var(--home-ink)",
   };
 }
@@ -34,7 +34,7 @@ function getOptionStyle(active: boolean): CSSProperties {
 function getFieldStyle(): CSSProperties {
   return {
     borderColor: "var(--home-rule)",
-    background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
     color: "var(--home-ink)",
   };
 }
@@ -204,7 +204,7 @@ export function DraftSetup({ settings, onSaveSettings, onStartDraft }: DraftSetu
         className="mt-6 flex flex-wrap items-center justify-between gap-3 rounded-[1.3rem] border px-4 py-4"
         style={{
           borderColor: "var(--home-rule)",
-          background: "color-mix(in srgb, var(--home-paper-alt) 52%, white)",
+          background: "color-mix(in srgb, var(--home-paper-alt) 52%, var(--home-elev-mix))",
         }}
       >
         <p className="text-sm" style={{ color: "var(--home-ink-muted)" }}>

--- a/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
+++ b/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
@@ -90,7 +90,7 @@ export function DraftTrackerClient() {
               className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 font-medium"
               style={{
                 borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
               }}
             >
               {metadata ? `${metadata.season} ${getFantasyWeekLabel(metadata.week)}` : "Loading snapshot"}
@@ -99,7 +99,7 @@ export function DraftTrackerClient() {
               className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 font-medium"
               style={{
                 borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
               }}
             >
               Source updated {formatUpdatedAt(overallSliceMetadata?.updatedAt ?? metadata?.upstreamUpdatedAt)}
@@ -108,7 +108,7 @@ export function DraftTrackerClient() {
               className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 font-medium"
               style={{
                 borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
               }}
             >
               Built {formatUpdatedAt(metadata?.generatedAt)}
@@ -117,7 +117,7 @@ export function DraftTrackerClient() {
               className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 font-medium"
               style={{
                 borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
               }}
             >
               {FANTASY_SCORING_LABELS[scoringKey]} scoring
@@ -161,7 +161,7 @@ export function DraftTrackerClient() {
                   className="rounded-[1.5rem] border px-4 py-4"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 52%, white)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 52%, var(--home-elev-mix))",
                   }}
                 >
                   <p className="home-kicker mb-1">Snapshot</p>
@@ -236,7 +236,7 @@ export function DraftTrackerClient() {
                   className="rounded-[1.2rem] border px-4 py-3"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                   }}
                 >
                   <p className="home-kicker mb-1">On clock</p>
@@ -246,7 +246,7 @@ export function DraftTrackerClient() {
                   className="rounded-[1.2rem] border px-4 py-3"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                   }}
                 >
                   <p className="home-kicker mb-1">Current pick</p>
@@ -258,7 +258,7 @@ export function DraftTrackerClient() {
                   className="rounded-[1.2rem] border px-4 py-3"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                   }}
                 >
                   <p className="home-kicker mb-1">Round</p>
@@ -283,7 +283,7 @@ export function DraftTrackerClient() {
                       className="rounded-[1.2rem] border px-4 py-3"
                       style={{
                         borderColor: "var(--home-rule)",
-                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                       }}
                     >
                       <p className="text-sm font-semibold">{pick.player.name}</p>
@@ -315,7 +315,7 @@ export function DraftTrackerClient() {
                       className="rounded-[1.2rem] border px-4 py-3"
                       style={{
                         borderColor: "var(--home-rule)",
-                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                       }}
                     >
                       <p className="text-sm font-semibold">{pick.player.name}</p>
@@ -337,7 +337,7 @@ export function DraftTrackerClient() {
                   className="flex min-h-[48px] items-center justify-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+                    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
                     color: "var(--home-ink)",
                   }}
                 >
@@ -364,7 +364,7 @@ export function DraftTrackerClient() {
                   className="flex min-h-[48px] items-center justify-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+                    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
                     color: "var(--home-ink)",
                   }}
                 >

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -129,7 +129,7 @@ function getPositionTone(position: string): CSSProperties {
       };
     default:
       return {
-        background: "color-mix(in srgb, var(--home-paper-alt) 90%, white)",
+        background: "color-mix(in srgb, var(--home-paper-alt) 90%, var(--home-elev-mix))",
         borderColor: "var(--home-rule)",
       };
   }
@@ -156,7 +156,7 @@ function getPillStyle(active: boolean, unavailable = false): CSSProperties {
 
   return {
     borderColor: "var(--home-rule)",
-    background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
     color: "var(--home-ink)",
   };
 }
@@ -417,7 +417,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                         className="min-h-[48px] w-full rounded-[1.2rem] border px-11 pr-4 text-sm transition-[background-color,border-color,box-shadow] duration-200 placeholder:text-[var(--home-ink-muted)] disabled:cursor-not-allowed disabled:opacity-60"
                         style={{
                           borderColor: "var(--home-rule)",
-                          background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+                          background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
                           color: "var(--home-ink)",
                         }}
                       />
@@ -428,7 +428,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                     className="rounded-[1.5rem] border px-4 py-4"
                     style={{
                       borderColor: "var(--home-rule)",
-                      background: "color-mix(in srgb, var(--home-paper-alt) 62%, white)",
+                      background: "color-mix(in srgb, var(--home-paper-alt) 62%, var(--home-elev-mix))",
                     }}
                   >
                     <p className="home-kicker mb-1">Status</p>
@@ -468,7 +468,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                       className="h-[104px] animate-pulse rounded-[1.5rem] border"
                       style={{
                         borderColor: "var(--home-rule)",
-                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                       }}
                     />
                   ))
@@ -493,7 +493,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                     className="rounded-[1.5rem] border px-5 py-12 text-center"
                     style={{
                       borderColor: "var(--home-rule)",
-                      background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                      background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                     }}
                   >
                     <p className="text-lg font-semibold">No matching players</p>
@@ -508,7 +508,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                       className="grid gap-4 rounded-[1.5rem] border px-4 py-4 sm:grid-cols-[72px_minmax(0,1.55fr)_110px_140px_140px] sm:items-center"
                       style={{
                         borderColor: "var(--home-rule)",
-                        background: "color-mix(in srgb, var(--home-paper-alt) 42%, white)",
+                        background: "color-mix(in srgb, var(--home-paper-alt) 42%, var(--home-elev-mix))",
                       }}
                     >
                       <div>
@@ -569,7 +569,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                   className="rounded-[1.2rem] border px-4 py-3"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                   }}
                 >
                   <p className="home-kicker mb-1">Source updated</p>
@@ -579,7 +579,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                   className="rounded-[1.2rem] border px-4 py-3"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                   }}
                 >
                   <p className="home-kicker mb-1">Snapshot built</p>
@@ -616,7 +616,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                       className="flex items-center justify-between rounded-[1.2rem] border px-4 py-3"
                       style={{
                         borderColor: "var(--home-rule)",
-                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, white)",
+                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                       }}
                     >
                       <span className="text-sm font-semibold">Tier {tier}</span>

--- a/src/app/fintech-tools/budget-planner/budget-planner-client.tsx
+++ b/src/app/fintech-tools/budget-planner/budget-planner-client.tsx
@@ -195,7 +195,7 @@ export function BudgetPlannerClient() {
           variants={motionVariants}
           initial="hidden"
           animate="visible"
-          className="mb-8 overflow-hidden rounded-[32px] border border-[color-mix(in_srgb,var(--home-haze)_14%,var(--home-rule))] bg-[linear-gradient(135deg,color-mix(in_srgb,color-mix(in srgb, var(--home-paper) 92%, white)_94%,var(--home-haze)_6%)_0%,color-mix(in srgb, var(--home-paper) 92%, white)_45%,color-mix(in_srgb,var(--home-paper-alt)_88%,var(--color-success)_12%)_100%)] shadow-[var(--shadow-lg)]"
+          className="mb-8 overflow-hidden rounded-[32px] border border-[color-mix(in_srgb,var(--home-haze)_14%,var(--home-rule))] bg-[linear-gradient(135deg,color-mix(in_srgb,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_94%,var(--home-haze)_6%)_0%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_45%,color-mix(in_srgb,var(--home-paper-alt)_88%,var(--color-success)_12%)_100%)] shadow-[var(--shadow-lg)]"
         >
           <div className="grid gap-8 border-b border-[var(--home-rule)]/80 px-6 py-6 sm:px-8 lg:grid-cols-[minmax(0,1.25fr)_auto] lg:items-end">
             <div className="min-w-0">
@@ -216,12 +216,12 @@ export function BudgetPlannerClient() {
                 type="button"
                 aria-label="Previous month"
                 onClick={() => handleMonthChange(getAdjacentBudgetMonthKey(activeMonthKey, -1))}
-                className="tap-target inline-flex min-h-[48px] items-center justify-center rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-4 text-[var(--home-ink)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)]"
+                className="tap-target inline-flex min-h-[48px] items-center justify-center rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-4 text-[var(--home-ink)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)]"
               >
                 <ArrowLeft className="h-4 w-4" />
               </button>
 
-              <label className="flex min-h-[48px] flex-col justify-center rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-4 py-2">
+              <label className="flex min-h-[48px] flex-col justify-center rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-4 py-2">
                 <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
                   Budget month
                 </span>
@@ -241,7 +241,7 @@ export function BudgetPlannerClient() {
                 type="button"
                 aria-label="Next month"
                 onClick={() => handleMonthChange(getAdjacentBudgetMonthKey(activeMonthKey, 1))}
-                className="tap-target inline-flex min-h-[48px] items-center justify-center rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-4 text-[var(--home-ink)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)]"
+                className="tap-target inline-flex min-h-[48px] items-center justify-center rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-4 text-[var(--home-ink)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)]"
               >
                 <ArrowRight className="h-4 w-4" />
               </button>
@@ -275,7 +275,7 @@ export function BudgetPlannerClient() {
           <motion.div variants={motionVariants} initial="hidden" animate="visible">
             <WarmCard
               padding="none"
-              className="overflow-hidden rounded-[30px] border-[color-mix(in_srgb,var(--home-haze)_14%,var(--home-rule))] bg-[linear-gradient(180deg,color-mix(in srgb, var(--home-paper) 92%, white)_0%,color-mix(in_srgb,var(--home-paper-alt)_72%,color-mix(in srgb, var(--home-paper) 92%, white))_100%)]"
+              className="overflow-hidden rounded-[30px] border-[color-mix(in_srgb,var(--home-haze)_14%,var(--home-rule))] bg-[linear-gradient(180deg,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_0%,color-mix(in_srgb,var(--home-paper-alt)_72%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_100%)]"
             >
               <div className="border-b border-[var(--home-rule)] px-6 py-5 sm:px-8">
                 <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-[var(--home-haze)]">
@@ -488,7 +488,7 @@ export function BudgetPlannerClient() {
           <motion.div variants={motionVariants} initial="hidden" animate="visible">
             <WarmCard
               padding="none"
-              className="overflow-hidden rounded-[30px] border-[color-mix(in_srgb,var(--home-haze)_10%,var(--home-rule))] bg-[linear-gradient(180deg,color-mix(in srgb, var(--home-paper) 92%, white)_0%,color-mix(in_srgb,var(--home-paper-alt)_58%,color-mix(in srgb, var(--home-paper) 92%, white))_100%)]"
+              className="overflow-hidden rounded-[30px] border-[color-mix(in_srgb,var(--home-haze)_10%,var(--home-rule))] bg-[linear-gradient(180deg,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_0%,color-mix(in_srgb,var(--home-paper-alt)_58%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_100%)]"
             >
               <div className="border-b border-[var(--home-rule)] px-6 py-5 sm:px-8">
                 <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-[var(--home-haze)]">
@@ -692,7 +692,7 @@ export function BudgetPlannerClient() {
         >
           <WarmCard
             padding="none"
-            className="overflow-hidden rounded-[30px] border-[color-mix(in_srgb,var(--home-haze)_10%,var(--home-rule))] bg-[linear-gradient(180deg,color-mix(in srgb, var(--home-paper) 92%, white)_0%,color-mix(in_srgb,var(--home-paper-alt)_54%,color-mix(in srgb, var(--home-paper) 92%, white))_100%)]"
+            className="overflow-hidden rounded-[30px] border-[color-mix(in_srgb,var(--home-haze)_10%,var(--home-rule))] bg-[linear-gradient(180deg,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_0%,color-mix(in_srgb,var(--home-paper-alt)_54%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_100%)]"
           >
             <div className="border-b border-[var(--home-rule)] px-6 py-5 sm:px-8">
               <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-[var(--home-haze)]">

--- a/src/app/fintech-tools/interchange-iq/interchange-iq-client.tsx
+++ b/src/app/fintech-tools/interchange-iq/interchange-iq-client.tsx
@@ -298,7 +298,7 @@ export function InterchangeIQClient() {
                 className="text-xs rounded-lg p-3 leading-relaxed mb-0"
                 style={{
                   ...bodyStyle,
-                  background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)",
+                  background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))",
                   border: "1px solid var(--home-rule)",
                 }}
               >
@@ -408,7 +408,7 @@ export function InterchangeIQClient() {
               className="flex items-start gap-3 p-4 rounded-xl"
               style={{
                 border: "1px solid var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)",
+                background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))",
               }}
             >
               <IconInfoCircle
@@ -516,7 +516,7 @@ export function InterchangeIQClient() {
                   key={r.id}
                   className="text-center p-3 rounded-xl space-y-1"
                   style={{
-                    background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))",
                     border: "1px solid var(--home-rule)",
                   }}
                 >

--- a/src/app/formula-1/formula-1-client.tsx
+++ b/src/app/formula-1/formula-1-client.tsx
@@ -131,7 +131,7 @@ function getMeetingToneStyle(status: Formula1MeetingSummary["status"]): CSSPrope
     default:
       return {
         borderColor: "var(--home-rule)",
-        background: "color-mix(in srgb, var(--home-paper-alt) 80%, white)",
+        background: "color-mix(in srgb, var(--home-paper-alt) 80%, var(--home-elev-mix))",
       };
   }
 }
@@ -205,7 +205,7 @@ function ViewToggle({
             }
           : {
               borderColor: "var(--home-rule)",
-              background: "color-mix(in srgb, var(--home-paper-alt) 80%, white)",
+              background: "color-mix(in srgb, var(--home-paper-alt) 80%, var(--home-elev-mix))",
             }
       }
       aria-pressed={isActive}
@@ -684,7 +684,7 @@ export function Formula1Client({ initialState, snapshot }: Formula1ClientProps) 
         style={{
           borderColor: "color-mix(in srgb, var(--home-haze) 24%, var(--home-rule))",
           background:
-            "radial-gradient(circle at top right, color-mix(in srgb, var(--home-haze) 18%, transparent) 0%, transparent 38%), linear-gradient(140deg, color-mix(in srgb, var(--home-paper) 94%, white) 0%, color-mix(in srgb, var(--home-paper-alt) 88%, white) 100%)",
+            "radial-gradient(circle at top right, color-mix(in srgb, var(--home-haze) 18%, transparent) 0%, transparent 38%), linear-gradient(140deg, color-mix(in srgb, var(--home-paper) 94%, var(--home-elev-mix)) 0%, color-mix(in srgb, var(--home-paper-alt) 88%, var(--home-elev-mix)) 100%)",
           boxShadow: "var(--shadow-sm)",
         }}
       >

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -147,6 +147,14 @@
   --home-dark-ink: #F4EEE1;
   --home-dark-muted: #CFC5B1;
   --home-dark-rule: rgba(244, 238, 225, 0.12);
+
+  /*
+   * Theme-aware elevation mix. In light mode, mixing surfaces toward white
+   * lifts them off the page. In dark mode, mixing toward black adds depth
+   * so raised panels read as distinct from the base paper. Use this anywhere
+   * you'd otherwise hardcode `white` or `black` inside a color-mix().
+   */
+  --home-elev-mix: white;
 }
 
 .dark {
@@ -194,6 +202,8 @@
   --home-dark-ink: #F6F1E7;
   --home-dark-muted: #CEC4AE;
   --home-dark-rule: rgba(246, 241, 231, 0.12);
+
+  --home-elev-mix: black;
 }
 
 @layer base {
@@ -1045,7 +1055,7 @@
 
   .home-spotlight-tags span {
     display: inline-flex;
-    min-height: 40px;
+    min-height: 44px;
     align-items: center;
     border-radius: 999px;
     border: 1px solid color-mix(in srgb, var(--home-stone) 72%, var(--home-ink) 18%);

--- a/src/app/golf/golf-client.tsx
+++ b/src/app/golf/golf-client.tsx
@@ -172,7 +172,7 @@ function StatBlock({
     <div
       className="rounded-[24px] px-5 py-4"
       style={{
-        background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+        background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
         border: "1px solid var(--home-rule)",
       }}
     >
@@ -203,7 +203,7 @@ function ScorePill({ value }: { value: number }) {
     <span
       className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold"
       style={{
-        background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+        background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
         border: "1px solid var(--home-rule)",
         color: "var(--home-ink)",
         fontFamily: "var(--font-home-sans)",
@@ -229,7 +229,7 @@ function LeaderboardTable({
         <thead>
           <tr
             style={{
-              background: "color-mix(in srgb, var(--home-paper-alt) 70%, white)",
+              background: "color-mix(in srgb, var(--home-paper-alt) 70%, var(--home-elev-mix))",
               color: "var(--home-ink-muted)",
             }}
           >
@@ -636,7 +636,7 @@ export function GolfClient({
           style={{
             borderColor: "color-mix(in srgb, var(--color-warning) 28%, var(--home-rule))",
             background:
-              "linear-gradient(180deg, color-mix(in srgb, var(--color-warning) 10%, white), color-mix(in srgb, var(--home-paper-alt) 82%, white))",
+              "linear-gradient(180deg, color-mix(in srgb, var(--color-warning) 10%, var(--home-elev-mix)), color-mix(in srgb, var(--home-paper-alt) 82%, var(--home-elev-mix)))",
           }}
         >
           <div className="grid gap-8 lg:grid-cols-[minmax(0,1.4fr)_minmax(280px,0.8fr)]">
@@ -674,7 +674,7 @@ export function GolfClient({
               className="rounded-[28px] border px-5 py-5"
               style={{
                 borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper-alt) 86%, white)",
+                background: "color-mix(in srgb, var(--home-paper-alt) 86%, var(--home-elev-mix))",
               }}
             >
               <p className="home-kicker mb-2">This week</p>
@@ -797,7 +797,7 @@ export function GolfClient({
               className="rounded-[26px] border px-5 py-5"
               style={{
                 borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper-alt) 82%, white)",
+                background: "color-mix(in srgb, var(--home-paper-alt) 82%, var(--home-elev-mix))",
               }}
             >
               <p className="home-kicker mb-2">Snapshot note</p>
@@ -816,7 +816,7 @@ export function GolfClient({
               className="rounded-[30px] border px-5 py-5 sm:px-6"
               style={{
                 borderColor: "color-mix(in srgb, var(--color-warning) 22%, var(--home-rule))",
-                background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+                background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
               }}
             >
               <p className="home-kicker mb-2">Selected player</p>
@@ -910,7 +910,7 @@ export function GolfClient({
                           className="rounded-[22px] border px-4 py-4"
                           style={{
                             borderColor: "var(--home-rule)",
-                            background: "color-mix(in srgb, var(--home-paper-alt) 88%, white)",
+                            background: "color-mix(in srgb, var(--home-paper-alt) 88%, var(--home-elev-mix))",
                           }}
                         >
                           <p className="home-kicker mb-2">Player profile</p>
@@ -937,7 +937,7 @@ export function GolfClient({
                         className="rounded-[22px] border px-4 py-4"
                         style={{
                           borderColor: "var(--home-rule)",
-                          background: "color-mix(in srgb, var(--home-paper-alt) 88%, white)",
+                          background: "color-mix(in srgb, var(--home-paper-alt) 88%, var(--home-elev-mix))",
                         }}
                       >
                         <p className="home-kicker mb-3">Round by round</p>
@@ -974,7 +974,7 @@ export function GolfClient({
                         className="rounded-[22px] border px-4 py-4"
                         style={{
                           borderColor: "var(--home-rule)",
-                          background: "color-mix(in srgb, var(--home-paper-alt) 88%, white)",
+                          background: "color-mix(in srgb, var(--home-paper-alt) 88%, var(--home-elev-mix))",
                         }}
                       >
                         <p className="home-kicker mb-3">Scoring split</p>

--- a/src/app/investments/investments-client.tsx
+++ b/src/app/investments/investments-client.tsx
@@ -137,7 +137,7 @@ export function InvestmentsClient({ initialState }: InvestmentsClientProps) {
         </motion.div>
 
         <div
-          className="mb-8 inline-flex flex-wrap gap-2 rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/90 p-2 shadow-[var(--shadow-sm)] backdrop-blur"
+          className="mb-8 inline-flex flex-wrap gap-2 rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/90 p-2 shadow-[var(--shadow-sm)] backdrop-blur"
           role="tablist"
           aria-label="Investments tabs"
         >

--- a/src/app/mba-internship-notifications/mba-jobs-client.tsx
+++ b/src/app/mba-internship-notifications/mba-jobs-client.tsx
@@ -179,16 +179,16 @@ function getRoleFamilyAccent(family: MBAJobRoleFamily): string {
 function getTrackedCompanyButtonStyle(company: MBACompany, active: boolean): CSSProperties {
   if (active) {
     return {
-      background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)",
+      background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))",
       borderColor: `color-mix(in srgb, ${company.color} 28%, var(--home-rule))`,
       color: "var(--home-ink)",
-      boxShadow: "inset 0 0 0 1px color-mix(in srgb, var(--home-paper) 88%, white)",
+      boxShadow: "inset 0 0 0 1px color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
       fontFamily: CHIP_FONT_FAMILY,
     };
   }
 
   return {
-    background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+    background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
     borderColor: "var(--home-rule)",
     color: "var(--home-ink-muted)",
     fontFamily: CHIP_FONT_FAMILY,
@@ -953,7 +953,7 @@ function CompanyFilterStrip({
         className="flex w-full items-start justify-between gap-4 rounded-[1.2rem] border px-4 py-4 text-left transition-[border-color,background-color] duration-200 ease sm:items-center"
         style={{
           borderColor: "var(--home-rule)",
-          background: "color-mix(in srgb, var(--home-paper-alt) 56%, white)",
+          background: "color-mix(in srgb, var(--home-paper-alt) 56%, var(--home-elev-mix))",
         }}
         aria-expanded={isExpanded}
         aria-controls="tracked-companies-controls"
@@ -985,7 +985,7 @@ function CompanyFilterStrip({
             className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border"
             style={{
               borderColor: "var(--home-rule)",
-              background: "color-mix(in srgb, var(--home-paper) 92%, white)",
+              background: "color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))",
             }}
             aria-hidden="true"
           >
@@ -1043,7 +1043,7 @@ function CompanyFilterStrip({
                   className="rounded-[1.2rem] border p-3 sm:p-4"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 58%, white)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 58%, var(--home-elev-mix))",
                   }}
                 >
                   <button
@@ -1304,7 +1304,7 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                   className="rounded-[1.35rem] border p-4"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 62%, white)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 62%, var(--home-elev-mix))",
                   }}
                 >
                   <p className="home-meta mb-0">Coverage</p>
@@ -1317,7 +1317,7 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                   className="rounded-[1.35rem] border p-4"
                   style={{
                     borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 62%, white)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 62%, var(--home-elev-mix))",
                   }}
                 >
                   <p className="home-meta mb-0">Workflow</p>
@@ -1441,7 +1441,7 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                       aria-label="Search roles"
                       className="w-full min-h-[48px] rounded-[1rem] border pl-11 pr-12 text-sm outline-none transition-[border-color,box-shadow] duration-200 ease"
                       style={{
-                        background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+                        background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
                         borderColor: "var(--home-rule)",
                         color: "var(--home-ink)",
                         fontFamily: "var(--font-home-sans)",
@@ -1476,7 +1476,7 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                       aria-label="Filter by location"
                       className="w-full min-h-[48px] rounded-[1rem] border pl-11 pr-12 text-sm outline-none transition-[border-color,box-shadow] duration-200 ease"
                       style={{
-                        background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+                        background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
                         borderColor: "var(--home-rule)",
                         color: "var(--home-ink)",
                         fontFamily: "var(--font-home-sans)",
@@ -1520,7 +1520,7 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                     className="rounded-[1rem] border px-4 py-4"
                     style={{
                       borderColor: "var(--home-rule)",
-                      background: "color-mix(in srgb, var(--home-paper-alt) 62%, white)",
+                      background: "color-mix(in srgb, var(--home-paper-alt) 62%, var(--home-elev-mix))",
                     }}
                   >
                     <div className="flex flex-wrap items-center justify-between gap-2">
@@ -1650,7 +1650,7 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                       <span
                         className="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold"
                         style={{
-                          background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+                          background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
                           color: "var(--home-ink)",
                           fontFamily: CHIP_FONT_FAMILY,
                         }}
@@ -1690,7 +1690,7 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                       <span
                         className="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold"
                         style={{
-                          background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+                          background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
                           color: "var(--home-ink)",
                           fontFamily: CHIP_FONT_FAMILY,
                         }}
@@ -1737,7 +1737,7 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                   <span
                     className="resume-chip"
                     style={{
-                      background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)",
+                      background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))",
                       color: "var(--home-ink)",
                     }}
                   >

--- a/src/app/news-pulse/news-pulse-client.tsx
+++ b/src/app/news-pulse/news-pulse-client.tsx
@@ -345,7 +345,7 @@ export function NewsPulseClient({ initialState }: NewsPulseClientProps) {
           >
             <div
               className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full"
-              style={{ background: "color-mix(in srgb, var(--home-paper) 88%, white)" }}
+              style={{ background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))" }}
             >
               <CircleAlert
                 className="h-4 w-4"
@@ -510,7 +510,7 @@ function HeadlinesView({
                 style={{
                   fontFamily: "var(--font-home-sans)",
                   color: "var(--home-ink)",
-                  background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+                  background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
                 }}
               >
                 {article.category}
@@ -837,7 +837,7 @@ function AnalysisView({
 
                 <div
                   className="flex h-5 w-full overflow-hidden rounded-full"
-                  style={{ background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)" }}
+                  style={{ background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))" }}
                 >
                   <div
                     className="transition-[width] duration-500 ease"
@@ -929,7 +929,7 @@ function AnalysisView({
 
                 <div
                   className="h-4 w-full overflow-hidden rounded-full"
-                  style={{ background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)" }}
+                  style={{ background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))" }}
                 >
                   <div
                     className="h-full rounded-full transition-[width] duration-500 ease"

--- a/src/app/polling-aggregator/polling-aggregator-client.tsx
+++ b/src/app/polling-aggregator/polling-aggregator-client.tsx
@@ -290,7 +290,7 @@ function RaceSidebar({ race }: { race: Race }) {
                       style={{
                         color: partyColor(c.party),
                         borderColor: `color-mix(in srgb, ${partyColor(c.party)} 30%, var(--home-rule))`,
-                        background: `color-mix(in srgb, ${partyColor(c.party)} 8%, color-mix(in srgb, var(--home-paper-alt) 80%, white))`,
+                        background: `color-mix(in srgb, ${partyColor(c.party)} 8%, color-mix(in srgb, var(--home-paper-alt) 80%, var(--home-elev-mix)))`,
                       }}
                     >
                       {c.name.split(" ").pop()} {c.support}%{c.incumbent ? " ★" : ""}
@@ -688,7 +688,7 @@ export function PollingAggregatorClient({ initialState, snapshot }: Props) {
           className="flex flex-wrap gap-2 rounded-[1.5rem] p-2"
           style={{
             border: "1px solid var(--home-rule)",
-            background: "color-mix(in srgb, var(--home-paper-alt) 90%, white)",
+            background: "color-mix(in srgb, var(--home-paper-alt) 90%, var(--home-elev-mix))",
             width: "fit-content",
           }}
         >

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -74,7 +74,7 @@ const strongStyle = {
 
 const chipStyle = {
   fontFamily: "var(--font-home-sans)",
-  background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+  background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
   color: "var(--home-ink)",
   border: "1px solid var(--home-rule)",
   letterSpacing: "0.02em",
@@ -83,7 +83,7 @@ const chipStyle = {
 const outlineButtonStyle = {
   fontFamily: "var(--font-home-sans)",
   color: "var(--home-ink)",
-  background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+  background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
   border: "1px solid var(--home-rule)",
 } as const;
 
@@ -306,7 +306,7 @@ export default function CaseStudyPage({
 
             <div
               className="home-card p-6 sm:p-8 space-y-3"
-              style={{ background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)" }}
+              style={{ background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))" }}
             >
               <h3 className="text-xl mb-0" style={subsectionTitleStyle}>
                 Stakes
@@ -403,7 +403,7 @@ export default function CaseStudyPage({
                     <div
                       className="rounded-xl p-4 space-y-1"
                       style={{
-                        background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)",
+                        background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))",
                         border: "1px solid var(--home-rule)",
                       }}
                     >
@@ -445,7 +445,7 @@ export default function CaseStudyPage({
               <div
                 className="home-card p-6 sm:p-8 space-y-4"
                 style={{
-                  background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)",
+                  background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))",
                   borderLeft: "3px solid var(--home-haze)",
                 }}
               >
@@ -481,7 +481,7 @@ export default function CaseStudyPage({
             </h2>
             <div
               className="home-card p-6 sm:p-8 space-y-3"
-              style={{ background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)" }}
+              style={{ background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))" }}
             >
               <h3 className="text-lg mb-0" style={subsectionTitleStyle}>
                 What I&apos;d do differently

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -81,7 +81,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
                 className="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold"
                 style={{
                   fontFamily: "var(--font-home-sans)",
-                  background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+                  background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
                   color: "var(--home-ink)",
                   border: "1px solid var(--home-rule)",
                   letterSpacing: "0.02em",

--- a/src/app/spacex-mission-control/spacex-mission-control-client.tsx
+++ b/src/app/spacex-mission-control/spacex-mission-control-client.tsx
@@ -406,7 +406,7 @@ export function SpaceXMissionControlClient({
     >
       <div className="mx-auto w-full max-w-[1700px] px-4 pb-10 pt-6 sm:px-6 sm:pb-12 sm:pt-8 lg:px-8 xl:px-10 2xl:px-12">
         <motion.div
-          className="mb-5 overflow-hidden rounded-[32px] border border-[color-mix(in_srgb,var(--home-haze)_14%,var(--home-rule))] bg-[linear-gradient(135deg,color-mix(in_srgb,var(--home-haze)_7%,color-mix(in srgb, var(--home-paper) 92%, white))_0%,color-mix(in srgb, var(--home-paper) 92%, white)_50%,color-mix(in_srgb,var(--color-success)_7%,color-mix(in srgb, var(--home-paper) 92%, white))_100%)] p-5 shadow-[var(--shadow-md)] sm:p-6"
+          className="mb-5 overflow-hidden rounded-[32px] border border-[color-mix(in_srgb,var(--home-haze)_14%,var(--home-rule))] bg-[linear-gradient(135deg,color-mix(in_srgb,var(--home-haze)_7%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_0%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_50%,color-mix(in_srgb,var(--color-success)_7%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_100%)] p-5 shadow-[var(--shadow-md)] sm:p-6"
           {...motionProps}
         >
           <div className="min-w-0">
@@ -414,7 +414,7 @@ export function SpaceXMissionControlClient({
               <span className="rounded-full border border-[color-mix(in_srgb,var(--home-haze)_24%,var(--home-rule))] bg-[color-mix(in_srgb,var(--home-paper)_72%,transparent)] px-3 py-1 font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--home-haze)]">
                 SpaceX Mission Control
               </span>
-              <span className="rounded-full border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-3 py-1 text-xs font-medium text-[var(--home-ink-muted)]">
+              <span className="rounded-full border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-3 py-1 text-xs font-medium text-[var(--home-ink-muted)]">
                 Local API backed
               </span>
             </div>
@@ -432,7 +432,7 @@ export function SpaceXMissionControlClient({
               <button
                 type="button"
                 onClick={handleRetryAll}
-                className="tap-target inline-flex items-center gap-2 rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-4 py-3 text-sm font-semibold text-[var(--home-ink)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)]"
+                className="tap-target inline-flex items-center gap-2 rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-4 py-3 text-sm font-semibold text-[var(--home-ink)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)]"
               >
                 <RefreshCcw className="h-4 w-4" />
                 Refresh data

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -212,7 +212,7 @@ export default async function BlogPostPage({ params }: PageProps) {
               <section
                 className="home-card mb-10 space-y-4"
                 style={{
-                  background: "color-mix(in srgb, var(--home-paper-alt) 86%, white)",
+                  background: "color-mix(in srgb, var(--home-paper-alt) 86%, var(--home-elev-mix))",
                   padding: "1.8rem",
                 }}
               >

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -148,7 +148,7 @@ function ArchiveWritingCard({ post }: { post: WritingCardPost }) {
         className="flex h-full flex-col rounded-[1.5rem] border"
         style={{
           padding: "1.25rem",
-          borderColor: "color-mix(in srgb, var(--home-rule) 78%, white)",
+          borderColor: "color-mix(in srgb, var(--home-rule) 78%, var(--home-elev-mix))",
           background:
             "color-mix(in srgb, var(--home-paper) 82%, var(--home-paper-alt) 18%)",
         }}
@@ -256,7 +256,7 @@ function ArchiveBucketSection({
       data-testid={`writing-archive-${toSectionId(bucket)}`}
       className="rounded-[2rem] border p-6 md:p-7"
       style={{
-        borderColor: "color-mix(in srgb, var(--home-rule) 74%, white)",
+        borderColor: "color-mix(in srgb, var(--home-rule) 74%, var(--home-elev-mix))",
         background:
           "color-mix(in srgb, var(--home-paper) 76%, var(--home-paper-alt) 24%)",
       }}
@@ -370,7 +370,7 @@ export default function WritingPage() {
               style={{
                 borderColor: "var(--home-rule)",
                 background:
-                  "linear-gradient(135deg, color-mix(in srgb, var(--home-paper-alt) 84%, white) 0%, color-mix(in srgb, var(--home-paper) 88%, var(--home-paper-alt) 12%) 100%)",
+                  "linear-gradient(135deg, color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix)) 0%, color-mix(in srgb, var(--home-paper) 88%, var(--home-paper-alt) 12%) 100%)",
               }}
             >
               <div className="space-y-3">
@@ -400,7 +400,7 @@ export default function WritingPage() {
                     key={stat.label}
                     className="rounded-[1.35rem] border px-4 py-4 text-center"
                     style={{
-                      borderColor: "color-mix(in srgb, var(--home-rule) 82%, white)",
+                      borderColor: "color-mix(in srgb, var(--home-rule) 82%, var(--home-elev-mix))",
                       background:
                         "color-mix(in srgb, var(--home-paper) 72%, var(--home-paper-alt) 28%)",
                     }}
@@ -444,9 +444,9 @@ export default function WritingPage() {
                     href={`#${sectionId}`}
                     className="group flex min-h-[56px] items-center justify-between gap-3 rounded-[1.2rem] border px-4 py-3 transition-[border-color,background-color,color]"
                     style={{
-                      borderColor: "color-mix(in srgb, var(--home-rule) 84%, white)",
+                      borderColor: "color-mix(in srgb, var(--home-rule) 84%, var(--home-elev-mix))",
                       background:
-                        "color-mix(in srgb, var(--home-paper-alt) 76%, white)",
+                        "color-mix(in srgb, var(--home-paper-alt) 76%, var(--home-elev-mix))",
                     }}
                   >
                     <div className="space-y-1">

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -55,7 +55,7 @@ export default function About() {
               className="flex flex-wrap justify-center gap-2 rounded-[1.5rem] p-2"
               style={{
                 border: "1px solid var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper-alt) 90%, white)",
+                background: "color-mix(in srgb, var(--home-paper-alt) 90%, var(--home-elev-mix))",
               }}
             >
               {tabs.map((tab, index) => (

--- a/src/components/ContactContent.tsx
+++ b/src/components/ContactContent.tsx
@@ -128,7 +128,7 @@ export function ContactContent() {
             <div
               className="rounded-2xl p-6"
               style={{
-                background: "color-mix(in srgb, var(--home-paper-alt) 80%, white)",
+                background: "color-mix(in srgb, var(--home-paper-alt) 80%, var(--home-elev-mix))",
                 border: "1px solid var(--home-rule)",
               }}
             >

--- a/src/components/PortfolioProjectCard.tsx
+++ b/src/components/PortfolioProjectCard.tsx
@@ -77,7 +77,7 @@ export function PortfolioProjectCard({
             <div
               className="px-4 py-3 rounded-xl"
               style={{
-                background: "color-mix(in srgb, var(--home-paper-alt) 80%, white)",
+                background: "color-mix(in srgb, var(--home-paper-alt) 80%, var(--home-elev-mix))",
                 border: "1px solid var(--home-rule)",
               }}
             >
@@ -92,7 +92,7 @@ export function PortfolioProjectCard({
             <div
               className="px-4 py-3 rounded-xl"
               style={{
-                background: "color-mix(in srgb, var(--home-paper-alt) 80%, white)",
+                background: "color-mix(in srgb, var(--home-paper-alt) 80%, var(--home-elev-mix))",
                 border: "1px solid var(--home-rule)",
               }}
             >

--- a/src/components/ProjectsContent.tsx
+++ b/src/components/ProjectsContent.tsx
@@ -640,7 +640,7 @@ export function ProjectsContent() {
                     project.impact) && (
                     <button
                       onClick={() => openProjectDetail(project)}
-                      className="p-2 rounded-lg bg-[color-mix(in srgb, var(--home-paper) 92%, white)] hover:bg-[var(--home-haze)]/10 border border-[var(--home-rule)] hover:border-[var(--home-haze)]/50 transition-all"
+                      className="p-2 rounded-lg bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] hover:bg-[var(--home-haze)]/10 border border-[var(--home-rule)] hover:border-[var(--home-haze)]/50 transition-all"
                       aria-label="View project details"
                     >
                       <IconEye className="h-4 w-4 text-[var(--home-haze)]" />
@@ -651,7 +651,7 @@ export function ProjectsContent() {
                       href={project.github}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="p-2 rounded-lg bg-[color-mix(in srgb, var(--home-paper) 92%, white)] hover:bg-[var(--home-haze)]/10 border border-[var(--home-rule)] hover:border-[var(--home-haze)]/50 transition-all"
+                      className="p-2 rounded-lg bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] hover:bg-[var(--home-haze)]/10 border border-[var(--home-rule)] hover:border-[var(--home-haze)]/50 transition-all"
                       aria-label="View source code"
                     >
                       <IconBrandGithub className="h-4 w-4 text-[var(--home-haze)]" />
@@ -661,7 +661,7 @@ export function ProjectsContent() {
                     (project.link.startsWith("/") ? (
                       <Link
                         href={project.link}
-                        className="p-2 rounded-lg bg-[color-mix(in srgb, var(--home-paper) 92%, white)] hover:bg-[var(--home-haze)]/10 border border-[var(--home-rule)] hover:border-[var(--home-haze)]/50 transition-all"
+                        className="p-2 rounded-lg bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] hover:bg-[var(--home-haze)]/10 border border-[var(--home-rule)] hover:border-[var(--home-haze)]/50 transition-all"
                         aria-label="View live project"
                       >
                         <IconExternalLink className="h-4 w-4 text-[var(--home-haze)]" />
@@ -671,7 +671,7 @@ export function ProjectsContent() {
                         href={project.link}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="p-2 rounded-lg bg-[color-mix(in srgb, var(--home-paper) 92%, white)] hover:bg-[var(--home-haze)]/10 border border-[var(--home-rule)] hover:border-[var(--home-haze)]/50 transition-all"
+                        className="p-2 rounded-lg bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] hover:bg-[var(--home-haze)]/10 border border-[var(--home-rule)] hover:border-[var(--home-haze)]/50 transition-all"
                         aria-label="View live project"
                       >
                         <IconExternalLink className="h-4 w-4 text-[var(--home-haze)]" />

--- a/src/components/editorial/EditorialPillButton.tsx
+++ b/src/components/editorial/EditorialPillButton.tsx
@@ -19,7 +19,7 @@ export function getPillStyle(active: boolean): CSSProperties {
   }
 
   return {
-    background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+    background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
     color: "var(--home-ink-muted)",
     borderColor: "var(--home-rule)",
   };

--- a/src/components/editorial/StatusPanel.tsx
+++ b/src/components/editorial/StatusPanel.tsx
@@ -35,7 +35,7 @@ export function StatusPanel({
           }
         : {
             borderColor: "var(--home-rule)",
-            background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)",
+            background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))",
             accent: "var(--home-haze)",
           };
 
@@ -52,7 +52,7 @@ export function StatusPanel({
         <div
           className="mx-auto mb-4 flex h-11 w-11 items-center justify-center rounded-full"
           style={{
-            background: "color-mix(in srgb, var(--home-paper) 88%, white)",
+            background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
             color: toneStyle.accent,
           }}
         >

--- a/src/components/editorial/UtilityStrip.tsx
+++ b/src/components/editorial/UtilityStrip.tsx
@@ -14,7 +14,7 @@ export function UtilityStrip({ children }: UtilityStripProps) {
     <div
       className="rounded-full px-4 py-2.5"
       style={{
-        background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+        background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
         border: "1px solid var(--home-rule)",
       }}
     >

--- a/src/components/football/StatCard.tsx
+++ b/src/components/football/StatCard.tsx
@@ -23,7 +23,7 @@ export function StatCard({
 }) {
   if (variant === "compact") {
     return (
-      <div className="rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-4 py-4">
+      <div className="rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-4 py-4">
         <div className="flex items-center justify-between gap-3">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
             {eyebrow}

--- a/src/components/football/SurfaceCard.tsx
+++ b/src/components/football/SurfaceCard.tsx
@@ -11,7 +11,7 @@ export function SurfaceCard({
   return (
     <div
       className={cn(
-        "rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] shadow-[var(--shadow-sm)]",
+        "rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] shadow-[var(--shadow-sm)]",
         className
       )}
     >

--- a/src/components/investments/AllocationChart.tsx
+++ b/src/components/investments/AllocationChart.tsx
@@ -61,7 +61,7 @@ export function AllocationChart({ holdings }: Props) {
       .join("path")
       .attr("d", arc)
       .attr("fill", (_, i) => PALETTE[i % PALETTE.length])
-      .attr("stroke", "color-mix(in srgb, var(--home-paper) 92%, white)")
+      .attr("stroke", "color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))")
       .attr("stroke-width", 2)
       .style("cursor", "pointer")
       .style("transition", "opacity 0.15s ease");

--- a/src/components/investments/ComparisonTab.tsx
+++ b/src/components/investments/ComparisonTab.tsx
@@ -322,7 +322,7 @@ export function ComparisonTab() {
   // ── Render ─────────────────────────────────────────────────────────────
   return (
     <div className="space-y-6">
-      <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-4 shadow-[var(--shadow-sm)] sm:p-5">
+      <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4 shadow-[var(--shadow-sm)] sm:p-5">
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] lg:items-end">
           <div className="flex flex-col gap-2">
             <label className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
@@ -369,7 +369,7 @@ export function ComparisonTab() {
         <Skeleton />
       ) : (
         <>
-          <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-5 shadow-[var(--shadow-sm)] sm:p-6">
+          <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-5 shadow-[var(--shadow-sm)] sm:p-6">
             <ComparisonRadarChart
               data={radarData}
               symbolA={symbolA}

--- a/src/components/investments/FinancialStatementsPanel.tsx
+++ b/src/components/investments/FinancialStatementsPanel.tsx
@@ -101,7 +101,7 @@ function StatementTable({
       <table className="w-full text-xs min-w-[480px]" aria-label={`${section.replace("_", " ")} statement`}>
         <thead>
           <tr className="border-b border-[var(--home-rule)]">
-            <th className="text-left py-2 px-2 text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))] font-medium w-40 sticky left-0 bg-[color-mix(in srgb, var(--home-paper) 92%, white)]">
+            <th className="text-left py-2 px-2 text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))] font-medium w-40 sticky left-0 bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]">
               Metric
             </th>
             {periodCols.map((col) => (
@@ -120,7 +120,7 @@ function StatementTable({
               key={i}
               className="border-b border-[var(--home-rule)] last:border-0 hover:bg-[var(--home-paper-alt)] transition-colors"
             >
-              <td className="py-2 px-2 text-[var(--home-ink-muted)] font-medium sticky left-0 bg-[color-mix(in srgb, var(--home-paper) 92%, white)] whitespace-nowrap">
+              <td className="py-2 px-2 text-[var(--home-ink-muted)] font-medium sticky left-0 bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] whitespace-nowrap">
                 {String(row[labelCol] ?? "")}
               </td>
               {periodCols.map((col) => {

--- a/src/components/investments/PortfolioPerformanceChart.tsx
+++ b/src/components/investments/PortfolioPerformanceChart.tsx
@@ -345,7 +345,7 @@ export function PortfolioPerformanceChart({ snapshots }: Props) {
         style={{
           opacity: 0,
           padding: "8px 10px",
-            backgroundColor: "color-mix(in srgb, var(--home-paper) 92%, white)",
+            backgroundColor: "color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))",
             border: "1px solid var(--home-rule)",
             zIndex: 10,
           }}

--- a/src/components/investments/PortfolioSummary.tsx
+++ b/src/components/investments/PortfolioSummary.tsx
@@ -73,7 +73,7 @@ export function PortfolioSummary({ summary, isLoading }: Props) {
               variants={v.itemVariants}
               className="grid gap-3 sm:grid-cols-2"
             >
-              <div className="rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-4">
+              <div className="rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
                   Today
                 </p>
@@ -81,7 +81,7 @@ export function PortfolioSummary({ summary, isLoading }: Props) {
                   {formatCurrency(summary.dayChange)} ({formatPercent(summary.dayChangePercent)})
                 </p>
               </div>
-              <div className="rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-4">
+              <div className="rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
                   Total Cost
                 </p>

--- a/src/components/investments/PortfolioTracker.tsx
+++ b/src/components/investments/PortfolioTracker.tsx
@@ -41,7 +41,7 @@ export function PortfolioTracker({ onResearch }: Props) {
   return (
     <section aria-label="Portfolio tracker" className="space-y-6">
       {!isEmpty && (
-        <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-4 shadow-[var(--shadow-sm)] sm:p-5">
+        <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4 shadow-[var(--shadow-sm)] sm:p-5">
           <div className="mb-4 grid gap-3 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-center">
             <div>
               <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
@@ -79,7 +79,7 @@ export function PortfolioTracker({ onResearch }: Props) {
       </div>
 
       {isEmpty ? (
-        <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
+        <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
           <p className="mb-2 text-sm font-semibold text-[var(--home-ink)]">
             No positions yet
           </p>

--- a/src/components/investments/PriceChartPanel.tsx
+++ b/src/components/investments/PriceChartPanel.tsx
@@ -318,7 +318,7 @@ export function PriceChartPanel({ symbol }: Props) {
           <svg ref={volumeRef} className="mt-2 w-full" />
           <div
             ref={tooltipRef}
-            className="absolute pointer-events-none hidden z-10 bg-[color-mix(in srgb, var(--home-paper) 92%, white)] border border-[var(--home-rule)] rounded px-2 py-1 text-xs text-[var(--home-ink)] shadow-md whitespace-nowrap"
+            className="absolute pointer-events-none hidden z-10 bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] border border-[var(--home-rule)] rounded px-2 py-1 text-xs text-[var(--home-ink)] shadow-md whitespace-nowrap"
           />
         </div>
       )}

--- a/src/components/investments/ResearchSidebar.tsx
+++ b/src/components/investments/ResearchSidebar.tsx
@@ -132,7 +132,7 @@ export function ResearchSidebar({ symbol, onSymbolChange, isInPortfolio = false 
   return (
     <div className="space-y-3">
       {/* Search */}
-      <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-4 shadow-[var(--shadow-sm)]">
+      <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4 shadow-[var(--shadow-sm)]">
         <div className="mb-2 flex items-center justify-between gap-2">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
             Research Symbol
@@ -155,7 +155,7 @@ export function ResearchSidebar({ symbol, onSymbolChange, isInPortfolio = false 
       {symbol ? (
         <>
           {/* Company identity + stance */}
-          <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-4 shadow-[var(--shadow-sm)]">
+          <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4 shadow-[var(--shadow-sm)]">
             <p className="text-sm font-semibold leading-snug text-[var(--home-ink)]">
               {[displayName || symbol, symbol !== (displayName || symbol) ? symbol : null, info?.sector, info?.industry].filter(Boolean).join(" · ")}
             </p>
@@ -167,7 +167,7 @@ export function ResearchSidebar({ symbol, onSymbolChange, isInPortfolio = false 
           </div>
 
           {/* Live price */}
-          <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-4 shadow-[var(--shadow-sm)]">
+          <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4 shadow-[var(--shadow-sm)]">
             <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
               Latest Price
             </p>
@@ -213,7 +213,7 @@ export function ResearchSidebar({ symbol, onSymbolChange, isInPortfolio = false 
           </div>
 
           {/* Key metrics */}
-          <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-4 shadow-[var(--shadow-sm)]">
+          <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4 shadow-[var(--shadow-sm)]">
             <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
               Key Metrics
             </p>
@@ -246,12 +246,12 @@ export function ResearchSidebar({ symbol, onSymbolChange, isInPortfolio = false 
           </div>
 
           {/* Dataset freshness */}
-          <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-4 py-3 shadow-[var(--shadow-sm)]">
+          <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-4 py-3 shadow-[var(--shadow-sm)]">
             <DataFreshnessIndicator lastUpdated={dataFreshnessLastUpdated} mode="dataset" />
           </div>
         </>
       ) : (
-        <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-5 py-10 text-center shadow-[var(--shadow-sm)]">
+        <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-5 py-10 text-center shadow-[var(--shadow-sm)]">
           <p className="text-sm text-[var(--home-ink-muted)]">
             Enter a ticker to see metrics and research data.
           </p>

--- a/src/components/investments/ResearchSummaryStrip.tsx
+++ b/src/components/investments/ResearchSummaryStrip.tsx
@@ -89,7 +89,7 @@ function MetricTile({
         : "text-[var(--home-ink)]";
 
   return (
-    <div className="flex min-h-[112px] flex-col justify-between rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/70 px-4 py-3">
+    <div className="flex min-h-[112px] flex-col justify-between rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/70 px-4 py-3">
       <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
         {label}
       </p>
@@ -152,14 +152,14 @@ export function ResearchSummaryStrip({ symbol }: Props) {
   return (
     <WarmCard
       padding="none"
-      className="relative overflow-hidden rounded-[30px] border-[color-mix(in_srgb,var(--home-haze)_18%,var(--home-rule))] bg-[linear-gradient(135deg,color-mix(in_srgb,var(--home-haze)_8%,color-mix(in srgb, var(--home-paper) 92%, white))_0%,color-mix(in srgb, var(--home-paper) 92%, white)_42%,color-mix(in_srgb,var(--color-success)_8%,color-mix(in srgb, var(--home-paper) 92%, white))_100%)] shadow-[var(--shadow-sm)]"
+      className="relative overflow-hidden rounded-[30px] border-[color-mix(in_srgb,var(--home-haze)_18%,var(--home-rule))] bg-[linear-gradient(135deg,color-mix(in_srgb,var(--home-haze)_8%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_0%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_42%,color-mix(in_srgb,var(--color-success)_8%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_100%)] shadow-[var(--shadow-sm)]"
     >
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,color-mix(in_srgb,var(--home-haze)_18%,transparent),transparent_34%)]" />
       <div className="relative p-5 sm:p-6 lg:p-7">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(300px,360px)] xl:items-start">
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--home-ink-muted)]">
+              <span className="rounded-full border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--home-ink-muted)]">
                 {symbol}
               </span>
               {info?.sector ? (
@@ -184,7 +184,7 @@ export function ResearchSummaryStrip({ symbol }: Props) {
                 </p>
               </div>
 
-              <div className="rounded-3xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-4 py-3.5 shadow-[var(--shadow-sm)]">
+              <div className="rounded-3xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-4 py-3.5 shadow-[var(--shadow-sm)]">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
                     <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
@@ -243,7 +243,7 @@ export function ResearchSummaryStrip({ symbol }: Props) {
             ) : null}
           </div>
 
-          <div className="h-full rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-4 shadow-[var(--shadow-sm)] lg:p-5">
+          <div className="h-full rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4 shadow-[var(--shadow-sm)] lg:p-5">
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
               Current Read
             </p>

--- a/src/components/investments/StockResearch.tsx
+++ b/src/components/investments/StockResearch.tsx
@@ -121,7 +121,7 @@ export function StockResearch({
     return (
       <section aria-label="Stock research">
         <div
-          className="mb-4 flex gap-2 overflow-x-auto rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-2 shadow-[var(--shadow-sm)]"
+          className="mb-4 flex gap-2 overflow-x-auto rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-2 shadow-[var(--shadow-sm)]"
           role="tablist"
           aria-label="Research sections"
         >
@@ -162,7 +162,7 @@ export function StockResearch({
         <div className="min-w-0 space-y-4">
           {visibleTabs.length > 0 ? (
             <div
-              className="flex gap-2 overflow-x-auto rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] p-2 shadow-[var(--shadow-sm)]"
+              className="flex gap-2 overflow-x-auto rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-2 shadow-[var(--shadow-sm)]"
               role="tablist"
               aria-label="Research sections"
             >
@@ -195,7 +195,7 @@ export function StockResearch({
               exit="hidden"
             >
               {!symbol ? (
-                <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
+                <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
                   <p className="text-sm font-semibold text-[var(--home-ink)]">
                     Start with a ticker symbol
                   </p>
@@ -204,7 +204,7 @@ export function StockResearch({
                   </p>
                 </div>
               ) : showLoadingState ? (
-                <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
+                <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
                   <p className="text-sm font-semibold text-[var(--home-ink)]">
                     Loading research data…
                   </p>

--- a/src/components/investments/ValuationRatiosPanel.tsx
+++ b/src/components/investments/ValuationRatiosPanel.tsx
@@ -74,7 +74,7 @@ function StandaloneMetric({
   detail?: string;
 }) {
   return (
-    <div className="rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-4 py-3">
+    <div className="rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-4 py-3">
       <p className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
         {label}
         <MetricTooltip term={label} />

--- a/src/components/search/SearchFilters.tsx
+++ b/src/components/search/SearchFilters.tsx
@@ -33,7 +33,7 @@ function getPillStyle(active: boolean) {
     } as const;
   }
   return {
-    background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+    background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
     color: "var(--home-ink)",
     border: "1px solid var(--home-rule)",
   } as const;
@@ -52,7 +52,7 @@ export function SearchFilters({
     <div
       className="space-y-4 rounded-xl p-4"
       style={{
-        background: "color-mix(in srgb, var(--home-paper-alt) 78%, white)",
+        background: "color-mix(in srgb, var(--home-paper-alt) 78%, var(--home-elev-mix))",
         border: "1px solid var(--home-rule)",
       }}
     >

--- a/src/components/search/SearchInterface.tsx
+++ b/src/components/search/SearchInterface.tsx
@@ -292,7 +292,7 @@ export function SearchInterface({
                 className="w-full min-h-[44px] pl-12 pr-12 py-3 rounded-xl transition-colors"
                 style={{
                   fontFamily: "var(--font-home-sans)",
-                  background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+                  background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
                   border: "1px solid var(--home-rule)",
                   color: "var(--home-ink)",
                 }}
@@ -321,7 +321,7 @@ export function SearchInterface({
                       border: "1px solid var(--home-ink)",
                     }
                   : {
-                      background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+                      background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
                       color: "var(--home-ink-muted)",
                       border: "1px solid var(--home-rule)",
                     }

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -33,7 +33,7 @@ const strongBodyStyle = {
 
 const tagPillStyle = {
   fontFamily: "var(--font-home-sans)",
-  background: "color-mix(in srgb, var(--home-paper-alt) 84%, white)",
+  background: "color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix))",
   color: "var(--home-ink)",
   border: "1px solid var(--home-rule)",
   letterSpacing: "0.02em",

--- a/src/components/spacex/MissionControlHero.tsx
+++ b/src/components/spacex/MissionControlHero.tsx
@@ -59,7 +59,7 @@ function MissionCountdown({
   return (
     <div
       data-testid="mission-countdown"
-      className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--color-success)_25%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-success)_10%,color-mix(in srgb, var(--home-paper) 92%, white))] px-4 py-2 font-mono text-sm font-semibold tracking-[0.16em] text-[var(--home-ink)]"
+      className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--color-success)_25%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-success)_10%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))] px-4 py-2 font-mono text-sm font-semibold tracking-[0.16em] text-[var(--home-ink)]"
     >
       <Radar className="h-4 w-4 text-[var(--color-success)]" />
       {countdown}
@@ -82,7 +82,7 @@ export function MissionControlHero({
       <section
         data-testid="mission-hero"
         aria-label="Next launch hero"
-        className="rounded-[32px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/90 p-6 shadow-[var(--shadow-lg)] sm:p-8"
+        className="rounded-[32px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/90 p-6 shadow-[var(--shadow-lg)] sm:p-8"
       >
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1.25fr)_220px]">
           <div className="space-y-3">
@@ -102,7 +102,7 @@ export function MissionControlHero({
       <section
         data-testid="mission-hero"
         aria-label="Next launch hero"
-        className="rounded-[32px] border border-[color-mix(in_srgb,var(--color-warning)_24%,var(--home-rule))] bg-[linear-gradient(145deg,color-mix(in_srgb,var(--color-warning)_8%,color-mix(in srgb, var(--home-paper) 92%, white))_0%,color-mix(in srgb, var(--home-paper) 92%, white)_100%)] p-6 shadow-[var(--shadow-lg)] sm:p-8"
+        className="rounded-[32px] border border-[color-mix(in_srgb,var(--color-warning)_24%,var(--home-rule))] bg-[linear-gradient(145deg,color-mix(in_srgb,var(--color-warning)_8%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_0%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_100%)] p-6 shadow-[var(--shadow-lg)] sm:p-8"
       >
         <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-3">
@@ -139,7 +139,7 @@ export function MissionControlHero({
     <section
       data-testid="mission-hero"
       aria-label="Next launch hero"
-      className="overflow-hidden rounded-[32px] border border-[color-mix(in_srgb,var(--home-haze)_16%,var(--home-rule))] bg-[linear-gradient(135deg,color-mix(in_srgb,var(--home-haze)_9%,color-mix(in srgb, var(--home-paper) 92%, white))_0%,color-mix(in srgb, var(--home-paper) 92%, white)_45%,color-mix(in_srgb,var(--color-success)_8%,color-mix(in srgb, var(--home-paper) 92%, white))_100%)] p-5 shadow-[var(--shadow-lg)] sm:p-6"
+      className="overflow-hidden rounded-[32px] border border-[color-mix(in_srgb,var(--home-haze)_16%,var(--home-rule))] bg-[linear-gradient(135deg,color-mix(in_srgb,var(--home-haze)_9%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_0%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_45%,color-mix(in_srgb,var(--color-success)_8%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_100%)] p-5 shadow-[var(--shadow-lg)] sm:p-6"
     >
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1.24fr)_220px]">
         <div className="min-w-0">
@@ -147,7 +147,7 @@ export function MissionControlHero({
             <span className="rounded-full border border-[color-mix(in_srgb,var(--home-haze)_25%,var(--home-rule))] bg-[color-mix(in_srgb,var(--home-paper)_78%,transparent)] px-3 py-1 font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--home-haze)]">
               {summary?.heroMode === "fallback" ? "Latest completed mission" : "Next mission"}
             </span>
-            <span className="rounded-full border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-3 py-1 text-xs font-medium text-[var(--home-ink-muted)]">
+            <span className="rounded-full border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-3 py-1 text-xs font-medium text-[var(--home-ink-muted)]">
               Flight #{heroLaunch.flightNumber}
             </span>
           </div>
@@ -163,7 +163,7 @@ export function MissionControlHero({
                 initialNow={initialRenderTimestampMs}
               />
             ) : (
-              <div className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-4 py-2 text-sm font-semibold text-[var(--home-ink)]">
+              <div className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-4 py-2 text-sm font-semibold text-[var(--home-ink)]">
                 <Clock3 className="h-4 w-4 text-[var(--home-haze)]" />
                 {formatMissionScheduleLabel(heroLaunch)}
               </div>
@@ -171,7 +171,7 @@ export function MissionControlHero({
           </div>
 
           <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:max-w-[700px] xl:grid-cols-4">
-            <div className="rounded-[22px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/90 p-3.5">
+            <div className="rounded-[22px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/90 p-3.5">
               <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
                 Rocket
               </p>
@@ -179,7 +179,7 @@ export function MissionControlHero({
                 {heroLaunch.rocketName ?? "Unspecified"}
               </p>
             </div>
-            <div className="rounded-[22px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/90 p-3.5">
+            <div className="rounded-[22px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/90 p-3.5">
               <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
                 Launchpad
               </p>
@@ -187,7 +187,7 @@ export function MissionControlHero({
                 {heroLaunch.launchpadName ?? "Unspecified"}
               </p>
             </div>
-            <div className="rounded-[22px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/90 p-3.5">
+            <div className="rounded-[22px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/90 p-3.5">
               <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
                 Payloads
               </p>
@@ -195,7 +195,7 @@ export function MissionControlHero({
                 {heroLaunch.payloadCount}
               </p>
             </div>
-            <div className="rounded-[22px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/90 p-3.5">
+            <div className="rounded-[22px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/90 p-3.5">
               <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
                 Location
               </p>
@@ -226,7 +226,7 @@ export function MissionControlHero({
                 href={link.href}
                 target="_blank"
                 rel="noreferrer"
-                className="tap-target inline-flex items-center gap-2 rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-5 py-3 text-sm font-semibold text-[var(--home-ink)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)]"
+                className="tap-target inline-flex items-center gap-2 rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-5 py-3 text-sm font-semibold text-[var(--home-ink)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)]"
               >
                 {link.label}
                 <ArrowUpRight className="h-4 w-4" />
@@ -244,7 +244,7 @@ export function MissionControlHero({
             label="Vehicle view"
             dataTestId="mission-hero-visual"
           />
-          <div className="rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/90 p-4 shadow-[var(--shadow-sm)]">
+          <div className="rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/90 p-4 shadow-[var(--shadow-sm)]">
             <div className="flex items-center gap-2">
               <CalendarDays className="h-4 w-4 text-[var(--home-haze)]" />
               <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">

--- a/src/components/spacex/MissionDetailPanel.tsx
+++ b/src/components/spacex/MissionDetailPanel.tsx
@@ -64,7 +64,7 @@ export function MissionDetailPanel({
     <aside
       data-testid="mission-detail-panel"
       aria-label="Mission detail panel"
-      className="rounded-[30px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/92 p-4 shadow-[var(--shadow-md)] sm:p-5"
+      className="rounded-[30px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/92 p-4 shadow-[var(--shadow-md)] sm:p-5"
     >
       <div className="flex flex-col gap-4 border-b border-[var(--home-rule)] pb-5">
         <div>

--- a/src/components/spacex/MissionInsightsStrip.tsx
+++ b/src/components/spacex/MissionInsightsStrip.tsx
@@ -18,13 +18,13 @@ export function MissionInsightsStrip({
         ? Array.from({ length: 4 }, (_, index) => (
             <div
               key={index}
-              className="h-[94px] animate-pulse rounded-[22px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/85"
+              className="h-[94px] animate-pulse rounded-[22px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/85"
             />
           ))
         : insights.map((insight) => (
             <article
               key={insight.id}
-              className="rounded-[22px] border border-[color-mix(in_srgb,var(--home-haze)_10%,var(--home-rule))] bg-[linear-gradient(150deg,color-mix(in_srgb,var(--home-haze)_6%,color-mix(in srgb, var(--home-paper) 92%, white))_0%,color-mix(in srgb, var(--home-paper) 92%, white)_100%)] p-3.5 shadow-[var(--shadow-sm)]"
+              className="rounded-[22px] border border-[color-mix(in_srgb,var(--home-haze)_10%,var(--home-rule))] bg-[linear-gradient(150deg,color-mix(in_srgb,var(--home-haze)_6%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_0%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_100%)] p-3.5 shadow-[var(--shadow-sm)]"
             >
               <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
                 {insight.label}

--- a/src/components/spacex/MissionLaunchBoard.tsx
+++ b/src/components/spacex/MissionLaunchBoard.tsx
@@ -33,7 +33,7 @@ export function MissionLaunchBoard({
     <section
       data-testid="mission-board"
       aria-label="Mission board"
-      className="rounded-[30px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)]/92 p-4 shadow-[var(--shadow-md)] sm:p-5"
+      className="rounded-[30px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/92 p-4 shadow-[var(--shadow-md)] sm:p-5"
     >
       <div className="mb-5 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
@@ -82,7 +82,7 @@ export function MissionLaunchBoard({
           <button
             type="button"
             onClick={onRetry}
-            className="tap-target mt-4 rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, white)] px-4 py-3 text-sm font-semibold text-[var(--home-ink)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)]"
+            className="tap-target mt-4 rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-4 py-3 text-sm font-semibold text-[var(--home-ink)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)]"
           >
             Retry board
           </button>

--- a/src/components/spacex/MissionPatch.tsx
+++ b/src/components/spacex/MissionPatch.tsx
@@ -21,7 +21,7 @@ export function MissionPatch({
       alt={`${name} mission patch`}
       imageFit="contain"
       imageInsetClassName="p-2.5"
-      className={`flex items-center justify-center rounded-[22px] border border-[color-mix(in_srgb,var(--home-haze)_22%,var(--home-rule))] bg-[linear-gradient(160deg,color-mix(in_srgb,var(--home-haze)_12%,color-mix(in srgb, var(--home-paper) 92%, white))_0%,color-mix(in srgb, var(--home-paper) 92%, white)_72%)] shadow-[var(--shadow-md)] ${className}`}
+      className={`flex items-center justify-center rounded-[22px] border border-[color-mix(in_srgb,var(--home-haze)_22%,var(--home-rule))] bg-[linear-gradient(160deg,color-mix(in_srgb,var(--home-haze)_12%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_0%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_72%)] shadow-[var(--shadow-md)] ${className}`}
     />
   );
 }

--- a/src/components/spacex/MissionVehiclePhoto.tsx
+++ b/src/components/spacex/MissionVehiclePhoto.tsx
@@ -25,7 +25,7 @@ export function MissionVehiclePhoto({
       dataTestId={dataTestId}
       alt={`${name} ${label.toLowerCase()}`}
       priority={dataTestId === "mission-hero-visual"}
-      className={`flex items-center justify-center rounded-[28px] border border-[color-mix(in_srgb,var(--home-haze)_18%,var(--home-rule))] bg-[linear-gradient(160deg,color-mix(in_srgb,var(--home-haze)_10%,color-mix(in srgb, var(--home-paper) 92%, white))_0%,color-mix(in srgb, var(--home-paper) 92%, white)_72%)] shadow-[var(--shadow-md)] ${className}`}
+      className={`flex items-center justify-center rounded-[28px] border border-[color-mix(in_srgb,var(--home-haze)_18%,var(--home-rule))] bg-[linear-gradient(160deg,color-mix(in_srgb,var(--home-haze)_10%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix)))_0%,color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))_72%)] shadow-[var(--shadow-md)] ${className}`}
     >
       <div
         aria-hidden="true"

--- a/src/components/ui/JourneyTimeline.tsx
+++ b/src/components/ui/JourneyTimeline.tsx
@@ -32,7 +32,7 @@ const TimelineItem = ({ item, isLast }: TimelineItemProps) => {
         <div
           className="rounded-full overflow-hidden"
           style={{
-            background: "color-mix(in srgb, var(--home-paper-alt) 80%, white)",
+            background: "color-mix(in srgb, var(--home-paper-alt) 80%, var(--home-elev-mix))",
             border: "1px solid var(--home-rule)",
           }}
         >

--- a/src/components/ui/OptimizedImage.tsx
+++ b/src/components/ui/OptimizedImage.tsx
@@ -98,8 +98,8 @@ export function OptimizedImage({
   // Error fallback
   if (hasError) {
     return (
-      <div 
-        className={`flex items-center justify-center bg-[var(--neutral-200)] text-slate-500 ${className}`}
+      <div
+        className={`flex items-center justify-center bg-[var(--neutral-200)] text-[var(--home-ink-muted)] ${className}`}
         style={{ width, height }}
       >
         <svg className="w-8 h-8" fill="currentColor" viewBox="0 0 20 20">
@@ -113,17 +113,14 @@ export function OptimizedImage({
     <div ref={imgRef} className={`relative overflow-hidden ${className}`}>
       {/* Loading placeholder */}
       {!isLoaded && (
-        <div 
+        <div
           className="absolute inset-0 bg-[var(--neutral-200)] animate-pulse"
-          style={{ 
-            backgroundColor: 'rgba(30, 41, 59, 0.5)',
-            ...(placeholder === 'blur' && {
-              backgroundImage: `url(${blurDataURL || defaultBlurDataURL})`,
-              backgroundSize: 'cover',
-              backgroundPosition: 'center',
-              filter: 'blur(10px)',
-            })
-          }}
+          style={placeholder === 'blur' ? {
+            backgroundImage: `url(${blurDataURL || defaultBlurDataURL})`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            filter: 'blur(10px)',
+          } : undefined}
         />
       )}
 


### PR DESCRIPTION
## Summary

Styling audit findings landed as concrete fixes. Three classes of issues: dark-mode blown-out panels, a sub-44px touch target, and one component overriding its own themed placeholder.

## What Changed

- **New `--home-elev-mix` CSS variable** in `globals.css` — `white` in `:root`, `black` in `.dark`. Raised surfaces now flip their mix direction so light mode lifts toward white and dark mode deepens toward black (the existing `.home-card` / `.dark .home-card` pattern already did this manually).
- **174 occurrences migrated** across 50 component/page files: `color-mix(in srgb, var(--home-paper) 92%, white)` → `color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))`. Investments, SpaceX, fantasy draft tracker, golf, F1, news-pulse, polling, writing, portfolio, search, MBA jobs, budget planner, decision lab.
- **`.home-spotlight-tags span`**: `min-height: 40px` → `44px` (CLAUDE.md touch-target mandate).
- **`StatusPanel`**: inline `white` color-mix styles use the new var.
- **`OptimizedImage`**: removed a hardcoded `rgba(30, 41, 59, 0.5)` that was overriding the themed `bg-[var(--neutral-200)]` placeholder; swapped `text-slate-500` for `text-[var(--home-ink-muted)]` on the error fallback.

## Why

The audit surfaced dark-mode cards rendering with a white color-mix, which looked blown-out because `var(--home-paper)` in dark is `#12110F` and mixing with white forced it toward gray instead of depth. Introducing a theme-aware mix variable lets all editorial surfaces stay consistent without per-site `.dark` overrides.

## Out of Scope / Flagged Separately

- **Dead fantasy chart components** (`TierDisplay`, `VirtualizedPlayerList`, `TierChartEnhanced`, `LightweightTierChart`, `DraftControls`, `FantasyContentGrid`, `FantasyFootballLandingContent`) are defined but never imported by live pages. Spawned a separate task to verify and delete rather than fix styling in orphan code.
- **`text-success` / `text-primary` / `text-warning` / `text-error` utilities** don't compile (Tailwind v4 isn't picking up `tailwind.config.ts` without an `@config` directive). All usages are in dead components, so no user-visible impact — deferred.
- Hero component extraction and `/accessibility` + `/writing` shell modernization deferred as larger structural work.

## Test Plan

- [x] `npm run build` — exit 0, no new warnings
- [x] `npm run lint` — 200 pre-existing issues, 0 in files touched by this PR
- [ ] Manually sanity-check a few affected surfaces in dark mode (investments, fintech budget planner, mba-internship-notifications, portfolio detail) to confirm the mix flip looks right
- [ ] Verify `.home-spotlight-tags` on mobile Safari that pills now hit 44px