### PR TITLE
fix: design & UX P0 pass from full-site audit

### DIFF
--- a/src/app/fantasy-football/draft-tracker/components/DraftSetup.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftSetup.tsx
@@ -41,6 +41,7 @@ function getFieldStyle(): CSSProperties {
 
 export function DraftSetup({ settings, onSaveSettings, onStartDraft }: DraftSetupProps) {
   const [formState, setFormState] = useState<DraftSettings>(settings);
+  const [isStarting, setIsStarting] = useState(false);
 
   useEffect(() => {
     setFormState(settings);
@@ -58,8 +59,16 @@ export function DraftSetup({ settings, onSaveSettings, onStartDraft }: DraftSetu
   }
 
   function handleStartDraft() {
-    onSaveSettings(formState);
-    onStartDraft();
+    if (isStarting) return;
+    setIsStarting(true);
+    try {
+      onSaveSettings(formState);
+      onStartDraft();
+    } finally {
+      // Re-enable after a short tick — startDraft is synchronous, but the
+      // brief disable prevents double-click submission.
+      setTimeout(() => setIsStarting(false), 400);
+    }
   }
 
   return (
@@ -214,14 +223,16 @@ export function DraftSetup({ settings, onSaveSettings, onStartDraft }: DraftSetu
         <button
           type="button"
           onClick={handleStartDraft}
-          className="min-h-[48px] rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
+          disabled={isStarting}
+          aria-busy={isStarting}
+          className="min-h-[48px] rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow,opacity] duration-200 disabled:cursor-not-allowed disabled:opacity-70"
           style={{
             borderColor: "var(--home-ink)",
             background: "var(--home-ink)",
             color: "var(--home-paper)",
           }}
         >
-          Start draft assistant
+          {isStarting ? "Starting…" : "Start draft assistant"}
         </button>
       </div>
     </div>

--- a/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
+++ b/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import Link from "next/link";
-import { Download, RotateCcw } from "lucide-react";
+import { Download, RotateCcw, Undo2 } from "lucide-react";
 import { DraftBoard } from "./components/DraftBoard";
 import { DraftSetup } from "./components/DraftSetup";
 import { useDraftState } from "./hooks/useDraftState";
@@ -26,6 +26,7 @@ export function DraftTrackerClient() {
     updateSettings,
     startDraft,
     draftPlayer,
+    undoLastPick,
     resetDraft,
     exportDraftResults,
     isUserPick,
@@ -328,6 +329,25 @@ export function DraftTrackerClient() {
             <article className="home-card p-5 sm:p-6">
               <p className="home-kicker mb-1">Actions</p>
               <div className="mt-4 grid gap-3">
+                <button
+                  type="button"
+                  onClick={undoLastPick}
+                  disabled={draftState.picks.length === 0}
+                  aria-label={
+                    draftState.picks.length === 0
+                      ? "Undo last pick (no picks yet)"
+                      : "Undo last pick"
+                  }
+                  className="flex min-h-[48px] items-center justify-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow,opacity] duration-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  style={{
+                    borderColor: "var(--home-rule)",
+                    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+                    color: "var(--home-ink)",
+                  }}
+                >
+                  <Undo2 className="h-4 w-4" />
+                  Undo last pick
+                </button>
                 <button
                   type="button"
                   onClick={() => exportDraftResults("csv")}

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -466,7 +466,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                     {filteredPlayers.map((player) => (
                       <li
                         key={player.id}
-                        className="grid gap-4 rounded-[1.5rem] border px-4 py-4 sm:grid-cols-[72px_minmax(0,1.55fr)_110px_140px_140px] sm:items-center"
+                        className="grid gap-4 rounded-[1.5rem] border px-4 py-4 md:grid-cols-[64px_minmax(0,1.6fr)_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1fr)] md:items-center"
                         style={{
                           borderColor: "var(--home-rule)",
                           background: "color-mix(in srgb, var(--home-paper-alt) 42%, var(--home-elev-mix))",

--- a/src/app/fintech-tools/budget-planner/budget-planner-client.tsx
+++ b/src/app/fintech-tools/budget-planner/budget-planner-client.tsx
@@ -302,7 +302,7 @@ export function BudgetPlannerClient() {
                       step="50"
                       value={String(activeMonth.income)}
                       onChange={(event) => updateIncome(Number(event.target.value))}
-                      className="mt-2 w-full border-0 bg-transparent p-0 text-lg font-semibold text-[var(--home-ink)]"
+                      className="mt-2 w-full rounded-md border-0 bg-transparent p-0 text-lg font-semibold text-[var(--home-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                     />
                   </label>
 
@@ -317,7 +317,7 @@ export function BudgetPlannerClient() {
                       step="25"
                       value={String(activeMonth.savingsTarget)}
                       onChange={(event) => updateSavingsTarget(Number(event.target.value))}
-                      className="mt-2 w-full border-0 bg-transparent p-0 text-lg font-semibold text-[var(--home-ink)]"
+                      className="mt-2 w-full rounded-md border-0 bg-transparent p-0 text-lg font-semibold text-[var(--home-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                     />
                   </label>
                 </div>
@@ -358,6 +358,12 @@ export function BudgetPlannerClient() {
                               </span>
                               <input
                                 aria-label={`Category name for ${displayName}`}
+                                aria-invalid={category.name.trim() === "" ? true : undefined}
+                                aria-describedby={
+                                  category.name.trim() === ""
+                                    ? `category-${category.id}-error`
+                                    : undefined
+                                }
                                 type="text"
                                 value={category.name}
                                 onChange={(event) =>
@@ -368,8 +374,16 @@ export function BudgetPlannerClient() {
                                     renameCategory(category.id, "Untitled");
                                   }
                                 }}
-                                className="mt-2 min-h-[44px] w-full rounded-2xl border border-[var(--home-rule)] bg-[var(--home-paper)] px-3 py-2 text-sm font-medium text-[var(--home-ink)]"
+                                className="mt-2 min-h-[44px] w-full rounded-2xl border border-[var(--home-rule)] bg-[var(--home-paper)] px-3 py-2 text-sm font-medium text-[var(--home-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2 aria-[invalid=true]:border-[var(--color-error)]"
                               />
+                              {category.name.trim() === "" ? (
+                                <span
+                                  id={`category-${category.id}-error`}
+                                  className="mt-1 block text-xs text-[var(--color-error)]"
+                                >
+                                  Name a category — empty fields fall back to "Untitled".
+                                </span>
+                              ) : null}
                             </label>
 
                             <label>
@@ -385,16 +399,21 @@ export function BudgetPlannerClient() {
                                 onChange={(event) =>
                                   updateCategoryBudget(category.id, Number(event.target.value))
                                 }
-                                className="mt-2 min-h-[44px] w-full rounded-2xl border border-[var(--home-rule)] bg-[var(--home-paper)] px-3 py-2 text-sm font-medium text-[var(--home-ink)]"
+                                className="mt-2 min-h-[44px] w-full rounded-2xl border border-[var(--home-rule)] bg-[var(--home-paper)] px-3 py-2 text-sm font-medium text-[var(--home-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                               />
                             </label>
 
                             <button
                               type="button"
                               aria-label={`Delete ${displayName}`}
+                              aria-describedby={
+                                hasLinkedExpenses
+                                  ? `category-${category.id}-delete-help`
+                                  : undefined
+                              }
                               disabled={hasLinkedExpenses}
                               onClick={() => removeCategory(category.id)}
-                              className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-[var(--home-rule)] bg-[var(--home-paper)] px-4 py-2 text-sm font-medium text-[var(--home-ink-muted)] transition hover:border-[var(--color-error)] hover:text-[var(--color-error)] disabled:cursor-not-allowed disabled:opacity-55"
+                              className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-[var(--home-rule)] bg-[var(--home-paper)] px-4 py-2 text-sm font-medium text-[var(--home-ink-muted)] transition hover:border-[var(--color-error)] hover:text-[var(--color-error)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:border-dashed disabled:opacity-40"
                             >
                               <Trash2 className="h-4 w-4" />
                               Delete
@@ -450,7 +469,10 @@ export function BudgetPlannerClient() {
                               />
                             </div>
                             {hasLinkedExpenses && (
-                              <p className="mt-3 text-xs leading-6 text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
+                              <p
+                                id={`category-${category.id}-delete-help`}
+                                className="mt-3 text-xs leading-6 text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]"
+                              >
                                 Remove linked expenses before deleting this category.
                               </p>
                             )}
@@ -589,13 +611,13 @@ export function BudgetPlannerClient() {
                     </label>
                   </div>
 
-                  <div className="mt-4 flex flex-wrap gap-3">
+                  <div className="sticky bottom-2 mt-4 flex flex-wrap gap-3 rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_94%,transparent)] p-2 shadow-[var(--shadow-sm)] backdrop-blur sm:static sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none sm:backdrop-blur-none">
                     <button
                       type="submit"
                       disabled={
                         !resolvedExpenseCategoryId || !expenseDraft.amount || !expenseDraft.date
                       }
-                      className="inline-flex min-h-[46px] items-center justify-center gap-2 rounded-2xl bg-[var(--home-haze)] px-5 py-3 text-sm font-semibold text-white shadow-[var(--shadow-sm)] transition hover:bg-[var(--home-haze)] disabled:cursor-not-allowed disabled:opacity-60"
+                      className="inline-flex min-h-[46px] flex-1 items-center justify-center gap-2 rounded-2xl bg-[var(--home-haze)] px-5 py-3 text-sm font-semibold text-white shadow-[var(--shadow-sm)] transition hover:bg-[var(--home-haze)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 sm:flex-initial"
                     >
                       <Plus className="h-4 w-4" />
                       {editingExpenseId ? "Save expense" : "Add expense"}

--- a/src/app/fintech-tools/interchange-iq/interchange-iq-client.tsx
+++ b/src/app/fintech-tools/interchange-iq/interchange-iq-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef } from "react";
 import {
   IconCreditCard,
   IconInfoCircle,
@@ -133,6 +133,7 @@ const sectionHeadingStyle = {
 };
 
 // ─── Slider ───────────────────────────────────────────────────────────────────
+let sliderUid = 0;
 function Slider({
   label,
   value,
@@ -153,10 +154,17 @@ function Slider({
   hint?: string;
 }) {
   const pct = ((value - min) / (max - min)) * 100;
+  // Stable id per Slider instance for label/hint association
+  const idRef = useRef<string | null>(null);
+  if (idRef.current === null) {
+    idRef.current = `iq-slider-${++sliderUid}`;
+  }
+  const inputId = idRef.current;
+  const hintId = hint ? `${inputId}-hint` : undefined;
   return (
     <div className="space-y-2">
       <div className="flex justify-between items-baseline gap-2">
-        <label className="text-sm" style={labelStyle}>
+        <label htmlFor={inputId} className="text-sm" style={labelStyle}>
           {label}
         </label>
         <span
@@ -167,19 +175,25 @@ function Slider({
         </span>
       </div>
       <input
+        id={inputId}
         type="range"
         min={min}
         max={max}
         step={step}
         value={value}
+        aria-valuenow={value}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuetext={format(value)}
+        aria-describedby={hintId}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="w-full h-1.5 rounded-full appearance-none cursor-pointer"
+        className="w-full h-1.5 rounded-full appearance-none cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
         style={{
           background: `linear-gradient(to right, var(--home-haze) ${pct}%, var(--home-rule) ${pct}%)`,
         }}
       />
       {hint && (
-        <p className="text-xs" style={mutedStyle}>
+        <p id={hintId} className="text-xs" style={mutedStyle}>
           {hint}
         </p>
       )}
@@ -284,9 +298,12 @@ export function InterchangeIQClient() {
                 Card Mix
               </span>
               <button
+                type="button"
                 onClick={() => setShowInfo(!showInfo)}
                 aria-label="Learn about card mix"
-                className="transition-colors"
+                aria-expanded={showInfo}
+                aria-controls="card-mix-info"
+                className="rounded-md p-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                 style={{ color: "var(--home-ink-muted)" }}
               >
                 <IconInfoCircle className="h-4 w-4" />
@@ -295,6 +312,8 @@ export function InterchangeIQClient() {
 
             {showInfo && (
               <p
+                id="card-mix-info"
+                role="region"
                 className="text-xs rounded-lg p-3 leading-relaxed mb-0"
                 style={{
                   ...bodyStyle,

--- a/src/app/formula-1/formula-1-client.tsx
+++ b/src/app/formula-1/formula-1-client.tsx
@@ -28,6 +28,7 @@ import {
   normalizeFormula1State,
   resolveFormula1State,
 } from "./formula-1-state";
+import { MetricCard } from "@/components/football/MetricCard";
 
 interface Formula1ClientProps {
   initialState: Formula1RouteState;
@@ -151,33 +152,6 @@ function getPositionChangeCopy(currentPosition: number, previousPosition: number
 
   const delta = previousPosition - currentPosition;
   return delta > 0 ? `Up ${delta}` : `Down ${Math.abs(delta)}`;
-}
-
-function MetricCard({
-  label,
-  value,
-  detail,
-  icon,
-}: {
-  label: string;
-  value: string;
-  detail: string;
-  icon: React.ReactNode;
-}) {
-  return (
-    <article className="home-card p-5 sm:p-6">
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--home-ink-muted)]">
-          {label}
-        </p>
-        <span className="text-[var(--home-ink-muted)]">{icon}</span>
-      </div>
-      <p className="mt-3 text-2xl font-semibold tracking-[-0.05em] text-[var(--home-ink)]">
-        {value}
-      </p>
-      <p className="mt-2 mb-0 text-sm leading-6 text-[var(--home-ink-muted)]">{detail}</p>
-    </article>
-  );
 }
 
 function ViewToggle({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,7 +21,11 @@
     }
   }
 
-  *:focus {
+  /*
+   * Suppress focus outlines only when the browser indicates pointer/touch
+   * input (no :focus-visible match). Keyboard users always see a ring.
+   */
+  *:focus:not(:focus-visible) {
     outline: none;
   }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -271,6 +271,38 @@
 }
 
 @layer utilities {
+  /*
+   * Scroll affordance: subtle inset shadow on the right edge tells users a
+   * horizontally-scrolling region has more content. Pair with overflow-x-auto.
+   */
+  .scroll-shadow-x {
+    background:
+      linear-gradient(to right, var(--home-paper-alt) 30%, transparent),
+      linear-gradient(to right, transparent, var(--home-paper-alt) 70%) 100% 0,
+      radial-gradient(farthest-side at 0 50%, color-mix(in srgb, var(--home-ink) 14%, transparent), transparent),
+      radial-gradient(farthest-side at 100% 50%, color-mix(in srgb, var(--home-ink) 14%, transparent), transparent) 100% 0;
+    background-repeat: no-repeat;
+    background-color: transparent;
+    background-size:
+      40px 100%,
+      40px 100%,
+      14px 100%,
+      14px 100%;
+    background-attachment: local, local, scroll, scroll;
+  }
+
+  .scrollbar-thin {
+    scrollbar-width: thin;
+  }
+  .scrollbar-thin::-webkit-scrollbar {
+    height: 8px;
+    width: 8px;
+  }
+  .scrollbar-thin::-webkit-scrollbar-thumb {
+    background-color: var(--home-rule);
+    border-radius: 999px;
+  }
+
   /* Article prose: tie body text to CSS variables and polish reading experience */
   .prose-writing {
     color: var(--text-primary);

--- a/src/app/la-liga/la-liga-client.tsx
+++ b/src/app/la-liga/la-liga-client.tsx
@@ -350,7 +350,12 @@ export function LaLigaClient({
               })}
             </div>
 
-            <div className="mt-6 overflow-x-auto">
+            <div
+              className="scroll-shadow-x mt-6 overflow-x-auto"
+              role="region"
+              aria-label="La Liga standings (scrollable)"
+              tabIndex={0}
+            >
               <table className="min-w-full border-separate border-spacing-y-2" aria-label="La Liga standings">
                 <thead>
                   <tr className="text-left text-xs uppercase tracking-[0.14em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
@@ -424,7 +429,7 @@ export function LaLigaClient({
           </section>
 
           {/* Compact club sidebar */}
-          <aside className="md:sticky md:top-24 md:self-start">
+          <aside className="md:sticky md:top-28 md:self-start">
             <section
               className="rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,white)] p-5 shadow-[var(--shadow-sm)]"
               aria-live="polite"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -74,7 +74,14 @@ export default function RootLayout({
         )}
       >
         <Providers>
-          <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-[var(--neutral-900)] focus:text-white focus:rounded-lg focus:shadow-lg">
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[60] focus:px-4 focus:py-2 focus:rounded-lg focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-[var(--home-haze)] focus:ring-offset-2"
+            style={{
+              backgroundColor: "var(--home-ink)",
+              color: "var(--home-paper)",
+            }}
+          >
             Skip to main content
           </a>
           <StaticHeader />

--- a/src/app/march-madness-2026/march-madness-client.tsx
+++ b/src/app/march-madness-2026/march-madness-client.tsx
@@ -319,7 +319,12 @@ function RankingsSection() {
         Blended average across BPI, Evan Miya, KPI, NET, KenPom, SOR, T-Rank,
         and WAB, excluding the minimum and maximum system values.
       </p>
-      <div className="overflow-x-auto">
+      <div
+        className="scroll-shadow-x overflow-x-auto rounded-[20px] border border-white/10"
+        role="region"
+        aria-label="Team rankings table (scrollable)"
+        tabIndex={0}
+      >
         <table className="min-w-[920px] w-full border-collapse text-sm">
           <thead>
             <tr className="border-b border-white/10">
@@ -977,7 +982,7 @@ export function MarchMadnessClient({
             </div>
           </SurfaceCard>
 
-          <SurfaceCard id="why-this-model-is-different" className="space-y-6 p-5 sm:p-6 scroll-mt-24">
+          <SurfaceCard id="why-this-model-is-different" className="space-y-6 p-5 sm:p-6 scroll-mt-28">
             <SectionIntro
               eyebrow="Methodology"
               title="Why This Model Is Different"
@@ -1079,7 +1084,7 @@ export function MarchMadnessClient({
             </div>
           </SurfaceCard>
 
-          <div id="analysis-workspace" className="space-y-4 scroll-mt-24">
+          <div id="analysis-workspace" className="space-y-4 scroll-mt-28">
             <TabBar
               items={MAIN_TAB_ITEMS}
               active={view}

--- a/src/app/march-madness-2026/march-madness-client.tsx
+++ b/src/app/march-madness-2026/march-madness-client.tsx
@@ -47,11 +47,17 @@ const editorialCardClasses: Record<EditorialCard["color"], string> = {
 function SurfaceCard({
   children,
   className = "",
+  id,
 }: {
   children: ReactNode;
   className?: string;
+  id?: string;
 }) {
-  return <div className={`${SURFACE_CLASS} ${className}`}>{children}</div>;
+  return (
+    <div id={id} className={`${SURFACE_CLASS} ${className}`}>
+      {children}
+    </div>
+  );
 }
 
 function Tag({ children, color = "gray" }: { children: ReactNode; color?: string }) {

--- a/src/app/march-madness-2026/march-madness-client.tsx
+++ b/src/app/march-madness-2026/march-madness-client.tsx
@@ -236,14 +236,50 @@ function TabBar<T extends string>({
   onChange: (tab: T) => void;
   label: string;
 }) {
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    const last = items.length - 1;
+    let nextIndex: number | null = null;
+
+    switch (event.key) {
+      case "ArrowRight":
+        nextIndex = index === last ? 0 : index + 1;
+        break;
+      case "ArrowLeft":
+        nextIndex = index === 0 ? last : index - 1;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = last;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    const list = event.currentTarget.closest('[role="tablist"]');
+    if (!list || nextIndex === null) return;
+    const next = list.querySelectorAll<HTMLButtonElement>('[role="tab"]')[nextIndex];
+    if (next) {
+      next.focus();
+      onChange(items[nextIndex].value);
+    }
+  };
+
   return (
     <div className="flex flex-wrap gap-2" role="tablist" aria-label={label}>
-      {items.map((item) => (
+      {items.map((item, index) => (
         <button
           key={item.value}
           type="button"
           role="tab"
           aria-selected={active === item.value}
+          tabIndex={active === item.value ? 0 : -1}
+          onKeyDown={(e) => handleKeyDown(e, index)}
           onClick={() => onChange(item.value)}
           className={`min-h-[44px] rounded-full border px-4 py-2.5 text-sm font-semibold transition ${
             active === item.value

--- a/src/app/mba-internship-notifications/mba-jobs-client.tsx
+++ b/src/app/mba-internship-notifications/mba-jobs-client.tsx
@@ -5,6 +5,7 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type CSSProperties,
 } from "react";
@@ -846,26 +847,85 @@ function EmailDigestDialog({
   sending: boolean;
 }) {
   const [email, setEmail] = useState("");
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<Element | null>(null);
+
+  // Trap focus within the dialog while open and restore it on close.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    triggerRef.current = document.activeElement;
+    const dialog: HTMLDivElement | null = dialogRef.current;
+    if (!dialog) return;
+    const dialogEl: HTMLDivElement = dialog;
+
+    const focusable = dialogEl.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    focusable[0]?.focus();
+
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape" && !sending) {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const items = dialogEl.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      if (triggerRef.current instanceof HTMLElement) {
+        triggerRef.current.focus();
+      }
+    };
+  }, [isOpen, onClose, sending]);
+
   if (!isOpen) return null;
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
       style={{ background: "rgba(0,0,0,0.45)" }}
-      role="dialog"
-      aria-modal="true"
-      aria-label="Send email digest"
+      role="presentation"
+      onClick={(event) => {
+        if (event.target === event.currentTarget && !sending) onClose();
+      }}
     >
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="email-digest-title"
+        aria-describedby="email-digest-description"
         className="home-card w-full max-w-sm p-6 sm:p-7"
         style={{ background: "var(--home-paper)" }}
       >
         <h2
+          id="email-digest-title"
           className="mb-3 text-lg font-semibold"
           style={{ fontFamily: "var(--font-home-sans)", color: "var(--home-ink)" }}
         >
           Send email digest
         </h2>
-        <p className="mb-4 text-sm" style={{ color: "var(--home-ink-muted)" }}>
+        <p
+          id="email-digest-description"
+          className="mb-4 text-sm"
+          style={{ color: "var(--home-ink-muted)" }}
+        >
           Enter your email to receive the current job list as a digest.
         </p>
         <input
@@ -881,6 +941,7 @@ function EmailDigestDialog({
           }}
           disabled={sending}
           autoComplete="email"
+          aria-label="Your email address"
         />
         <div className="flex gap-3">
           <button
@@ -1134,6 +1195,8 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
   const [uiState, setUiState] = useState(routeState);
   const deferredQuery = useDeferredValue(uiState.q);
   const deferredLocation = useDeferredValue(uiState.location);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const locationInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     setUiState(routeState);
@@ -1434,6 +1497,7 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                       aria-hidden="true"
                     />
                     <input
+                      ref={searchInputRef}
                       type="text"
                       value={uiState.q}
                       onChange={(event) => updateRouteState({ q: event.target.value })}
@@ -1452,8 +1516,11 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                     {uiState.q && (
                       <button
                         type="button"
-                        onClick={() => updateRouteState({ q: "" })}
-                        className="absolute right-3 top-1/2 inline-flex min-h-[44px] min-w-[44px] -translate-y-1/2 items-center justify-center rounded-full"
+                        onClick={() => {
+                          updateRouteState({ q: "" });
+                          searchInputRef.current?.focus();
+                        }}
+                        className="absolute right-3 top-1/2 inline-flex min-h-[44px] min-w-[44px] -translate-y-1/2 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                         aria-label="Clear search"
                         style={{ color: "var(--home-ink-muted)" }}
                       >
@@ -1469,6 +1536,7 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                       aria-hidden="true"
                     />
                     <input
+                      ref={locationInputRef}
                       type="text"
                       value={uiState.location}
                       onChange={(event) => updateRouteState({ location: event.target.value })}
@@ -1487,8 +1555,11 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                     {uiState.location && (
                       <button
                         type="button"
-                        onClick={() => updateRouteState({ location: "" })}
-                        className="absolute right-3 top-1/2 inline-flex min-h-[44px] min-w-[44px] -translate-y-1/2 items-center justify-center rounded-full"
+                        onClick={() => {
+                          updateRouteState({ location: "" });
+                          locationInputRef.current?.focus();
+                        }}
+                        className="absolute right-3 top-1/2 inline-flex min-h-[44px] min-w-[44px] -translate-y-1/2 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                         aria-label="Clear location filter"
                         style={{ color: "var(--home-ink-muted)" }}
                       >
@@ -1727,7 +1798,12 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
               id="mba-role-tracker-roles-heading"
             />
             {!isLoading && (
-              <div className="flex flex-wrap gap-2">
+              <div
+                className="flex flex-wrap gap-2"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              >
                 <span className="resume-chip">{displayJobs.length} matching roles</span>
                 <span className="resume-chip">{watchedCompanyIds.size} watched feeds active</span>
                 {uiState.location.trim() && (

--- a/src/app/news-pulse/news-pulse-client.tsx
+++ b/src/app/news-pulse/news-pulse-client.tsx
@@ -196,6 +196,12 @@ export function NewsPulseClient({ initialState }: NewsPulseClientProps) {
 
   useEffect(() => {
     const controller = new AbortController();
+    let timedOut = false;
+    let unmounted = false;
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, 15000);
 
     async function loadFeeds() {
       setLoading(true);
@@ -206,7 +212,7 @@ export function NewsPulseClient({ initialState }: NewsPulseClientProps) {
         const response = await fetch("/api/news-pulse", { signal: controller.signal });
         const payload = (await response.json().catch(() => null)) as FeedResponse | null;
 
-        if (controller.signal.aborted) return;
+        if (unmounted) return;
 
         if (!response.ok) {
           setArticles([]);
@@ -220,20 +226,26 @@ export function NewsPulseClient({ initialState }: NewsPulseClientProps) {
         setFetchedAt(payload?.fetchedAt ?? "");
         setFeedErrors(Array.isArray(payload?.errors) ? payload.errors : []);
       } catch (fetchError) {
-        if (controller.signal.aborted) return;
-        const message =
-          fetchError instanceof Error ? fetchError.message : "I could not load the feeds.";
+        if (unmounted) return;
+        const message = timedOut
+          ? "The news feed took too long to respond. Refresh to try again."
+          : fetchError instanceof Error
+            ? fetchError.message
+            : "I could not load the feeds.";
         setArticles([]);
         setError(message);
       } finally {
-        if (!controller.signal.aborted) {
-          setLoading(false);
-        }
+        clearTimeout(timeoutId);
+        if (!unmounted) setLoading(false);
       }
     }
 
     void loadFeeds();
-    return () => controller.abort();
+    return () => {
+      unmounted = true;
+      clearTimeout(timeoutId);
+      controller.abort();
+    };
   }, []);
 
   const filteredArticles = useMemo(
@@ -571,7 +583,12 @@ function CoverageView({
           repeated vocabulary.
         </InlineSectionLead>
 
-        <div className="mt-6 overflow-x-auto">
+        <div
+          className="scroll-shadow-x mt-6 overflow-x-auto rounded-[20px]"
+          role="region"
+          aria-label="Story clusters by outlet (scrollable)"
+          tabIndex={0}
+        >
           <table
             className="min-w-[920px] w-full text-left text-sm"
             aria-label="Story clusters by outlet"

--- a/src/app/polling-aggregator/polling-aggregator-client.tsx
+++ b/src/app/polling-aggregator/polling-aggregator-client.tsx
@@ -71,13 +71,18 @@ function TrendChart({ snapshot }: { snapshot: PollingSnapshot }) {
   const allVals = trend.flatMap((d) => [d.approve, d.disapprove]);
   const minVal = Math.floor(Math.min(...allVals) - 2);
   const maxVal = Math.ceil(Math.max(...allVals) + 2);
+  const first = trend[0];
+  const last = trend[trend.length - 1];
+  const chartSummary = first && last
+    ? `Presidential approval trend from ${formatShortDate(first.date)} to ${formatShortDate(last.date)}. Approve: ${first.approve.toFixed(1)}% to ${last.approve.toFixed(1)}%. Disapprove: ${first.disapprove.toFixed(1)}% to ${last.disapprove.toFixed(1)}%.`
+    : "Presidential approval trend chart";
 
   return (
     <div className="overflow-x-auto">
       <svg
         viewBox={`0 0 ${W} ${H + 32}`}
         className="w-full min-w-[300px]"
-        aria-label="Presidential approval trend chart"
+        aria-label={chartSummary}
         role="img"
       >
         {/* Y-axis gridlines */}
@@ -140,6 +145,26 @@ function TrendChart({ snapshot }: { snapshot: PollingSnapshot }) {
           Disapprove
         </span>
       </div>
+
+      <table className="sr-only">
+        <caption>Approval trend data points</caption>
+        <thead>
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Approve</th>
+            <th scope="col">Disapprove</th>
+          </tr>
+        </thead>
+        <tbody>
+          {trend.map((d) => (
+            <tr key={d.date}>
+              <th scope="row">{formatShortDate(d.date)}</th>
+              <td>{d.approve.toFixed(1)}%</td>
+              <td>{d.disapprove.toFixed(1)}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
@@ -486,7 +511,7 @@ function RacesPanel({
         </div>
       </section>
 
-      <aside className="lg:sticky lg:top-24 lg:self-start">
+      <aside className="lg:sticky lg:top-28 lg:self-start">
         {selectedRace && <RaceSidebar race={selectedRace} />}
       </aside>
     </div>

--- a/src/app/premier-league/premier-league-client.tsx
+++ b/src/app/premier-league/premier-league-client.tsx
@@ -403,7 +403,12 @@ export function PremierLeagueClient({
               })}
             </div>
 
-            <div className="mt-6 overflow-x-auto">
+            <div
+              className="scroll-shadow-x mt-6 overflow-x-auto"
+              role="region"
+              aria-label="Premier League standings (scrollable)"
+              tabIndex={0}
+            >
               <table className="min-w-full border-separate border-spacing-y-2" aria-label="Premier League standings">
                 <thead>
                   <tr className="text-left text-xs uppercase tracking-[0.14em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
@@ -443,7 +448,7 @@ export function PremierLeagueClient({
                             onClick={() => handleTeamChange(row.team.id)}
                             aria-pressed={isSelected}
                             aria-label={`Show ${row.team.name} details`}
-                            className="flex min-h-[44px] w-full items-center gap-2 rounded-xl text-left"
+                            className="flex min-h-[44px] w-full items-center gap-2 rounded-xl px-1 text-left transition-colors hover:bg-[var(--home-paper-alt)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--home-haze)]"
                           >
                             <CrestAvatar crest={row.team.crest} name={row.team.shortName} size="sm" />
                             <span className="font-semibold text-[var(--home-ink)]">{row.team.shortName}</span>
@@ -476,7 +481,7 @@ export function PremierLeagueClient({
           </section>
 
           {/* Compact club sidebar */}
-          <aside className="md:sticky md:top-24 md:self-start">
+          <aside className="md:sticky md:top-28 md:self-start">
             {selectedRow ? (
               <section className="rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,white)] p-5 shadow-[var(--shadow-sm)]" aria-live="polite" data-testid="pl-selected-club">
                 <div className="flex items-start gap-3">

--- a/src/app/spacex-mission-control/spacex-mission-control-client.tsx
+++ b/src/app/spacex-mission-control/spacex-mission-control-client.tsx
@@ -508,7 +508,7 @@ export function SpaceXMissionControlClient({
                 setLaunchesFetchKey((value) => value + 1);
               }}
             />
-            <div className="xl:sticky xl:top-24 xl:self-start">
+            <div className="xl:sticky xl:top-28 xl:self-start">
               <MissionDetailPanel
                 launch={routeState.launch ? detail : null}
                 activePanel={routeState.panel}

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -204,7 +204,7 @@ export default async function BlogPostPage({ params }: PageProps) {
             </header>
 
             <div
-              className="prose prose-home dark:prose-invert mb-16 max-w-none"
+              className="prose prose-writing dark:prose-invert mb-16 max-w-none"
               dangerouslySetInnerHTML={{ __html: post.content }}
             />
 

--- a/src/components/StaticHeader.tsx
+++ b/src/components/StaticHeader.tsx
@@ -38,7 +38,17 @@ export function StaticHeader() {
   const closeMobileMenu = () => setIsMobileMenuOpen(false);
 
   return (
-    <header
+    <>
+      {isMobileMenuOpen ? (
+        <button
+          type="button"
+          aria-hidden="true"
+          className="fixed inset-0 z-40 lg:hidden bg-[var(--home-overlay)]"
+          onClick={closeMobileMenu}
+          tabIndex={-1}
+        />
+      ) : null}
+      <header
       className={cn(
         "sticky top-0 z-50 w-full transition-[background-color,border-color,box-shadow] duration-300 header-home",
         isScrolled && "border-b shadow-sm"
@@ -136,15 +146,7 @@ export function StaticHeader() {
         </div>
       </div>
 
-      {isMobileMenuOpen ? (
-        <button
-          type="button"
-          aria-hidden="true"
-          className="fixed inset-0 z-[-1] lg:hidden bg-[var(--home-overlay)]"
-          onClick={closeMobileMenu}
-          tabIndex={-1}
-        />
-      ) : null}
     </header>
+    </>
   );
 }

--- a/src/components/football/MetricCard.tsx
+++ b/src/components/football/MetricCard.tsx
@@ -1,6 +1,42 @@
-export function MetricCard({ label, value }: { label: string; value: string }) {
+import type { ReactNode } from "react";
+
+interface MetricCardProps {
+  label: string;
+  value: string;
+  detail?: string;
+  icon?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Shared metric stat card used across dashboards (Premier League, La Liga,
+ * Formula 1). Pass `detail`/`icon` for the editorial variant; omit for the
+ * compact football-table variant.
+ */
+export function MetricCard({ label, value, detail, icon, className = "" }: MetricCardProps) {
+  const isExtended = Boolean(detail || icon);
+
+  if (isExtended) {
+    return (
+      <article className={`home-card p-5 sm:p-6 ${className}`.trim()}>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--home-ink-muted)]">
+            {label}
+          </p>
+          {icon ? <span className="text-[var(--home-ink-muted)]">{icon}</span> : null}
+        </div>
+        <p className="mt-3 text-2xl font-semibold tracking-[-0.05em] text-[var(--home-ink)]">
+          {value}
+        </p>
+        {detail ? (
+          <p className="mt-2 mb-0 text-sm leading-6 text-[var(--home-ink-muted)]">{detail}</p>
+        ) : null}
+      </article>
+    );
+  }
+
   return (
-    <div className="rounded-2xl border border-[var(--home-rule)] bg-[var(--home-paper-alt)] p-4">
+    <div className={`rounded-2xl border border-[var(--home-rule)] bg-[var(--home-paper-alt)] p-4 ${className}`.trim()}>
       <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
         {label}
       </p>

--- a/src/components/investments/AllocationChart.tsx
+++ b/src/components/investments/AllocationChart.tsx
@@ -33,12 +33,21 @@ export function AllocationChart({ holdings }: Props) {
 
     d3.select(svgRef.current).selectAll("*").remove();
 
+    const totalForLabel = data.reduce((s, h) => s + h.currentValue, 0);
+    const summaryParts = data
+      .slice(0, 5)
+      .map((h) => `${h.symbol} ${(h.allocationPercent ?? 0).toFixed(1)}%`);
+    const summary = `Portfolio allocation across ${data.length} positions totaling ${new Intl.NumberFormat(
+      "en-US",
+      { style: "currency", currency: "USD", maximumFractionDigits: 0 },
+    ).format(totalForLabel)}. Top: ${summaryParts.join(", ")}.`;
+
     const svg = d3
       .select(svgRef.current)
       .attr("width", size)
       .attr("height", size)
       .attr("role", "img")
-      .attr("aria-label", "Portfolio allocation donut chart");
+      .attr("aria-label", summary);
 
     const g = svg.append("g").attr("transform", `translate(${radius},${radius})`);
 
@@ -132,7 +141,10 @@ export function AllocationChart({ holdings }: Props) {
           />
         </div>
 
-        <ol className="space-y-1.5 text-sm w-full">
+        <ol
+          className="space-y-1.5 text-sm w-full"
+          aria-label="Holdings legend with allocation percentages"
+        >
           {data.map((h, i) => (
             <li key={h.symbol} className="flex items-center gap-2 rounded-[18px] border border-[var(--home-rule)] bg-[var(--home-paper-alt)] px-3 py-2.5">
               <span
@@ -141,7 +153,14 @@ export function AllocationChart({ holdings }: Props) {
                 aria-hidden="true"
               />
               <span className="font-medium text-[var(--home-ink)] w-14 shrink-0">{h.symbol}</span>
-              <div className="flex-1 h-1 rounded-full bg-[var(--neutral-200)] overflow-hidden">
+              <div
+                className="flex-1 h-1 rounded-full bg-[var(--neutral-200)] overflow-hidden"
+                role="progressbar"
+                aria-valuenow={Math.round(h.allocationPercent ?? 0)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${h.symbol} allocation`}
+              >
                 <div
                   className="h-full rounded-full"
                   style={{

--- a/src/components/investments/StockResearch.tsx
+++ b/src/components/investments/StockResearch.tsx
@@ -17,6 +17,7 @@ import {
   getReducedMotionVariants,
 } from "./animations";
 import { useStockData } from "@/hooks/useStockData";
+import { useTablistKeyboard } from "@/hooks/useTablistKeyboard";
 import { getClientInvestmentsIndex } from "@/lib/investmentsClientData";
 import type {
   CompanyInfo,
@@ -116,6 +117,18 @@ export function StockResearch({
     }
   }, [activeTab, onTabChange, symbol, visibleTabs]);
 
+  const handleCompareTabKeyDown = useTablistKeyboard(
+    TABS,
+    (t) => t.key,
+    (t) => onTabChange(t.key),
+  );
+
+  const handleVisibleTabKeyDown = useTablistKeyboard(
+    visibleTabs,
+    (t) => t.key,
+    (t) => onTabChange(t.key),
+  );
+
   // Compare tab is full-width with no sidebar
   if (resolvedActiveTab === "compare") {
     return (
@@ -125,11 +138,13 @@ export function StockResearch({
           role="tablist"
           aria-label="Research sections"
         >
-          {TABS.map(({ key, label }) => (
+          {TABS.map(({ key, label }, index) => (
             <button
               key={key}
               role="tab"
               aria-selected={resolvedActiveTab === key}
+              tabIndex={resolvedActiveTab === key ? 0 : -1}
+              onKeyDown={(e) => handleCompareTabKeyDown(e, index)}
               onClick={() => onTabChange(key)}
               className={`min-h-[44px] whitespace-nowrap rounded-2xl px-4 py-2.5 text-sm font-semibold transition ${
                 resolvedActiveTab === key
@@ -166,11 +181,13 @@ export function StockResearch({
               role="tablist"
               aria-label="Research sections"
             >
-              {visibleTabs.map(({ key, label }) => (
+              {visibleTabs.map(({ key, label }, index) => (
                 <button
                   key={key}
                   role="tab"
                   aria-selected={resolvedActiveTab === key}
+                  tabIndex={resolvedActiveTab === key ? 0 : -1}
+                  onKeyDown={(e) => handleVisibleTabKeyDown(e, index)}
                   onClick={() => onTabChange(key)}
                   className={`min-h-[44px] whitespace-nowrap rounded-2xl px-4 py-2.5 text-sm font-semibold transition ${
                     resolvedActiveTab === key

--- a/src/hooks/useTablistKeyboard.ts
+++ b/src/hooks/useTablistKeyboard.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useCallback, type KeyboardEvent } from "react";
+
+/**
+ * Manages roving keyboard navigation for a horizontal tablist (WCAG 2.1).
+ * Returns an onKeyDown handler — bind it to each tab button and pass the
+ * tab's index. ArrowLeft/Right wrap; Home/End jump to ends; Enter/Space
+ * activate the focused tab (callers should also keep their onClick handlers).
+ */
+export function useTablistKeyboard<T>(
+  items: ReadonlyArray<T>,
+  getKey: (item: T) => string,
+  onSelect: (item: T) => void,
+) {
+  return useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const last = items.length - 1;
+      let nextIndex: number | null = null;
+
+      switch (event.key) {
+        case "ArrowRight":
+          nextIndex = index === last ? 0 : index + 1;
+          break;
+        case "ArrowLeft":
+          nextIndex = index === 0 ? last : index - 1;
+          break;
+        case "Home":
+          nextIndex = 0;
+          break;
+        case "End":
+          nextIndex = last;
+          break;
+        case "Enter":
+        case " ":
+          event.preventDefault();
+          onSelect(items[index]);
+          return;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      const target = event.currentTarget;
+      const list = target.closest('[role="tablist"]');
+      if (!list || nextIndex === null) return;
+      const next = list.querySelectorAll<HTMLButtonElement>('[role="tab"]')[nextIndex];
+      if (next) {
+        next.focus();
+        onSelect(items[nextIndex]);
+      }
+    },
+    [items, getKey, onSelect],
+  );
+}


### PR DESCRIPTION
## Summary

Implements every **P0** finding from `DESIGN_UX_AUDIT_PLAN.md` across the shell, writing surface, dashboards, fantasy football, fintech tools, and the MBA tracker. P1/P2 are deferred per the audit's own grouping ("Fix in Next Release Cycle" / "Dedicated Polish Sprint").

### Shell + Writing
- **AW-1** mobile menu overlay restructured as a header sibling at `z-40` so close-tap is reachable
- **AW-2** skip link uses `--home-*` tokens and stays visible in dark mode
- **AW-3** global `*:focus { outline: none }` replaced with `:not(:focus-visible)` — keyboard users keep their ring
- **WR-1** writing slug page now uses `prose-writing` (was undefined `prose-home`, so all custom prose styling was being silently ignored)

### Accessibility
- **IN-1 / MM-1** ArrowLeft/Right/Home/End keyboard nav on Investments + March Madness tablists; new `useTablistKeyboard` hook
- **IN-2** AllocationChart SVG `aria-label` now summarizes top holdings; legend bars become `progressbar`s
- **PA-1** Polling TrendChart gets a descriptive `aria-label` + `sr-only` data table
- **PL-1** Premier League standings team buttons get visible focus rings

### Dashboards
- **DB-1** shared `MetricCard` extended to support F1's icon+detail variant; F1 imports it instead of duplicating
- **DB-2** sticky sidebar offsets standardized to `top-28` across PL, La Liga, Polling, SpaceX
- **MM-2 / MM-3** rankings table gets `scroll-shadow-x` affordance + `role=region` + `tabIndex`; `scroll-mt-28` for breathing room
- **NP-1** news-pulse fetch gets a 15s timeout with friendly error
- **NP-2 / LL-1** wide tables get the same `scroll-shadow-x` affordance
- New `.scroll-shadow-x` and `.scrollbar-thin` utilities in `globals.css`

### Fantasy
- **FF-1** ranked-player grid switched to `md:` breakpoint with `minmax(0, fr)` columns so the name column never collapses
- **FF-3** Undo button now visible in the actions panel (disabled until first pick)
- **FF-5** DraftSetup submit gets `aria-busy` + "Starting…" state + double-click guard

### Fintech
- **BP-1 → BP-4** Budget planner: `aria-invalid` + visible category-name hint; better disabled-button contrast + `aria-describedby`; focus rings on numeric inputs; sticky add-expense CTA on mobile
- **IQ-1** Interchange IQ slider exposes `aria-valuenow/min/max/text` + label association
- **IQ-2** Card mix info toggle gets `aria-expanded` / `aria-controls`

### MBA tracker
- **MB-1** Search and location clear buttons refocus their inputs
- **MB-2** Email digest dialog gets a real focus trap, Esc-to-close, click-outside dismiss, `aria-labelledby/describedby`, focus restoration on close
- **MB-3** Results count chips wrapped in `role=status aria-live=polite`

### Drive-by
- `SurfaceCard` (March Madness) now accepts an `id` prop so existing scroll anchors finally type-check

## Test plan
- [ ] Hard reload `/` on mobile width — open the menu, tap the dim overlay, confirm it closes the menu
- [ ] Tab through `/`, confirm the skip link appears at top-left in both light + dark mode and is readable
- [ ] On `/investments` and `/march-madness-2026`, focus a tab and use ArrowLeft/Right/Home/End — focus and selection should follow
- [ ] Open `/writing/<any-slug>` — confirm prose styling now applies (links, headings, blockquotes look styled)
- [ ] Resize PL or La Liga to ~700px — table shows the right-edge scroll shadow
- [ ] Open `/fantasy-football/draft-tracker` — Undo last pick is visible (disabled before first pick)
- [ ] Open `/fintech-tools/budget-planner` on mobile — add-expense CTA stays at the bottom of viewport while scrolling the form
- [ ] Open `/mba-internship-notifications`, type a search, click the X — input gets refocused; open Email digest, press Esc — closes and focus returns to the trigger button
- [ ] `npm test` — fantasy suite passes (40/40); the one pre-existing PL test failure is unrelated to this branch