### PR TITLE
feat(home): editorial hero from the design-system handoff

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -735,14 +735,67 @@
   }
 
   .home-wordmark {
-    margin-bottom: 1rem;
+    /*
+     * Edge-to-edge fluid wordmark. Sized off the shell so it never
+     * overflows even on tight viewports — caps at 14rem on the largest
+     * screens. Tight tracking and 0.82 line-height match the design
+     * system's manifesto-scale treatment.
+     */
+    display: block;
+    margin: 0 0 0.75rem;
     font-family: var(--font-home-sans);
-    font-size: clamp(3rem, 9vw, 6.75rem);
+    font-size: clamp(3.2rem, 14.2vw, 14rem);
     font-weight: 700;
-    line-height: 0.9;
-    letter-spacing: -0.08em;
+    line-height: 0.82;
+    letter-spacing: -0.085em;
     text-transform: uppercase;
     color: var(--home-ink);
+    text-indent: -0.04em;
+    white-space: nowrap;
+    text-align: left;
+  }
+
+  .home-hero-meta-strip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: clamp(1rem, 2vw, 2rem);
+    border-top: 1px solid color-mix(in srgb, var(--home-ink) 18%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--home-ink) 18%, transparent);
+    padding: 14px 0;
+    margin: 14px 0 clamp(1.75rem, 3vw, 2.5rem);
+    font-family: var(--font-home-sans);
+  }
+  .home-hero-meta-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+  .home-hero-meta-lbl {
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--home-ink-muted);
+  }
+  .home-hero-meta-val {
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    color: var(--home-ink);
+    line-height: 1.25;
+  }
+  .home-hero-meta-val em {
+    font-family: var(--font-home-serif);
+    font-style: italic;
+    font-weight: 500;
+    color: color-mix(in srgb, var(--home-ink) 78%, var(--home-ink-muted));
+  }
+  @media (max-width: 880px) {
+    .home-hero-meta-strip {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1rem;
+    }
   }
 
   .home-intro-block {
@@ -790,25 +843,154 @@
 
   .home-hero-grid {
     display: grid;
-    gap: 2rem;
-    align-items: center;
+    gap: clamp(1.5rem, 3vw, 3rem);
+    align-items: stretch;
+  }
+
+  .home-hero-copy {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: clamp(1.25rem, 2.5vw, 2rem);
+  }
+  .home-hero-copy-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
   }
 
   .home-hero-title {
-    max-width: 12ch;
-    margin-bottom: 1rem;
+    max-width: 18ch;
+    margin: 0;
     font-family: var(--font-home-sans);
-    font-size: clamp(2.85rem, 7vw, 5.8rem);
+    font-size: clamp(2.6rem, 5.4vw, 4.6rem);
     font-weight: 600;
-    line-height: 0.92;
-    letter-spacing: -0.08em;
+    line-height: 0.94;
+    letter-spacing: -0.075em;
     color: var(--home-ink);
     text-wrap: balance;
   }
