### PR TITLE
fix: re-land hydration + async-params fixes; silence font-preload warnings

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,25 +11,41 @@ import { ConditionalLayout } from "@/components/ConditionalLayout";
 import { Providers } from "@/components/Providers";
 import { StaticHeader } from "@/components/StaticHeader";
 
+// Inter is body text everywhere, but Chrome was warning that the
+// preloaded weight subset wasn't used "within a few seconds" of the
+// load event — the wordmark uses Instrument Sans above the fold and
+// Inter sits below. preload: false skips the link-preload header; the
+// system font stack covers first paint and Inter swaps in as expected
+// once the woff2 lands. Weights are pinned to what we actually use so
+// Next doesn't ship extra weight subsets.
 const inter = Inter({
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
   variable: "--font-inter",
   display: "swap",
+  preload: false,
 });
 
+// JetBrains Mono only appears in code blocks / kicker meta. Skip the
+// link-preload so Chromium stops warning that it loaded but went unused
+// on pages with no code or meta — it still loads on demand.
 const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   variable: "--font-jetbrains-mono",
   display: "swap",
+  preload: false,
 });
 
 // Display-only fonts use display: "optional" so the browser falls back to
 // the system stack if the webfont isn't immediately available, avoiding the
 // late layout shift that swap can cause on these decorative families.
+// preload: false matches optional — preloading + skipping-on-late-load
+// triggered the "preloaded but not used" warnings on every page.
 const instrumentSans = Instrument_Sans({
   subsets: ["latin"],
   variable: "--font-instrument-sans",
   display: "optional",
+  preload: false,
 });
 
 const instrumentSerif = Instrument_Serif({
@@ -38,6 +54,7 @@ const instrumentSerif = Instrument_Serif({
   style: ["normal", "italic"],
   variable: "--font-instrument-serif",
   display: "optional",
+  preload: false,
 });
 
 export const metadata = constructMetadata();

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -14,9 +14,10 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
-  const caseStudy = caseStudiesData[params.slug];
+  const { slug } = await params;
+  const caseStudy = caseStudiesData[slug];
 
   if (!caseStudy) {
     return {
@@ -31,7 +32,7 @@ export async function generateMetadata({
     articleAuthor: "https://isaacavazquez.com/about",
     articleSection: "Product Management",
     articleTags: ["Product Management", caseStudy.role, ...caseStudy.tools.slice(0, 3)],
-    canonicalUrl: `/portfolio/${params.slug}`,
+    canonicalUrl: `/portfolio/${slug}`,
     aiMetadata: {
       profession: "Product Manager",
       expertise: caseStudy.tools,
@@ -87,12 +88,13 @@ const outlineButtonStyle = {
   border: "1px solid var(--home-rule)",
 } as const;
 
-export default function CaseStudyPage({
+export default async function CaseStudyPage({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }) {
-  const caseStudy = caseStudiesData[params.slug];
+  const { slug } = await params;
+  const caseStudy = caseStudiesData[slug];
 
   if (!caseStudy) {
     notFound();
@@ -103,7 +105,7 @@ export default function CaseStudyPage({
   }
 
   const allSlugs = getPortfolioProjects().map((study) => study.slug);
-  const currentIndex = allSlugs.indexOf(params.slug);
+  const currentIndex = allSlugs.indexOf(slug);
   const nextSlug =
     currentIndex < allSlugs.length - 1 ? allSlugs[currentIndex + 1] : null;
   const nextCaseStudy = nextSlug ? caseStudiesData[nextSlug] : null;

--- a/src/hooks/useMBAJobs.ts
+++ b/src/hooks/useMBAJobs.ts
@@ -156,13 +156,19 @@ export function useMBAJobs(): UseMBAJobsResult {
   }, [watchedCompanyIds]);
 
   // ── Notification permission ────────────────────────────────────────────
+  // Always start "unsupported" on both server and first client render so
+  // hydration matches; resolve the real permission in an effect after mount.
+  // Reading window.Notification synchronously in the initializer caused
+  // the bell to render conditionally in different positions across server
+  // and client, triggering a hydration mismatch around NotificationBell.
   const [notificationPermission, setNotificationPermission] = useState<
     NotificationPermission | "unsupported"
-  >(() => {
-    if (typeof window === "undefined" || !("Notification" in window))
-      return "unsupported";
-    return Notification.permission;
-  });
+  >("unsupported");
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("Notification" in window)) return;
+    setNotificationPermission(Notification.permission);
+  }, []);
 
   // ── Fetch state ────────────────────────────────────────────────────────
   const [jobs, setJobs] = useState<MBAJob[]>([]);


### PR DESCRIPTION
## Summary

Two parts. The **hydration mismatch** + **async-params** fixes from the post-#94 console scan never made it into main — they were pushed to PR #94's branch *after* the squash-merge, so they were orphaned. This PR brings them back. On top of that, the only remaining noise from the scan — five \`preloaded but not used\` font warnings on every page — is silenced.

### Re-landed (orphaned by PR #94 merge)

- **MBA tracker hydration mismatch.** \`useMBAJobs\` initialized \`notificationPermission\` from \`window.Notification\` synchronously in \`useState\`'s initializer. Server returned \`"unsupported"\`, client returned \`"default"\`, and \`NotificationBell\` rendered \`null\` server-side but a button client-side — so React reconciled the wrong attributes onto the *next* sibling (Mail-icon → Bell-icon, \`disabled\` → not). Fix: always start \`"unsupported"\`, resolve the real permission in an effect after mount.
- **\`/portfolio/<slug>\` 404'd for every slug.** Next 16 makes \`params\` a \`Promise\`. \`generateMetadata\` and the page component were destructuring \`params.slug\` synchronously → \`undefined\` → \`notFound()\`. Awaiting \`params\` restores the redirect-to-link path and silences the \`.next/types/...\` TS errors.

### New: font-preload warnings

Five "preloaded but not used within a few seconds" warnings fired on every route — one per font weight subset Next was preloading from the four families. Per family:

- **Inter** — pinned to \`weight: ["400", "500", "600", "700"]\` (what the CSS actually uses) and dropped \`preload\`. Above-the-fold is Instrument Sans for the wordmark, so Inter doesn't land inside Chrome's preload-window threshold; the system fallback covers first paint and Inter swaps in (\`display: swap\`) as expected.
- **JetBrains Mono** — only appears in code blocks / kicker meta. \`preload: false\` so the warning stops on pages without code.
- **Instrument Sans / Serif** — already \`display: optional\` from PR #92. Added matching \`preload: false\`. Optional + preload was a contradictory combo and was the original trigger for two of the warnings.

After: home, writing slug, and MBA tracker all show **0 errors / 0 warnings** in the console.

## Test plan
- [ ] DevTools console on \`/\` — no font-preload warnings
- [ ] DevTools console on \`/mba-internship-notifications\` — no hydration overlay; the bell renders only once \`useEffect\` resolves the permission
- [ ] \`/portfolio/fantasy-football-analytics\` redirects to \`/fantasy-football\` (and likewise for other slugs)
- [ ] First paint on a cold load — Instrument Sans wordmark resolves with system fallback first; Inter swaps in once loaded (no late layout shift)