### PR TITLE
Surface investments data freshness and harden refresh pipeline

### DIFF
--- a/.github/workflows/update-investments.yml
+++ b/.github/workflows/update-investments.yml
@@ -47,6 +47,30 @@ jobs:
         env:
           NODE_ENV: production
 
+      - name: Verify index lastUpdated advanced
+        id: verify_freshness
+        run: |
+          node -e "
+          const fs = require('fs');
+          const index = JSON.parse(fs.readFileSync('public/data/investments/index.json', 'utf8'));
+          const lastUpdated = new Date(index.lastUpdated);
+          const ageHours = (Date.now() - lastUpdated.getTime()) / (1000 * 60 * 60);
+          const successCount = Array.isArray(index.symbols) ? index.symbols.length : 0;
+          const failedCount = Array.isArray(index.failed) ? index.failed.length : 0;
+          console.log('Index lastUpdated:', index.lastUpdated);
+          console.log('Age (hours):', ageHours.toFixed(2));
+          console.log('Symbols succeeded:', successCount, 'failed:', failedCount);
+          if (ageHours > 2) {
+            console.error('::error::index.lastUpdated is older than 2 hours after a refresh run. The Python fetch likely failed silently.');
+            process.exit(1);
+          }
+          if (successCount === 0) {
+            console.error('::error::index.symbols is empty. The Python fetch produced no successful symbols.');
+            process.exit(1);
+          }
+          fs.writeFileSync(process.env.GITHUB_OUTPUT, 'success_count=' + successCount + '\nfailed_count=' + failedCount + '\n', { flag: 'a' });
+          "
+
       - name: Check for investments data changes
         id: check_changes
         run: |
@@ -69,6 +93,80 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Notify on failure via GitHub issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const today = new Date().toISOString().slice(0, 10);
+            const title = `Investments refresh failed ${today}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `The **Refresh Investments Snapshots** workflow failed on ${today}.`,
+              ``,
+              `**Run:** ${runUrl}`,
+              `**Commit:** ${context.sha}`,
+              `**Trigger:** ${context.eventName}`,
+              ``,
+              `Check the run logs to diagnose. Common causes:`,
+              `- \`defeatbeta-api\` upstream data outage or pip install failure`,
+              `- Post-fetch sanity check caught a stale \`index.lastUpdated\``,
+              `- Git push blocked by branch protection`,
+              ``,
+              `This issue will be updated if the next run also fails, and auto-closed on the first successful run.`
+            ].join('\n');
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'investments-refresh-failure',
+              per_page: 5,
+            });
+            if (existing.data.length > 0) {
+              const issue = existing.data[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Failed again on ${today}. Run: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['investments-refresh-failure', 'automation'],
+              });
+            }
+
+      - name: Close resolved failure issues
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'investments-refresh-failure',
+              per_page: 10,
+            });
+            for (const issue of existing.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Refresh succeeded at ${new Date().toISOString()}. Auto-closing.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }
+
       - name: Create job summary
         if: always()
         run: |
@@ -78,6 +176,11 @@ jobs:
           echo "**Run Date:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_STEP_SUMMARY"
           echo "**Schedule:** Weekdays at 22:15 UTC" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${{ steps.verify_freshness.outputs.success_count }}" ]; then
+            echo "**Symbols succeeded:** ${{ steps.verify_freshness.outputs.success_count }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Symbols failed:** ${{ steps.verify_freshness.outputs.failed_count }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [ "${{ steps.check_changes.outputs.changed }}" = "true" ]; then
             echo "✅ Investments snapshots changed and were committed." >> "$GITHUB_STEP_SUMMARY"
           else

--- a/src/app/investments/investments-client.tsx
+++ b/src/app/investments/investments-client.tsx
@@ -10,6 +10,7 @@ import {
   fadeInVariants,
   getReducedMotionVariants,
 } from "@/components/investments/animations";