+  .home-hero-title em {
+    font-family: var(--font-home-serif);
+    font-style: italic;
+    font-weight: 500;
+    color: color-mix(in srgb, var(--home-ink) 72%, var(--home-ink-muted));
+  }
 
   .home-hero-body {
-    max-width: 33rem;
-    margin-bottom: 1.75rem;
+    max-width: 38rem;
+    margin: 0;
+  }
+
+  .home-hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .home-hero-now-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 14px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--home-acid) 32%, var(--home-paper));
+    border: 1px solid color-mix(in srgb, var(--home-ink) 16%, transparent);
+    font-family: var(--font-home-sans);
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--home-ink);
+    white-space: nowrap;
+  }
+  .home-hero-now-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 999px;
+    background: #2BA84A;
+    box-shadow: 0 0 0 4px rgba(43, 168, 74, 0.16);
+  }
+
+  .home-hero-aside {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    min-width: 0;
+  }
+
+  .home-hero-aside-chips {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+  .home-hero-aside-chip {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px 14px;
+    border-radius: 0.9rem;
+    border: 1px solid color-mix(in srgb, var(--home-ink) 14%, transparent);
+    background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+    text-decoration: none;
+    color: var(--home-ink);
+    transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+    min-width: 0;
+  }
+  .home-hero-aside-chip:hover,
+  .home-hero-aside-chip:focus-visible {
+    border-color: color-mix(in srgb, var(--home-haze) 45%, var(--home-rule));
+    background: color-mix(in srgb, var(--home-acid) 14%, var(--home-paper));
+  }
+  .home-hero-aside-chip-lbl {
+    font-family: var(--font-home-sans);
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--home-ink-muted);
+  }
+  .home-hero-aside-chip-val {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    font-family: var(--font-home-sans);
+    font-size: 0.92rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    color: var(--home-ink);
+    line-height: 1.25;
+  }
+
+  .home-headshot-caption {
+    position: absolute;
+    left: 14px;
+    right: 14px;
+    bottom: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--home-paper) 90%, transparent);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid color-mix(in srgb, var(--home-ink) 14%, transparent);
+    font-family: var(--font-home-sans);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--home-ink);
+  }
+  .home-headshot-caption-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: var(--home-ink);
+    flex: 0 0 auto;
   }
 
   .home-button {
@@ -998,10 +1180,11 @@
 
   .home-headshot-frame {
     position: relative;
-    width: min(100%, 26rem);
-    aspect-ratio: 3/4;
+    width: 100%;
+    max-width: 28rem;
+    aspect-ratio: 4 / 5;
     overflow: hidden;
-    border-radius: 1.8rem;
+    border-radius: 1.6rem;
     box-shadow: var(--shadow-xl);
     /* Paper-toned fallback so an empty frame doesn't read as a hollow box
        if the image ever fails to load (HP-1). */
@@ -1392,8 +1575,8 @@
     }
 
     .home-hero-grid {
-      grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
-      gap: 3.5rem;
+      grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
+      gap: clamp(2rem, 4vw, 3.5rem);
     }
 
     .home-section-intro {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1264,17 +1264,28 @@
   }
 
   .home-spotlight-board {
+    /*
+     * Per the design system handoff: the board owns its own stretch +
+     * spacing rules so consumers don't need a Tailwind `h-full` utility
+     * to fill the grid row. justify-content + gap distribute the note,
+     * poster, and tags from top to bottom; min-height keeps it readable
+     * if the manifesto column happens to be short on a given viewport.
+     */
     position: relative;
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
+    gap: 1.25rem;
+    height: 100%;
+    min-height: 22rem;
     overflow: hidden;
     border: 1px solid color-mix(in srgb, var(--home-ink) 16%, transparent);
     border-radius: 1.8rem;
     background:
       radial-gradient(circle at 80% 18%, color-mix(in srgb, var(--home-haze) 32%, transparent), transparent 30%),
       linear-gradient(180deg, color-mix(in srgb, var(--home-paper) 65%, white) 0%, color-mix(in srgb, var(--home-paper-alt) 94%, white) 100%);
-    padding: 1.5rem;
-    box-shadow: var(--shadow-xl);
+    padding: clamp(1.25rem, 2.5vw, 2rem);
+    box-shadow: var(--shadow-md);
   }
 
   .home-spotlight-note {
@@ -1291,9 +1302,10 @@
   }
 
   .home-spotlight-poster {
+    /* Sits in the flex flow — the board's justify-content distributes the
+       note (top), poster (center), and tags (bottom). No more margin: auto. */
     display: grid;
     gap: 0.15rem;
-    margin-top: auto;
     font-family: var(--font-home-sans);
     font-size: clamp(1.6rem, 3.5vw, 3rem);
     font-weight: 600;
@@ -1311,8 +1323,6 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.65rem;
-    margin-top: auto;
-    padding-top: 1.5rem;
   }
 
   .home-spotlight-tags span {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,14 @@
 import { StructuredData } from "@/components/StructuredData";
 import { AIStructuredData } from "@/components/AIStructuredData";
 import { HomePageContent } from "@/components/home/HomePageContent";
-import { getHomepageFeaturedCaseStudies } from "@/constants/caseStudies";
-import { getHomepageProofOfWorkBlogPostPreviews } from "@/lib/blog";
+import {
+  getHomepageFeaturedCaseStudies,
+  getPortfolioProjects,
+} from "@/constants/caseStudies";
+import {
+  getAllBlogPostPreviews,
+  getHomepageProofOfWorkBlogPostPreviews,
+} from "@/lib/blog";
 import { profile, profileSameAs } from "@/lib/profile";
 
 export { metadata } from "./metadata";
@@ -11,11 +17,27 @@ export default function Home() {
   const featuredProjects = getHomepageFeaturedCaseStudies();
   const proofOfWorkPosts = getHomepageProofOfWorkBlogPostPreviews();
 
+  // Hero meta strip + quick-fact chips read live counts and the latest
+  // writing entry so the editorial hero stays accurate as content ships.
+  const allPosts = getAllBlogPostPreviews();
+  const allProjects = getPortfolioProjects();
+  const liveTools = allProjects.filter((p) => Boolean(p.link)).length;
+  const heroIndex = {
+    projectCount: allProjects.length,
+    essayCount: allPosts.length,
+    liveToolCount: liveTools,
+  };
+  const latestPost = allPosts[0] ?? null;
+  const featuredEssay = allPosts.find((p) => !p.cluster) ?? latestPost;
+
   return (
     <div className="w-full scroll-smooth bg-[var(--home-paper)]">
       <HomePageContent
         featuredProjects={featuredProjects}
         proofOfWorkPosts={proofOfWorkPosts}
+        heroIndex={heroIndex}
+        latestPost={latestPost}
+        featuredEssay={featuredEssay}
       />
 
       <StructuredData type="ProfilePage" />

--- a/src/components/home/HomePageContent.tsx
+++ b/src/components/home/HomePageContent.tsx
@@ -290,8 +290,8 @@ export function HomePageContent({
             </div>
 
             <div className="home-reveal home-reveal-delay-1 h-full">
-              <div className="home-spotlight-board h-full" aria-hidden="true">
-                <div className="home-spotlight-note w-fit">Point of view</div>
+              <div className="home-spotlight-board" aria-hidden="true">
+                <div className="home-spotlight-note">Point of view</div>
                 <div className="home-spotlight-poster">
                   <span>Tradeoffs</span>
                   <span>legible.</span>

--- a/src/components/home/HomePageContent.tsx
+++ b/src/components/home/HomePageContent.tsx
@@ -16,6 +16,13 @@ import { publishedDateFormatter } from "@/lib/utils";
 interface HomePageContentProps {
   featuredProjects: CaseStudyData[];
   proofOfWorkPosts: BlogPostPreview[];
+  heroIndex: {
+    projectCount: number;
+    essayCount: number;
+    liveToolCount: number;
+  };
+  latestPost: BlogPostPreview | null;
+  featuredEssay: BlogPostPreview | null;
 }
 
 function HomeProjectCard({
@@ -87,6 +94,9 @@ function HomeWritingCard({ post }: { post: BlogPostPreview }) {
 export function HomePageContent({
   featuredProjects,
   proofOfWorkPosts,
+  heroIndex,
+  latestPost,
+  featuredEssay,
 }: HomePageContentProps) {
   return (
     <div className="home-page">
@@ -96,40 +106,78 @@ export function HomePageContent({
         data-testid="hero"
       >
         <div className="home-shell">
-          <div className="home-wordmark home-reveal mx-auto text-center">ISAAC VAZQUEZ</div>
+          <h2
+            className="home-wordmark home-reveal"
+            aria-label="Isaac Vazquez"
+          >
+            ISAAC VAZQUEZ
+          </h2>
 
-          <div className="home-intro-block home-reveal home-reveal-delay-1">
-            <p className="home-kicker">Product work, writing, and live tools</p>
-            <p className="home-body home-intro-copy">
-              Most of my work lives where product judgment, AI workflows, and
-              clear decision support have to hold together at the same time.
-            </p>
+          <div className="home-hero-meta-strip home-reveal home-reveal-delay-1">
+            <div className="home-hero-meta-cell">
+              <span className="home-hero-meta-lbl">Role</span>
+              <span className="home-hero-meta-val">
+                Product manager <em>&amp;</em> builder
+              </span>
+            </div>
+            <div className="home-hero-meta-cell">
+              <span className="home-hero-meta-lbl">Focus</span>
+              <span className="home-hero-meta-val">
+                AI workflows · Fintech · Analytics
+              </span>
+            </div>
+            <div className="home-hero-meta-cell">
+              <span className="home-hero-meta-lbl">Based</span>
+              <span className="home-hero-meta-val">
+                Berkeley, CA <em>·</em>&nbsp;Haas MBA &apos;27
+              </span>
+            </div>
+            <div className="home-hero-meta-cell">
+              <span className="home-hero-meta-lbl">Index</span>
+              <span className="home-hero-meta-val">
+                {heroIndex.projectCount} projects · {heroIndex.essayCount} essays ·{" "}
+                {heroIndex.liveToolCount} live tools
+              </span>
+            </div>
           </div>
 
           <div className="home-hero-grid">
-            <div className="home-reveal home-reveal-delay-2 lg:ml-auto">
-              <h1 id="home-hero-heading" className="home-hero-title max-w-3xl">
-                I build products that make hard problems easier to act on.
-              </h1>
-              <p className="home-body home-hero-body max-w-3xl">
-                Product case studies, PM-focused AI writing, and interactive
-                fintech and analytics tools built to make complex choices
-                easier to inspect.
-              </p>
+            <div className="home-hero-copy home-reveal home-reveal-delay-2">
+              <div className="home-hero-copy-stack">
+                <p className="home-kicker mb-0">Product work, writing, and live tools</p>
+                <h1 id="home-hero-heading" className="home-hero-title">
+                  I build products that make hard problems <em>easier</em> to act on.
+                </h1>
+                <p className="home-body home-hero-body">
+                  Most of my work lives where product judgment, AI workflows,
+                  and clear decision support have to hold together at the same
+                  time. Case studies, PM-focused writing, and interactive
+                  fintech and analytics tools built to make complex choices
+                  easier to inspect.
+                </p>
+              </div>
 
-              <div className="flex flex-wrap gap-3">
+              <div className="home-hero-actions">
                 <Link href="/portfolio" className="home-button home-button-secondary">
                   <Briefcase className="h-4 w-4" />
                   View projects
                 </Link>
-                <Link href="/about" className="home-button home-button-secondary">
+                <Link href="/writing" className="home-button home-button-secondary">
                   <Article className="h-4 w-4" />
-                  About
+                  Read writing
                 </Link>
+                <span
+                  className="home-hero-now-pill"
+                  role="status"
+                  aria-label="Available for new work"
+                >
+                  <span className="home-hero-now-dot" aria-hidden="true" />
+                  Available for new work
+                </span>
               </div>
             </div>
 
-            <div className="home-reveal home-reveal-delay-3 flex justify-center lg:justify-end">
+            <div className="home-hero-aside home-reveal home-reveal-delay-3">
               <div className="home-headshot-frame">
                 {/*
                  * unoptimized: the source is already a hand-tuned 90KB webp
@@ -146,6 +194,44 @@ export function HomePageContent({
                   priority
                   unoptimized
                 />
+                <div className="home-headshot-caption" aria-hidden="true">
+                  <span>Berkeley, CA</span>
+                  <span className="home-headshot-caption-dot" />
+                  <span>Open to roles</span>
+                </div>
+              </div>
+
+              <div className="home-hero-aside-chips">
+                {latestPost ? (
+                  <Link
+                    href={`/writing/${latestPost.slug}`}
+                    className="home-hero-aside-chip group"
+                  >
+                    <span className="home-hero-aside-chip-lbl">Latest</span>
+                    <span className="home-hero-aside-chip-val">{latestPost.title}</span>
+                  </Link>
+                ) : (
+                  <div className="home-hero-aside-chip">
+                    <span className="home-hero-aside-chip-lbl">Latest</span>
+                    <span className="home-hero-aside-chip-val">New writing in progress</span>
+                  </div>
+                )}
+                {featuredEssay && featuredEssay.slug !== latestPost?.slug ? (
+                  <Link
+                    href={`/writing/${featuredEssay.slug}`}
+                    className="home-hero-aside-chip group"
+                  >
+                    <span className="home-hero-aside-chip-lbl">Writing</span>
+                    <span className="home-hero-aside-chip-val">{featuredEssay.title}</span>
+                  </Link>
+                ) : (
+                  <Link href="/writing" className="home-hero-aside-chip group">
+                    <span className="home-hero-aside-chip-lbl">Writing</span>
+                    <span className="home-hero-aside-chip-val">
+                      Essays on PM, AI workflows, and fintech tools
+                    </span>
+                  </Link>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

First slice of the Claude Design handoff bundle — implements the homepage hero pass the user iterated to a finished state in the chat ("I think we could use the space here better"). Replaces the centered wordmark + intro block with the dense editorial grid the design system spec calls for.

### Visual changes
- **Edge-to-edge wordmark.** \`clamp(3.2rem, 14.2vw, 14rem)\`, tracking -0.085em, line-height 0.82, white-space nowrap — fills the shell.
- **4-cell meta strip** under the wordmark: Role / Focus / Based / Index, top + bottom ink hairlines, kicker labels in 10.5px / 0.14em / uppercase, values with italic Instrument Serif accents (the \`&\` in "Product manager & builder", the \`·\` in "Berkeley, CA · Haas MBA '27") per the voice rules.
- **1.55fr / 1fr hero grid** at lg+ — headline + lede + actions on the left, headshot + chips on the right.
- **Italic accent in the headline** — "…hard problems _easier_ to act on." pulls Instrument Serif italic, the design's manifesto-emphasis treatment (only place serif italic appears on the page).
- **"Available for new work" pill** alongside the action buttons with a green pulse dot.
- **Headshot frame** becomes 4:5 portrait at 28rem max width with a paper-pill caption ("Berkeley, CA · Open to roles") backdrop-blurred at the bottom.
- **Two quick-fact aside chips** below the headshot — Latest + Writing, both linkable, wired to the real most-recent blog post and a featured essay so the hero stays current as content ships.

### Wiring
- Real counts in the index cell — \`getPortfolioProjects()\` + \`getAllBlogPostPreviews()\` produce "11 projects · 53 essays · 11 live tools" right now.
- Latest / Writing chips fall back gracefully when no posts exist.

### Verified
Playwright pass at 1440px / 700px / 375px viewports. Console: 0 errors, 0 warnings on the new hero.

### Out of scope (future PRs)
The handoff also has Investments dashboard, Investments research, and Writing-page redesigns. Each is a meaningful surface rebuild on its own — splitting them out so this one ships fast and the others can be reviewed independently.

## Test plan
- [ ] Hard reload \`/\` at desktop — wordmark fills shell, meta strip + grid line up
- [ ] Resize to 880px — meta strip drops to 2 columns, hero stacks vertically
- [ ] Resize to 375px — wordmark stays edge-to-edge per design intent
- [ ] Tab order: header → wordmark heading → meta cells → kicker → headline → action buttons → headshot caption → aside chips
- [ ] In a screen reader: "Available for new work" announces via role=status; aside chips announce as links to the right post titles