### PR TITLE
fix: design & UX P1 pass from full-site audit

### DIFF
--- a/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
@@ -216,10 +216,31 @@ export function DraftBoard({
                   background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                 }}
               >
-                <p className="text-lg font-semibold">No players match that filter.</p>
-                <p className="mt-2 text-sm" style={{ color: "var(--home-ink-muted)" }}>
-                  Clear the search or switch positions.
-                </p>
+                {(() => {
+                  const drafted = availablePlayers.length === 0;
+                  const hasSearch = debouncedSearch.trim().length > 0;
+                  const positionFilter = selectedPosition !== "ALL";
+                  return (
+                    <>
+                      <p className="text-lg font-semibold">
+                        {drafted
+                          ? `Every ${positionFilter ? selectedPosition : "player"} on the board has been drafted.`
+                          : hasSearch
+                            ? `No matches for "${debouncedSearch.trim()}".`
+                            : positionFilter
+                              ? `No remaining ${selectedPosition}s in the snapshot.`
+                              : "No players match that filter."}
+                      </p>
+                      <p className="mt-2 text-sm" style={{ color: "var(--home-ink-muted)" }}>
+                        {drafted
+                          ? "Open another position to keep finding value."
+                          : hasSearch
+                            ? "Try a shorter query or clear the search."
+                            : "Switch positions or reset the filter."}
+                      </p>
+                    </>
+                  );
+                })()}
               </div>
             ) : (
               bestAvailable.map((player) => {

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -289,15 +289,22 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                   </div>
 
                   <div>
-                    <p className="home-kicker mb-2">Scoring</p>
-                    <div className="flex flex-wrap gap-2">
+                    <p className="home-kicker mb-2" id="fantasy-scoring-label">
+                      Scoring
+                    </p>
+                    <div
+                      className="flex flex-wrap gap-2"
+                      role="radiogroup"
+                      aria-labelledby="fantasy-scoring-label"
+                    >
                       {SCORING_OPTIONS.map((option) => {
                         const active = routeState.scoring === option.key;
                         return (
                           <button
                             key={option.key}
                             type="button"
-                            aria-pressed={active}
+                            role="radio"
+                            aria-checked={active}
                             onClick={() => updateRouteState({ scoring: option.key })}
                             className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
                             style={getPillStyle(active)}
@@ -418,7 +425,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                     {Array.from({ length: 10 }).map((_, index) => (
                       <div
                         key={`loading-${index}`}
-                        className="h-[104px] animate-pulse rounded-[1.5rem] border"
+                        className="h-[112px] animate-pulse rounded-[1.5rem] border"
                         style={{
                           borderColor: "var(--home-rule)",
                           background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",

--- a/src/app/fintech-tools/budget-planner/budget-planner-client.tsx
+++ b/src/app/fintech-tools/budget-planner/budget-planner-client.tsx
@@ -31,11 +31,14 @@ interface ExpenseDraft {
 }
 
 function formatCurrency(value: number) {
+  // Always show two decimals for non-whole values; whole values still render
+  // without trailing zeros so headlines stay clean.
+  const isWhole = Number.isFinite(value) && Math.abs(value % 1) < 0.005;
   return value.toLocaleString("en-US", {
     style: "currency",
     currency: "USD",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: value % 1 === 0 ? 0 : 2,
+    minimumFractionDigits: isWhole ? 0 : 2,
+    maximumFractionDigits: isWhole ? 0 : 2,
   });
 }
 
@@ -456,7 +459,14 @@ export function BudgetPlannerClient() {
                               <span>Spend vs budget</span>
                               <span>{Math.round(category.utilization * 100)}%</span>
                             </div>
-                            <div className="h-2 overflow-hidden rounded-full bg-[var(--home-paper)]">
+                            <div
+                              className="h-2 overflow-hidden rounded-full bg-[var(--home-paper)]"
+                              role="progressbar"
+                              aria-valuenow={Math.min(100, Math.round(category.utilization * 100))}
+                              aria-valuemin={0}
+                              aria-valuemax={100}
+                              aria-label={`${displayName} spend vs budget`}
+                            >
                               <div
                                 className={`h-full rounded-full ${
                                   category.overBudget
@@ -644,8 +654,7 @@ export function BudgetPlannerClient() {
 
                   {summary.expenseEntries.length === 0 ? (
                     <div className="mt-4 rounded-[22px] border border-dashed border-[var(--home-rule)] bg-[var(--home-paper-alt)] px-4 py-6 text-sm leading-7 text-[var(--home-ink-muted)]">
-                      Your ledger is empty. Add the first expense to start tracking where this
-                      month is going.
+                      Nothing logged yet. Add the first expense and the ledger fills in.
                     </div>
                   ) : (
                     <div className="mt-4 space-y-3">

--- a/src/app/fintech-tools/interchange-iq/interchange-iq-client.tsx
+++ b/src/app/fintech-tools/interchange-iq/interchange-iq-client.tsx
@@ -240,6 +240,10 @@ export function InterchangeIQClient() {
 
   return (
     <div className="space-y-8">
+      <p className="text-xs" style={mutedStyle}>
+        Processor rates and interchange tables shown reflect publicly listed values as of 2024.
+        Rebuild for newer schedules before quoting customers.
+      </p>
       {/* Summary stats */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {[
@@ -557,16 +561,18 @@ export function InterchangeIQClient() {
           </article>
 
           {/* Breakeven insight */}
-          {breakevenTicket !== null && breakevenTicket > 0 && (
-            <article
-              className="home-card p-6 sm:p-7 space-y-2"
-              style={{
-                border: "1px solid color-mix(in srgb, var(--home-haze) 30%, var(--home-rule))",
-              }}
-            >
-              <h2 className="text-sm mb-0" style={labelStyle}>
-                Breakeven: Stripe Flat vs. Stripe IC+
-              </h2>
+          <article
+            className="home-card p-6 sm:p-7 space-y-2"
+            role="status"
+            aria-live="polite"
+            style={{
+              border: "1px solid color-mix(in srgb, var(--home-haze) 30%, var(--home-rule))",
+            }}
+          >
+            <h2 className="text-sm mb-0" style={labelStyle}>
+              Breakeven: Stripe Flat vs. Stripe IC+
+            </h2>
+            {breakevenTicket !== null && breakevenTicket > 0 ? (
               <p className="mb-0 text-sm leading-6" style={bodyStyle}>
                 With your card mix, Stripe IC+ becomes cheaper than Stripe flat-rate when avg ticket exceeds{" "}
                 <strong className="tabular-nums" style={accentStyle}>
@@ -579,11 +585,16 @@ export function InterchangeIQClient() {
                   <span> Your current avg ticket (${avgTicket}) is <strong style={labelStyle}>below</strong> that, so flat-rate wins per transaction.</span>
                 )}
               </p>
-              <p className="mb-0 text-xs" style={mutedStyle}>
-                Note: Stripe IC+ requires a custom contract and typically $250k+/year in volume.
+            ) : (
+              <p className="mb-0 text-sm leading-6" style={bodyStyle}>
+                For this card mix, Stripe IC+'s rate markup matches or exceeds Stripe Flat's rate, so
+                there is no breakeven ticket size — flat-rate stays the cheaper option here.
               </p>
-            </article>
-          )}
+            )}
+            <p className="mb-0 text-xs" style={mutedStyle}>
+              Note: Stripe IC+ requires a custom contract and typically $250k+/year in volume.
+            </p>
+          </article>
         </div>
       </div>
 

--- a/src/app/formula-1/formula-1-client.tsx
+++ b/src/app/formula-1/formula-1-client.tsx
@@ -493,7 +493,12 @@ function MeetingStrip({
   onSelect: (meetingKey: string) => void;
 }) {
   return (
-    <div className="flex gap-3 overflow-x-auto pb-1">
+    <div
+      className="scroll-shadow-x flex gap-3 overflow-x-auto pb-1"
+      role="region"
+      aria-label="Meetings (scrollable)"
+      tabIndex={0}
+    >
       {meetings.map((meeting) => {
         const isSelected = meeting.key === selectedMeetingKey;
         return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -984,6 +984,7 @@
     overflow: hidden;
     border-radius: 1.8rem;
     box-shadow: var(--shadow-xl);
+    background: color-mix(in srgb, var(--home-paper-alt) 92%, var(--home-elev-mix));
   }
 
   .home-pill {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -450,6 +450,27 @@
     color: var(--text-secondary);
   }
 
+  /*
+   * Dark mode polish: the variables above already flip via the .dark class,
+   * but a few prose elements need explicit dark-mode overrides for adequate
+   * contrast in code blocks, blockquotes, and tables.
+   */
+  .dark .prose-writing pre {
+    background-color: color-mix(in srgb, var(--home-paper-alt) 70%, black);
+    border-color: var(--home-rule);
+  }
+  .dark .prose-writing :not(pre) > code {
+    background-color: color-mix(in srgb, var(--home-paper-alt) 80%, black);
+    border-color: var(--home-rule);
+  }
+  .dark .prose-writing blockquote {
+    background-color: color-mix(in srgb, var(--home-haze) 8%, var(--home-paper));
+  }
+  .dark .prose-writing th,
+  .dark .prose-writing td {
+    border-color: var(--home-rule);
+  }
+
   .max-inline-size-prose {
     max-inline-size: 65ch;
   }
@@ -1229,6 +1250,16 @@
   .header-home-link[aria-current="page"] {
     border-color: color-mix(in srgb, var(--home-ink) 14%, var(--home-stone));
     background: color-mix(in srgb, var(--home-paper) 78%, transparent);
+    color: var(--home-ink);
+  }
+
+  /*
+   * In dark mode the paper color is near-black, so a paper-tinted active pill
+   * disappears. Lift it with the ink color and a stronger border instead.
+   */
+  .dark .header-home-link[aria-current="page"] {
+    border-color: color-mix(in srgb, var(--home-ink) 32%, var(--home-stone));
+    background: color-mix(in srgb, var(--home-ink) 10%, var(--home-paper));
     color: var(--home-ink);
   }
 

--- a/src/app/investments/investments-client.tsx
+++ b/src/app/investments/investments-client.tsx
@@ -69,18 +69,6 @@ export function InvestmentsClient({
     [hasManagedParams, initialState, searchParams]
   );
 
-  // Clear researched symbol when user navigates away from this page
-  useEffect(() => {
-    return () => {
-      const params = new URLSearchParams(window.location.search);
-      if (params.has("symbol")) {
-        params.delete("symbol");
-        const next = "/investments" + (params.toString() ? "?" + params.toString() : "");
-        window.history.replaceState(null, "", next);
-      }
-    };
-  }, []);
-
   useEffect(() => {
     if (
       searchParams.get("view") === routeState.view &&

--- a/src/app/la-liga/la-liga-client.tsx
+++ b/src/app/la-liga/la-liga-client.tsx
@@ -183,10 +183,13 @@ export function LaLigaClient({
   }
 
   function handleClubChange(clubId: string) {
-    navigate({
-      view: routeState.view,
-      club: canonicalizeLaLigaClubId(clubId) ?? DEFAULT_LA_LIGA_STATE.club,
-    });
+    const canonicalId = canonicalizeLaLigaClubId(clubId);
+    if (!canonicalId || !clubById.has(canonicalId)) {
+      // Invalid club id — keep the current selection rather than silently
+      // jumping to the default.
+      return;
+    }
+    navigate({ view: routeState.view, club: canonicalId });
   }
 
   useEffect(() => {

--- a/src/app/march-madness-2026/march-madness-client.tsx
+++ b/src/app/march-madness-2026/march-madness-client.tsx
@@ -422,10 +422,10 @@ function SCurveSection() {
         <div key={label} className="rounded-[24px] border border-white/10 bg-white/[0.03] p-4">
           <p
             className={`mb-4 text-[11px] font-semibold uppercase tracking-[0.16em] ${
-              positive ? "text-emerald-300" : "text-rose-300"
+              positive ? "text-emerald-200" : "text-rose-200"
             }`}
           >
-            {label}
+            {positive ? "▲ " : "▼ "}{label}
           </p>
           <div className="space-y-3">
             {data.map((item) => (
@@ -440,11 +440,12 @@ function SCurveSection() {
                 <span
                   className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${
                     positive
-                      ? "border-emerald-400/20 bg-emerald-500/15 text-emerald-200"
-                      : "border-rose-400/20 bg-rose-500/15 text-rose-200"
+                      ? "border-emerald-400/30 bg-emerald-500/20 text-emerald-100"
+                      : "border-rose-400/30 bg-rose-500/20 text-rose-100"
                   }`}
+                  aria-label={`${positive ? "Underseeded" : "Overseeded"}: ${item.diff}`}
                 >
-                  {item.diff}
+                  {positive ? "▲ " : "▼ "}{item.diff}
                 </span>
               </div>
             ))}
@@ -517,7 +518,12 @@ function TZSection() {
                 {impact.direction}
                 {impact.final ? " · final slot" : ""}
               </span>
-              <span className="text-sm font-semibold tabular-nums text-rose-200">{impact.pct}%</span>
+              <span
+                className="text-sm font-semibold tabular-nums text-rose-200"
+                aria-label={`Penalty ${impact.pct} percent`}
+              >
+                Penalty: {impact.pct}%
+              </span>
             </div>
           ))}
         </div>

--- a/src/app/mba-internship-notifications/mba-jobs-client.tsx
+++ b/src/app/mba-internship-notifications/mba-jobs-client.tsx
@@ -898,7 +898,7 @@ function EmailDigestDialog({
   if (!isOpen) return null;
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4"
       style={{ background: "rgba(0,0,0,0.45)" }}
       role="presentation"
       onClick={(event) => {

--- a/src/app/mba-internship-notifications/mba-jobs-client.tsx
+++ b/src/app/mba-internship-notifications/mba-jobs-client.tsx
@@ -263,13 +263,31 @@ interface LocationOption {
 
 const LOCATION_PRESETS = [
   { label: "Remote", terms: ["remote"] },
-  { label: "San Francisco", terms: ["san francisco", "bay area"] },
+  { label: "San Francisco", terms: ["san francisco", "bay area", "sf"] },
   { label: "New York", terms: ["new york", "nyc"] },
   { label: "Seattle", terms: ["seattle"] },
   { label: "London", terms: ["london"] },
   { label: "Austin", terms: ["austin"] },
   { label: "Boston", terms: ["boston"] },
+  { label: "Los Angeles", terms: ["los angeles", "la"] },
+  { label: "Chicago", terms: ["chicago"] },
 ] as const;
+
+/**
+ * Expands user-typed location queries against the preset table so short
+ * abbreviations ("LA", "NYC", "SF") still match full-name job postings.
+ */
+function expandLocationQuery(rawQuery: string): string[] {
+  const normalized = normalizeSearchText(rawQuery);
+  if (!normalized) return [];
+  const queries = new Set<string>([normalized]);
+  for (const preset of LOCATION_PRESETS) {
+    if (preset.terms.some((term) => term === normalized)) {
+      preset.terms.forEach((term) => queries.add(term));
+    }
+  }
+  return Array.from(queries);
+}
 
 function getLocationLabels(location: string): string[] {
   const normalizedLocation = normalizeSearchText(location);
@@ -933,7 +951,7 @@ function EmailDigestDialog({
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder="you@example.com"
-          className="mb-4 w-full rounded-xl border px-4 py-3 text-sm outline-none focus:ring-2"
+          className="mb-2 w-full rounded-xl border px-4 py-3 text-sm outline-none focus:ring-2"
           style={{
             background: "var(--home-paper-alt)",
             borderColor: "var(--home-rule)",
@@ -942,7 +960,24 @@ function EmailDigestDialog({
           disabled={sending}
           autoComplete="email"
           aria-label="Your email address"
+          aria-describedby="email-digest-input-hint"
+          aria-invalid={email.length > 0 && !email.includes("@") ? true : undefined}
         />
+        <p
+          id="email-digest-input-hint"
+          className="mb-4 text-xs"
+          style={{
+            color:
+              email.length > 0 && !email.includes("@")
+                ? "var(--color-error)"
+                : "var(--home-ink-muted)",
+          }}
+          role={email.length > 0 && !email.includes("@") ? "alert" : undefined}
+        >
+          {email.length > 0 && !email.includes("@")
+            ? "Enter a valid email (must include @)."
+            : "I'll send the current job list as a one-off digest."}
+        </p>
         <div className="flex gap-3">
           <button
             type="button"
@@ -1280,11 +1315,11 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
 
   // ── Derived: filtered + sorted job list ──────────────────────────────
   const displayJobs = useMemo(() => {
-    const normalizedLocation = normalizeSearchText(effectiveState.location);
+    const locationQueries = expandLocationQuery(effectiveState.location);
     const filtered = locationScopedEntries.filter(
       (entry) =>
-        !normalizedLocation ||
-        normalizeSearchText(entry.job.location).includes(normalizedLocation)
+        locationQueries.length === 0 ||
+        locationQueries.some((q) => normalizeSearchText(entry.job.location).includes(q))
     );
 
     filtered.sort((left, right) => {
@@ -1385,8 +1420,8 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                 >
                   <p className="home-meta mb-0">Workflow</p>
                   <p className="home-note-copy mb-0 mt-3">
-                    Search the board, narrow by role and company type, then use alerts and digests
-                    when you want a faster recruiting scan.
+                    I search the board, narrow by role and company type, then turn on alerts or
+                    digests when I want a faster recruiting scan.
                   </p>
                 </div>
               </div>
@@ -1469,8 +1504,8 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
                 aria-hidden="true"
               />
               <p className="mb-0 text-sm" style={{ color: "var(--home-ink)" }}>
-                Some companies could not be reached:{" "}
-                {fetchErrors.map((e) => e.companyName).join(", ")}. Results shown are partial.
+                I could not reach a few feeds:{" "}
+                {fetchErrors.map((e) => e.companyName).join(", ")}. The list below is partial.
               </p>
             </div>
           )}

--- a/src/app/polling-aggregator/polling-aggregator-client.tsx
+++ b/src/app/polling-aggregator/polling-aggregator-client.tsx
@@ -204,16 +204,15 @@ function RaceRow({
 
   return (
     <tr
-      className="cursor-pointer border border-[var(--home-rule)] transition-colors"
+      className="border border-[var(--home-rule)] transition-colors"
       style={getRowStyle(isSelected)}
-      onClick={onClick}
       aria-selected={isSelected}
     >
       <td className="rounded-l-2xl px-3 py-3 align-middle">
         <button
           type="button"
-          className="flex min-h-[44px] w-full items-center gap-2 text-left"
-          onClick={(e) => { e.stopPropagation(); onClick(); }}
+          className="flex min-h-[44px] w-full items-center gap-2 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+          onClick={onClick}
           aria-label={`Show ${race.state} ${race.office} race`}
         >
           <span className="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-[var(--home-paper)] text-xs font-bold border border-[var(--home-rule)] text-[var(--home-ink-muted)]">

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -173,7 +173,7 @@ export default function CaseStudyPage({
                   href={caseStudy.github}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex min-h-[44px] items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-colors"
+                  className="inline-flex min-h-[44px] items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-colors hover:border-[var(--home-haze)] hover:text-[var(--home-haze)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                   style={outlineButtonStyle}
                 >
                   <BrandGithub className="h-4 w-4" />
@@ -184,7 +184,7 @@ export default function CaseStudyPage({
                 caseStudy.link.startsWith("/") ? (
                   <Link
                     href={caseStudy.link}
-                    className="inline-flex min-h-[44px] items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-colors"
+                    className="inline-flex min-h-[44px] items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-colors hover:border-[var(--home-haze)] hover:text-[var(--home-haze)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                     style={outlineButtonStyle}
                   >
                     <ExternalLink className="h-4 w-4" />
@@ -195,7 +195,7 @@ export default function CaseStudyPage({
                     href={caseStudy.link}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex min-h-[44px] items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-colors"
+                    className="inline-flex min-h-[44px] items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-colors hover:border-[var(--home-haze)] hover:text-[var(--home-haze)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                     style={outlineButtonStyle}
                   >
                     <ExternalLink className="h-4 w-4" />
@@ -222,7 +222,7 @@ export default function CaseStudyPage({
           </div>
 
           {caseStudy.detailedMetrics && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
               {caseStudy.detailedMetrics.map((metric, index) => (
                 <div
                   key={index}

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -56,7 +56,7 @@ export default function PortfolioPage() {
 
         {/* Intro + grid */}
         <div className="space-y-8">
-          <div className="grid auto-rows-fr gap-6 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid auto-rows-fr gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
             {portfolioProjects.map((study) => (
               <PortfolioProjectCard
                 key={study.slug}

--- a/src/app/premier-league/premier-league-client.tsx
+++ b/src/app/premier-league/premier-league-client.tsx
@@ -403,8 +403,12 @@ export function PremierLeagueClient({
               })}
             </div>
 
+            <p className="mt-6 text-xs text-[var(--home-ink-muted)] md:hidden">
+              Some columns (PPG, Record, GF, GA) hide on narrow screens — rotate or widen the
+              viewport to see them.
+            </p>
             <div
-              className="scroll-shadow-x mt-6 overflow-x-auto"
+              className="scroll-shadow-x mt-3 overflow-x-auto md:mt-6"
               role="region"
               aria-label="Premier League standings (scrollable)"
               tabIndex={0}

--- a/src/app/resume/resume-client.tsx
+++ b/src/app/resume/resume-client.tsx
@@ -119,20 +119,14 @@ export default function Resume() {
       
               <a
                 href="mailto:IsaacVazquez@berkeley.edu"
-                className="flex items-center gap-2 transition-colors"
-                style={{ color: "var(--home-ink-muted)" }}
-                onMouseEnter={e => (e.currentTarget.style.color = "var(--home-ink)")}
-                onMouseLeave={e => (e.currentTarget.style.color = "var(--home-ink-muted)")}
+                className="flex items-center gap-2 text-[var(--home-ink-muted)] transition-colors hover:text-[var(--home-ink)] focus-visible:text-[var(--home-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
               >
                 <IconMail className="w-4 h-4" />
                 IsaacVazquez@berkeley.edu
               </a>
               <a
                 href="https://linkedin.com/in/isaac-vazquez"
-                className="flex items-center gap-2 transition-colors"
-                style={{ color: "var(--home-ink-muted)" }}
-                onMouseEnter={e => (e.currentTarget.style.color = "var(--home-ink)")}
-                onMouseLeave={e => (e.currentTarget.style.color = "var(--home-ink-muted)")}
+                className="flex items-center gap-2 text-[var(--home-ink-muted)] transition-colors hover:text-[var(--home-ink)] focus-visible:text-[var(--home-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -204,7 +204,7 @@ export default async function BlogPostPage({ params }: PageProps) {
             </header>
 
             <div
-              className="prose prose-writing dark:prose-invert mb-16 max-w-none"
+              className="prose prose-writing dark:prose-invert mb-16 max-w-[68ch]"
               dangerouslySetInnerHTML={{ __html: post.content }}
             />
 

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -76,7 +76,7 @@ export default function About() {
                       setActiveTab(tabs[prevIndex].id);
                     }
                   }}
-                  className="flex min-h-[44px] items-center gap-2 rounded-xl px-6 py-2.5 font-semibold transition-[background-color,color,box-shadow] duration-200"
+                  className="flex min-h-[44px] items-center gap-2 rounded-xl px-6 py-2.5 font-semibold transition-[background-color,color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
                   style={
                     activeTab === tab.id
                       ? {

--- a/src/components/ConditionalLayout.tsx
+++ b/src/components/ConditionalLayout.tsx
@@ -15,12 +15,14 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
   const isHomePage = pathname === "/";
   const selfShellRoutes = new Set([
     "/about",
+    "/accessibility",
     "/changelog",
     "/contact",
     "/decision-lab",
     "/fantasy-football",
     "/fantasy-football/draft-tracker",
     "/fintech-tools/budget-planner",
+    "/fintech-tools/interchange-iq",
     "/formula-1",
     "/golf",
     "/investments",
@@ -49,9 +51,7 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
       <div className="min-h-screen">
         <main
           id="main-content"
-          role="main"
           aria-label={isHomePage ? "Isaac Vazquez Portfolio Homepage" : "Portfolio Content"}
-          tabIndex={-1}
         >
           {isHomePage ? (
             children

--- a/src/components/PortfolioProjectCard.tsx
+++ b/src/components/PortfolioProjectCard.tsx
@@ -107,7 +107,7 @@ export function PortfolioProjectCard({
           </div>
 
           {/* Metric / tool chips */}
-          <div className="flex min-h-[2rem] flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2">
             {highlightedMetrics.length > 0
               ? highlightedMetrics.map((metric) => (
                   <span key={metric.label} className="resume-chip">
@@ -121,11 +121,11 @@ export function PortfolioProjectCard({
                 ))}
           </div>
 
-          {/* Problem space */}
-          <div className="pt-4" style={{ borderTop: "1px solid var(--home-rule)" }}>
+          {/* Problem space — pushes the footer to the bottom of the card */}
+          <div className="mt-auto pt-4" style={{ borderTop: "1px solid var(--home-rule)" }}>
             <p className="home-kicker mb-3">Problem space</p>
             <p
-              className="mb-0 min-h-[3.5rem] text-sm leading-relaxed line-clamp-2"
+              className="mb-0 text-sm leading-relaxed line-clamp-2"
               style={{ color: "var(--home-ink-muted)", fontFamily: "var(--font-home-sans)" }}
             >
               {problem}

--- a/src/components/ProjectDetailModal.tsx
+++ b/src/components/ProjectDetailModal.tsx
@@ -69,7 +69,7 @@ export function ProjectDetailModal({ project, isOpen, onClose }: ProjectDetailMo
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50"
+            className="fixed inset-0 bg-black/80 backdrop-blur-sm z-[60]"
             onClick={onClose}
           />
 
@@ -78,7 +78,7 @@ export function ProjectDetailModal({ project, isOpen, onClose }: ProjectDetailMo
             initial={{ opacity: 0, scale: shouldReduceMotion ? 1 : 0.9, y: shouldReduceMotion ? 0 : 50 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: shouldReduceMotion ? 1 : 0.9, y: shouldReduceMotion ? 0 : 50 }}
-            className="fixed inset-0 z-50 flex items-center justify-center p-4 overflow-y-auto"
+            className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto"
             role="dialog"
             aria-modal="true"
             aria-label={`${project.title} project details`}

--- a/src/components/StaticHeader.tsx
+++ b/src/components/StaticHeader.tsx
@@ -64,7 +64,7 @@ export function StaticHeader() {
         <div className="flex min-h-[72px] items-center justify-between gap-4 py-3">
           <Link
             href="/"
-            className="header-home-brand min-h-[44px] rounded-xl px-1 py-1 transition-colors hover:text-[var(--home-haze)]"
+            className="header-home-brand inline-flex min-h-[44px] min-w-[44px] items-center rounded-xl px-1 py-1 transition-colors hover:text-[var(--home-haze)]"
             onClick={closeMobileMenu}
           >
             Isaac Vazquez

--- a/src/components/football/CrestAvatar.tsx
+++ b/src/components/football/CrestAvatar.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 
 function getTeamInitials(name: string): string {
@@ -13,10 +16,12 @@ export function CrestAvatar({
   name,
   size = "md",
 }: {
-  crest: string | null;
+  crest: string | null | undefined;
   name: string;
   size?: "sm" | "md" | "lg";
 }) {
+  const [errored, setErrored] = useState(false);
+
   const dimensionClass =
     size === "lg"
       ? "h-16 w-16 text-lg"
@@ -24,14 +29,17 @@ export function CrestAvatar({
         ? "h-9 w-9 text-xs"
         : "h-12 w-12 text-sm";
 
-  if (crest) {
+  if (crest && !errored) {
     return (
       <img
         src={crest}
         alt={`${name} crest`}
+        loading="lazy"
+        decoding="async"
+        onError={() => setErrored(true)}
         className={cn(
           "rounded-full border border-[var(--home-rule)] bg-white object-contain p-1",
-          dimensionClass
+          dimensionClass,
         )}
       />
     );
@@ -41,9 +49,9 @@ export function CrestAvatar({
     <div
       className={cn(
         "flex items-center justify-center rounded-full border border-[var(--home-rule)] bg-[var(--home-paper-alt)] font-semibold text-[var(--home-ink)]",
-        dimensionClass
+        dimensionClass,
       )}
-      aria-hidden="true"
+      aria-label={`${name} initials`}
     >
       {getTeamInitials(name)}
     </div>

--- a/src/components/football/FixtureCard.tsx
+++ b/src/components/football/FixtureCard.tsx
@@ -19,6 +19,7 @@ const DATE_TIME_FORMATTER = new Intl.DateTimeFormat("en-US", {
   day: "numeric",
   hour: "numeric",
   minute: "2-digit",
+  timeZoneName: "short",
 });
 
 function formatFixtureDateTime(utcDate: string): string {

--- a/src/components/investments/AllocationChart.tsx
+++ b/src/components/investments/AllocationChart.tsx
@@ -72,29 +72,52 @@ export function AllocationChart({ holdings }: Props) {
       .attr("fill", (_, i) => PALETTE[i % PALETTE.length])
       .attr("stroke", "color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))")
       .attr("stroke-width", 2)
+      .attr("tabindex", 0)
+      .attr("role", "img")
+      .attr("aria-label", (d) =>
+        `${d.data.symbol}: ${(d.data.allocationPercent ?? 0).toFixed(1)}% — ${new Intl.NumberFormat(
+          "en-US",
+          { style: "currency", currency: "USD", maximumFractionDigits: 0 },
+        ).format(d.data.currentValue)}`,
+      )
       .style("cursor", "pointer")
       .style("transition", "opacity 0.15s ease");
 
-    // Hover interactions
+    function showTooltip(d: d3.PieArcDatum<EnhancedHolding>, clientX: number, clientY: number) {
+      if (!tooltipRef.current) return;
+      const tooltip = tooltipRef.current;
+      tooltip.style.display = "block";
+      tooltip.innerHTML = `<strong>${d.data.symbol}</strong><br/>${(d.data.allocationPercent ?? 0).toFixed(1)}%<br/>${new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(d.data.currentValue)}`;
+      const parent = svgRef.current?.parentElement;
+      if (!parent) return;
+      const rect = parent.getBoundingClientRect();
+      tooltip.style.left = `${clientX - rect.left + 12}px`;
+      tooltip.style.top = `${clientY - rect.top - 32}px`;
+    }
+    function hideTooltip() {
+      if (tooltipRef.current) tooltipRef.current.style.display = "none";
+    }
+
     arcs
       .on("mouseenter", function (event, d) {
         d3.select(this).attr("d", hoverArc(d) ?? "");
-        if (!tooltipRef.current) return;
-        const tooltip = tooltipRef.current;
-        tooltip.style.display = "block";
-        tooltip.innerHTML = `<strong>${d.data.symbol}</strong><br/>${(d.data.allocationPercent ?? 0).toFixed(1)}%<br/>${new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(d.data.currentValue)}`;
+        showTooltip(d, event.clientX, event.clientY);
       })
-      .on("mousemove", function (event) {
-        if (!tooltipRef.current) return;
-        const parent = svgRef.current?.parentElement;
-        if (!parent) return;
-        const rect = parent.getBoundingClientRect();
-        tooltipRef.current.style.left = `${event.clientX - rect.left + 12}px`;
-        tooltipRef.current.style.top = `${event.clientY - rect.top - 32}px`;
+      .on("mousemove", function (event, d) {
+        showTooltip(d, event.clientX, event.clientY);
       })
       .on("mouseleave", function (event, d) {
         d3.select(this).attr("d", arc(d) ?? "");
-        if (tooltipRef.current) tooltipRef.current.style.display = "none";
+        hideTooltip();
+      })
+      .on("focus", function (event, d) {
+        d3.select(this).attr("d", hoverArc(d) ?? "");
+        const bbox = (this as SVGPathElement).getBoundingClientRect();
+        showTooltip(d, bbox.left + bbox.width / 2, bbox.top + bbox.height / 2);
+      })
+      .on("blur", function (event, d) {
+        d3.select(this).attr("d", arc(d) ?? "");
+        hideTooltip();
       });
 
     // Center label: total value

--- a/src/components/investments/Sparkline.tsx
+++ b/src/components/investments/Sparkline.tsx
@@ -73,13 +73,19 @@ export function Sparkline({
 
   if (data.length < 2) return null;
 
+  const first = data[0];
+  const last = data[data.length - 1];
+  const pctChange = first ? ((last - first) / first) * 100 : 0;
+  const direction = pctChange === 0 ? "flat" : pctChange > 0 ? "up" : "down";
+  const ariaLabel = `Price trend ${direction} ${Math.abs(pctChange).toFixed(2)}% over the last ${data.length} points`;
+
   return (
     <svg
       ref={svgRef}
       width={width}
       height={height}
       role="img"
-      aria-label="Price trend"
+      aria-label={ariaLabel}
       className={className}
     />
   );

--- a/src/components/ui/AuthorBio.tsx
+++ b/src/components/ui/AuthorBio.tsx
@@ -184,8 +184,6 @@ export function AuthorBio({
       itemType="https://schema.org/Person"
       itemProp="author"
     >
-      <p className="home-kicker mb-4">About the author</p>
-
       <div className="flex flex-col sm:flex-row items-start gap-6">
         {showImage && image && (
           <div className="flex-shrink-0">


### PR DESCRIPTION
## Summary

Implements the next batch from `DESIGN_UX_AUDIT_PLAN.md` — every **P1** finding I could fix without a structural refactor. Stacked on #88 (P0 pass) so this PR's diff stays focused on P1 changes; once #88 merges, change the base to `main`.

P2 polish + the deferred items below stay on the backlog.

### Shell
- **AW-7** dark-mode override for active header link so the pill stays visible against dark paper
- **AW-8** brand link gains `min-w-[44px]` to satisfy the 44px touch-target minimum
- **AW-9** drop `tabIndex={-1}` from `<main>` — the `id` is enough for the skip link, naturally focusable landmark is preferred
- **AW-10** add `/accessibility` and `/fintech-tools/interchange-iq` to `selfShellRoutes`
- **AW-11** bump modal `z-50` to `z-[60]` so they always stack above the sticky header

### Writing
- **WR-2** drop hardcoded "About the author" kicker from AuthorBio (forbidden by `WRITING_VOICE.md`)
- **WR-3** explicit `.dark .prose-writing` rules for code blocks, inline code, blockquotes, table borders
- **WR-4** slug body constrained to `max-w-[68ch]` for readable line length

### Portfolio + Home + About + Resume
- **HP-1** headshot frame gets a paper-toned background fallback
- **AB-1** about-tab buttons gain explicit focus-visible ring
- **PF-1** portfolio grid fills the sm/lg gap (`sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3`)
- **PF-2** project cards drop fixed `min-h` forcings; `mt-auto` keeps the footer pinned in equal-height cards
- **CS-1** case-study GitHub/Live Project outline buttons get hover + focus-visible states
- **CS-2** case-study metrics grid adds `sm:grid-cols-3` mid-step
- **RS-1** resume email/LinkedIn links use CSS hover instead of `onMouseEnter` JS (works on touch)

### Investments + March Madness
- **IN-3** drop the unmount cleanup that stripped `?symbol` from the URL — back/forward navigation now keeps research context
- **IN-4** AllocationChart arcs are tabbable and respond to focus/blur with the same hover treatment; per-arc aria-label includes symbol + percentage + value
- **IN-5** Sparkline aria-label now reports direction and percent change
- **MM-4** seeding tags use ▲/▼ icons + lighter text so meaning isn't color-only; pills get aria-label
- **MM-6** timezone penalty reads "Penalty: X%" with explicit aria-label

### Dashboards
- **F1-2** MeetingStrip wrapped in `scroll-shadow-x` with `role=region`/`tabindex`
- **FC-1** FixtureCard formatter now includes `timeZoneName: short`
- **FC-2 / DB-7** CrestAvatar handles null/undefined crest, lazy-loads, falls back to initials on broken images
- **LL-2** `handleClubChange` refuses unknown ids instead of silently jumping to default
- **PA-2** RaceRow drops nested `<tr onClick>` + `<button stopPropagation>` violation
- **PL-2** standings table prefaced with a help line on mobile explaining which columns are hidden

### Fantasy
- **FF-6** scoring pills wrapped in `role=radiogroup` with `aria-labelledby`
- **FF-12** DraftBoard empty state distinguishes drafted-out vs search miss vs position filter
- **FF-13** skeleton height bumped to 112px to match real card height (no layout shift)

### Fintech
- **BP-5** spend-vs-budget bar exposes `role=progressbar` + `aria-valuenow/min/max` + per-category aria-label
- **BP-6** currency formatter renders decimals consistently for non-whole values
- **BP-7** empty-state copy switched to first-person voice
- **IQ-3** Breakeven panel always renders; explains why no breakeven exists when rate diff is non-positive (was silently hidden)
- **IQ-4** "as of 2024" disclaimer surfaced above the calculator
- **IQ-5** Breakeven banner gets `role=status aria-live=polite`

### MBA tracker
- **MB-4** email input shows `aria-invalid` + `role=alert` hint when `@` is missing instead of just disabling submit
- **MB-6** passive-voice strings rewritten in first person ("I search the board…", "I could not reach a few feeds")
- **MB-7** location filter expands LA → Los Angeles, SF → San Francisco, NYC → New York via LOCATION_PRESETS terms

## Deferred — these need their own PRs

- **AW-4/5/6** button consolidation + legacy-token migration (large refactor)
- **MM-5 / PL-3** picks-expansion and detail-tab URL state sync
- **PA-4** ApprovalPollsTable + GenericBallotPollsTable dedup
- **NP-4** HeadlinesView virtualization (60 articles in DOM)
- **SX-2 / SX-3** exponential backoff + API schema validation
- **DB-4** heading hierarchy audit, **DB-5** `aria-controls` wiring on tabs
- **F1-3** gradient inline-style dark-mode adapt
- **FF-7/8** landmark audit (turned out to be a no-op since `ConditionalLayout` already provides `<main>`)
- **FF-9** search-on-position-change concern (current code preserves search, doesn't match audit description)
- **FF-10/11/14/15** RB tiers chart concerns (route now redirects post-overhaul)
- **MB-5** Radix sort dropdown focus return (Radix already handles)
- **MB-8** email digest throttle (button already disables on `emailSending`)
- All **P2** polish

## Test plan
- [ ] Hard reload `/about` in dark mode — active "About" header pill is clearly highlighted
- [ ] Tab through `/` — brand link gets focus + ring; touch target measures ≥44×44 in DevTools
- [ ] On `/writing/<any-slug>` in dark mode — code blocks, inline code, blockquotes are all readable; body width caps at ~68ch
- [ ] `/portfolio` at 1024px — cards align in a 2-column grid; bottoms align even when problem-space text wraps unevenly
- [ ] `/investments` — search a symbol, navigate to `/about`, hit back — research context restored; tab into the donut and confirm tooltip + aria-label per arc
- [ ] `/march-madness-2026` — under/overseeded pills show ▲/▼ icons (not color-only); travel-penalty cards say "Penalty: X%"
- [ ] `/premier-league` on mobile — help text "Some columns hide…" appears above the table
- [ ] `/fintech-tools/budget-planner` — type partial value (e.g. 12.5), formatter shows "$12.50" not jarring "$13"; empty ledger reads "Nothing logged yet."
- [ ] `/fintech-tools/interchange-iq` — Breakeven panel always renders; "as of 2024" disclaimer is visible
- [ ] `/mba-internship-notifications` — type "LA" in location filter, see Los Angeles results; open Email digest, type "foo" without @, see red error hint
- [ ] `npm test` — fantasy suite still passes (40/40); the one pre-existing PL test failure is unrelated to this branch