+import { InvestmentsFreshnessBanner } from "@/components/investments/InvestmentsFreshnessBanner";
 import {
   buildInvestmentsHref,
   type InvestmentsSearchState,
@@ -39,9 +40,17 @@ const TABS: { key: InvestmentsView; label: string }[] = [
 
 interface InvestmentsClientProps {
   initialState: InvestmentsSearchState;
+  datasetLastUpdated?: string | null;
+  datasetSymbolCount?: number;
+  datasetFailedCount?: number;
 }
 
-export function InvestmentsClient({ initialState }: InvestmentsClientProps) {
+export function InvestmentsClient({
+  initialState,
+  datasetLastUpdated = null,
+  datasetSymbolCount = 0,
+  datasetFailedCount = 0,
+}: InvestmentsClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { holdings } = useInvestments();
@@ -135,6 +144,12 @@ export function InvestmentsClient({ initialState }: InvestmentsClientProps) {
             I built this to stress-test investment theses in one place. Company snapshots, valuation history, and a portfolio tracker that lives in your browser with no logins or cloud sync.
           </p>
         </motion.div>
+
+        <InvestmentsFreshnessBanner
+          lastUpdated={datasetLastUpdated}
+          symbolCount={datasetSymbolCount}
+          failedCount={datasetFailedCount}
+        />
 
         <div
           className="mb-8 inline-flex flex-wrap gap-2 rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/90 p-2 shadow-[var(--shadow-sm)] backdrop-blur"

--- a/src/app/investments/page.tsx
+++ b/src/app/investments/page.tsx
@@ -1,5 +1,7 @@
 import { StructuredData } from "@/components/StructuredData";
 import { constructMetadata, generateBreadcrumbStructuredData } from "@/lib/seo";
+import { getInvestmentsIndex } from "@/lib/investmentsData";
+import type { InvestmentsIndex } from "@/types/investment";
 import { InvestmentsClient } from "./investments-client";
 import { normalizeInvestmentsState } from "./investments-state";
 
@@ -45,8 +47,19 @@ interface InvestmentsPageProps {
   }>;
 }
 
+async function loadIndexSafely(): Promise<InvestmentsIndex | null> {
+  try {
+    return await getInvestmentsIndex();
+  } catch {
+    return null;
+  }
+}
+
 export default async function InvestmentsPage({ searchParams }: InvestmentsPageProps) {
-  const initialState = normalizeInvestmentsState(await searchParams);
+  const [initialState, index] = await Promise.all([
+    Promise.resolve(normalizeInvestmentsState(await searchParams)),
+    loadIndexSafely(),
+  ]);
   const breadcrumbs = [
     { name: "Home", url: "/" },
     { name: "Investments", url: "/investments" },
@@ -79,7 +92,12 @@ export default async function InvestmentsPage({ searchParams }: InvestmentsPageP
           ],
         }}
       />
-      <InvestmentsClient initialState={initialState} />
+      <InvestmentsClient
+        initialState={initialState}
+        datasetLastUpdated={index?.lastUpdated ?? null}
+        datasetSymbolCount={index?.symbols?.length ?? 0}
+        datasetFailedCount={index?.failed?.length ?? 0}
+      />
     </>
   );
 }

--- a/src/components/investments/AllocationChart.tsx
+++ b/src/components/investments/AllocationChart.tsx
@@ -128,7 +128,7 @@ export function AllocationChart({ holdings }: Props) {
           <div
             ref={tooltipRef}
             style={{ display: "none", position: "absolute", pointerEvents: "none" }}
-            className="px-2 py-1.5 rounded text-xs bg-[var(--neutral-900)] text-white shadow-lg whitespace-nowrap leading-relaxed"
+            className="px-2 py-1.5 rounded text-xs bg-[var(--home-ink)] text-[var(--home-paper)] shadow-lg whitespace-nowrap leading-relaxed"
           />
         </div>
 

--- a/src/components/investments/InvestmentsFreshnessBanner.tsx
+++ b/src/components/investments/InvestmentsFreshnessBanner.tsx
@@ -1,0 +1,57 @@
+import { DataFreshnessIndicator } from "@/components/investments/DataFreshnessIndicator";
+
+const STALE_THRESHOLD_DAYS = 7;
+
+interface InvestmentsFreshnessBannerProps {
+  lastUpdated: string | null;
+  symbolCount: number;
+  failedCount?: number;
+}
+
+function diffDays(lastUpdated: string | null): number | null {
+  if (!lastUpdated) return null;
+  const ts = Date.parse(lastUpdated);
+  if (!Number.isFinite(ts)) return null;
+  return Math.floor((Date.now() - ts) / (1000 * 60 * 60 * 24));
+}
+
+export function InvestmentsFreshnessBanner({
+  lastUpdated,
+  symbolCount,
+  failedCount,
+}: InvestmentsFreshnessBannerProps) {
+  const days = diffDays(lastUpdated);
+  const isStale = days !== null && days >= STALE_THRESHOLD_DAYS;
+
+  return (
+    <div
+      className="mb-6 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-[20px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-4 py-3 text-xs shadow-[var(--shadow-sm)] sm:text-[13px]"
+      role="status"
+      aria-label="Investments data freshness"
+    >
+      <DataFreshnessIndicator lastUpdated={lastUpdated} mode="dataset" />
+      {symbolCount > 0 && (
+        <span className="text-[var(--home-ink-muted)]">
+          <span className="font-semibold text-[var(--home-ink)]">{symbolCount}</span>{" "}
+          {symbolCount === 1 ? "company" : "companies"}
+          {failedCount && failedCount > 0 ? (
+            <span className="ml-1 text-[var(--color-warning)]">
+              ({failedCount} unavailable)
+            </span>
+          ) : null}
+        </span>
+      )}
+      <span className="text-[var(--home-ink-muted)]">
+        Live prices via Finnhub
+      </span>
+      {isStale && (
+        <span
+          className="inline-flex items-center gap-1 rounded-full bg-[color-mix(in_srgb,var(--color-warning)_18%,var(--home-paper))] px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-warning)]"
+          title="The automated refresh has not produced newer data. Runs weekdays at 22:15 UTC."
+        >
+          Refresh pending
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/investments/MetricTooltip.tsx
+++ b/src/components/investments/MetricTooltip.tsx
@@ -66,7 +66,7 @@ export function MetricTooltip({ term, definition }: Props) {
       </span>
       <span
         role="tooltip"
-        className="pointer-events-none absolute bottom-full left-0 z-50 mb-2 w-52 rounded-2xl bg-[var(--home-ink)] px-3 py-2.5 text-[11px] leading-snug text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100"
+        className="pointer-events-none absolute bottom-full left-0 z-50 mb-2 w-52 rounded-2xl bg-[var(--home-ink)] px-3 py-2.5 text-[11px] leading-snug text-[var(--home-paper)] opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100"
       >
         {text}
         <span className="absolute left-3 top-full border-4 border-transparent border-t-[var(--home-ink)]" />

--- a/src/hooks/useInvestments.ts
+++ b/src/hooks/useInvestments.ts
@@ -11,11 +11,22 @@ import type { PortfolioSnapshot } from "@/components/investments/PortfolioPerfor
 
 const STORAGE_KEY = "portfolio_holdings";
 const SNAPSHOTS_KEY = "portfolio_snapshots";
+const QUOTES_CACHE_KEY = "portfolio_quotes_cache";
 const MAX_SNAPSHOTS = 365;
+const QUOTE_CACHE_TTL_MS = 5 * 60 * 1000;
 const PARTIAL_FALLBACK_WARNING =
   "Some live prices are temporarily unavailable. Portfolio totals are using your saved cost basis where needed.";
 
 // ─── localStorage helpers ────────────────────────────────────────────────────
+
+function safeWrite(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Quota exceeded or storage disabled — fail silently; callers degrade gracefully.
+  }
+}
 
 function loadHoldings(): PortfolioHolding[] {
   if (typeof window === "undefined") return [];
@@ -28,8 +39,7 @@ function loadHoldings(): PortfolioHolding[] {
 }
 
 function saveHoldings(holdings: PortfolioHolding[]): void {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(holdings));
+  safeWrite(STORAGE_KEY, JSON.stringify(holdings));
 }
 
 function loadSnapshots(): PortfolioSnapshot[] {
@@ -59,7 +69,53 @@ function saveSnapshot(snapshot: PortfolioSnapshot): void {
   if (typeof window === "undefined") return;
   const existing = loadSnapshots();
   const updated = upsertSnapshots(existing, snapshot);
-  localStorage.setItem(SNAPSHOTS_KEY, JSON.stringify(updated));
+  safeWrite(SNAPSHOTS_KEY, JSON.stringify(updated));
+}
+
+interface CachedQuotes {
+  timestamp: number;
+  quotes: StockQuote[];
+}
+
+function loadCachedQuotes(): {
+  quotes: Map<string, StockQuote>;
+  fetchedAt: Date;
+} | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(QUOTES_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CachedQuotes;
+    if (
+      !parsed ||
+      typeof parsed.timestamp !== "number" ||
+      !Array.isArray(parsed.quotes)
+    ) {
+      return null;
+    }
+    if (Date.now() - parsed.timestamp > QUOTE_CACHE_TTL_MS) {
+      return null;
+    }
+    const map = new Map<string, StockQuote>();
+    for (const q of parsed.quotes) {
+      if (q && typeof q.symbol === "string") map.set(q.symbol, q);
+    }
+    return { quotes: map, fetchedAt: new Date(parsed.timestamp) };
+  } catch {
+    return null;
+  }
+}
+
+function saveCachedQuotes(quotes: Map<string, StockQuote>): void {
+  const payload: CachedQuotes = {
+    timestamp: Date.now(),
+    quotes: Array.from(quotes.values()),
+  };
+  safeWrite(QUOTES_CACHE_KEY, JSON.stringify(payload));
+}
+
+function symbolKey(holdings: PortfolioHolding[]): string {
+  return Array.from(new Set(holdings.map((h) => h.symbol))).sort().join(",");
 }
 
 // ─── Quote fetching with retry ───────────────────────────────────────────────
@@ -195,12 +251,24 @@ export function useInvestments(): UseInvestmentsReturn {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [snapshots, setSnapshots] = useState<PortfolioSnapshot[]>([]);
   const isMounted = useRef(true);
+  const fetchedSymbolKeyRef = useRef<string>("");
 
-  // Hydrate from localStorage on mount
+  // Hydrate from localStorage on mount — including cached quotes for instant paint
   useEffect(() => {
     isMounted.current = true;
-    setHoldings(loadHoldings());
+    const initial = loadHoldings();
+    setHoldings(initial);
     setSnapshots(loadSnapshots());
+    const cached = loadCachedQuotes();
+    if (cached && cached.quotes.size > 0) {
+      setQuotes(cached.quotes);
+      setLastUpdated(cached.fetchedAt);
+      // Mark this symbol set as already fetched so the symbol-diff effect
+      // below won't immediately refetch if the cache covers current holdings.
+      if (initial.every((h) => cached.quotes.has(h.symbol))) {
+        fetchedSymbolKeyRef.current = symbolKey(initial);
+      }
+    }
     return () => { isMounted.current = false; };
   }, []);
 
@@ -218,6 +286,7 @@ export function useInvestments(): UseInvestmentsReturn {
         );
 
         setQuotes(q);
+        saveCachedQuotes(q);
         if (canPersistSnapshot) {
           setLastUpdated(new Date());
         }
@@ -247,8 +316,13 @@ export function useInvestments(): UseInvestmentsReturn {
     }
   }, []);
 
-  // Fetch quotes whenever holdings change
+  // Fetch quotes only when the *set of symbols* changes — edits to shares/cost
+  // on existing holdings don't require a refetch, since derived values recompute
+  // from the existing quotes map.
   useEffect(() => {
+    const key = symbolKey(holdings);
+    if (key === fetchedSymbolKeyRef.current) return;
+    fetchedSymbolKeyRef.current = key;
     fetchAllQuotes(holdings);
   }, [holdings, fetchAllQuotes]);
 


### PR DESCRIPTION
## Summary

Four targeted fixes to the `/investments` tool, scoped to one PR. Focus: the `public/data/investments/index.json` is 11 days stale today despite the weekday refresh workflow — and users had no way to see that.

- **Freshness banner** on both tabs — shows dataset age, company count, and a "Refresh pending" pill when data is ≥ 7 days old. Server-rendered, no client roundtrip.
- **Workflow reliability** — post-fetch sanity check fails the run if `index.lastUpdated` didn't advance, catching silent Python fetch failures. Auto-creates/updates a GitHub issue on failure, auto-closes on next success.
- **Quote fetch optimization** — `useInvestments` only refetches when the *symbol set* changes (edits to shares/cost no longer hit Finnhub). Quotes persist to `localStorage` with a 5-min TTL so refresh paints instantly. All `localStorage` writes are quota-safe.
- **Dark-mode fixes** — two tooltips (`AllocationChart`, `MetricTooltip`) flipped to white-on-white in dark mode because their background var flipped but `text-white` didn't. Swapped to the `--home-ink`/`--home-paper` pair which flips together.

## Why

The review surfaced two real frictions:
1. **Data could be weeks stale and no one would know.** The weekday cron was silently failing — no alerting, no visible signal on page.
2. **Quote fetching misfired on benign edits.** Updating share count on one holding refetched every Finnhub quote, and a browser refresh threw away fresh data.

Scope was bounded to "top 3–5 high-impact fixes, keep data in-git, automate refresh." Full plan and alternatives considered are in `~/.claude/plans/look-at-how-we-effervescent-sparrow.md`.

## Files

**Modified**
- `.github/workflows/update-investments.yml` — freshness sanity check + failure-notification issues
- `src/app/investments/page.tsx` — fetch index server-side, pass through as props
- `src/app/investments/investments-client.tsx` — render the banner
- `src/hooks/useInvestments.ts` — symbol-diff tracking, quote cache, quota-safe writes
- `src/components/investments/AllocationChart.tsx` — tooltip dark-mode fix
- `src/components/investments/MetricTooltip.tsx` — tooltip dark-mode fix

**New**
- `src/components/investments/InvestmentsFreshnessBanner.tsx` — freshness strip component

## Test plan

- [x] `npm run build` — passes end-to-end, `/investments` renders dynamically
- [x] `npx tsc --noEmit` — clean on all changed files
- [x] `npx jest` on investments suites — 41/41 tests pass (same as `main`; one pre-existing suite-level failure from console.error gating, not caused by this PR)
- [x] Lint on changed files — reduced pre-existing errors on `useInvestments.ts` from 2 → 1
- [ ] **Manually trigger the refresh workflow** via GitHub Actions UI. On success: step summary shows symbol counts, `index.lastUpdated` advances to today's date. On failure: an issue labeled `investments-refresh-failure` is created with the run URL.
- [ ] Load `/investments` — freshness banner visible under the page title on both tabs. If `lastUpdated` is ≥ 7 days, the "Refresh pending" pill appears.
- [ ] DevTools network tab: add a holding (one `/api/investments/quotes` request), then edit its share count (no new request), remove it (one request). Previous behavior: every edit triggered a refetch.
- [ ] Refresh the page while quotes are fresh (< 5 min) — portfolio summary paints immediately without a loading spinner.
- [ ] Toggle OS dark mode. Hover over a slice in the allocation donut and over a `?` icon in the research panels — tooltips remain legible in both themes.

## Notes for review

- The workflow's sanity check exits the run with `process.exit(1)` if `index.lastUpdated` is > 2 hours old after the fetch completed. That threshold accommodates runs that take ~20+ minutes without being brittle.
- The symbol-diff `useEffect` uses a `useRef` rather than adding to the dependency array because the check must compare *previous* vs *current* — a state-based approach would cause double renders.
- The banner defaults to `null` / `0` when server-side index load fails (errors are caught and swallowed in `loadIndexSafely`) so the page never crashes on a missing index.