### PR TITLE
fix: bypass broken image optimizer for home headshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build
 coverage
 playwright-report/
 test-results/
+.playwright-mcp/
 
 # Environment
 .env

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1003,6 +1003,9 @@
     overflow: hidden;
     border-radius: 1.8rem;
     box-shadow: var(--shadow-xl);
+    /* Paper-toned fallback so an empty frame doesn't read as a hollow box
+       if the image ever fails to load (HP-1). */
+    background: color-mix(in srgb, var(--home-paper-alt) 92%, var(--home-elev-mix));
   }
 
   .home-pill {

--- a/src/components/home/HomePageContent.tsx
+++ b/src/components/home/HomePageContent.tsx
@@ -131,12 +131,20 @@ export function HomePageContent({
 
             <div className="home-reveal home-reveal-delay-3 flex justify-center lg:justify-end">
               <div className="home-headshot-frame">
+                {/*
+                 * unoptimized: the source is already a hand-tuned 90KB webp
+                 * and the Netlify image optimizer pipeline behind Cloudflare
+                 * has been returning 502s for this asset, breaking the hero
+                 * on prod. Serving the static file directly bypasses the
+                 * broken transform without changing visual output.
+                 */}
                 <Image
                   src="/images/headshot-home.webp"
                   alt="Isaac Vazquez"
                   fill
                   className="object-cover object-top"
                   priority
+                  unoptimized
                 />
               </div>
             </div>


### PR DESCRIPTION
## Root cause

On production, `https://isaacavazquez.com/_next/image?url=%2Fimages%2Fheadshot-home.webp&w=1200&q=75` is returning **502 Bad Gateway** from Cloudflare → Netlify. The static file itself is fine (`/images/headshot-home.webp` returns 200, 89.5KB) — only the Next.js image-optimizer pipeline is broken for this asset, leaving the hero frame empty.

```
$ curl -sI https://isaacavazquez.com/images/headshot-home.webp
HTTP/2 200, content-type: image/webp, length: 89540

$ curl -sI 'https://isaacavazquez.com/_next/image?url=%2Fimages%2Fheadshot-home.webp&w=1200&q=75'
HTTP/2 502
server: cloudflare        ← never reached Netlify (no x-nf-request-id)
```

## Fix

The source is already a hand-tuned 90KB webp, so running it through the optimizer was redundant anyway. Adding `unoptimized` to the `<Image>` makes it serve the static file directly, dodging the broken pipeline entirely. Visual output is identical.

## Drive-by

- Lands **HP-1** from the original audit (`.home-headshot-frame` gets a paper-toned background fallback) so an empty frame never reads as a hollow box if the image ever fails again. HP-1 was scoped in PR #89 but didn't survive the squash-merge.
- Adds `.playwright-mcp/` to `.gitignore` so future Playwright debugging artifacts don't accidentally land in commits.

## Test plan
- [ ] After deploy, hard-refresh https://isaacavazquez.com/ — headshot loads in the hero
- [ ] DevTools → Network: the request URL is `/images/headshot-home.webp` directly, not `/_next/image?...`
- [ ] If the static file ever fails, frame still has a paper-toned color block instead of looking hollow