### PR TITLE
feat(investments): hero balance card + dense stats grid

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1722,6 +1722,24 @@ img {
 /* ==========================================================================
  * Investments dashboard — three-column shell adapted from the design handoff
  * ========================================================================== */
+.invest-page-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+.invest-research-band {
+  border-radius: 28px;
+  border: 1px solid var(--home-rule);
+  background:
+    radial-gradient(circle at 6% -4%, color-mix(in srgb, var(--home-haze) 12%, transparent), transparent 32%),
+    color-mix(in srgb, var(--home-paper) 96%, var(--home-elev-mix));
+  box-shadow: var(--shadow-sm);
+  padding: 26px 30px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
 .invest-shell {
   display: grid;
   grid-template-columns: 220px minmax(0, 1fr) 290px;
@@ -2165,6 +2183,18 @@ img {
   min-width: 220px;
 }
 
+/* Stats grid cells — reserve consistent label/sub heights across the row */
+.invest-stats-cell-label {
+  min-height: calc(2 * 1.4em);
+  display: block;
+  line-height: 1.4;
+}
+.invest-stats-cell-sub {
+  min-height: 1.4em;
+  display: block;
+  line-height: 1.4;
+}
+
 /* Compact dataset freshness chip — replaces the wide banner */
 .invest-dataset-chip {
   display: flex;
@@ -2211,8 +2241,6 @@ img {
   justify-content: space-between;
   gap: 16px;
   flex-wrap: wrap;
-  padding-top: 8px;
-  border-top: 1px dashed var(--home-rule);
 }
 .invest-section-kicker {
   margin: 0;
@@ -2317,7 +2345,9 @@ img {
 .research-asset-bio--muted { font-style: italic; }
 
 .research-key-metrics {
-  margin-top: 12px;
+  margin-top: 18px;
+  position: relative;
+  z-index: 1;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1768,10 +1768,7 @@ img {
 }
 
 .invest-sidebar {
-  position: sticky;
-  top: 88px;
-  align-self: start;
-  max-height: calc(100vh - 100px);
+  align-self: stretch;
   padding: 22px 14px;
   border-right: 1px solid var(--home-rule);
   background: color-mix(in srgb, var(--home-paper) 96%, var(--home-elev-mix));

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1719,6 +1719,464 @@ img {
   max-width: 65ch;
 }
 
+/* ==========================================================================
+ * Investments dashboard — three-column shell adapted from the design handoff
+ * ========================================================================== */
+.invest-shell {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr) 290px;
+  gap: 0;
+  background:
+    radial-gradient(circle at 6% -2%, color-mix(in srgb, var(--home-acid) 18%, transparent), transparent 28%),
+    radial-gradient(circle at 96% 4%, color-mix(in srgb, var(--home-haze) 18%, transparent), transparent 26%),
+    var(--home-paper);
+  border-radius: 28px;
+  border: 1px solid var(--home-rule);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+@media (max-width: 1280px) {
+  .invest-shell { grid-template-columns: 200px minmax(0, 1fr); }
+  .invest-rail { display: none !important; }
+}
+@media (max-width: 900px) {
+  .invest-shell { grid-template-columns: 1fr; border-radius: 20px; }
+  .invest-sidebar { display: none !important; }
+}
+
+/* Drop sparkline column on narrower main columns to keep the P/L + actions columns visible */
+@media (max-width: 1500px) {
+  .invest-holdings .col-trend { display: none; }
+}
+
+.invest-sidebar {
+  position: sticky;
+  top: 88px;
+  align-self: start;
+  height: calc(100vh - 100px);
+  padding: 22px 14px;
+  border-right: 1px solid var(--home-rule);
+  background: color-mix(in srgb, var(--home-paper) 96%, var(--home-elev-mix));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.invest-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 8px 18px;
+  border-bottom: 1px solid var(--home-rule);
+  margin-bottom: 14px;
+}
+.invest-brand-iv {
+  width: 34px; height: 34px; border-radius: 12px;
+  background:
+    radial-gradient(circle at 32% 36%, var(--home-acid) 0%, transparent 58%),
+    radial-gradient(circle at 70% 64%, var(--home-haze) 0%, transparent 60%),
+    var(--home-ink);
+  display: grid; place-items: center;
+  color: var(--home-paper);
+  font-weight: 700; font-size: 14px; letter-spacing: -0.04em;
+  box-shadow: var(--shadow-sm);
+  flex: 0 0 auto;
+}
+.invest-brand-name {
+  font-size: 13.5px; font-weight: 700; letter-spacing: -0.04em;
+  color: var(--home-ink); line-height: 1.1;
+  min-width: 0;
+}
+.invest-brand-name small {
+  display: block;
+  font-size: 10px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--home-ink-muted); margin-top: 3px;
+}
+.invest-nav-label {
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+  padding: 14px 10px 6px;
+}
+.invest-nav-link {
+  display: flex; align-items: center; gap: 12px;
+  padding: 9px 12px;
+  border-radius: 14px;
+  color: var(--home-ink-muted);
+  text-decoration: none;
+  font-size: 13.5px; font-weight: 500;
+  border: 1px solid transparent;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+  background: transparent;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+}
+.invest-nav-link:hover {
+  background: color-mix(in srgb, var(--home-acid) 18%, transparent);
+  color: var(--home-ink);
+}
+.invest-nav-link[aria-current="true"],
+.invest-nav-link.is-active {
+  background: var(--home-ink);
+  color: var(--home-paper);
+  border-color: var(--home-ink);
+}
+.invest-nav-link svg { width: 18px; height: 18px; flex: 0 0 auto; }
+.invest-nav-pill {
+  margin-left: auto;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+  background: color-mix(in srgb, var(--home-acid) 40%, transparent);
+  color: var(--home-ink);
+  padding: 2px 8px; border-radius: 999px;
+}
+.invest-nav-link[aria-current="true"] .invest-nav-pill,
+.invest-nav-link.is-active .invest-nav-pill {
+  background: color-mix(in srgb, var(--home-paper) 22%, transparent);
+  color: var(--home-paper);
+}
+.invest-sidebar-footer {
+  margin-top: auto;
+  padding: 14px 12px;
+  border-top: 1px solid var(--home-rule);
+  display: flex; align-items: center; gap: 10px;
+  font-size: 12.5px; color: var(--home-ink-muted);
+}
+
+.invest-main {
+  padding: 22px 26px 40px;
+  min-width: 0;
+}
+.invest-topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 16px; margin-bottom: 22px; flex-wrap: wrap;
+}
+.invest-crumbs {
+  font-size: 11px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+}
+.invest-crumbs strong { color: var(--home-ink); }
+.invest-topbar h1 {
+  margin: 6px 0 0;
+  font-size: clamp(1.4rem, 1.4vw + 1rem, 1.85rem);
+  font-weight: 600; letter-spacing: -0.04em; line-height: 1;
+  color: var(--home-ink);
+}
+.invest-search {
+  flex: 0 1 320px;
+  display: flex; align-items: center; gap: 10px;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  border: 1px solid var(--home-rule);
+  border-radius: 999px;
+  padding: 9px 14px;
+  font-size: 13px; color: var(--home-ink-muted);
+  box-shadow: var(--shadow-sm);
+}
+.invest-search input {
+  all: unset;
+  flex: 1;
+  color: var(--home-ink);
+  font-size: 13px;
+}
+.invest-search input::placeholder { color: var(--home-ink-muted); }
+.invest-search-kbd {
+  font: 10.5px var(--font-mono);
+  color: var(--home-ink-muted);
+  letter-spacing: 0.04em;
+}
+.invest-avatar {
+  width: 38px; height: 38px; border-radius: 999px;
+  background: var(--home-ink); color: var(--home-paper);
+  display: grid; place-items: center; font-weight: 700; font-size: 13px;
+  letter-spacing: 0.02em;
+  flex: 0 0 auto;
+}
+
+/* Hero balance card with embedded chart */
+.invest-hero {
+  position: relative;
+  border-radius: 28px;
+  border: 1px solid var(--home-rule);
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  box-shadow: var(--shadow-md);
+  padding: 26px 28px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+  gap: 28px;
+  align-items: stretch;
+}
+@media (max-width: 1100px) {
+  .invest-hero { grid-template-columns: 1fr; }
+}
+.invest-hero::before {
+  content: "";
+  position: absolute;
+  inset: -40% -10% auto auto;
+  width: 360px; height: 360px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--home-haze) 18%, transparent), transparent 60%);
+  filter: blur(20px);
+  pointer-events: none;
+}
+.invest-hero-left {
+  position: relative; z-index: 2;
+  display: flex; flex-direction: column;
+  min-width: 0;
+}
+.invest-hero-eyebrow {
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.invest-hero-livedot {
+  width: 7px; height: 7px; border-radius: 999px;
+  background: var(--color-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 22%, transparent);
+  animation: invest-livepulse 1.6s ease-in-out infinite;
+}
+@keyframes invest-livepulse {
+  0%, 100% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 22%, transparent); }
+  50%      { box-shadow: 0 0 0 6px color-mix(in srgb, var(--color-success) 0%, transparent); }
+}
+.invest-hero-balance {
+  margin: 14px 0 6px;
+  font-size: clamp(2.2rem, 3.2vw + .8rem, 3.4rem);
+  font-weight: 600; letter-spacing: -0.06em; line-height: 0.98;
+  color: var(--home-ink);
+  font-variant-numeric: tabular-nums;
+  display: flex; align-items: baseline; gap: 6px; flex-wrap: wrap;
+}
+.invest-hero-balance .cents {
+  color: color-mix(in srgb, var(--home-ink) 38%, var(--home-paper));
+  font-size: 0.5em; font-weight: 500;
+}
+.invest-hero-balance .ccy {
+  font-size: 0.34em; font-weight: 600; letter-spacing: 0.04em;
+  color: var(--home-ink-muted); margin-left: 2px;
+}
+.invest-hero-delta {
+  display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  font-size: 13px; font-weight: 600;
+}
+.invest-hero-delta .chip {
+  padding: 4px 10px; border-radius: 999px; font-size: 12px;
+  border: 1px solid transparent;
+}
+.invest-hero-delta .chip.pos {
+  background: color-mix(in srgb, var(--color-success) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-success) 28%, transparent);
+  color: var(--color-success);
+}
+.invest-hero-delta .chip.neg {
+  background: color-mix(in srgb, var(--color-error) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-error) 28%, transparent);
+  color: var(--color-error);
+}
+.invest-hero-delta .muted {
+  color: var(--home-ink-muted); font-weight: 500;
+}
+.invest-hero-actions {
+  margin-top: auto;
+  padding-top: 18px;
+  display: flex; gap: 10px; flex-wrap: wrap;
+}
+
+/* Right side of the hero — chart wrapper */
+.invest-chart-wrap {
+  position: relative;
+  align-self: stretch;
+  border-radius: 22px;
+  background: color-mix(in srgb, var(--home-paper-alt) 56%, var(--home-elev-mix));
+  border: 1px solid var(--home-rule);
+  padding: 14px 16px 10px;
+  min-height: 240px;
+  display: flex; flex-direction: column;
+  z-index: 1;
+}
+.invest-timeframe {
+  display: inline-flex; gap: 2px;
+  background: color-mix(in srgb, var(--home-paper-alt) 70%, var(--home-elev-mix));
+  border: 1px solid var(--home-rule);
+  border-radius: 999px;
+  padding: 3px;
+  width: fit-content;
+}
+.invest-timeframe button {
+  border: 0; background: transparent;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font: inherit; font-size: 11.5px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+  cursor: pointer;
+  min-height: 28px;
+}
+.invest-timeframe button.is-on {
+  background: var(--home-ink);
+  color: var(--home-paper);
+}
+
+.invest-ghost {
+  border: 1px solid var(--home-rule);
+  background: color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix));
+  border-radius: 999px;
+  padding: 8px 14px;
+  font: inherit; font-size: 12.5px; font-weight: 600;
+  color: var(--home-ink); cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease;
+  display: inline-flex; align-items: center; gap: 8px;
+  text-decoration: none;
+  min-height: 36px;
+}
+.invest-ghost:hover {
+  background: color-mix(in srgb, var(--home-acid) 22%, transparent);
+}
+.invest-ghost.is-primary {
+  background: var(--home-ink); color: var(--home-paper); border-color: var(--home-ink);
+}
+.invest-ghost.is-primary:hover {
+  background: color-mix(in srgb, var(--home-ink) 90%, var(--home-haze));
+}
+
+/* Holdings table */
+.invest-panel {
+  border-radius: 28px;
+  border: 1px solid var(--home-rule);
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+.invest-panel-head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--home-rule);
+  gap: 12px; flex-wrap: wrap;
+}
+.invest-panel-head h2 {
+  margin: 0;
+  font-size: 16px; font-weight: 700; letter-spacing: -0.02em;
+  color: var(--home-ink);
+}
+.invest-panel-head-meta {
+  font-size: 12px; color: var(--home-ink-muted); margin-top: 2px;
+}
+.invest-panel-tabs {
+  display: inline-flex; gap: 2px;
+  background: var(--home-paper-alt); border-radius: 999px; padding: 3px;
+  border: 1px solid var(--home-rule);
+}
+.invest-panel-tabs button {
+  border: 0; background: transparent;
+  padding: 7px 14px; border-radius: 999px;
+  font: inherit; font-size: 12px; font-weight: 600;
+  color: var(--home-ink-muted); cursor: pointer;
+  min-height: 32px;
+}
+.invest-panel-tabs button.is-on {
+  background: color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix));
+  color: var(--home-ink);
+  border: 1px solid var(--home-rule);
+  padding: 6px 13px;
+}
+
+.invest-holdings {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+.invest-holdings thead th {
+  text-align: left;
+  padding: 12px 14px;
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+  border-bottom: 1px solid var(--home-rule);
+  background: color-mix(in srgb, var(--home-paper-alt) 30%, var(--home-elev-mix));
+  white-space: nowrap;
+}
+.invest-holdings thead th:first-child { padding-left: 22px; }
+.invest-holdings thead th:last-child { padding-right: 22px; }
+.invest-holdings thead th.num { text-align: right; }
+.invest-holdings tbody td {
+  padding: 14px;
+  border-bottom: 1px solid var(--home-rule);
+  vertical-align: middle;
+  font-size: 13.5px; color: var(--home-ink);
+}
+.invest-holdings tbody td:first-child { padding-left: 22px; }
+.invest-holdings tbody td:last-child { padding-right: 22px; }
+.invest-holdings tbody tr:last-child td { border-bottom: 0; }
+.invest-holdings tbody tr {
+  transition: background 160ms ease;
+}
+.invest-holdings tbody tr:hover {
+  background: color-mix(in srgb, var(--home-acid) 8%, transparent);
+}
+.invest-holdings td.num { text-align: right; }
+
+.invest-ticker {
+  display: inline-flex; align-items: center; gap: 12px;
+  min-width: 0;
+}
+.invest-logo {
+  width: 36px; height: 36px;
+  border-radius: 999px;
+  display: grid; place-items: center;
+  color: var(--home-paper);
+  font-weight: 700; font-size: 11.5px; letter-spacing: -0.02em;
+  border: 1px solid var(--home-rule);
+  flex: 0 0 auto;
+}
+.invest-ticker-info { line-height: 1.2; min-width: 0; }
+.invest-ticker-sym {
+  font-weight: 700; font-size: 14px; letter-spacing: -0.02em;
+  color: var(--home-ink);
+  white-space: nowrap;
+}
+.invest-ticker-name {
+  font-size: 11.5px; color: var(--home-ink-muted);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  max-width: 16ch;
+}
+.invest-alloc-bar {
+  display: inline-flex; align-items: center; gap: 8px;
+  width: 110px;
+}
+.invest-alloc-track {
+  flex: 1; height: 6px;
+  background: var(--home-paper-alt);
+  border: 1px solid var(--home-rule);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.invest-alloc-fill {
+  height: 100%;
+  border-radius: 999px;
+}
+.invest-alloc-pct {
+  font-size: 12px; color: var(--home-ink-muted);
+  width: 44px; text-align: right;
+}
+.invest-spark { width: 86px; height: 26px; display: block; }
+.invest-row-actions { display: inline-flex; gap: 6px; align-items: center; justify-content: flex-end; }
+.invest-holdings .invest-row-actions .invest-ghost {
+  width: 32px; height: 32px;
+  padding: 0;
+  justify-content: center;
+  min-height: 0;
+}
+
+/* Right rail */
+.invest-rail {
+  position: sticky; top: 88px;
+  align-self: start;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+  padding: 22px 22px 40px;
+  border-left: 1px solid var(--home-rule);
+  background: color-mix(in srgb, var(--home-paper) 96%, var(--home-elev-mix));
+  display: flex; flex-direction: column; gap: 16px;
+}
+.invest-rail-section-label {
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+  margin: 0 0 8px;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .home-reveal,
   .home-gradient-drift {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2316,6 +2316,52 @@ img {
 }
 .research-asset-bio--muted { font-style: italic; }
 
+.research-key-metrics {
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  border: 1px solid var(--home-rule);
+  border-radius: 18px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--home-paper) 96%, var(--home-elev-mix));
+}
+@media (max-width: 900px) {
+  .research-key-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+.research-key-metric {
+  padding: 12px 14px;
+  border-right: 1px solid var(--home-rule);
+  border-bottom: 1px solid var(--home-rule);
+  display: flex; flex-direction: column; gap: 4px;
+  min-width: 0;
+}
+.research-key-metric:nth-child(4n) { border-right: 0; }
+.research-key-metric:nth-last-child(-n+4) { border-bottom: 0; }
+@media (max-width: 900px) {
+  .research-key-metric:nth-child(4n) { border-right: 1px solid var(--home-rule); }
+  .research-key-metric:nth-child(2n) { border-right: 0; }
+  .research-key-metric:nth-last-child(-n+4) { border-bottom: 1px solid var(--home-rule); }
+  .research-key-metric:nth-last-child(-n+2) { border-bottom: 0; }
+}
+.research-key-metric-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--home-ink-muted);
+  cursor: help;
+  width: fit-content;
+}
+.research-key-metric-value {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+  word-break: break-word;
+}
+
 .research-asset-price {
   text-align: right;
   margin-left: auto;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2160,6 +2160,176 @@ img {
   min-height: 0;
 }
 
+.research-topbar-search {
+  flex: 0 1 360px;
+  min-width: 220px;
+}
+
+/* Research view — asset header card */
+.research-asset-card {
+  position: relative;
+  border: 1px solid var(--home-rule);
+  border-radius: 28px;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  box-shadow: var(--shadow-md);
+  padding: 24px 26px;
+  overflow: hidden;
+}
+.research-asset-card::before {
+  content: "";
+  position: absolute;
+  right: -10%; top: -60%;
+  width: 480px; height: 480px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--home-haze) 14%, transparent), transparent 60%);
+  filter: blur(18px);
+  pointer-events: none;
+}
+.research-asset-row {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.research-asset-logo {
+  width: 64px; height: 64px;
+  border-radius: 22px;
+  color: var(--home-paper);
+  display: grid; place-items: center;
+  font-weight: 700; font-size: 20px;
+  letter-spacing: -0.04em;
+  border: 1px solid var(--home-rule);
+  box-shadow: var(--shadow-sm);
+  flex: 0 0 auto;
+}
+.research-asset-meta { flex: 1; min-width: 220px; }
+.research-asset-titleline {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+.research-asset-titleline h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw + 0.6rem, 2.05rem);
+  font-weight: 600; letter-spacing: -0.04em; line-height: 1;
+  color: var(--home-ink);
+}
+.research-ticker-pill {
+  font: 12px var(--font-mono);
+  background: var(--home-paper-alt);
+  border: 1px solid var(--home-rule);
+  color: var(--home-ink);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+.research-badge-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  padding: 5px 11px; border-radius: 999px;
+}
+.research-badge-pill.held {
+  background: color-mix(in srgb, var(--home-haze) 12%, transparent);
+  color: var(--home-haze);
+  border: 1px solid color-mix(in srgb, var(--home-haze) 30%, transparent);
+}
+.research-badge-pill.tag {
+  background: color-mix(in srgb, var(--home-acid) 32%, transparent);
+  color: var(--home-ink);
+}
+.research-asset-bio {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--home-ink-muted);
+  max-width: 60ch;
+}
+.research-asset-bio--muted { font-style: italic; }
+
+.research-asset-price {
+  text-align: right;
+  margin-left: auto;
+  flex: 0 0 auto;
+  min-width: 200px;
+}
+.research-asset-price-eyebrow {
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.research-asset-px {
+  margin: 6px 0;
+  font-size: clamp(2rem, 2.4vw + 0.6rem, 2.6rem);
+  font-weight: 600; letter-spacing: -0.06em; line-height: 0.95;
+  color: var(--home-ink);
+  font-variant-numeric: tabular-nums;
+}
+.research-asset-px .cents {
+  color: color-mix(in srgb, var(--home-ink) 38%, var(--home-paper));
+  font-size: 0.55em;
+  font-weight: 500;
+}
+.research-asset-delta {
+  display: inline-flex; gap: 8px; align-items: center;
+  font-size: 13px; font-weight: 600;
+}
+.research-asset-delta .chip {
+  padding: 4px 10px; border-radius: 999px; font-size: 12px;
+  border: 1px solid transparent;
+}
+.research-asset-delta .chip.pos {
+  background: color-mix(in srgb, var(--color-success) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-success) 28%, transparent);
+  color: var(--color-success);
+}
+.research-asset-delta .chip.neg {
+  background: color-mix(in srgb, var(--color-error) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-error) 28%, transparent);
+  color: var(--color-error);
+}
+.research-asset-delta .pos { color: var(--color-success); }
+.research-asset-delta .neg { color: var(--color-error); }
+
+.research-asset-actions {
+  position: relative;
+  z-index: 1;
+  margin-top: 18px;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.research-asset-actions-clock {
+  margin-left: auto;
+  cursor: default;
+  font-size: 12px;
+  background: transparent !important;
+  border-color: transparent !important;
+  color: var(--home-ink-muted) !important;
+}
+
+/* Section panels inside the research view */
+.research-panel {
+  border: 1px solid var(--home-rule);
+  border-radius: 28px;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  box-shadow: var(--shadow-sm);
+  padding: 22px 24px;
+}
+.research-panel-head {
+  display: flex; align-items: end; justify-content: space-between;
+  flex-wrap: wrap; gap: 10px;
+  margin-bottom: 4px;
+}
+.research-panel-head h2 {
+  margin: 0;
+  font-size: 16px; font-weight: 700; letter-spacing: -0.02em; line-height: 1.2;
+  color: var(--home-ink);
+}
+.research-panel-head .meta {
+  font-size: 12px; color: var(--home-ink-muted); margin-top: 2px;
+}
+
 /* Right rail */
 .invest-rail {
   position: sticky; top: 88px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1753,7 +1753,7 @@ img {
   position: sticky;
   top: 88px;
   align-self: start;
-  height: calc(100vh - 100px);
+  max-height: calc(100vh - 100px);
   padding: 22px 14px;
   border-right: 1px solid var(--home-rule);
   background: color-mix(in srgb, var(--home-paper) 96%, var(--home-elev-mix));
@@ -2165,6 +2165,76 @@ img {
   min-width: 220px;
 }
 
+/* Compact dataset freshness chip — replaces the wide banner */
+.invest-dataset-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 8px 14px;
+  border: 1px solid var(--home-rule);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  font-size: 11.5px;
+  color: var(--home-ink-muted);
+  box-shadow: var(--shadow-sm);
+}
+.invest-dataset-chip strong {
+  color: var(--home-ink);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+.invest-dataset-chip-dot {
+  width: 7px; height: 7px;
+  border-radius: 999px;
+  background: var(--color-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 18%, transparent);
+}
+.invest-dataset-chip-divider { opacity: 0.5; }
+.invest-dataset-chip-spacer { flex: 1; min-width: 8px; }
+.invest-dataset-chip-meta {
+  font: 10.5px var(--font-mono);
+  color: var(--home-ink-muted);
+  letter-spacing: 0.04em;
+}
+.invest-dataset-chip-warn {
+  color: var(--color-warning, #B45309);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* In-page section header (Research / etc) */
+.invest-section-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding-top: 8px;
+  border-top: 1px dashed var(--home-rule);
+}
+.invest-section-kicker {
+  margin: 0;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--home-ink-muted);
+}
+.invest-section-title {
+  margin: 4px 0 0;
+  font-size: clamp(1.4rem, 1.4vw + 0.8rem, 1.85rem);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  color: var(--home-ink);
+  line-height: 1.1;
+}
+.invest-section-search {
+  flex: 0 1 320px;
+  min-width: 220px;
+}
+
 /* Research view — asset header card */
 .research-asset-card {
   position: relative;
@@ -2332,20 +2402,56 @@ img {
 
 /* Right rail */
 .invest-rail {
-  position: sticky; top: 88px;
-  align-self: start;
-  max-height: calc(100vh - 100px);
-  overflow-y: auto;
   padding: 22px 22px 40px;
   border-left: 1px solid var(--home-rule);
   background: color-mix(in srgb, var(--home-paper) 96%, var(--home-elev-mix));
   display: flex; flex-direction: column; gap: 16px;
+  align-self: stretch;
 }
 .invest-rail-section-label {
   font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
   color: var(--home-ink-muted);
   margin: 0 0 8px;
 }
+
+.invest-rail-mover-list {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.invest-rail-mover {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid var(--home-rule);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease, border-color 160ms ease;
+  font: inherit;
+  text-align: left;
+  color: var(--home-ink);
+}
+.invest-rail-mover:hover {
+  background: color-mix(in srgb, var(--home-acid) 18%, transparent);
+  transform: translateY(-1px);
+}
+.invest-rail-mover-sym {
+  font-weight: 700; font-size: 13px; letter-spacing: -0.02em;
+}
+.invest-rail-mover-name {
+  font-size: 11.5px; color: var(--home-ink-muted);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  max-width: 12ch;
+}
+.invest-rail-mover-delta {
+  font-size: 11.5px; font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.invest-rail-mover-delta.pos { color: var(--color-success); }
+.invest-rail-mover-delta.neg { color: var(--color-error); }
 
 @media (prefers-reduced-motion: reduce) {
   .home-reveal,

--- a/src/app/investments/investments-client.tsx
+++ b/src/app/investments/investments-client.tsx
@@ -1,42 +1,14 @@
 "use client";
 
-import React, { lazy, Suspense, startTransition, useEffect, useMemo } from "react";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import React, { startTransition, useEffect, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useInvestments } from "@/hooks/useInvestments";
-import {
-  containerVariants,
-  itemVariants,
-  fadeInVariants,
-  getReducedMotionVariants,
-} from "@/components/investments/animations";
-import { InvestmentsFreshnessBanner } from "@/components/investments/InvestmentsFreshnessBanner";
+import { InvestmentsDashboard } from "@/components/investments/InvestmentsDashboard";
 import {
   buildInvestmentsHref,
   type InvestmentsSearchState,
   normalizeInvestmentsState,
-  type InvestmentsView,
 } from "./investments-state";
-
-const PortfolioTracker = lazy(() =>
-  import("@/components/investments/PortfolioTracker").then((m) => ({ default: m.PortfolioTracker }))
-);
-const StockResearch = lazy(() =>
-  import("@/components/investments/StockResearch").then((m) => ({ default: m.StockResearch }))
-);
-
-function TabFallback() {
-  return (
-    <div className="flex items-center justify-center h-64">
-      <div className="w-8 h-8 border-2 border-[var(--home-haze)] border-t-transparent rounded-full animate-spin" />
-    </div>
-  );
-}
-
-const TABS: { key: InvestmentsView; label: string }[] = [
-  { key: "research",  label: "Research" },
-  { key: "portfolio", label: "My Portfolio" },
-];
+import type { ResearchTab } from "./investments-state";
 
 interface InvestmentsClientProps {
   initialState: InvestmentsSearchState;
@@ -53,15 +25,10 @@ export function InvestmentsClient({
 }: InvestmentsClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { holdings } = useInvestments();
-  const portfolioSymbols = holdings.map((h) => h.symbol);
-  const shouldReduceMotion = useReducedMotion();
   const shellClassName =
     "mx-auto w-full max-w-[1680px] px-4 pb-12 pt-8 sm:px-6 sm:pb-14 sm:pt-10 lg:px-8 xl:px-10 2xl:px-12";
 
-  const variants = shouldReduceMotion ? getReducedMotionVariants() : { containerVariants, itemVariants, fadeInVariants };
   const hasManagedParams =
-    searchParams.get("view") !== null ||
     searchParams.get("symbol") !== null ||
     searchParams.get("section") !== null;
   const routeState = useMemo(
@@ -69,7 +36,8 @@ export function InvestmentsClient({
     [hasManagedParams, initialState, searchParams]
   );
 
-  // Clear researched symbol when user navigates away from this page
+  // Clear researched symbol when user navigates away from this page so the
+  // next visit doesn't auto-load a stale ticker.
   useEffect(() => {
     return () => {
       const params = new URLSearchParams(window.location.search);
@@ -81,9 +49,9 @@ export function InvestmentsClient({
     };
   }, []);
 
+  // Keep URL in sync with normalized route state.
   useEffect(() => {
     if (
-      searchParams.get("view") === routeState.view &&
       searchParams.get("symbol") === routeState.symbol &&
       searchParams.get("section") === routeState.section
     ) {
@@ -95,10 +63,7 @@ export function InvestmentsClient({
     });
   }, [routeState, router, searchParams]);
 
-  function updateRouteState(
-    nextState: Partial<InvestmentsSearchState>,
-    options?: { replace?: boolean }
-  ) {
+  function updateRouteState(nextState: Partial<InvestmentsSearchState>) {
     const href = buildInvestmentsHref(
       {
         ...routeState,
@@ -108,110 +73,34 @@ export function InvestmentsClient({
     );
 
     startTransition(() => {
-      if (options?.replace) {
-        router.replace(href, { scroll: false });
-      } else {
-        router.push(href, { scroll: false });
-      }
+      router.push(href, { scroll: false });
     });
   }
 
-  function handleResearch(symbol: string) {
-    updateRouteState({
-      view: "research",
-      symbol,
-    });
+  function handleSymbolChange(symbol: string) {
+    updateRouteState({ symbol });
+  }
+
+  function handleTabChange(section: ResearchTab) {
+    updateRouteState({ section });
   }
 
   return (
     <section
       className="min-h-screen bg-[radial-gradient(circle_at_top_left,color-mix(in_srgb,var(--home-haze)_10%,transparent),transparent_28%),linear-gradient(180deg,var(--home-paper)_0%,color-mix(in_srgb,var(--home-paper-alt)_65%,var(--home-paper))_100%)]"
-      aria-label="Investment research workspace"
+      aria-label="Investments dashboard"
       data-testid="investments-shell"
     >
       <div className={shellClassName}>
-        <motion.div
-          className="mb-6"
-          variants={variants.fadeInVariants}
-          initial="hidden"
-          animate="visible"
-        >
-          <p className="home-kicker">Investment Research</p>
-          <h1 className="mt-2 text-3xl font-bold tracking-tight text-[var(--home-ink)] sm:text-4xl">
-            Investment Research Platform
-          </h1>
-          <p className="mt-2 max-w-[64ch] text-sm leading-6 text-[var(--home-ink-muted)]">
-            I built this to stress-test investment theses in one place. Company snapshots, valuation history, and a portfolio tracker that lives in your browser with no logins or cloud sync.
-          </p>
-        </motion.div>
-
-        <InvestmentsFreshnessBanner
-          lastUpdated={datasetLastUpdated}
-          symbolCount={datasetSymbolCount}
-          failedCount={datasetFailedCount}
+        <InvestmentsDashboard
+          researchSymbol={routeState.symbol}
+          researchTab={routeState.section}
+          onResearchSymbolChange={handleSymbolChange}
+          onResearchTabChange={handleTabChange}
+          datasetLastUpdated={datasetLastUpdated}
+          datasetSymbolCount={datasetSymbolCount}
+          datasetFailedCount={datasetFailedCount}
         />
-
-        <div
-          className="mb-8 inline-flex flex-wrap gap-2 rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))]/90 p-2 shadow-[var(--shadow-sm)] backdrop-blur"
-          role="tablist"
-          aria-label="Investments tabs"
-        >
-          {TABS.map(({ key, label }) => (
-            <button
-              key={key}
-              id={`investments-tab-${key}`}
-              role="tab"
-              aria-selected={routeState.view === key}
-              aria-controls={`investments-panel-${key}`}
-              tabIndex={routeState.view === key ? 0 : -1}
-              onClick={() => updateRouteState({ view: key })}
-              className={`min-h-[46px] rounded-2xl px-5 py-3 text-sm font-semibold transition ${
-                routeState.view === key
-                  ? "bg-[var(--home-haze)] text-white shadow-[var(--shadow-sm)]"
-                  : "text-[var(--home-ink-muted)] hover:bg-[var(--home-paper-alt)] hover:text-[var(--home-ink)]"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={routeState.view}
-            id={`investments-panel-${routeState.view}`}
-            role="tabpanel"
-            aria-labelledby={`investments-tab-${routeState.view}`}
-            className="w-full"
-            variants={variants.fadeInVariants}
-            initial="hidden"
-            animate="visible"
-            exit="hidden"
-          >
-            <Suspense fallback={<TabFallback />}>
-              {routeState.view === "portfolio" && <PortfolioTracker onResearch={handleResearch} />}
-              {routeState.view === "research" && (
-                <StockResearch
-                  symbol={routeState.symbol}
-                  activeTab={routeState.section}
-                  onSymbolChange={(symbol) =>
-                    updateRouteState({
-                      view: "research",
-                      symbol,
-                    })
-                  }
-                  onTabChange={(section) =>
-                    updateRouteState({
-                      view: "research",
-                      section,
-                    })
-                  }
-                  portfolioSymbols={portfolioSymbols}
-                />
-              )}
-            </Suspense>
-          </motion.div>
-        </AnimatePresence>
       </div>
     </section>
   );

--- a/src/app/investments/investments-state.ts
+++ b/src/app/investments/investments-state.ts
@@ -23,8 +23,8 @@ type SearchParamInput =
   | Record<string, string | string[] | undefined | null>;
 
 export const DEFAULT_INVESTMENTS_STATE: InvestmentsSearchState = {
-  view: "research",
-  symbol: "AAPL",
+  view: "portfolio",
+  symbol: "",
   section: "overview",
 };
 
@@ -56,6 +56,7 @@ function readParam(input: SearchParamInput, key: keyof InvestmentsSearchState): 
 
 function normalizeSymbol(rawSymbol: string | null): string {
   const upper = rawSymbol?.trim().toUpperCase() ?? "";
+  if (!upper) return DEFAULT_INVESTMENTS_STATE.symbol;
   return VALID_SYMBOL_PATTERN.test(upper) ? upper : DEFAULT_INVESTMENTS_STATE.symbol;
 }
 
@@ -80,8 +81,13 @@ export function buildInvestmentsHref(
   baseSearchParams?: URLSearchParams | ReadonlyURLSearchParams
 ): string {
   const params = new URLSearchParams(baseSearchParams ? Array.from(baseSearchParams.entries()) : []);
-  params.set("view", state.view);
-  params.set("symbol", state.symbol);
+  // The unified dashboard no longer uses ?view=, so strip any legacy values.
+  params.delete("view");
+  if (state.symbol) {
+    params.set("symbol", state.symbol);
+  } else {
+    params.delete("symbol");
+  }
   params.set("section", state.section);
   return `/investments?${params.toString()}`;
 }

--- a/src/components/investments/AllocationChart.tsx
+++ b/src/components/investments/AllocationChart.tsx
@@ -131,8 +131,8 @@ export function AllocationChart({ holdings }: Props) {
           Position weights based on current market value.
         </p>
       </div>
-      <div className="flex flex-col gap-5 xl:flex-row xl:items-start">
-        <div className="relative shrink-0 self-center rounded-[24px] border border-[var(--home-rule)] bg-[var(--home-paper-alt)] px-3 py-4">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-start">
+        <div className="relative shrink-0 self-center">
           <svg ref={svgRef} />
           <div
             ref={tooltipRef}

--- a/src/components/investments/HoldingsTable.tsx
+++ b/src/components/investments/HoldingsTable.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import React, { useState } from "react";
+import { IconCheck, IconPencil, IconSearch, IconTrash, IconX } from "@tabler/icons-react";
+import { useStockData } from "@/hooks/useStockData";
+import type { EnhancedHolding, PriceData, StockPrice } from "@/types/investment";
+
+interface Props {
+  holdings: EnhancedHolding[];
+  onUpdate: (symbol: string, updates: { shares?: number; averageCost?: number }) => void;
+  onRemove: (symbol: string) => void;
+  onResearch: (symbol: string) => void;
+}
+
+const TICKER_COLORS = [
+  "#5672F8", // haze
+  "#5C8531", // green
+  "#4D8AD0", // blue
+  "#B22B2F", // red
+  "#1F7A6E", // teal
+  "#6B5A3E", // bronze
+  "#3F4B57", // slate
+  "#4A6CF0", // azure
+];
+
+function fmtCurrency(n: number, fractionDigits = 2): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(n);
+}
+
+function fmtSignedCurrency(n: number): string {
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  return `${sign}${fmtCurrency(Math.abs(n))}`;
+}
+
+function fmtPercent(n: number): string {
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  return `${sign}${Math.abs(n).toFixed(2)}%`;
+}
+
+function sparkPath(data: number[], w = 86, h = 26): string {
+  if (data.length < 2) return "";
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const span = max - min || 1;
+  const stepX = w / (data.length - 1);
+  return data
+    .map((v, i) => {
+      const x = i * stepX;
+      const y = h - ((v - min) / span) * (h - 4) - 2;
+      return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+interface RowProps {
+  holding: EnhancedHolding;
+  color: string;
+  onUpdate: Props["onUpdate"];
+  onRemove: Props["onRemove"];
+  onResearch: Props["onResearch"];
+}
+
+function HoldingRow({ holding, color, onUpdate, onRemove, onResearch }: RowProps) {
+  const [editing, setEditing] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [editShares, setEditShares] = useState(String(holding.shares));
+  const [editCost, setEditCost] = useState(String(holding.averageCost));
+
+  const { data: priceData } = useStockData<PriceData>(holding.symbol, "price");
+  const sparkData = React.useMemo(() => {
+    if (!priceData || !Array.isArray(priceData)) return [];
+    return (priceData as StockPrice[]).slice(-30).map((p) => p.close);
+  }, [priceData]);
+
+  const dayPositive = holding.dayChangePercent >= 0;
+  const plPositive = holding.gainLoss >= 0;
+  const allocPct = holding.allocationPercent ?? 0;
+  const allocBarWidth = Math.min(100, allocPct * 4);
+
+  function handleSave() {
+    const shares = parseFloat(editShares);
+    const cost = parseFloat(editCost);
+    if (!isNaN(shares) && shares > 0 && !isNaN(cost) && cost > 0) {
+      onUpdate(holding.symbol, { shares, averageCost: cost });
+    }
+    setEditing(false);
+  }
+
+  function handleCancelEdit() {
+    setEditShares(String(holding.shares));
+    setEditCost(String(holding.averageCost));
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <tr>
+        <td colSpan={8} className="!py-3">
+          <div className="flex flex-wrap items-center gap-3 px-1">
+            <div className="invest-ticker">
+              <div className="invest-logo" style={{ background: color }}>
+                {holding.symbol.replace(".", "").slice(0, 4)}
+              </div>
+              <div className="invest-ticker-info">
+                <div className="invest-ticker-sym">{holding.symbol}</div>
+                <div className="invest-ticker-name">Edit position</div>
+              </div>
+            </div>
+            <label className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--home-ink-muted)]">
+              Shares
+              <input
+                type="number"
+                step="0.0001"
+                min="0"
+                value={editShares}
+                onChange={(e) => setEditShares(e.target.value)}
+                className="ml-2 w-28 rounded-full border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-3 py-1.5 text-sm text-[var(--home-ink)] focus:outline-none focus:ring-2 focus:ring-[var(--home-haze)]/40"
+              />
+            </label>
+            <label className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--home-ink-muted)]">
+              Avg cost
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                value={editCost}
+                onChange={(e) => setEditCost(e.target.value)}
+                className="ml-2 w-28 rounded-full border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-3 py-1.5 text-sm text-[var(--home-ink)] focus:outline-none focus:ring-2 focus:ring-[var(--home-haze)]/40"
+              />
+            </label>
+            <div className="invest-row-actions ml-auto">
+              <button
+                type="button"
+                className="invest-ghost is-primary"
+                onClick={handleSave}
+              >
+                <IconCheck size={14} aria-hidden="true" />
+                Save
+              </button>
+              <button
+                type="button"
+                className="invest-ghost"
+                onClick={handleCancelEdit}
+              >
+                <IconX size={14} aria-hidden="true" />
+                Cancel
+              </button>
+            </div>
+          </div>
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <tr>
+      <td>
+        <div className="invest-ticker">
+          <div className="invest-logo" style={{ background: color }}>
+            {holding.symbol.replace(".", "").slice(0, 4)}
+          </div>
+          <div className="invest-ticker-info">
+            <div className="invest-ticker-sym">{holding.symbol}</div>
+            <div className="invest-ticker-name" title={holding.name ?? holding.symbol}>
+              {holding.name ?? holding.symbol}
+            </div>
+          </div>
+        </div>
+      </td>
+      <td className="num">{fmtCurrency(holding.currentPrice)}</td>
+      <td className="num">
+        <span
+          className={dayPositive ? "text-[var(--color-success)]" : "text-[var(--color-error)]"}
+          style={{ fontWeight: 600 }}
+        >
+          {fmtPercent(holding.dayChangePercent)}
+        </span>
+      </td>
+      <td className="col-trend">
+        {sparkData.length >= 2 ? (
+          <svg className="invest-spark" viewBox="0 0 86 26" preserveAspectRatio="none" aria-hidden="true">
+            <path
+              d={sparkPath(sparkData)}
+              fill="none"
+              stroke={color}
+              strokeWidth={1.6}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : (
+          <span className="text-[11px] text-[var(--home-ink-muted)]">—</span>
+        )}
+      </td>
+      <td className="num" style={{ color: "var(--home-ink-muted)", fontWeight: 600 }}>
+        {fmtCurrency(holding.currentValue)}
+      </td>
+      <td>
+        <div className="invest-alloc-bar">
+          <div className="invest-alloc-track">
+            <div
+              className="invest-alloc-fill"
+              style={{ width: `${allocBarWidth}%`, background: color }}
+            />
+          </div>
+          <span className="invest-alloc-pct">{allocPct.toFixed(1)}%</span>
+        </div>
+      </td>
+      <td className="num">
+        <div
+          className={plPositive ? "text-[var(--color-success)]" : "text-[var(--color-error)]"}
+          style={{ fontWeight: 600 }}
+        >
+          {fmtSignedCurrency(holding.gainLoss)}
+        </div>
+        <div className="text-[11px] text-[var(--home-ink-muted)]">
+          {fmtPercent(holding.gainLossPercent)}
+        </div>
+      </td>
+      <td>
+        <div className="invest-row-actions">
+          {confirmDelete ? (
+            <>
+              <button
+                type="button"
+                className="invest-ghost is-primary"
+                aria-label="Confirm remove holding"
+                onClick={() => {
+                  onRemove(holding.symbol);
+                  setConfirmDelete(false);
+                }}
+              >
+                <IconCheck size={14} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                className="invest-ghost"
+                aria-label="Cancel remove"
+                onClick={() => setConfirmDelete(false)}
+              >
+                <IconX size={14} aria-hidden="true" />
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                className="invest-ghost is-primary"
+                onClick={() => onResearch(holding.symbol)}
+                aria-label={`Research ${holding.symbol}`}
+                title={`Research ${holding.symbol}`}
+              >
+                <IconSearch size={14} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                className="invest-ghost"
+                onClick={() => setEditing(true)}
+                aria-label={`Edit ${holding.symbol}`}
+                title={`Edit ${holding.symbol}`}
+              >
+                <IconPencil size={14} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                className="invest-ghost"
+                onClick={() => setConfirmDelete(true)}
+                aria-label={`Remove ${holding.symbol}`}
+                title={`Remove ${holding.symbol}`}
+              >
+                <IconTrash size={14} aria-hidden="true" />
+              </button>
+            </>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export function HoldingsTable({ holdings, onUpdate, onRemove, onResearch }: Props) {
+  const sorted = React.useMemo(
+    () =>
+      [...holdings].sort(
+        (a, b) => (b.allocationPercent ?? 0) - (a.allocationPercent ?? 0),
+      ),
+    [holdings],
+  );
+
+  return (
+    <section id="holdings-list" className="invest-panel scroll-mt-28">
+      <div className="invest-panel-head">
+        <div>
+          <h2>Holdings</h2>
+          <div className="invest-panel-head-meta">
+            {holdings.length} {holdings.length === 1 ? "position" : "positions"} · sorted by allocation
+          </div>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="invest-holdings">
+          <thead>
+            <tr>
+              <th>Asset</th>
+              <th className="num">Price</th>
+              <th className="num">Day</th>
+              <th className="col-trend">Trend (30d)</th>
+              <th className="num">Holdings</th>
+              <th>Allocation</th>
+              <th className="num">P/L</th>
+              <th aria-label="Row actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((h, i) => (
+              <HoldingRow
+                key={h.symbol}
+                holding={h}
+                color={TICKER_COLORS[i % TICKER_COLORS.length]}
+                onUpdate={onUpdate}
+                onRemove={onRemove}
+                onResearch={onResearch}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/investments/InvestmentsDashboard.tsx
+++ b/src/components/investments/InvestmentsDashboard.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  IconBookmark,
+  IconChartArcs3,
+  IconChartLine,
+  IconCircleHalf,
+  IconHelp,
+  IconHome,
+  IconList,
+  IconReportMoney,
+  IconSearch,
+  IconWallet,
+} from "@tabler/icons-react";
+import { PortfolioSummary } from "./PortfolioSummary";
+import { AddStockForm } from "./AddStockForm";
+import { AllocationChart } from "./AllocationChart";
+import { DataFreshnessIndicator } from "./DataFreshnessIndicator";
+import { HoldingsTable } from "./HoldingsTable";
+import { ResearchSection } from "./ResearchSection";
+import { StockSearch } from "./StockSearch";
+import { useInvestments } from "@/hooks/useInvestments";
+import type { ResearchTab } from "@/app/investments/investments-state";
+
+interface Props {
+  researchSymbol: string;
+  researchTab: ResearchTab;
+  onResearchSymbolChange: (symbol: string) => void;
+  onResearchTabChange: (tab: ResearchTab) => void;
+  datasetLastUpdated?: string | null;
+  datasetSymbolCount?: number;
+  datasetFailedCount?: number;
+}
+
+interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  pill?: string;
+}
+
+function formatDatasetDate(raw: string | null | undefined): string {
+  if (!raw) return "—";
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return raw;
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+export function InvestmentsDashboard({
+  researchSymbol,
+  researchTab,
+  onResearchSymbolChange,
+  onResearchTabChange,
+  datasetLastUpdated,
+  datasetSymbolCount = 0,
+  datasetFailedCount = 0,
+}: Props) {
+  const {
+    enhancedHoldings,
+    summary,
+    isLoading,
+    error,
+    lastUpdated,
+    snapshots,
+    addHolding,
+    updateHolding,
+    removeHolding,
+    refetch,
+  } = useInvestments();
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const addHoldingRef = useRef<HTMLDivElement | null>(null);
+  const researchSectionRef = useRef<HTMLDivElement | null>(null);
+
+  const filteredHoldings = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return enhancedHoldings;
+    return enhancedHoldings.filter(
+      (h) =>
+        h.symbol.toLowerCase().includes(q) ||
+        (h.name ?? "").toLowerCase().includes(q),
+    );
+  }, [enhancedHoldings, searchQuery]);
+
+  const portfolioSymbols = useMemo(
+    () => enhancedHoldings.map((h) => h.symbol),
+    [enhancedHoldings],
+  );
+
+  const isEmpty = enhancedHoldings.length === 0;
+
+  const navItems: NavItem[] = useMemo(
+    () => [
+      { id: "home", label: "Overview", href: "#hero", icon: IconHome },
+      {
+        id: "holdings",
+        label: "Holdings",
+        href: "#holdings-list",
+        icon: IconList,
+        pill: enhancedHoldings.length > 0 ? String(enhancedHoldings.length) : undefined,
+      },
+      { id: "allocation", label: "Allocation", href: "#allocation", icon: IconChartArcs3 },
+      { id: "stats", label: "Portfolio stats", href: "#portfolio-stats", icon: IconCircleHalf },
+      { id: "performance", label: "Performance", href: "#hero", icon: IconChartLine },
+      { id: "research", label: "Research", href: "#research-section", icon: IconReportMoney },
+    ],
+    [enhancedHoldings.length],
+  );
+
+  function focusAddHolding() {
+    if (addHoldingRef.current) {
+      addHoldingRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+      const input = addHoldingRef.current.querySelector("input");
+      if (input instanceof HTMLInputElement) {
+        setTimeout(() => input.focus(), 200);
+      }
+    }
+  }
+
+  function handleResearch(symbol: string) {
+    onResearchSymbolChange(symbol);
+    setTimeout(() => {
+      researchSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 80);
+  }
+
+  function handleSymbolPick(symbol: string) {
+    onResearchSymbolChange(symbol);
+    setTimeout(() => {
+      researchSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 80);
+  }
+
+  return (
+    <div className="invest-shell" data-testid="invest-shell">
+      <aside className="invest-sidebar" aria-label="Investments navigation">
+        <div className="invest-brand">
+          <div className="invest-brand-iv" aria-hidden="true">IV</div>
+          <div className="invest-brand-name">
+            Isaac Vazquez
+            <small>Investments</small>
+          </div>
+        </div>
+
+        <nav className="flex flex-col gap-1.5" aria-label="Section navigation">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <a key={item.id} href={item.href} className="invest-nav-link">
+                <Icon size={18} aria-hidden="true" />
+                {item.label}
+                {item.pill ? <span className="invest-nav-pill">{item.pill}</span> : null}
+              </a>
+            );
+          })}
+        </nav>
+
+        <div className="invest-sidebar-footer">
+          <IconBookmark size={16} aria-hidden="true" />
+          <span>Local browser storage</span>
+        </div>
+      </aside>
+
+      <main className="invest-main" id="hero">
+        <div className="invest-topbar">
+          <div>
+            <p className="invest-crumbs">Investments / <strong>Dashboard</strong></p>
+            <h1>Investments</h1>
+          </div>
+
+          <label className="invest-search" aria-label="Filter holdings">
+            <IconSearch size={14} aria-hidden="true" />
+            <input
+              type="search"
+              placeholder="Filter holdings…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            <span className="invest-search-kbd" aria-hidden="true">⌘K</span>
+          </label>
+
+          <div className="flex items-center gap-2">
+            <DataFreshnessIndicator
+              lastUpdated={lastUpdated}
+              onRefresh={refetch}
+              isRefreshing={isLoading}
+            />
+            <span className="invest-avatar" aria-hidden="true">IV</span>
+          </div>
+        </div>
+
+        {/* Compact dataset freshness chip */}
+        <div className="invest-dataset-chip" role="status" aria-live="polite">
+          <span className="invest-dataset-chip-dot" aria-hidden="true" />
+          <span>
+            <strong>Curated snapshot</strong> · {formatDatasetDate(datasetLastUpdated)}
+          </span>
+          {datasetSymbolCount > 0 ? (
+            <span className="invest-dataset-chip-divider" aria-hidden="true">·</span>
+          ) : null}
+          {datasetSymbolCount > 0 ? (
+            <span>
+              {datasetSymbolCount} {datasetSymbolCount === 1 ? "company" : "companies"}
+            </span>
+          ) : null}
+          {datasetFailedCount > 0 ? (
+            <>
+              <span className="invest-dataset-chip-divider" aria-hidden="true">·</span>
+              <span className="invest-dataset-chip-warn">
+                {datasetFailedCount} pending
+              </span>
+            </>
+          ) : null}
+          <span className="invest-dataset-chip-spacer" />
+          <span className="invest-dataset-chip-meta">Live prices via Finnhub</span>
+        </div>
+
+        {error ? (
+          <div className="mt-4 rounded-2xl border border-[color-mix(in_srgb,var(--color-warning)_35%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-warning)_10%,var(--home-paper-alt))] px-4 py-3 text-sm text-[var(--home-ink-muted)]">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-5 space-y-5">
+          <PortfolioSummary
+            summary={summary}
+            holdings={enhancedHoldings}
+            snapshots={snapshots}
+            isLoading={isLoading}
+            onAddHolding={focusAddHolding}
+            onRefresh={refetch}
+            lastUpdated={lastUpdated}
+          />
+
+          {!isEmpty ? (
+            <HoldingsTable
+              holdings={filteredHoldings}
+              onUpdate={updateHolding}
+              onRemove={removeHolding}
+              onResearch={handleResearch}
+            />
+          ) : (
+            <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
+              <p className="mb-2 text-sm font-semibold text-[var(--home-ink)]">
+                No positions yet
+              </p>
+              <p className="mx-auto max-w-xs text-sm text-[color-mix(in_srgb,var(--home-ink)_45%,var(--home-paper))]">
+                Add your first stock using the form on the right. Holdings are saved in your browser and persist across visits.
+              </p>
+            </div>
+          )}
+
+          {/* Research deep-dive section — picks up the symbol set by clicking
+              "Research" on a holding row, or by typing in the picker below. */}
+          <div ref={researchSectionRef} className="space-y-4">
+            <div className="invest-section-header">
+              <div>
+                <p className="invest-section-kicker">Deep dive</p>
+                <h2 className="invest-section-title">Research</h2>
+              </div>
+              <div className="invest-section-search">
+                <StockSearch value={researchSymbol} onChange={handleSymbolPick} />
+              </div>
+            </div>
+
+            <ResearchSection
+              symbol={researchSymbol}
+              activeTab={researchTab}
+              onTabChange={onResearchTabChange}
+              portfolioSymbols={portfolioSymbols}
+            />
+          </div>
+        </div>
+      </main>
+
+      <aside className="invest-rail" aria-label="Portfolio side panel">
+        <section ref={addHoldingRef} id="add-holding" className="scroll-mt-28">
+          <p className="invest-rail-section-label">
+            <IconWallet size={12} aria-hidden="true" className="mr-1.5 inline align-middle" />
+            Add a holding
+          </p>
+          <AddStockForm onAdd={addHolding} />
+        </section>
+
+        {!isEmpty ? (
+          <section id="allocation" className="scroll-mt-28">
+            <p className="invest-rail-section-label">Allocation</p>
+            <AllocationChart holdings={enhancedHoldings} />
+          </section>
+        ) : null}
+
+        {!isEmpty ? (
+          <section className="invest-rail-movers">
+            <p className="invest-rail-section-label">Today's movers</p>
+            <ul className="invest-rail-mover-list">
+              {[...enhancedHoldings]
+                .sort(
+                  (a, b) =>
+                    Math.abs(b.dayChangePercent) - Math.abs(a.dayChangePercent),
+                )
+                .slice(0, 4)
+                .map((h) => {
+                  const positive = h.dayChangePercent >= 0;
+                  const showName =
+                    h.name && h.name.toUpperCase() !== h.symbol.toUpperCase();
+                  return (
+                    <li key={h.symbol}>
+                      <button
+                        type="button"
+                        className="invest-rail-mover"
+                        onClick={() => handleResearch(h.symbol)}
+                      >
+                        <span className="invest-rail-mover-sym">{h.symbol}</span>
+                        <span className="invest-rail-mover-name">
+                          {showName ? h.name : ""}
+                        </span>
+                        <span
+                          className={
+                            positive
+                              ? "invest-rail-mover-delta pos"
+                              : "invest-rail-mover-delta neg"
+                          }
+                        >
+                          {positive ? "+" : "−"}
+                          {Math.abs(h.dayChangePercent).toFixed(2)}%
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+            </ul>
+          </section>
+        ) : null}
+
+        <p className="mt-auto flex items-center gap-2 text-[11.5px] text-[var(--home-ink-muted)]">
+          <IconHelp size={14} aria-hidden="true" />
+          Holdings live only in your browser — no logins, no cloud sync.
+        </p>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/investments/InvestmentsDashboard.tsx
+++ b/src/components/investments/InvestmentsDashboard.tsx
@@ -134,6 +134,7 @@ export function InvestmentsDashboard({
   }
 
   return (
+    <div className="invest-page-stack">
     <div className="invest-shell" data-testid="invest-shell">
       <aside className="invest-sidebar" aria-label="Investments navigation">
         <div className="invest-brand">
@@ -251,27 +252,6 @@ export function InvestmentsDashboard({
               </p>
             </div>
           )}
-
-          {/* Research deep-dive section — picks up the symbol set by clicking
-              "Research" on a holding row, or by typing in the picker below. */}
-          <div ref={researchSectionRef} className="space-y-4">
-            <div className="invest-section-header">
-              <div>
-                <p className="invest-section-kicker">Deep dive</p>
-                <h2 className="invest-section-title">Research</h2>
-              </div>
-              <div className="invest-section-search">
-                <StockSearch value={researchSymbol} onChange={handleSymbolPick} />
-              </div>
-            </div>
-
-            <ResearchSection
-              symbol={researchSymbol}
-              activeTab={researchTab}
-              onTabChange={onResearchTabChange}
-              portfolioSymbols={portfolioSymbols}
-            />
-          </div>
         </div>
       </main>
 
@@ -339,6 +319,33 @@ export function InvestmentsDashboard({
           Holdings live only in your browser — no logins, no cloud sync.
         </p>
       </aside>
+    </div>
+
+    {/* Research deep-dive — full width below the shell so it doesn't leave
+        the rail empty next to a long single-asset view. Symbol comes from
+        clicking "Research" on a holding row or the picker below. */}
+    <section
+      ref={researchSectionRef}
+      className="invest-research-band"
+      aria-label="Research deep dive"
+    >
+      <div className="invest-section-header">
+        <div>
+          <p className="invest-section-kicker">Deep dive</p>
+          <h2 className="invest-section-title">Research</h2>
+        </div>
+        <div className="invest-section-search">
+          <StockSearch value={researchSymbol} onChange={handleSymbolPick} />
+        </div>
+      </div>
+
+      <ResearchSection
+        symbol={researchSymbol}
+        activeTab={researchTab}
+        onTabChange={onResearchTabChange}
+        portfolioSymbols={portfolioSymbols}
+      />
+    </section>
     </div>
   );
 }

--- a/src/components/investments/PortfolioHeroCard.tsx
+++ b/src/components/investments/PortfolioHeroCard.tsx
@@ -342,8 +342,8 @@ export function PortfolioHeroCard({
               {formatRefreshLabel(lastUpdated)}
             </button>
           ) : null}
-          <a href="#performance-chart" className="invest-ghost">
-            Performance detail
+          <a href="#research-section" className="invest-ghost">
+            Open research
           </a>
         </div>
       </div>

--- a/src/components/investments/PortfolioHeroCard.tsx
+++ b/src/components/investments/PortfolioHeroCard.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import * as d3 from "d3";
+import type { PortfolioSummary as PortfolioSummaryType } from "@/types/investment";
+import type { PortfolioSnapshot } from "./PortfolioPerformanceChart";
+
+interface Props {
+  summary: PortfolioSummaryType;
+  snapshots: PortfolioSnapshot[];
+  isLoading: boolean;
+  onAddHolding?: () => void;
+  onRefresh?: () => void;
+  lastUpdated?: Date | null;
+}
+
+const RANGES = [
+  { label: "1W", days: 7 },
+  { label: "1M", days: 30 },
+  { label: "3M", days: 90 },
+  { label: "1Y", days: 365 },
+  { label: "ALL", days: Infinity },
+] as const;
+
+type RangeLabel = (typeof RANGES)[number]["label"];
+
+function formatBalance(n: number): { whole: string; cents: string } {
+  if (!Number.isFinite(n)) return { whole: "$0", cents: ".00" };
+  const sign = n < 0 ? "−" : "";
+  const abs = Math.abs(n);
+  const whole = Math.floor(abs);
+  const cents = Math.round((abs - whole) * 100);
+  return {
+    whole: `${sign}$${whole.toLocaleString("en-US")}`,
+    cents: `.${cents.toString().padStart(2, "0")}`,
+  };
+}
+
+function formatSignedCurrency(n: number): string {
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  const abs = Math.abs(n);
+  return `${sign}${new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(abs)}`;
+}
+
+function formatPercent(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  return `${sign}${Math.abs(n).toFixed(2)}%`;
+}
+
+function formatRefreshLabel(lastUpdated: Date | null | undefined): string {
+  if (!lastUpdated) return "Refresh data";
+  const minutes = Math.max(0, Math.floor((Date.now() - lastUpdated.getTime()) / 60000));
+  if (minutes < 1) return "Refresh data · just now";
+  if (minutes === 1) return "Refresh data · 1m ago";
+  if (minutes < 60) return `Refresh data · ${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `Refresh data · ${hours}h ago`;
+}
+
+export function PortfolioHeroCard({
+  summary,
+  snapshots,
+  isLoading,
+  onAddHolding,
+  onRefresh,
+  lastUpdated,
+}: Props) {
+  const [range, setRange] = useState<RangeLabel>("1M");
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const [width, setWidth] = useState(0);
+
+  const filteredSnapshots = useMemo(() => {
+    const r = RANGES.find((x) => x.label === range);
+    if (!r || r.days === Infinity) return snapshots;
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - r.days);
+    const cutoffStr = cutoff.toISOString().slice(0, 10);
+    return snapshots.filter((s) => s.date >= cutoffStr);
+  }, [snapshots, range]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) setWidth(e.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg || width === 0) return;
+    const HEIGHT = 220;
+    const MARGIN = { top: 12, right: 60, bottom: 22, left: 8 };
+    const innerW = Math.max(40, width - MARGIN.left - MARGIN.right);
+    const innerH = HEIGHT - MARGIN.top - MARGIN.bottom;
+
+    d3.select(svg).selectAll("*").remove();
+
+    if (filteredSnapshots.length < 2) {
+      const root = d3
+        .select(svg)
+        .attr("width", width)
+        .attr("height", HEIGHT)
+        .append("g")
+        .attr("transform", `translate(${MARGIN.left},${MARGIN.top})`);
+      root
+        .append("text")
+        .attr("x", innerW / 2)
+        .attr("y", innerH / 2)
+        .attr("text-anchor", "middle")
+        .attr("dominant-baseline", "middle")
+        .attr("fill", "var(--home-ink-muted)")
+        .style("font-size", "12px")
+        .style("font-style", "italic")
+        .text(
+          snapshots.length === 0
+            ? "Performance chart appears once you save snapshots"
+            : "Not enough data for this range yet",
+        );
+      return;
+    }
+
+    const data = filteredSnapshots.map((s) => ({ date: new Date(s.date), value: s.totalValue }));
+
+    const xScale = d3
+      .scaleTime()
+      .domain(d3.extent(data, (d) => d.date) as [Date, Date])
+      .range([0, innerW]);
+    const yMin = d3.min(data, (d) => d.value) as number;
+    const yMax = d3.max(data, (d) => d.value) as number;
+    const yPad = (yMax - yMin) * 0.12 || 1;
+    const yScale = d3
+      .scaleLinear()
+      .domain([yMin - yPad, yMax + yPad])
+      .range([innerH, 0]);
+
+    const root = d3
+      .select(svg)
+      .attr("width", width)
+      .attr("height", HEIGHT)
+      .append("g")
+      .attr("transform", `translate(${MARGIN.left},${MARGIN.top})`);
+
+    const defs = d3.select(svg).append("defs");
+    const fillId = `inv-hero-fill-${range}`;
+    const strokeId = `inv-hero-stroke-${range}`;
+    const fillGrad = defs
+      .append("linearGradient")
+      .attr("id", fillId)
+      .attr("x1", 0)
+      .attr("x2", 0)
+      .attr("y1", 0)
+      .attr("y2", 1);
+    fillGrad.append("stop").attr("offset", "0%").attr("stop-color", "var(--home-haze)").attr("stop-opacity", 0.28);
+    fillGrad.append("stop").attr("offset", "100%").attr("stop-color", "var(--home-haze)").attr("stop-opacity", 0);
+
+    const strokeGrad = defs
+      .append("linearGradient")
+      .attr("id", strokeId)
+      .attr("x1", 0)
+      .attr("x2", 1)
+      .attr("y1", 0)
+      .attr("y2", 0);
+    strokeGrad.append("stop").attr("offset", "0%").attr("stop-color", "var(--home-haze)");
+    strokeGrad.append("stop").attr("offset", "100%").attr("stop-color", "var(--home-ink)");
+
+    [0.25, 0.5, 0.75].forEach((p) => {
+      root
+        .append("line")
+        .attr("x1", 0)
+        .attr("x2", innerW)
+        .attr("y1", innerH * p)
+        .attr("y2", innerH * p)
+        .attr("stroke", "color-mix(in srgb, var(--home-ink) 8%, transparent)")
+        .attr("stroke-dasharray", "3 4");
+    });
+
+    const area = d3
+      .area<(typeof data)[number]>()
+      .x((d) => xScale(d.date))
+      .y0(innerH)
+      .y1((d) => yScale(d.value))
+      .curve(d3.curveMonotoneX);
+    root.append("path").datum(data).attr("d", area).attr("fill", `url(#${fillId})`);
+
+    const line = d3
+      .line<(typeof data)[number]>()
+      .x((d) => xScale(d.date))
+      .y((d) => yScale(d.value))
+      .curve(d3.curveMonotoneX);
+    root
+      .append("path")
+      .datum(data)
+      .attr("d", line)
+      .attr("fill", "none")
+      .attr("stroke", `url(#${strokeId})`)
+      .attr("stroke-width", 2.4)
+      .attr("stroke-linecap", "round")
+      .attr("stroke-linejoin", "round");
+
+    const last = data[data.length - 1];
+    const lastX = xScale(last.date);
+    const lastY = yScale(last.value);
+    root.append("circle").attr("cx", lastX).attr("cy", lastY).attr("r", 4).attr("fill", "var(--home-ink)");
+    const pulse = root
+      .append("circle")
+      .attr("cx", lastX)
+      .attr("cy", lastY)
+      .attr("r", 6)
+      .attr("fill", "none")
+      .attr("stroke", "var(--home-haze)")
+      .attr("stroke-opacity", 0.5);
+    pulse
+      .append("animate")
+      .attr("attributeName", "r")
+      .attr("values", "6;14;6")
+      .attr("dur", "2.4s")
+      .attr("repeatCount", "indefinite");
+    pulse
+      .append("animate")
+      .attr("attributeName", "stroke-opacity")
+      .attr("values", "0.55;0;0.55")
+      .attr("dur", "2.4s")
+      .attr("repeatCount", "indefinite");
+
+    const yAxisG = d3
+      .select(svg)
+      .append("g")
+      .attr("transform", `translate(${width - MARGIN.right + 8},${MARGIN.top})`);
+    const tickValues = yScale.ticks(4);
+    tickValues.forEach((v) => {
+      yAxisG
+        .append("text")
+        .attr("x", 0)
+        .attr("y", yScale(v))
+        .attr("dominant-baseline", "middle")
+        .attr("fill", "color-mix(in srgb, var(--home-ink) 38%, var(--home-paper))")
+        .style("font", "10.5px var(--font-mono)")
+        .text(`$${d3.format(".2~s")(v).replace("G", "B")}`);
+    });
+
+    const xAxisG = d3
+      .select(svg)
+      .append("g")
+      .attr("transform", `translate(${MARGIN.left},${HEIGHT - 6})`);
+    const tickCount = Math.min(data.length, 5);
+    const xTicks = xScale.ticks(tickCount);
+    xTicks.forEach((d) => {
+      xAxisG
+        .append("text")
+        .attr("x", xScale(d))
+        .attr("y", 0)
+        .attr("text-anchor", "middle")
+        .attr("fill", "color-mix(in srgb, var(--home-ink) 38%, var(--home-paper))")
+        .style("font", "10.5px var(--font-mono)")
+        .text(d3.timeFormat("%b %d")(d));
+    });
+  }, [filteredSnapshots, snapshots.length, width, range]);
+
+  if (isLoading && snapshots.length === 0 && summary.totalValue === 0) {
+    return (
+      <div className="invest-hero">
+        <div className="invest-hero-left">
+          <span className="invest-hero-eyebrow">
+            <span className="invest-hero-livedot" aria-hidden="true" />
+            Total portfolio value · Live
+          </span>
+          <div className="my-3 h-12 w-56 rounded bg-[var(--home-paper-alt)] animate-pulse" />
+          <div className="h-5 w-44 rounded bg-[var(--home-paper-alt)] animate-pulse" />
+        </div>
+        <div className="invest-chart-wrap">
+          <div className="m-auto h-32 w-3/4 rounded bg-[var(--home-paper-alt)] animate-pulse" />
+        </div>
+      </div>
+    );
+  }
+
+  const balance = formatBalance(summary.totalValue);
+  const dayPositive = summary.dayChange >= 0;
+
+  return (
+    <section className="invest-hero" aria-label="Portfolio total value">
+      <div className="invest-hero-left">
+        <span className="invest-hero-eyebrow">
+          <span className="invest-hero-livedot" aria-hidden="true" />
+          Total portfolio value · Live
+        </span>
+
+        <p className="invest-hero-balance">
+          <span>{balance.whole}</span>
+          <span className="cents">{balance.cents}</span>
+          <span className="ccy">USD</span>
+        </p>
+
+        <div className="invest-hero-delta">
+          <span className={`chip ${dayPositive ? "pos" : "neg"}`}>
+            {formatSignedCurrency(summary.dayChange)}
+          </span>
+          <span className={dayPositive ? "text-[var(--color-success)]" : "text-[var(--color-error)]"}>
+            {formatPercent(summary.dayChangePercent)} today
+          </span>
+          <span className="muted">·</span>
+          <span className="muted">
+            {formatPercent(summary.totalGainLossPercent)} all time
+          </span>
+        </div>
+
+        <div className="mt-4">
+          <div className="invest-timeframe" role="tablist" aria-label="Performance timeframe">
+            {RANGES.map((r) => (
+              <button
+                key={r.label}
+                type="button"
+                role="tab"
+                aria-selected={range === r.label}
+                className={range === r.label ? "is-on" : ""}
+                onClick={() => setRange(r.label)}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="invest-hero-actions">
+          {onAddHolding ? (
+            <button type="button" className="invest-ghost is-primary" onClick={onAddHolding}>
+              Add holding
+            </button>
+          ) : null}
+          {onRefresh ? (
+            <button type="button" className="invest-ghost" onClick={onRefresh} disabled={isLoading}>
+              {formatRefreshLabel(lastUpdated)}
+            </button>
+          ) : null}
+          <a href="#performance-chart" className="invest-ghost">
+            Performance detail
+          </a>
+        </div>
+      </div>
+
+      <div className="invest-chart-wrap" ref={containerRef}>
+        <svg ref={svgRef} aria-hidden="true" />
+      </div>
+    </section>
+  );
+}

--- a/src/components/investments/PortfolioStatsGrid.tsx
+++ b/src/components/investments/PortfolioStatsGrid.tsx
@@ -110,7 +110,7 @@ function StatCell({ label, hint, value, sub, tone = "default", subTone = "defaul
   return (
     <div className="flex min-w-0 flex-col gap-1">
       <span
-        className="w-fit cursor-help text-[12.5px] font-medium text-[var(--home-ink-muted)] [text-decoration-color:color-mix(in_srgb,var(--home-ink)_28%,transparent)] [text-decoration-line:underline] [text-decoration-style:dotted] [text-underline-offset:3px]"
+        className="invest-stats-cell-label w-fit cursor-help text-[12.5px] font-medium text-[var(--home-ink-muted)] [text-decoration-color:color-mix(in_srgb,var(--home-ink)_28%,transparent)] [text-decoration-line:underline] [text-decoration-style:dotted] [text-underline-offset:3px]"
         title={hint}
       >
         {label}
@@ -120,9 +120,11 @@ function StatCell({ label, hint, value, sub, tone = "default", subTone = "defaul
       >
         {value}
       </span>
-      {sub ? (
-        <span className={`text-[11.5px] tabular-nums ${subColor}`}>{sub}</span>
-      ) : null}
+      <span
+        className={`invest-stats-cell-sub text-[11.5px] tabular-nums ${subColor}`}
+      >
+        {sub ?? " "}
+      </span>
     </div>
   );
 }

--- a/src/components/investments/PortfolioStatsGrid.tsx
+++ b/src/components/investments/PortfolioStatsGrid.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import React from "react";
+import type {
+  EnhancedHolding,
+  PortfolioSummary as PortfolioSummaryType,
+} from "@/types/investment";
+
+interface Props {
+  summary: PortfolioSummaryType;
+  holdings: EnhancedHolding[];
+}
+
+function formatCurrency(n: number, fractionDigits = 2): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(n);
+}
+
+function formatSignedCurrency(n: number): string {
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  return `${sign}${formatCurrency(Math.abs(n))}`;
+}
+
+function formatPercent(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  return `${sign}${Math.abs(n).toFixed(2)}%`;
+}
+
+interface ComputedStats {
+  topHolding: { symbol: string; allocationPercent: number } | null;
+  bestPerformer: { symbol: string; gainLossPercent: number } | null;
+  biggestDayMove: { symbol: string; dayChangePercent: number } | null;
+  positions: number;
+  concentration: number;
+}
+
+function computeStats(holdings: EnhancedHolding[]): ComputedStats {
+  const positions = holdings.length;
+  if (positions === 0) {
+    return {
+      topHolding: null,
+      bestPerformer: null,
+      biggestDayMove: null,
+      positions: 0,
+      concentration: 0,
+    };
+  }
+
+  const sortedByAllocation = [...holdings]
+    .filter((h) => h.allocationPercent !== null)
+    .sort((a, b) => (b.allocationPercent ?? 0) - (a.allocationPercent ?? 0));
+  const top = sortedByAllocation[0] ?? null;
+
+  const concentration = sortedByAllocation
+    .slice(0, 3)
+    .reduce((sum, h) => sum + (h.allocationPercent ?? 0), 0);
+
+  const sortedByReturn = [...holdings].sort(
+    (a, b) => b.gainLossPercent - a.gainLossPercent,
+  );
+  const best = sortedByReturn[0] ?? null;
+
+  const sortedByDayMove = [...holdings].sort(
+    (a, b) => Math.abs(b.dayChangePercent) - Math.abs(a.dayChangePercent),
+  );
+  const biggestMove = sortedByDayMove[0] ?? null;
+
+  return {
+    topHolding: top
+      ? { symbol: top.symbol, allocationPercent: top.allocationPercent ?? 0 }
+      : null,
+    bestPerformer: best
+      ? { symbol: best.symbol, gainLossPercent: best.gainLossPercent }
+      : null,
+    biggestDayMove: biggestMove
+      ? { symbol: biggestMove.symbol, dayChangePercent: biggestMove.dayChangePercent }
+      : null,
+    positions,
+    concentration,
+  };
+}
+
+interface StatCellProps {
+  label: string;
+  hint: string;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+  tone?: "default" | "pos" | "neg";
+  subTone?: "default" | "pos" | "neg";
+}
+
+function StatCell({ label, hint, value, sub, tone = "default", subTone = "default" }: StatCellProps) {
+  const valueColor =
+    tone === "pos"
+      ? "text-[var(--color-success)]"
+      : tone === "neg"
+        ? "text-[var(--color-error)]"
+        : "text-[var(--home-ink)]";
+  const subColor =
+    subTone === "pos"
+      ? "text-[var(--color-success)]"
+      : subTone === "neg"
+        ? "text-[var(--color-error)]"
+        : "text-[var(--home-ink-muted)]";
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <span
+        className="w-fit cursor-help text-[12.5px] font-medium text-[var(--home-ink-muted)] [text-decoration-color:color-mix(in_srgb,var(--home-ink)_28%,transparent)] [text-decoration-line:underline] [text-decoration-style:dotted] [text-underline-offset:3px]"
+        title={hint}
+      >
+        {label}
+      </span>
+      <span
+        className={`truncate text-[17px] font-semibold leading-[1.3] tracking-[-0.01em] tabular-nums ${valueColor}`}
+      >
+        {value}
+      </span>
+      {sub ? (
+        <span className={`text-[11.5px] tabular-nums ${subColor}`}>{sub}</span>
+      ) : null}
+    </div>
+  );
+}
+
+export function PortfolioStatsGrid({ summary, holdings }: Props) {
+  const gainPositive = summary.totalGainLoss >= 0;
+  const dayPositive = summary.dayChange >= 0;
+  const stats = computeStats(holdings);
+
+  return (
+    <section
+      id="portfolio-stats"
+      className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-6 shadow-[var(--shadow-sm)] sm:px-7 sm:py-7 scroll-mt-28"
+    >
+      <div className="mb-5 flex items-baseline justify-between gap-4">
+        <h2 className="m-0 text-[16px] font-bold tracking-[-0.02em] text-[var(--home-ink)]">
+          Portfolio stats
+        </h2>
+        <span className="inline-flex items-center gap-1.5 text-[11.5px] text-[var(--home-ink-muted)]">
+          <span
+            aria-hidden="true"
+            className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--color-success)]"
+            style={{ boxShadow: "0 0 0 3px color-mix(in srgb, var(--color-success) 18%, transparent)" }}
+          />
+          Live across saved positions
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-6 gap-y-5 lg:grid-cols-4">
+        <StatCell
+          label="Day P/L"
+          hint="Today's change in portfolio value, summed across all positions."
+          value={formatSignedCurrency(summary.dayChange)}
+          sub={formatPercent(summary.dayChangePercent)}
+          tone={dayPositive ? "pos" : "neg"}
+          subTone={dayPositive ? "pos" : "neg"}
+        />
+        <StatCell
+          label="All-time return"
+          hint="Total dollar return since you started tracking each position."
+          value={formatSignedCurrency(summary.totalGainLoss)}
+          sub={formatPercent(summary.totalGainLossPercent)}
+          tone={gainPositive ? "pos" : "neg"}
+          subTone={gainPositive ? "pos" : "neg"}
+        />
+        <StatCell
+          label="Cost basis"
+          hint="What you paid for the holdings you're still tracking."
+          value={formatCurrency(summary.totalCost)}
+          sub={
+            stats.positions === 0
+              ? undefined
+              : `Across ${stats.positions} ${stats.positions === 1 ? "position" : "positions"}`
+          }
+        />
+        <StatCell
+          label="Positions"
+          hint="Number of distinct tickers in the saved book."
+          value={String(stats.positions)}
+          sub={
+            stats.positions === 0
+              ? undefined
+              : `${stats.concentration.toFixed(1)}% in top three`
+          }
+        />
+        <StatCell
+          label="Top holding"
+          hint="Largest position by current market value."
+          value={stats.topHolding?.symbol ?? "—"}
+          sub={
+            stats.topHolding
+              ? `${stats.topHolding.allocationPercent.toFixed(1)}% of book`
+              : undefined
+          }
+        />
+        <StatCell
+          label="Best performer"
+          hint="Position with the strongest all-time return percentage."
+          value={stats.bestPerformer?.symbol ?? "—"}
+          sub={
+            stats.bestPerformer
+              ? formatPercent(stats.bestPerformer.gainLossPercent)
+              : undefined
+          }
+          subTone={
+            stats.bestPerformer && stats.bestPerformer.gainLossPercent >= 0
+              ? "pos"
+              : stats.bestPerformer
+                ? "neg"
+                : "default"
+          }
+        />
+        <StatCell
+          label="Biggest day move"
+          hint="Position with the largest absolute change today."
+          value={stats.biggestDayMove?.symbol ?? "—"}
+          sub={
+            stats.biggestDayMove
+              ? formatPercent(stats.biggestDayMove.dayChangePercent)
+              : undefined
+          }
+          subTone={
+            stats.biggestDayMove && stats.biggestDayMove.dayChangePercent >= 0
+              ? "pos"
+              : stats.biggestDayMove
+                ? "neg"
+                : "default"
+          }
+        />
+        <StatCell
+          label="Top-3 concentration"
+          hint="Combined allocation of your three largest positions — a quick read on portfolio shape."
+          value={`${stats.concentration.toFixed(1)}%`}
+          sub={
+            stats.positions <= 3
+              ? "Whole book"
+              : `${stats.positions - 3} more positions`
+          }
+        />
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-2 border-t border-dashed border-[color-mix(in_srgb,var(--home-ink)_14%,transparent)] pt-4">
+        <a href="#allocation" className="invest-ghost">
+          Allocation breakdown
+        </a>
+        <a href="#holdings-list" className="invest-ghost">
+          Per-position detail
+        </a>
+        <a href="#performance-chart" className="invest-ghost">
+          Performance over time
+        </a>
+        <a href="#add-holding" className="invest-ghost">
+          Add a holding
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/investments/PortfolioStatsGrid.tsx
+++ b/src/components/investments/PortfolioStatsGrid.tsx
@@ -251,7 +251,7 @@ export function PortfolioStatsGrid({ summary, holdings }: Props) {
         <a href="#holdings-list" className="invest-ghost">
           Per-position detail
         </a>
-        <a href="#performance-chart" className="invest-ghost">
+        <a href="#hero" className="invest-ghost">
           Performance over time
         </a>
         <a href="#add-holding" className="invest-ghost">

--- a/src/components/investments/PortfolioSummary.tsx
+++ b/src/components/investments/PortfolioSummary.tsx
@@ -3,7 +3,10 @@
 import React from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { WarmCard } from "@/components/ui/WarmCard";
-import type { PortfolioSummary as PortfolioSummaryType } from "@/types/investment";
+import type {
+  EnhancedHolding,
+  PortfolioSummary as PortfolioSummaryType,
+} from "@/types/investment";
 import {
   containerVariants,
   itemVariants,
@@ -12,29 +15,153 @@ import {
 
 interface Props {
   summary: PortfolioSummaryType;
+  holdings: EnhancedHolding[];
   isLoading: boolean;
 }
 
-function formatCurrency(n: number): string {
+function formatCurrency(n: number, fractionDigits = 2): string {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
-    maximumFractionDigits: 2,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
   }).format(n);
 }
 
-function formatPercent(n: number): string {
-  return `${n >= 0 ? "+" : ""}${n.toFixed(2)}%`;
+function formatSignedCurrency(n: number, fractionDigits = 2): string {
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  return `${sign}${formatCurrency(Math.abs(n), fractionDigits)}`;
 }
 
-export function PortfolioSummary({ summary, isLoading }: Props) {
+function formatPercent(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  return `${sign}${Math.abs(n).toFixed(2)}%`;
+}
+
+interface ComputedStats {
+  topHolding: { symbol: string; allocationPercent: number } | null;
+  bestPerformer: { symbol: string; gainLossPercent: number } | null;
+  biggestDayMove: { symbol: string; dayChangePercent: number } | null;
+  positions: number;
+  concentration: number;
+}
+
+function computeStats(holdings: EnhancedHolding[]): ComputedStats {
+  const positions = holdings.length;
+  if (positions === 0) {
+    return {
+      topHolding: null,
+      bestPerformer: null,
+      biggestDayMove: null,
+      positions: 0,
+      concentration: 0,
+    };
+  }
+
+  const sortedByAllocation = [...holdings]
+    .filter((h) => h.allocationPercent !== null)
+    .sort(
+      (a, b) =>
+        (b.allocationPercent ?? 0) - (a.allocationPercent ?? 0),
+    );
+  const top = sortedByAllocation[0] ?? null;
+
+  // Top-3 concentration as a portfolio-shape signal: how heavy the
+  // top three holdings are relative to the whole book.
+  const concentration = sortedByAllocation
+    .slice(0, 3)
+    .reduce((sum, h) => sum + (h.allocationPercent ?? 0), 0);
+
+  const sortedByReturn = [...holdings].sort(
+    (a, b) => b.gainLossPercent - a.gainLossPercent,
+  );
+  const best = sortedByReturn[0] ?? null;
+
+  const sortedByDayMove = [...holdings].sort(
+    (a, b) => Math.abs(b.dayChangePercent) - Math.abs(a.dayChangePercent),
+  );
+  const biggestMove = sortedByDayMove[0] ?? null;
+
+  return {
+    topHolding: top
+      ? {
+          symbol: top.symbol,
+          allocationPercent: top.allocationPercent ?? 0,
+        }
+      : null,
+    bestPerformer: best
+      ? {
+          symbol: best.symbol,
+          gainLossPercent: best.gainLossPercent,
+        }
+      : null,
+    biggestDayMove: biggestMove
+      ? {
+          symbol: biggestMove.symbol,
+          dayChangePercent: biggestMove.dayChangePercent,
+        }
+      : null,
+    positions,
+    concentration,
+  };
+}
+
+interface StatCellProps {
+  label: string;
+  hint: string;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+  tone?: "default" | "pos" | "neg";
+}
+
+function StatCell({ label, hint, value, sub, tone = "default" }: StatCellProps) {
+  const valueColor =
+    tone === "pos"
+      ? "text-[var(--color-success)]"
+      : tone === "neg"
+        ? "text-[var(--color-error)]"
+        : "text-[var(--home-ink)]";
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <span
+        className="w-fit cursor-help text-[12.5px] font-medium text-[var(--home-ink-muted)] [text-decoration-color:color-mix(in_srgb,var(--home-ink)_28%,transparent)] [text-decoration-line:underline] [text-decoration-style:dotted] [text-underline-offset:3px]"
+        title={hint}
+      >
+        {label}
+      </span>
+      <span
+        className={`truncate text-[17px] font-semibold leading-[1.3] tracking-[-0.01em] tabular-nums ${valueColor}`}
+      >
+        {value}
+      </span>
+      {sub ? (
+        <span className="text-[11.5px] tabular-nums text-[var(--home-ink-muted)]">
+          {sub}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function PortfolioSummary({ summary, holdings, isLoading }: Props) {
   const gainPositive = summary.totalGainLoss >= 0;
   const dayPositive = summary.dayChange >= 0;
-  const gainColor = gainPositive ? "text-[var(--color-success)]" : "text-[var(--color-error)]";
-  const dayColor = dayPositive ? "text-[var(--color-success)]" : "text-[var(--color-error)]";
+  const stats = computeStats(holdings);
 
   const shouldReduceMotion = useReducedMotion();
   const v = shouldReduceMotion ? getReducedMotionVariants() : { containerVariants, itemVariants };
+
+  if (isLoading) {
+    return (
+      <WarmCard padding="sm" className="rounded-[28px] shadow-[var(--shadow-sm)]">
+        <div className="space-y-3">
+          <div className="h-10 w-48 rounded bg-[var(--home-paper-alt)] animate-pulse" />
+          <div className="h-6 w-32 rounded bg-[var(--home-paper-alt)] animate-pulse" />
+        </div>
+      </WarmCard>
+    );
+  }
 
   return (
     <motion.div
@@ -43,56 +170,190 @@ export function PortfolioSummary({ summary, isLoading }: Props) {
       variants={v.containerVariants}
       initial="hidden"
       animate="visible"
+      className="space-y-5"
     >
-      <WarmCard padding="sm" className="rounded-[28px] shadow-[var(--shadow-sm)]">
-        {isLoading ? (
-          <div className="space-y-3">
-            <div className="h-10 w-48 rounded bg-[var(--home-paper-alt)] animate-pulse" />
-            <div className="h-6 w-32 rounded bg-[var(--home-paper-alt)] animate-pulse" />
-          </div>
-        ) : (
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
-            <div className="rounded-[24px] border border-[var(--home-rule)] bg-[var(--home-paper-alt)] p-5">
-              <motion.div variants={v.itemVariants}>
-                <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
-                  Total Portfolio Value
-                </p>
-                <p className="text-3xl font-bold text-[var(--home-ink)]">
-                  {formatCurrency(summary.totalValue)}
-                </p>
-              </motion.div>
+      {/* Hero balance card — live pulse, big balance, delta chip */}
+      <motion.div
+        variants={v.itemVariants}
+        className="relative overflow-hidden rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-6 shadow-[var(--shadow-md)] sm:px-7 sm:py-7"
+      >
+        {/* Periwinkle haze blur — sits behind balance like the design source */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -right-24 -top-24 h-[360px] w-[360px] rounded-full"
+          style={{
+            background:
+              "radial-gradient(circle, color-mix(in srgb, var(--home-haze) 18%, transparent), transparent 60%)",
+            filter: "blur(20px)",
+          }}
+        />
 
-              <motion.div variants={v.itemVariants} className="mt-2">
-                <p className={`text-base font-semibold ${gainColor}`}>
-                  {formatCurrency(summary.totalGainLoss)} ({formatPercent(summary.totalGainLossPercent)})
-                </p>
-              </motion.div>
-            </div>
+        <div className="relative z-[1] flex flex-col gap-4">
+          <span className="inline-flex items-center gap-2 text-[10.5px] font-bold uppercase tracking-[0.14em] text-[var(--home-ink-muted)]">
+            <span
+              aria-hidden="true"
+              className="motion-safe:animate-pulse h-[7px] w-[7px] rounded-full bg-[var(--color-success)]"
+              style={{
+                boxShadow:
+                  "0 0 0 3px color-mix(in srgb, var(--color-success) 22%, transparent)",
+              }}
+            />
+            Total portfolio value · Live
+          </span>
 
-            <motion.div
-              variants={v.itemVariants}
-              className="grid gap-3 sm:grid-cols-2"
+          <p className="m-0 flex items-baseline gap-2 text-[clamp(2.6rem,4vw+1rem,3.6rem)] font-semibold leading-[0.95] tracking-[-0.06em] tabular-nums text-[var(--home-ink)]">
+            {formatCurrency(summary.totalValue, 2)}
+            <span className="text-[0.34em] font-semibold tracking-[0.04em] text-[var(--home-ink-muted)]">
+              USD
+            </span>
+          </p>
+
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-[13.5px] font-semibold">
+            <span
+              className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[12px] font-semibold ${
+                gainPositive
+                  ? "border-[color-mix(in_srgb,var(--color-success)_28%,transparent)] bg-[color-mix(in_srgb,var(--color-success)_14%,transparent)] text-[var(--color-success)]"
+                  : "border-[color-mix(in_srgb,var(--color-error)_28%,transparent)] bg-[color-mix(in_srgb,var(--color-error)_14%,transparent)] text-[var(--color-error)]"
+              }`}
             >
-              <div className="rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
-                  Today
-                </p>
-                <p className={`mt-2 text-sm font-semibold ${dayColor}`}>
-                  {formatCurrency(summary.dayChange)} ({formatPercent(summary.dayChangePercent)})
-                </p>
-              </div>
-              <div className="rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
-                  Total Cost
-                </p>
-                <p className="mt-2 text-sm font-semibold text-[var(--home-ink)]">
-                  {formatCurrency(summary.totalCost)}
-                </p>
-              </div>
-            </motion.div>
+              {formatSignedCurrency(summary.totalGainLoss)}
+              {" · "}
+              {formatPercent(summary.totalGainLossPercent)}
+            </span>
+            <span className="font-medium text-[var(--home-ink-muted)]">
+              All-time return
+            </span>
           </div>
-        )}
-      </WarmCard>
+        </div>
+      </motion.div>
+
+      {/* Dense Gemini-style 8-fact stats grid */}
+      <motion.div
+        variants={v.itemVariants}
+        className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-6 shadow-[var(--shadow-sm)] sm:px-7 sm:py-7"
+      >
+        <div className="mb-5 flex items-baseline justify-between gap-4">
+          <h2 className="m-0 text-[16px] font-bold tracking-[-0.02em] text-[var(--home-ink)]">
+            Portfolio stats
+          </h2>
+          <span className="inline-flex items-center gap-1.5 text-[11.5px] text-[var(--home-ink-muted)]">
+            <span
+              aria-hidden="true"
+              className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--color-success)]"
+              style={{ boxShadow: "0 0 0 3px rgba(43,168,74,0.16)" }}
+            />
+            Live across saved positions
+          </span>
+        </div>
+
+        <div className="grid grid-cols-2 gap-x-6 gap-y-5 lg:grid-cols-4">
+          <StatCell
+            label="Day P/L"
+            hint="Today's change in portfolio value, summed across all positions."
+            value={formatSignedCurrency(summary.dayChange)}
+            sub={formatPercent(summary.dayChangePercent)}
+            tone={dayPositive ? "pos" : "neg"}
+          />
+          <StatCell
+            label="All-time return"
+            hint="Total dollar return since you started tracking each position."
+            value={formatSignedCurrency(summary.totalGainLoss)}
+            sub={formatPercent(summary.totalGainLossPercent)}
+            tone={gainPositive ? "pos" : "neg"}
+          />
+          <StatCell
+            label="Cost basis"
+            hint="What you paid for the holdings you're still tracking."
+            value={formatCurrency(summary.totalCost)}
+          />
+          <StatCell
+            label="Positions"
+            hint="Number of distinct tickers in the saved book."
+            value={String(stats.positions)}
+            sub={
+              stats.positions === 0
+                ? undefined
+                : `${stats.concentration.toFixed(1)}% in top three`
+            }
+          />
+          <StatCell
+            label="Top holding"
+            hint="Largest position by current market value."
+            value={stats.topHolding?.symbol ?? "—"}
+            sub={
+              stats.topHolding
+                ? `${stats.topHolding.allocationPercent.toFixed(1)}% of book`
+                : undefined
+            }
+          />
+          <StatCell
+            label="Best performer"
+            hint="Position with the strongest all-time return percentage."
+            value={stats.bestPerformer?.symbol ?? "—"}
+            sub={
+              stats.bestPerformer
+                ? formatPercent(stats.bestPerformer.gainLossPercent)
+                : undefined
+            }
+            tone={
+              stats.bestPerformer && stats.bestPerformer.gainLossPercent >= 0
+                ? "pos"
+                : stats.bestPerformer
+                  ? "neg"
+                  : "default"
+            }
+          />
+          <StatCell
+            label="Biggest day move"
+            hint="Position with the largest absolute change today."
+            value={stats.biggestDayMove?.symbol ?? "—"}
+            sub={
+              stats.biggestDayMove
+                ? formatPercent(stats.biggestDayMove.dayChangePercent)
+                : undefined
+            }
+            tone={
+              stats.biggestDayMove && stats.biggestDayMove.dayChangePercent >= 0
+                ? "pos"
+                : stats.biggestDayMove
+                  ? "neg"
+                  : "default"
+            }
+          />
+          <StatCell
+            label="Top-3 concentration"
+            hint="Combined allocation of your three largest positions — a quick read on portfolio shape."
+            value={`${stats.concentration.toFixed(1)}%`}
+            sub={
+              stats.positions <= 3
+                ? "Whole book"
+                : `${stats.positions - 3} more positions`
+            }
+          />
+        </div>
+
+        {/* Quick-link pill row — Whitepaper/Website-style affordances */}
+        <div className="mt-5 flex flex-wrap gap-2 border-t border-dashed border-[color-mix(in_srgb,var(--home-ink)_14%,transparent)] pt-4">
+          <a
+            href="#allocation-chart"
+            className="inline-flex items-center gap-2 rounded-full border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_88%,var(--home-elev-mix))] px-3.5 py-2 text-[12.5px] font-semibold text-[var(--home-ink)] transition hover:-translate-y-px hover:border-[color-mix(in_srgb,var(--home-ink)_18%,transparent)] hover:bg-[color-mix(in_srgb,var(--home-acid)_20%,var(--home-paper))]"
+          >
+            Allocation breakdown
+          </a>
+          <a
+            href="#holdings-list"
+            className="inline-flex items-center gap-2 rounded-full border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_88%,var(--home-elev-mix))] px-3.5 py-2 text-[12.5px] font-semibold text-[var(--home-ink)] transition hover:-translate-y-px hover:border-[color-mix(in_srgb,var(--home-ink)_18%,transparent)] hover:bg-[color-mix(in_srgb,var(--home-acid)_20%,var(--home-paper))]"
+          >
+            Per-position detail
+          </a>
+          <a
+            href="#performance-chart"
+            className="inline-flex items-center gap-2 rounded-full border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_88%,var(--home-elev-mix))] px-3.5 py-2 text-[12.5px] font-semibold text-[var(--home-ink)] transition hover:-translate-y-px hover:border-[color-mix(in_srgb,var(--home-ink)_18%,transparent)] hover:bg-[color-mix(in_srgb,var(--home-acid)_20%,var(--home-paper))]"
+          >
+            Performance over time
+          </a>
+        </div>
+      </motion.div>
     </motion.div>
   );
 }

--- a/src/components/investments/PortfolioSummary.tsx
+++ b/src/components/investments/PortfolioSummary.tsx
@@ -1,359 +1,44 @@
 "use client";
 
 import React from "react";
-import { motion, useReducedMotion } from "framer-motion";
-import { WarmCard } from "@/components/ui/WarmCard";
 import type {
   EnhancedHolding,
   PortfolioSummary as PortfolioSummaryType,
 } from "@/types/investment";
-import {
-  containerVariants,
-  itemVariants,
-  getReducedMotionVariants,
-} from "./animations";
+import type { PortfolioSnapshot } from "./PortfolioPerformanceChart";
+import { PortfolioHeroCard } from "./PortfolioHeroCard";
+import { PortfolioStatsGrid } from "./PortfolioStatsGrid";
 
 interface Props {
   summary: PortfolioSummaryType;
   holdings: EnhancedHolding[];
   isLoading: boolean;
+  snapshots: PortfolioSnapshot[];
+  onAddHolding?: () => void;
+  onRefresh?: () => void;
+  lastUpdated?: Date | null;
 }
 
-function formatCurrency(n: number, fractionDigits = 2): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: fractionDigits,
-    maximumFractionDigits: fractionDigits,
-  }).format(n);
-}
-
-function formatSignedCurrency(n: number, fractionDigits = 2): string {
-  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
-  return `${sign}${formatCurrency(Math.abs(n), fractionDigits)}`;
-}
-
-function formatPercent(n: number): string {
-  if (!Number.isFinite(n)) return "—";
-  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
-  return `${sign}${Math.abs(n).toFixed(2)}%`;
-}
-
-interface ComputedStats {
-  topHolding: { symbol: string; allocationPercent: number } | null;
-  bestPerformer: { symbol: string; gainLossPercent: number } | null;
-  biggestDayMove: { symbol: string; dayChangePercent: number } | null;
-  positions: number;
-  concentration: number;
-}
-
-function computeStats(holdings: EnhancedHolding[]): ComputedStats {
-  const positions = holdings.length;
-  if (positions === 0) {
-    return {
-      topHolding: null,
-      bestPerformer: null,
-      biggestDayMove: null,
-      positions: 0,
-      concentration: 0,
-    };
-  }
-
-  const sortedByAllocation = [...holdings]
-    .filter((h) => h.allocationPercent !== null)
-    .sort(
-      (a, b) =>
-        (b.allocationPercent ?? 0) - (a.allocationPercent ?? 0),
-    );
-  const top = sortedByAllocation[0] ?? null;
-
-  // Top-3 concentration as a portfolio-shape signal: how heavy the
-  // top three holdings are relative to the whole book.
-  const concentration = sortedByAllocation
-    .slice(0, 3)
-    .reduce((sum, h) => sum + (h.allocationPercent ?? 0), 0);
-
-  const sortedByReturn = [...holdings].sort(
-    (a, b) => b.gainLossPercent - a.gainLossPercent,
-  );
-  const best = sortedByReturn[0] ?? null;
-
-  const sortedByDayMove = [...holdings].sort(
-    (a, b) => Math.abs(b.dayChangePercent) - Math.abs(a.dayChangePercent),
-  );
-  const biggestMove = sortedByDayMove[0] ?? null;
-
-  return {
-    topHolding: top
-      ? {
-          symbol: top.symbol,
-          allocationPercent: top.allocationPercent ?? 0,
-        }
-      : null,
-    bestPerformer: best
-      ? {
-          symbol: best.symbol,
-          gainLossPercent: best.gainLossPercent,
-        }
-      : null,
-    biggestDayMove: biggestMove
-      ? {
-          symbol: biggestMove.symbol,
-          dayChangePercent: biggestMove.dayChangePercent,
-        }
-      : null,
-    positions,
-    concentration,
-  };
-}
-
-interface StatCellProps {
-  label: string;
-  hint: string;
-  value: React.ReactNode;
-  sub?: React.ReactNode;
-  tone?: "default" | "pos" | "neg";
-}
-
-function StatCell({ label, hint, value, sub, tone = "default" }: StatCellProps) {
-  const valueColor =
-    tone === "pos"
-      ? "text-[var(--color-success)]"
-      : tone === "neg"
-        ? "text-[var(--color-error)]"
-        : "text-[var(--home-ink)]";
+export function PortfolioSummary({
+  summary,
+  holdings,
+  isLoading,
+  snapshots,
+  onAddHolding,
+  onRefresh,
+  lastUpdated,
+}: Props) {
   return (
-    <div className="flex min-w-0 flex-col gap-1">
-      <span
-        className="w-fit cursor-help text-[12.5px] font-medium text-[var(--home-ink-muted)] [text-decoration-color:color-mix(in_srgb,var(--home-ink)_28%,transparent)] [text-decoration-line:underline] [text-decoration-style:dotted] [text-underline-offset:3px]"
-        title={hint}
-      >
-        {label}
-      </span>
-      <span
-        className={`truncate text-[17px] font-semibold leading-[1.3] tracking-[-0.01em] tabular-nums ${valueColor}`}
-      >
-        {value}
-      </span>
-      {sub ? (
-        <span className="text-[11.5px] tabular-nums text-[var(--home-ink-muted)]">
-          {sub}
-        </span>
-      ) : null}
+    <div className="space-y-5">
+      <PortfolioHeroCard
+        summary={summary}
+        snapshots={snapshots}
+        isLoading={isLoading}
+        onAddHolding={onAddHolding}
+        onRefresh={onRefresh}
+        lastUpdated={lastUpdated}
+      />
+      <PortfolioStatsGrid summary={summary} holdings={holdings} />
     </div>
-  );
-}
-
-export function PortfolioSummary({ summary, holdings, isLoading }: Props) {
-  const gainPositive = summary.totalGainLoss >= 0;
-  const dayPositive = summary.dayChange >= 0;
-  const stats = computeStats(holdings);
-
-  const shouldReduceMotion = useReducedMotion();
-  const v = shouldReduceMotion ? getReducedMotionVariants() : { containerVariants, itemVariants };
-
-  if (isLoading) {
-    return (
-      <WarmCard padding="sm" className="rounded-[28px] shadow-[var(--shadow-sm)]">
-        <div className="space-y-3">
-          <div className="h-10 w-48 rounded bg-[var(--home-paper-alt)] animate-pulse" />
-          <div className="h-6 w-32 rounded bg-[var(--home-paper-alt)] animate-pulse" />
-        </div>
-      </WarmCard>
-    );
-  }
-
-  return (
-    <motion.div
-      role="region"
-      aria-label="Portfolio summary"
-      variants={v.containerVariants}
-      initial="hidden"
-      animate="visible"
-      className="space-y-5"
-    >
-      {/* Hero balance card — live pulse, big balance, delta chip */}
-      <motion.div
-        variants={v.itemVariants}
-        className="relative overflow-hidden rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-6 shadow-[var(--shadow-md)] sm:px-7 sm:py-7"
-      >
-        {/* Periwinkle haze blur — sits behind balance like the design source */}
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -right-24 -top-24 h-[360px] w-[360px] rounded-full"
-          style={{
-            background:
-              "radial-gradient(circle, color-mix(in srgb, var(--home-haze) 18%, transparent), transparent 60%)",
-            filter: "blur(20px)",
-          }}
-        />
-
-        <div className="relative z-[1] flex flex-col gap-4">
-          <span className="inline-flex items-center gap-2 text-[10.5px] font-bold uppercase tracking-[0.14em] text-[var(--home-ink-muted)]">
-            <span
-              aria-hidden="true"
-              className="motion-safe:animate-pulse h-[7px] w-[7px] rounded-full bg-[var(--color-success)]"
-              style={{
-                boxShadow:
-                  "0 0 0 3px color-mix(in srgb, var(--color-success) 22%, transparent)",
-              }}
-            />
-            Total portfolio value · Live
-          </span>
-
-          <p className="m-0 flex items-baseline gap-2 text-[clamp(2.6rem,4vw+1rem,3.6rem)] font-semibold leading-[0.95] tracking-[-0.06em] tabular-nums text-[var(--home-ink)]">
-            {formatCurrency(summary.totalValue, 2)}
-            <span className="text-[0.34em] font-semibold tracking-[0.04em] text-[var(--home-ink-muted)]">
-              USD
-            </span>
-          </p>
-
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-[13.5px] font-semibold">
-            <span
-              className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[12px] font-semibold ${
-                gainPositive
-                  ? "border-[color-mix(in_srgb,var(--color-success)_28%,transparent)] bg-[color-mix(in_srgb,var(--color-success)_14%,transparent)] text-[var(--color-success)]"
-                  : "border-[color-mix(in_srgb,var(--color-error)_28%,transparent)] bg-[color-mix(in_srgb,var(--color-error)_14%,transparent)] text-[var(--color-error)]"
-              }`}
-            >
-              {formatSignedCurrency(summary.totalGainLoss)}
-              {" · "}
-              {formatPercent(summary.totalGainLossPercent)}
-            </span>
-            <span className="font-medium text-[var(--home-ink-muted)]">
-              All-time return
-            </span>
-          </div>
-        </div>
-      </motion.div>
-
-      {/* Dense Gemini-style 8-fact stats grid */}
-      <motion.div
-        variants={v.itemVariants}
-        className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-6 shadow-[var(--shadow-sm)] sm:px-7 sm:py-7"
-      >
-        <div className="mb-5 flex items-baseline justify-between gap-4">
-          <h2 className="m-0 text-[16px] font-bold tracking-[-0.02em] text-[var(--home-ink)]">
-            Portfolio stats
-          </h2>
-          <span className="inline-flex items-center gap-1.5 text-[11.5px] text-[var(--home-ink-muted)]">
-            <span
-              aria-hidden="true"
-              className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--color-success)]"
-              style={{ boxShadow: "0 0 0 3px rgba(43,168,74,0.16)" }}
-            />
-            Live across saved positions
-          </span>
-        </div>
-
-        <div className="grid grid-cols-2 gap-x-6 gap-y-5 lg:grid-cols-4">
-          <StatCell
-            label="Day P/L"
-            hint="Today's change in portfolio value, summed across all positions."
-            value={formatSignedCurrency(summary.dayChange)}
-            sub={formatPercent(summary.dayChangePercent)}
-            tone={dayPositive ? "pos" : "neg"}
-          />
-          <StatCell
-            label="All-time return"
-            hint="Total dollar return since you started tracking each position."
-            value={formatSignedCurrency(summary.totalGainLoss)}
-            sub={formatPercent(summary.totalGainLossPercent)}
-            tone={gainPositive ? "pos" : "neg"}
-          />
-          <StatCell
-            label="Cost basis"
-            hint="What you paid for the holdings you're still tracking."
-            value={formatCurrency(summary.totalCost)}
-          />
-          <StatCell
-            label="Positions"
-            hint="Number of distinct tickers in the saved book."
-            value={String(stats.positions)}
-            sub={
-              stats.positions === 0
-                ? undefined
-                : `${stats.concentration.toFixed(1)}% in top three`
-            }
-          />
-          <StatCell
-            label="Top holding"
-            hint="Largest position by current market value."
-            value={stats.topHolding?.symbol ?? "—"}
-            sub={
-              stats.topHolding
-                ? `${stats.topHolding.allocationPercent.toFixed(1)}% of book`
-                : undefined
-            }
-          />
-          <StatCell
-            label="Best performer"
-            hint="Position with the strongest all-time return percentage."
-            value={stats.bestPerformer?.symbol ?? "—"}
-            sub={
-              stats.bestPerformer
-                ? formatPercent(stats.bestPerformer.gainLossPercent)
-                : undefined
-            }
-            tone={
-              stats.bestPerformer && stats.bestPerformer.gainLossPercent >= 0
-                ? "pos"
-                : stats.bestPerformer
-                  ? "neg"
-                  : "default"
-            }
-          />
-          <StatCell
-            label="Biggest day move"
-            hint="Position with the largest absolute change today."
-            value={stats.biggestDayMove?.symbol ?? "—"}
-            sub={
-              stats.biggestDayMove
-                ? formatPercent(stats.biggestDayMove.dayChangePercent)
-                : undefined
-            }
-            tone={
-              stats.biggestDayMove && stats.biggestDayMove.dayChangePercent >= 0
-                ? "pos"
-                : stats.biggestDayMove
-                  ? "neg"
-                  : "default"
-            }
-          />
-          <StatCell
-            label="Top-3 concentration"
-            hint="Combined allocation of your three largest positions — a quick read on portfolio shape."
-            value={`${stats.concentration.toFixed(1)}%`}
-            sub={
-              stats.positions <= 3
-                ? "Whole book"
-                : `${stats.positions - 3} more positions`
-            }
-          />
-        </div>
-
-        {/* Quick-link pill row — Whitepaper/Website-style affordances */}
-        <div className="mt-5 flex flex-wrap gap-2 border-t border-dashed border-[color-mix(in_srgb,var(--home-ink)_14%,transparent)] pt-4">
-          <a
-            href="#allocation-chart"
-            className="inline-flex items-center gap-2 rounded-full border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_88%,var(--home-elev-mix))] px-3.5 py-2 text-[12.5px] font-semibold text-[var(--home-ink)] transition hover:-translate-y-px hover:border-[color-mix(in_srgb,var(--home-ink)_18%,transparent)] hover:bg-[color-mix(in_srgb,var(--home-acid)_20%,var(--home-paper))]"
-          >
-            Allocation breakdown
-          </a>
-          <a
-            href="#holdings-list"
-            className="inline-flex items-center gap-2 rounded-full border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_88%,var(--home-elev-mix))] px-3.5 py-2 text-[12.5px] font-semibold text-[var(--home-ink)] transition hover:-translate-y-px hover:border-[color-mix(in_srgb,var(--home-ink)_18%,transparent)] hover:bg-[color-mix(in_srgb,var(--home-acid)_20%,var(--home-paper))]"
-          >
-            Per-position detail
-          </a>
-          <a
-            href="#performance-chart"
-            className="inline-flex items-center gap-2 rounded-full border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_88%,var(--home-elev-mix))] px-3.5 py-2 text-[12.5px] font-semibold text-[var(--home-ink)] transition hover:-translate-y-px hover:border-[color-mix(in_srgb,var(--home-ink)_18%,transparent)] hover:bg-[color-mix(in_srgb,var(--home-acid)_20%,var(--home-paper))]"
-          >
-            Performance over time
-          </a>
-        </div>
-      </motion.div>
-    </motion.div>
   );
 }

--- a/src/components/investments/PortfolioTracker.tsx
+++ b/src/components/investments/PortfolioTracker.tsx
@@ -1,22 +1,35 @@
 "use client";
 
-import React from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import React, { useMemo, useRef, useState } from "react";
+import {
+  IconBookmark,
+  IconChartArcs3,
+  IconChartLine,
+  IconCircleHalf,
+  IconHelp,
+  IconHome,
+  IconList,
+  IconReportMoney,
+  IconSearch,
+  IconWallet,
+} from "@tabler/icons-react";
 import { PortfolioSummary } from "./PortfolioSummary";
-import { StockCard } from "./StockCard";
 import { AddStockForm } from "./AddStockForm";
 import { AllocationChart } from "./AllocationChart";
 import { DataFreshnessIndicator } from "./DataFreshnessIndicator";
-import { PortfolioPerformanceChart } from "./PortfolioPerformanceChart";
+import { HoldingsTable } from "./HoldingsTable";
 import { useInvestments } from "@/hooks/useInvestments";
-import {
-  containerVariants,
-  itemVariants,
-  getReducedMotionVariants,
-} from "./animations";
 
 interface Props {
   onResearch: (symbol: string) => void;
+}
+
+interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  pill?: string;
 }
 
 export function PortfolioTracker({ onResearch }: Props) {
@@ -33,95 +46,187 @@ export function PortfolioTracker({ onResearch }: Props) {
     refetch,
   } = useInvestments();
 
-  const shouldReduceMotion = useReducedMotion();
-  const v = shouldReduceMotion ? getReducedMotionVariants() : { containerVariants, itemVariants };
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeSection, setActiveSection] = useState("home");
+  const addHoldingRef = useRef<HTMLDivElement | null>(null);
+
+  const filteredHoldings = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return enhancedHoldings;
+    return enhancedHoldings.filter(
+      (h) =>
+        h.symbol.toLowerCase().includes(q) ||
+        (h.name ?? "").toLowerCase().includes(q),
+    );
+  }, [enhancedHoldings, searchQuery]);
 
   const isEmpty = enhancedHoldings.length === 0;
 
+  const navItems: NavItem[] = useMemo(
+    () => [
+      { id: "home", label: "Overview", href: "#hero", icon: IconHome },
+      {
+        id: "holdings",
+        label: "Holdings",
+        href: "#holdings-list",
+        icon: IconList,
+        pill: enhancedHoldings.length > 0 ? String(enhancedHoldings.length) : undefined,
+      },
+      { id: "allocation", label: "Allocation", href: "#allocation", icon: IconChartArcs3 },
+      { id: "performance", label: "Performance", href: "#performance-chart", icon: IconChartLine },
+      { id: "stats", label: "Portfolio stats", href: "#portfolio-stats", icon: IconCircleHalf },
+      { id: "research", label: "Research", href: "#research-tools", icon: IconReportMoney },
+    ],
+    [enhancedHoldings.length],
+  );
+
+  function focusAddHolding() {
+    setActiveSection("add");
+    if (addHoldingRef.current) {
+      addHoldingRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+      const input = addHoldingRef.current.querySelector("input");
+      if (input instanceof HTMLInputElement) {
+        // Defer focus a tick so smooth scroll initiates first.
+        setTimeout(() => input.focus(), 200);
+      }
+    }
+  }
+
   return (
-    <section aria-label="Portfolio tracker" className="space-y-6">
-      {!isEmpty && (
-        <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-4 shadow-[var(--shadow-sm)] sm:p-5">
-          <div className="mb-4 grid gap-3 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-center">
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
-                Portfolio Overview
-              </p>
-              <p className="mt-1 text-sm text-[var(--home-ink-muted)]">
-                Track allocation, performance, and holding-level changes across your saved positions.
-              </p>
-            </div>
-            <div className="justify-self-start xl:justify-self-end">
-              <DataFreshnessIndicator
-                lastUpdated={lastUpdated}
-                onRefresh={refetch}
-                isRefreshing={isLoading}
-              />
-            </div>
+    <div className="invest-shell" data-testid="invest-shell">
+      <aside className="invest-sidebar" aria-label="Investments navigation">
+        <div className="invest-brand">
+          <div className="invest-brand-iv" aria-hidden="true">IV</div>
+          <div className="invest-brand-name">
+            Isaac Vazquez
+            <small>Investments</small>
           </div>
-          {error ? (
-            <div className="mb-4 rounded-2xl border border-[color-mix(in_srgb,var(--color-warning)_35%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-warning)_10%,var(--home-paper-alt))] px-4 py-3 text-sm text-[var(--home-ink-muted)]">
-              {error}
-            </div>
-          ) : null}
+        </div>
+
+        <nav className="flex flex-col gap-1.5" aria-label="Section navigation">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            const isActive = activeSection === item.id;
+            return (
+              <a
+                key={item.id}
+                href={item.href}
+                className="invest-nav-link"
+                aria-current={isActive ? "true" : undefined}
+                onClick={() => setActiveSection(item.id)}
+              >
+                <Icon size={18} aria-hidden="true" />
+                {item.label}
+                {item.pill ? <span className="invest-nav-pill">{item.pill}</span> : null}
+              </a>
+            );
+          })}
+        </nav>
+
+        <div className="invest-sidebar-footer">
+          <IconBookmark size={16} aria-hidden="true" />
+          <span>Local browser storage</span>
+        </div>
+      </aside>
+
+      <main className="invest-main" id="hero">
+        <div className="invest-topbar">
+          <div>
+            <p className="invest-crumbs">Investments / <strong>Portfolio</strong></p>
+            <h1>Portfolio</h1>
+          </div>
+
+          <label className="invest-search" aria-label="Filter holdings">
+            <IconSearch size={14} aria-hidden="true" />
+            <input
+              type="search"
+              placeholder="Filter holdings…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            <span className="invest-search-kbd" aria-hidden="true">⌘K</span>
+          </label>
+
+          <div className="flex items-center gap-2">
+            <DataFreshnessIndicator
+              lastUpdated={lastUpdated}
+              onRefresh={refetch}
+              isRefreshing={isLoading}
+            />
+            <span className="invest-avatar" aria-hidden="true">IV</span>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="mb-4 rounded-2xl border border-[color-mix(in_srgb,var(--color-warning)_35%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-warning)_10%,var(--home-paper-alt))] px-4 py-3 text-sm text-[var(--home-ink-muted)]">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="space-y-5">
           <PortfolioSummary
             summary={summary}
             holdings={enhancedHoldings}
+            snapshots={snapshots}
             isLoading={isLoading}
+            onAddHolding={focusAddHolding}
+            onRefresh={refetch}
+            lastUpdated={lastUpdated}
           />
+
+          {!isEmpty ? (
+            <HoldingsTable
+              holdings={filteredHoldings}
+              onUpdate={updateHolding}
+              onRemove={removeHolding}
+              onResearch={onResearch}
+            />
+          ) : (
+            <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
+              <p className="mb-2 text-sm font-semibold text-[var(--home-ink)]">
+                No positions yet
+              </p>
+              <p className="mx-auto max-w-xs text-sm text-[color-mix(in_srgb,var(--home-ink)_45%,var(--home-paper))]">
+                Add your first stock using the form on the right. Holdings are saved in your browser and persist across visits.
+              </p>
+            </div>
+          )}
         </div>
-      )}
+      </main>
 
-      {!isEmpty && snapshots.length >= 2 && (
-        <div id="performance-chart" className="scroll-mt-28">
-          <PortfolioPerformanceChart snapshots={snapshots} />
-        </div>
-      )}
-
-      <div>
-        <AddStockForm onAdd={addHolding} />
-      </div>
-
-      {isEmpty ? (
-        <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
-          <p className="mb-2 text-sm font-semibold text-[var(--home-ink)]">
-            No positions yet
+      <aside className="invest-rail" aria-label="Portfolio side panel">
+        <section ref={addHoldingRef} id="add-holding" className="scroll-mt-28">
+          <p className="invest-rail-section-label">
+            <IconWallet size={12} aria-hidden="true" className="mr-1.5 inline align-middle" />
+            Add a holding
           </p>
-          <p className="text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))] text-sm max-w-xs mx-auto">
-            Add your first stock using the form above. Holdings are saved in your browser and persist across visits.
-          </p>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 gap-6 2xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,0.8fr)]">
-          <div id="holdings-list" className="scroll-mt-28">
-            <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.18em] text-[var(--home-ink-muted)]">
-              Holdings ({enhancedHoldings.length})
-            </h2>
-            <motion.ul
-              className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-2"
-              role="list"
-              variants={v.containerVariants}
-              initial="hidden"
-              animate="visible"
-            >
-              {enhancedHoldings.map((h) => (
-                <motion.li key={h.symbol} variants={v.itemVariants}>
-                  <StockCard
-                    holding={h}
-                    onUpdate={updateHolding}
-                    onRemove={removeHolding}
-                    onResearch={onResearch}
-                  />
-                </motion.li>
-              ))}
-            </motion.ul>
-          </div>
+          <AddStockForm onAdd={addHolding} />
+        </section>
 
-          <div id="allocation-chart" className="scroll-mt-28">
+        {!isEmpty ? (
+          <section id="allocation" className="scroll-mt-28">
+            <p className="invest-rail-section-label">Allocation</p>
             <AllocationChart holdings={enhancedHoldings} />
-          </div>
-        </div>
-      )}
-    </section>
+          </section>
+        ) : null}
+
+        <section
+          id="research-tools"
+          className="scroll-mt-28 rounded-[18px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper-alt)_60%,var(--home-elev-mix))] p-4"
+        >
+          <p className="invest-rail-section-label">Research</p>
+          <p className="text-[12.5px] leading-relaxed text-[var(--home-ink-muted)]">
+            Click <strong className="text-[var(--home-ink)]">Research</strong> on any
+            holding to open the deep-dive view — fundamentals, valuation history, news,
+            and price chart with cost-basis overlay.
+          </p>
+        </section>
+
+        <p className="mt-auto flex items-center gap-2 text-[11.5px] text-[var(--home-ink-muted)]">
+          <IconHelp size={14} aria-hidden="true" />
+          Holdings live only in your browser — no logins, no cloud sync.
+        </p>
+      </aside>
+    </div>
   );
 }

--- a/src/components/investments/PortfolioTracker.tsx
+++ b/src/components/investments/PortfolioTracker.tsx
@@ -64,12 +64,16 @@ export function PortfolioTracker({ onResearch }: Props) {
               {error}
             </div>
           ) : null}
-          <PortfolioSummary summary={summary} isLoading={isLoading} />
+          <PortfolioSummary
+            summary={summary}
+            holdings={enhancedHoldings}
+            isLoading={isLoading}
+          />
         </div>
       )}
 
       {!isEmpty && snapshots.length >= 2 && (
-        <div>
+        <div id="performance-chart" className="scroll-mt-28">
           <PortfolioPerformanceChart snapshots={snapshots} />
         </div>
       )}
@@ -89,7 +93,7 @@ export function PortfolioTracker({ onResearch }: Props) {
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-6 2xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,0.8fr)]">
-          <div>
+          <div id="holdings-list" className="scroll-mt-28">
             <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.18em] text-[var(--home-ink-muted)]">
               Holdings ({enhancedHoldings.length})
             </h2>
@@ -113,7 +117,7 @@ export function PortfolioTracker({ onResearch }: Props) {
             </motion.ul>
           </div>
 
-          <div>
+          <div id="allocation-chart" className="scroll-mt-28">
             <AllocationChart holdings={enhancedHoldings} />
           </div>
         </div>

--- a/src/components/investments/ResearchAssetHeader.tsx
+++ b/src/components/investments/ResearchAssetHeader.tsx
@@ -10,7 +10,16 @@ import {
 } from "@tabler/icons-react";
 import { useLiveQuote } from "@/hooks/useLiveQuote";
 import { useStockData } from "@/hooks/useStockData";
-import type { CompanyInfo } from "@/types/investment";
+import type {
+  BetaData,
+  CompanyInfo,
+  DcfData,
+  Fundamentals,
+  MarginsData,
+  PriceData,
+  Profitability,
+  StockPrice,
+} from "@/types/investment";
 
 interface Props {
   symbol: string;
@@ -84,6 +93,73 @@ function logoChars(symbol: string): string {
   return symbol.replace(".", "").slice(0, 2).toUpperCase();
 }
 
+function formatCompactCurrency(n: number | undefined): string {
+  if (n === undefined || n === null || !Number.isFinite(n)) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(n);
+}
+
+function formatRatio(n: number | undefined, decimals = 1): string {
+  if (n === undefined || n === null || !Number.isFinite(n)) return "—";
+  return n.toFixed(decimals);
+}
+
+function formatPercent1(n: number | undefined, signed = false): string {
+  if (n === undefined || n === null || !Number.isFinite(n)) return "—";
+  const sign = signed && n > 0 ? "+" : signed && n < 0 ? "−" : "";
+  return `${sign}${Math.abs(n).toFixed(1)}%`;
+}
+
+function formatRange(low: number | undefined, high: number | undefined): string {
+  if (low === undefined || high === undefined) return "—";
+  const fmt = (v: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(v);
+  return `${fmt(low)}–${fmt(high)}`;
+}
+
+interface KeyMetric {
+  label: string;
+  hint: string;
+  value: string;
+  tone?: "default" | "pos" | "neg";
+}
+
+interface KeyMetricCellProps {
+  metric: KeyMetric;
+}
+
+function KeyMetricCell({ metric }: KeyMetricCellProps) {
+  const valueColor =
+    metric.tone === "pos"
+      ? "text-[var(--color-success)]"
+      : metric.tone === "neg"
+        ? "text-[var(--color-error)]"
+        : "text-[var(--home-ink)]";
+  return (
+    <div className="research-key-metric">
+      <span
+        className="research-key-metric-label"
+        title={metric.hint}
+      >
+        {metric.label}
+      </span>
+      <span
+        className={`research-key-metric-value ${valueColor}`}
+      >
+        {metric.value}
+      </span>
+    </div>
+  );
+}
+
 export function ResearchAssetHeader({
   symbol,
   isInPortfolio = false,
@@ -91,12 +167,93 @@ export function ResearchAssetHeader({
   onAddToPortfolio,
 }: Props) {
   const { data: info } = useStockData<CompanyInfo>(symbol || null, "info");
+  const { data: fundamentals } = useStockData<Fundamentals>(symbol || null, "fundamentals");
+  const { data: dcf } = useStockData<DcfData>(symbol || null, "dcf");
+  const { data: profitability } = useStockData<Profitability>(symbol || null, "profitability");
+  const { data: marginsRaw } = useStockData<MarginsData>(symbol || null, "margins");
+  const { data: beta } = useStockData<BetaData>(symbol || null, "beta");
+  const { data: priceRaw } = useStockData<PriceData>(symbol || null, "price");
   const {
     quote,
     isLoading: quoteLoading,
     error: quoteError,
     lastUpdated,
   } = useLiveQuote(symbol || null);
+
+  const margins = Array.isArray(marginsRaw) ? marginsRaw[marginsRaw.length - 1] : undefined;
+  const trailingYear = React.useMemo(() => {
+    if (!Array.isArray(priceRaw)) return [];
+    return (priceRaw as StockPrice[]).slice(-252);
+  }, [priceRaw]);
+  const trailingHigh = trailingYear.length
+    ? Math.max(...trailingYear.map((p) => p.high ?? p.close ?? 0))
+    : undefined;
+  const trailingLow = trailingYear.length
+    ? Math.min(...trailingYear.map((p) => p.low ?? p.close ?? 0))
+    : undefined;
+  const dcfUpside = dcf?.upside;
+
+  const keyMetrics: KeyMetric[] = [
+    {
+      label: "Market cap",
+      hint: "Total equity value at the latest close.",
+      value: formatCompactCurrency(fundamentals?.marketCap),
+    },
+    {
+      label: "P/E TTM",
+      hint: "Price to trailing-12-month earnings.",
+      value: formatRatio(fundamentals?.ttmPe, 1),
+    },
+    {
+      label: "EPS TTM",
+      hint: "Trailing-12-month earnings per share.",
+      value:
+        fundamentals?.ttmEps !== undefined
+          ? new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 }).format(fundamentals.ttmEps)
+          : "—",
+    },
+    {
+      label: "Net margin",
+      hint: "Trailing-12-month net income divided by revenue.",
+      value: formatPercent1(margins?.netMargin),
+    },
+    {
+      label: "ROIC",
+      hint: "Return on invested capital — how efficiently the business converts capital to profit.",
+      value: formatPercent1(profitability?.roic),
+      tone:
+        profitability?.roic === undefined
+          ? "default"
+          : profitability.roic >= 12
+            ? "pos"
+            : profitability.roic <= 5
+              ? "neg"
+              : "default",
+    },
+    {
+      label: "Beta 5Y",
+      hint: "Five-year price beta vs. the market.",
+      value: formatRatio(beta?.beta5y, 2),
+    },
+    {
+      label: "DCF upside",
+      hint: "Implied upside vs. the discounted-cash-flow fair value.",
+      value: formatPercent1(dcfUpside, true),
+      tone:
+        dcfUpside === undefined
+          ? "default"
+          : dcfUpside >= 15
+            ? "pos"
+            : dcfUpside <= -5
+              ? "neg"
+              : "default",
+    },
+    {
+      label: "52-week range",
+      hint: "Trailing 52-week intraday low / high from the price snapshot.",
+      value: formatRange(trailingLow, trailingHigh),
+    },
+  ];
 
   const upper = symbol.toUpperCase();
   const tone = tonForSymbol(upper);
@@ -147,15 +304,11 @@ export function ResearchAssetHeader({
               <span className="research-badge-pill tag">{info.industry}</span>
             ) : null}
           </div>
-          {info?.longBusinessSummary ? (
-            <p className="research-asset-bio">{info.longBusinessSummary}</p>
-          ) : (
-            <p className="research-asset-bio research-asset-bio--muted">
-              {quoteError && !info
-                ? "Live price is temporarily unavailable. Curated fundamentals below."
-                : "Loading company description…"}
-            </p>
-          )}
+          <div className="research-key-metrics" role="list" aria-label="Key metrics">
+            {keyMetrics.map((metric) => (
+              <KeyMetricCell key={metric.label} metric={metric} />
+            ))}
+          </div>
         </div>
 
         <div className="research-asset-price">

--- a/src/components/investments/ResearchAssetHeader.tsx
+++ b/src/components/investments/ResearchAssetHeader.tsx
@@ -304,11 +304,6 @@ export function ResearchAssetHeader({
               <span className="research-badge-pill tag">{info.industry}</span>
             ) : null}
           </div>
-          <div className="research-key-metrics" role="list" aria-label="Key metrics">
-            {keyMetrics.map((metric) => (
-              <KeyMetricCell key={metric.label} metric={metric} />
-            ))}
-          </div>
         </div>
 
         <div className="research-asset-price">
@@ -333,6 +328,12 @@ export function ResearchAssetHeader({
             </span>
           </div>
         </div>
+      </div>
+
+      <div className="research-key-metrics" role="list" aria-label="Key metrics">
+        {keyMetrics.map((metric) => (
+          <KeyMetricCell key={metric.label} metric={metric} />
+        ))}
       </div>
 
       <div className="research-asset-actions">

--- a/src/components/investments/ResearchAssetHeader.tsx
+++ b/src/components/investments/ResearchAssetHeader.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import React from "react";
+import {
+  IconBookmark,
+  IconExternalLink,
+  IconFileText,
+  IconPlus,
+  IconRefresh,
+} from "@tabler/icons-react";
+import { useLiveQuote } from "@/hooks/useLiveQuote";
+import { useStockData } from "@/hooks/useStockData";
+import type { CompanyInfo } from "@/types/investment";
+
+interface Props {
+  symbol: string;
+  isInPortfolio?: boolean;
+  portfolioShares?: number | null;
+  onAddToPortfolio?: () => void;
+}
+
+const TICKER_TONE: Record<string, string> = {
+  NVDA: "#5C8531",
+  AAPL: "#12110F",
+  MSFT: "#4D8AD0",
+  GOOGL: "#4A6CF0",
+  AMZN: "#1F7A6E",
+  TSLA: "#B22B2F",
+  "BRK.B": "#6B5A3E",
+  SPY: "#3F4B57",
+};
+
+function tonForSymbol(symbol: string): string {
+  const direct = TICKER_TONE[symbol];
+  if (direct) return direct;
+  // Hash for stable per-symbol color when not curated
+  let h = 0;
+  for (let i = 0; i < symbol.length; i++) {
+    h = (h << 5) - h + symbol.charCodeAt(i);
+    h |= 0;
+  }
+  const palette = ["#5672F8", "#5C8531", "#B22B2F", "#1F7A6E", "#4D8AD0", "#6B5A3E", "#3F4B57", "#615B52"];
+  return palette[Math.abs(h) % palette.length];
+}
+
+function formatBalance(n: number | undefined): { whole: string; cents: string } {
+  if (n === undefined || !Number.isFinite(n)) return { whole: "—", cents: "" };
+  const sign = n < 0 ? "−" : "";
+  const abs = Math.abs(n);
+  const whole = Math.floor(abs);
+  const cents = Math.round((abs - whole) * 100);
+  return {
+    whole: `${sign}$${whole.toLocaleString("en-US")}`,
+    cents: `.${cents.toString().padStart(2, "0")}`,
+  };
+}
+
+function formatSignedCurrency(n: number | undefined): string {
+  if (n === undefined || !Number.isFinite(n)) return "—";
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  const abs = Math.abs(n);
+  return `${sign}$${abs.toFixed(2)}`;
+}
+
+function formatPercent(n: number | undefined): string {
+  if (n === undefined || !Number.isFinite(n)) return "—";
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  return `${sign}${Math.abs(n).toFixed(2)}%`;
+}
+
+function formatRefreshLabel(raw: string | Date | null | undefined): string {
+  if (!raw) return "Refresh";
+  const d = raw instanceof Date ? raw : new Date(raw);
+  if (isNaN(d.getTime())) return "Refresh";
+  const minutes = Math.max(0, Math.floor((Date.now() - d.getTime()) / 60000));
+  if (minutes < 1) return "Refreshed just now";
+  if (minutes === 1) return "Refreshed 1m ago";
+  if (minutes < 60) return `Refreshed ${minutes}m ago`;
+  const h = Math.floor(minutes / 60);
+  return `Refreshed ${h}h ago`;
+}
+
+function logoChars(symbol: string): string {
+  return symbol.replace(".", "").slice(0, 2).toUpperCase();
+}
+
+export function ResearchAssetHeader({
+  symbol,
+  isInPortfolio = false,
+  portfolioShares = null,
+  onAddToPortfolio,
+}: Props) {
+  const { data: info } = useStockData<CompanyInfo>(symbol || null, "info");
+  const {
+    quote,
+    isLoading: quoteLoading,
+    error: quoteError,
+    lastUpdated,
+  } = useLiveQuote(symbol || null);
+
+  const upper = symbol.toUpperCase();
+  const tone = tonForSymbol(upper);
+  const quoteName = !quote?.error ? quote?.name : undefined;
+  const displayName =
+    info?.longName ||
+    info?.shortName ||
+    (quoteName && quoteName.toUpperCase() !== upper ? quoteName : null) ||
+    upper;
+
+  const livePrice = quote && !quote.error ? quote.price : undefined;
+  const dayChange = quote && !quote.error ? quote.change : undefined;
+  const dayChangePct = quote && !quote.error ? quote.changePercent : undefined;
+  const px = formatBalance(livePrice);
+  const positive = (dayChange ?? 0) >= 0;
+
+  return (
+    <section className="research-asset-card" aria-label={`${upper} asset summary`}>
+      <div className="research-asset-row">
+        <div
+          className="research-asset-logo"
+          aria-hidden="true"
+          style={{ background: tone }}
+        >
+          {logoChars(upper)}
+        </div>
+
+        <div className="research-asset-meta">
+          <div className="research-asset-titleline">
+            <h1>{displayName}</h1>
+            <span className="research-ticker-pill">
+              {upper}
+              {info?.industry || info?.sector ? " · " : null}
+              {info?.industry || info?.sector || ""}
+            </span>
+            {isInPortfolio ? (
+              <span className="research-badge-pill held">
+                Held
+                {typeof portfolioShares === "number" && portfolioShares > 0
+                  ? ` · ${portfolioShares.toLocaleString("en-US", { maximumFractionDigits: 4 })} sh`
+                  : ""}
+              </span>
+            ) : null}
+            {info?.sector ? (
+              <span className="research-badge-pill tag">{info.sector}</span>
+            ) : null}
+            {info?.industry && info.industry !== info.sector ? (
+              <span className="research-badge-pill tag">{info.industry}</span>
+            ) : null}
+          </div>
+          {info?.longBusinessSummary ? (
+            <p className="research-asset-bio">{info.longBusinessSummary}</p>
+          ) : (
+            <p className="research-asset-bio research-asset-bio--muted">
+              {quoteError && !info
+                ? "Live price is temporarily unavailable. Curated fundamentals below."
+                : "Loading company description…"}
+            </p>
+          )}
+        </div>
+
+        <div className="research-asset-price">
+          <span className="research-asset-price-eyebrow">
+            <span className="invest-hero-livedot" aria-hidden="true" />
+            {livePrice !== undefined
+              ? "Live quote"
+              : quoteLoading
+                ? "Fetching live quote"
+                : "Last close"}
+          </span>
+          <p className="research-asset-px">
+            <span>{px.whole}</span>
+            <span className="cents">{px.cents}</span>
+          </p>
+          <div className="research-asset-delta">
+            <span className={`chip ${positive ? "pos" : "neg"}`}>
+              {formatSignedCurrency(dayChange)}
+            </span>
+            <span className={positive ? "pos" : "neg"}>
+              {formatPercent(dayChangePct)} today
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="research-asset-actions">
+        {!isInPortfolio && onAddToPortfolio ? (
+          <button
+            type="button"
+            className="invest-ghost is-primary"
+            onClick={onAddToPortfolio}
+          >
+            <IconPlus size={14} aria-hidden="true" />
+            Add to portfolio
+          </button>
+        ) : null}
+        {info?.website ? (
+          <a
+            href={info.website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="invest-ghost"
+          >
+            <IconExternalLink size={14} aria-hidden="true" />
+            Investor relations
+          </a>
+        ) : null}
+        <a
+          href={`https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=${upper}&type=&dateb=&owner=include&count=40`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="invest-ghost"
+        >
+          <IconFileText size={14} aria-hidden="true" />
+          SEC filings
+        </a>
+        <a
+          href="#thesis-notes"
+          className="invest-ghost"
+        >
+          <IconBookmark size={14} aria-hidden="true" />
+          Research notes
+        </a>
+        <span className="invest-ghost research-asset-actions-clock" aria-hidden="true">
+          <IconRefresh size={14} aria-hidden="true" />
+          {formatRefreshLabel(lastUpdated)}
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/src/components/investments/ResearchSection.tsx
+++ b/src/components/investments/ResearchSection.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { ResearchAssetHeader } from "./ResearchAssetHeader";
+import { ResearchOverview } from "./ResearchOverview";
+import { FinancialStatementsPanel } from "./FinancialStatementsPanel";
+import { ValuationRatiosPanel } from "./ValuationRatiosPanel";
+import { ProfitabilityPanel } from "./ProfitabilityPanel";
+import { GrowthPanel } from "./GrowthPanel";
+import { IndustryPanel } from "./IndustryPanel";
+import { DCFPanel } from "./DCFPanel";
+import { ComparisonTab } from "./ComparisonTab";
+import { PriceChartPanel } from "./PriceChartPanel";
+import {
+  fadeInVariants,
+  getReducedMotionVariants,
+} from "./animations";
+import { useStockData } from "@/hooks/useStockData";
+import { useTablistKeyboard } from "@/hooks/useTablistKeyboard";
+import { getClientInvestmentsIndex } from "@/lib/investmentsClientData";
+import type {
+  CompanyInfo,
+  InvestmentCapabilities,
+  InvestmentsIndex,
+} from "@/types/investment";
+import type { ResearchTab } from "@/app/investments/investments-state";
+
+interface Props {
+  symbol: string;
+  activeTab: ResearchTab;
+  onTabChange: (tab: ResearchTab) => void;
+  portfolioSymbols?: string[];
+}
+
+const TABS: { key: ResearchTab; label: string }[] = [
+  { key: "overview",     label: "Overview" },
+  { key: "financials",   label: "Financials" },
+  { key: "growth",       label: "Growth" },
+  { key: "valuation",    label: "Valuation" },
+  { key: "industry",     label: "Industry" },
+  { key: "dcf",          label: "DCF" },
+  { key: "chart",        label: "Chart" },
+  { key: "compare",      label: "Compare" },
+];
+
+function getCuratedOnlyMessage(symbol: string) {
+  return `${symbol.toUpperCase()} is not in the current research set. Search by ticker or company name to pick an available symbol.`;
+}
+
+function getResearchErrorMessage(error: string | null) {
+  if (!error) return "Research data is temporarily unavailable. Try again shortly.";
+  if (/temporarily unavailable/i.test(error)) return "Research data is temporarily unavailable. Try again shortly.";
+  return error;
+}
+
+function isTabAvailable(tab: ResearchTab, capabilities: InvestmentCapabilities): boolean {
+  switch (tab) {
+    case "overview":    return capabilities.info !== false;
+    case "financials":  return capabilities.income_statement !== false && capabilities.balance_sheet !== false && capabilities.cash_flow !== false;
+    case "growth":      return capabilities.growth !== false;
+    case "valuation":   return capabilities.fundamentals !== false;
+    case "industry":    return capabilities.industry === true;
+    case "dcf":         return capabilities.dcf === true;
+    case "chart":       return capabilities.price !== false;
+    case "compare":     return capabilities.compare === true;
+    default:            return true;
+  }
+}
+
+export function ResearchSection({
+  symbol,
+  activeTab,
+  onTabChange,
+  portfolioSymbols = [],
+}: Props) {
+  const [, setDatasetLastUpdated] = useState<string | null>(null);
+  const shouldReduceMotion = useReducedMotion();
+  const {
+    error: symbolError,
+    isLoading: symbolLoading,
+    isNotFetched: symbolNotFetched,
+    source,
+    capabilities,
+  } = useStockData<CompanyInfo>(symbol || null, "info");
+
+  const v = shouldReduceMotion ? getReducedMotionVariants() : { fadeInVariants };
+
+  useEffect(() => {
+    getClientInvestmentsIndex()
+      .then((data: InvestmentsIndex) => {
+        if (data.lastUpdated) setDatasetLastUpdated(data.lastUpdated);
+      })
+      .catch(() => {});
+  }, []);
+
+  const hasResearchContext = source !== null && !symbolError;
+  const visibleTabs = useMemo(
+    () =>
+      symbol && hasResearchContext
+        ? TABS.filter((tab) => isTabAvailable(tab.key, capabilities))
+        : [],
+    [capabilities, hasResearchContext, symbol]
+  );
+
+  const isInPortfolio = !!(symbol && portfolioSymbols.includes(symbol));
+  const resolvedActiveTab = visibleTabs.some((tab) => tab.key === activeTab) ? activeTab : "overview";
+  const showCuratedOnlyState = !!symbol && !symbolLoading && symbolNotFetched && !hasResearchContext;
+  const showResearchErrorState = !!symbol && !symbolLoading && !!symbolError && !showCuratedOnlyState && !hasResearchContext;
+  const showLoadingState = !!symbol && symbolLoading && !hasResearchContext;
+
+  useEffect(() => {
+    if (symbol && visibleTabs.length > 0 && !visibleTabs.some((tab) => tab.key === activeTab)) {
+      onTabChange("overview");
+    }
+  }, [activeTab, onTabChange, symbol, visibleTabs]);
+
+  const handleVisibleTabKeyDown = useTablistKeyboard(
+    visibleTabs,
+    (t) => t.key,
+    (t) => onTabChange(t.key),
+  );
+
+  if (!symbol) {
+    return (
+      <section
+        id="research-section"
+        aria-label="Stock research"
+        className="scroll-mt-28 rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-12 text-center shadow-[var(--shadow-sm)]"
+      >
+        <p className="invest-rail-section-label">Research</p>
+        <p className="text-sm font-semibold text-[var(--home-ink)]">
+          Pick a holding to research
+        </p>
+        <p className="mx-auto mt-2 max-w-md text-sm text-[var(--home-ink-muted)]">
+          Click <strong className="text-[var(--home-ink)]">Research</strong> on any holding above
+          to load the deep-dive — fundamentals, valuation, growth, DCF, and price chart.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      id="research-section"
+      aria-label={`Research · ${symbol.toUpperCase()}`}
+      className="scroll-mt-28 space-y-5"
+    >
+      {showLoadingState ? (
+        <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
+          <p className="text-sm font-semibold text-[var(--home-ink)]">
+            Loading research data…
+          </p>
+          <p className="mt-2 text-sm text-[color-mix(in_srgb,var(--home-ink)_45%,var(--home-paper))]">
+            Pulling the latest curated snapshot for {symbol.toUpperCase()}.
+          </p>
+        </div>
+      ) : showCuratedOnlyState ? (
+        <div className="rounded-[28px] border border-[color-mix(in_srgb,var(--color-warning)_35%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-warning)_10%,var(--home-paper-alt))] px-5 py-6 text-center shadow-[var(--shadow-sm)]">
+          <p className="text-sm font-semibold text-[var(--home-ink)]">
+            This symbol is not in the current research set.
+          </p>
+          <p className="mt-2 text-sm text-[var(--home-ink-muted)]">
+            {getCuratedOnlyMessage(symbol)}
+          </p>
+        </div>
+      ) : showResearchErrorState ? (
+        <div className="rounded-[28px] border border-[color-mix(in_srgb,var(--color-error)_35%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-error)_8%,var(--home-paper-alt))] px-5 py-6 text-center shadow-[var(--shadow-sm)]">
+          <p className="text-sm font-semibold text-[var(--home-ink)]">
+            Research data is temporarily unavailable.
+          </p>
+          <p className="mt-2 text-sm text-[var(--home-ink-muted)]">
+            {getResearchErrorMessage(symbolError)}
+          </p>
+        </div>
+      ) : (
+        <>
+          <ResearchAssetHeader symbol={symbol} isInPortfolio={isInPortfolio} />
+
+          {visibleTabs.length > 0 ? (
+            <div
+              className="flex gap-2 overflow-x-auto rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] p-2 shadow-[var(--shadow-sm)]"
+              role="tablist"
+              aria-label="Research sections"
+            >
+              {visibleTabs.map(({ key, label }, index) => (
+                <button
+                  key={key}
+                  id={`research-tab-${key}`}
+                  role="tab"
+                  aria-selected={resolvedActiveTab === key}
+                  aria-controls={`research-panel-${key}`}
+                  tabIndex={resolvedActiveTab === key ? 0 : -1}
+                  onKeyDown={(e) => handleVisibleTabKeyDown(e, index)}
+                  onClick={() => onTabChange(key)}
+                  className={`min-h-[40px] whitespace-nowrap rounded-2xl px-4 py-2 text-sm font-semibold transition ${
+                    resolvedActiveTab === key
+                      ? "bg-[var(--home-ink)] text-[var(--home-paper)]"
+                      : "text-[var(--home-ink-muted)] hover:bg-[var(--home-paper-alt)] hover:text-[var(--home-ink)]"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={resolvedActiveTab}
+              id={`research-panel-${resolvedActiveTab}`}
+              role="tabpanel"
+              aria-labelledby={`research-tab-${resolvedActiveTab}`}
+              variants={v.fadeInVariants}
+              initial="hidden"
+              animate="visible"
+              exit="hidden"
+            >
+              {resolvedActiveTab === "overview" && (
+                <ResearchOverview symbol={symbol} showNews={capabilities.news !== false} />
+              )}
+              {resolvedActiveTab === "financials" && <FinancialStatementsPanel symbol={symbol} />}
+              {resolvedActiveTab === "growth" && (
+                <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+                  <GrowthPanel symbol={symbol} />
+                  <ProfitabilityPanel symbol={symbol} />
+                </div>
+              )}
+              {resolvedActiveTab === "valuation" && (
+                <ValuationRatiosPanel
+                  symbol={symbol}
+                  showIndustryComparison={capabilities.industry === true}
+                />
+              )}
+              {resolvedActiveTab === "industry" && <IndustryPanel symbol={symbol} />}
+              {resolvedActiveTab === "dcf" && <DCFPanel symbol={symbol} />}
+              {resolvedActiveTab === "chart" && <PriceChartPanel symbol={symbol} />}
+              {resolvedActiveTab === "compare" && <ComparisonTab />}
+            </motion.div>
+          </AnimatePresence>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/investments/StockResearch.tsx
+++ b/src/components/investments/StockResearch.tsx
@@ -2,7 +2,15 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
-import { ResearchSidebar } from "./ResearchSidebar";
+import {
+  IconChartArcs3,
+  IconChartLine,
+  IconCircleHalf,
+  IconHome,
+  IconList,
+  IconReportMoney,
+} from "@tabler/icons-react";
+import { ResearchAssetHeader } from "./ResearchAssetHeader";
 import { ResearchOverview } from "./ResearchOverview";
 import { FinancialStatementsPanel } from "./FinancialStatementsPanel";
 import { ValuationRatiosPanel } from "./ValuationRatiosPanel";
@@ -12,6 +20,7 @@ import { IndustryPanel } from "./IndustryPanel";
 import { DCFPanel } from "./DCFPanel";
 import { ComparisonTab } from "./ComparisonTab";
 import { PriceChartPanel } from "./PriceChartPanel";
+import { StockSearch } from "./StockSearch";
 import {
   fadeInVariants,
   getReducedMotionVariants,
@@ -44,6 +53,14 @@ const TABS: { key: ResearchTab; label: string }[] = [
   { key: "chart",        label: "Chart" },
   { key: "compare",      label: "Compare" },
 ];
+
+const NAV_ITEMS = [
+  { id: "overview", label: "Overview", icon: IconHome },
+  { id: "holdings", label: "My holdings", icon: IconList, href: "?view=portfolio#holdings-list" },
+  { id: "performance", label: "Performance", icon: IconChartLine, href: "?view=portfolio#performance-chart" },
+  { id: "allocation", label: "Allocation", icon: IconChartArcs3, href: "?view=portfolio#allocation" },
+  { id: "stats", label: "Portfolio stats", icon: IconCircleHalf, href: "?view=portfolio#portfolio-stats" },
+] as const;
 
 function getCuratedOnlyMessage(symbol: string) {
   return `${symbol.toUpperCase()} is not in the current research set. Search by ticker or company name to pick an available symbol.`;
@@ -117,149 +134,159 @@ export function StockResearch({
     }
   }, [activeTab, onTabChange, symbol, visibleTabs]);
 
-  const handleCompareTabKeyDown = useTablistKeyboard(
-    TABS,
-    (t) => t.key,
-    (t) => onTabChange(t.key),
-  );
-
   const handleVisibleTabKeyDown = useTablistKeyboard(
     visibleTabs,
     (t) => t.key,
     (t) => onTabChange(t.key),
   );
+  const handleAllTabsKeyDown = useTablistKeyboard(
+    TABS,
+    (t) => t.key,
+    (t) => onTabChange(t.key),
+  );
 
-  // Compare tab is full-width with no sidebar
+  // Compare tab is full-width with no asset header
   if (resolvedActiveTab === "compare") {
     return (
-      <section aria-label="Stock research">
-        <div
-          className="mb-4 flex gap-2 overflow-x-auto rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-2 shadow-[var(--shadow-sm)]"
-          role="tablist"
-          aria-label="Research sections"
-        >
-          {TABS.map(({ key, label }, index) => (
-            <button
-              key={key}
-              id={`research-tab-${key}`}
-              role="tab"
-              aria-selected={resolvedActiveTab === key}
-              aria-controls={`research-panel-${key}`}
-              tabIndex={resolvedActiveTab === key ? 0 : -1}
-              onKeyDown={(e) => handleCompareTabKeyDown(e, index)}
-              onClick={() => onTabChange(key)}
-              className={`min-h-[44px] whitespace-nowrap rounded-2xl px-4 py-2.5 text-sm font-semibold transition ${
-                resolvedActiveTab === key
-                  ? "bg-[var(--home-haze)] text-white"
-                  : "text-[var(--home-ink-muted)] hover:bg-[var(--home-paper-alt)] hover:text-[var(--home-ink)]"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-        <div
-          id={`research-panel-${resolvedActiveTab}`}
-          role="tabpanel"
-          aria-labelledby={`research-tab-${resolvedActiveTab}`}
-        >
-          <ComparisonTab />
-        </div>
-      </section>
+      <div className="invest-shell" data-testid="invest-research-shell">
+        <ResearchSidebar activeNavId="overview" />
+        <main className="invest-main">
+          <ResearchTopbar
+            symbol={symbol}
+            onSymbolChange={onSymbolChange}
+            crumbTrail="Compare"
+          />
+          <div
+            className="mb-4 flex gap-2 overflow-x-auto rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] p-2 shadow-[var(--shadow-sm)]"
+            role="tablist"
+            aria-label="Research sections"
+          >
+            {TABS.map(({ key, label }, index) => (
+              <button
+                key={key}
+                id={`research-tab-${key}`}
+                role="tab"
+                aria-selected={resolvedActiveTab === key}
+                aria-controls={`research-panel-${key}`}
+                tabIndex={resolvedActiveTab === key ? 0 : -1}
+                onKeyDown={(e) => handleAllTabsKeyDown(e, index)}
+                onClick={() => onTabChange(key)}
+                className={`min-h-[44px] whitespace-nowrap rounded-2xl px-4 py-2.5 text-sm font-semibold transition ${
+                  resolvedActiveTab === key
+                    ? "bg-[var(--home-haze)] text-white"
+                    : "text-[var(--home-ink-muted)] hover:bg-[var(--home-paper-alt)] hover:text-[var(--home-ink)]"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <div
+            id={`research-panel-${resolvedActiveTab}`}
+            role="tabpanel"
+            aria-labelledby={`research-tab-${resolvedActiveTab}`}
+          >
+            <ComparisonTab />
+          </div>
+        </main>
+      </div>
     );
   }
 
   return (
-    <section aria-label="Stock research">
-      <div className="grid gap-6 md:grid-cols-[280px_minmax(0,1fr)] lg:grid-cols-[300px_minmax(0,1fr)] items-start">
-        {/* Sidebar */}
-        <div className="md:sticky md:top-4">
-          <ResearchSidebar
-            symbol={symbol}
-            onSymbolChange={onSymbolChange}
-            isInPortfolio={isInPortfolio}
-          />
-        </div>
+    <div className="invest-shell" data-testid="invest-research-shell">
+      <ResearchSidebar activeNavId="overview" />
 
-        {/* Main content */}
-        <div className="min-w-0 space-y-4">
-          {visibleTabs.length > 0 ? (
-            <div
-              className="flex gap-2 overflow-x-auto rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] p-2 shadow-[var(--shadow-sm)]"
-              role="tablist"
-              aria-label="Research sections"
-            >
-              {visibleTabs.map(({ key, label }, index) => (
-                <button
-                  key={key}
-                  id={`research-tab-${key}`}
-                  role="tab"
-                  aria-selected={resolvedActiveTab === key}
-                  aria-controls={`research-panel-${key}`}
-                  tabIndex={resolvedActiveTab === key ? 0 : -1}
-                  onKeyDown={(e) => handleVisibleTabKeyDown(e, index)}
-                  onClick={() => onTabChange(key)}
-                  className={`min-h-[44px] whitespace-nowrap rounded-2xl px-4 py-2.5 text-sm font-semibold transition ${
-                    resolvedActiveTab === key
-                      ? "bg-[var(--home-haze)] text-white"
-                      : "text-[var(--home-ink-muted)] hover:bg-[var(--home-paper-alt)] hover:text-[var(--home-ink)]"
-                  }`}
-                >
-                  {label}
-                </button>
-              ))}
+      <main className="invest-main">
+        <ResearchTopbar
+          symbol={symbol}
+          onSymbolChange={onSymbolChange}
+          crumbTrail={symbol ? symbol.toUpperCase() : "Pick a ticker"}
+        />
+
+        <div className="space-y-5">
+          {!symbol ? (
+            <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
+              <p className="text-sm font-semibold text-[var(--home-ink)]">
+                Start with a ticker symbol
+              </p>
+              <p className="mt-2 text-sm text-[color-mix(in_srgb,var(--home-ink)_45%,var(--home-paper))]">
+                Search a ticker or company name in the bar above to start researching.
+              </p>
             </div>
-          ) : null}
+          ) : showLoadingState ? (
+            <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
+              <p className="text-sm font-semibold text-[var(--home-ink)]">
+                Loading research data…
+              </p>
+              <p className="mt-2 text-sm text-[color-mix(in_srgb,var(--home-ink)_45%,var(--home-paper))]">
+                Pulling the latest curated snapshot for {symbol.toUpperCase()}.
+              </p>
+            </div>
+          ) : showCuratedOnlyState ? (
+            <div className="rounded-[28px] border border-[color-mix(in_srgb,var(--color-warning)_35%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-warning)_10%,var(--home-paper-alt))] px-5 py-6 text-center shadow-[var(--shadow-sm)]">
+              <p className="text-sm font-semibold text-[var(--home-ink)]">
+                This symbol is not in the current research set.
+              </p>
+              <p className="mt-2 text-sm text-[var(--home-ink-muted)]">
+                {getCuratedOnlyMessage(symbol)}
+              </p>
+            </div>
+          ) : showResearchErrorState ? (
+            <div className="rounded-[28px] border border-[color-mix(in_srgb,var(--color-error)_35%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-error)_8%,var(--home-paper-alt))] px-5 py-6 text-center shadow-[var(--shadow-sm)]">
+              <p className="text-sm font-semibold text-[var(--home-ink)]">
+                Research data is temporarily unavailable.
+              </p>
+              <p className="mt-2 text-sm text-[var(--home-ink-muted)]">
+                {getResearchErrorMessage(symbolError)}
+              </p>
+            </div>
+          ) : (
+            <>
+              <ResearchAssetHeader
+                symbol={symbol}
+                isInPortfolio={isInPortfolio}
+              />
 
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={resolvedActiveTab}
-              id={`research-panel-${resolvedActiveTab}`}
-              role="tabpanel"
-              aria-labelledby={`research-tab-${resolvedActiveTab}`}
-              variants={v.fadeInVariants}
-              initial="hidden"
-              animate="visible"
-              exit="hidden"
-            >
-              {!symbol ? (
-                <div className="rounded-[28px] border border-dashed border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
-                  <p className="text-sm font-semibold text-[var(--home-ink)]">
-                    Start with a ticker symbol
-                  </p>
-                  <p className="mt-2 text-sm text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
-                    Enter a stock symbol in the sidebar to start researching.
-                  </p>
+              {visibleTabs.length > 0 ? (
+                <div
+                  className="flex gap-2 overflow-x-auto rounded-[24px] border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] p-2 shadow-[var(--shadow-sm)]"
+                  role="tablist"
+                  aria-label="Research sections"
+                >
+                  {visibleTabs.map(({ key, label }, index) => (
+                    <button
+                      key={key}
+                      id={`research-tab-${key}`}
+                      role="tab"
+                      aria-selected={resolvedActiveTab === key}
+                      aria-controls={`research-panel-${key}`}
+                      tabIndex={resolvedActiveTab === key ? 0 : -1}
+                      onKeyDown={(e) => handleVisibleTabKeyDown(e, index)}
+                      onClick={() => onTabChange(key)}
+                      className={`min-h-[40px] whitespace-nowrap rounded-2xl px-4 py-2 text-sm font-semibold transition ${
+                        resolvedActiveTab === key
+                          ? "bg-[var(--home-ink)] text-[var(--home-paper)]"
+                          : "text-[var(--home-ink-muted)] hover:bg-[var(--home-paper-alt)] hover:text-[var(--home-ink)]"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  ))}
                 </div>
-              ) : showLoadingState ? (
-                <div className="rounded-[28px] border border-[var(--home-rule)] bg-[color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))] px-6 py-16 text-center shadow-[var(--shadow-sm)]">
-                  <p className="text-sm font-semibold text-[var(--home-ink)]">
-                    Loading research data…
-                  </p>
-                  <p className="mt-2 text-sm text-[color-mix(in srgb, var(--home-ink) 45%, var(--home-paper))]">
-                    Pulling the latest curated snapshot for {symbol.toUpperCase()}.
-                  </p>
-                </div>
-              ) : showCuratedOnlyState ? (
-                <div className="rounded-[28px] border border-[color-mix(in_srgb,var(--color-warning)_35%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-warning)_10%,var(--home-paper-alt))] px-5 py-6 text-center shadow-[var(--shadow-sm)]">
-                  <p className="text-sm font-semibold text-[var(--home-ink)]">
-                    This symbol is not in the current research set.
-                  </p>
-                  <p className="mt-2 text-sm text-[var(--home-ink-muted)]">
-                    {getCuratedOnlyMessage(symbol)}
-                  </p>
-                </div>
-              ) : showResearchErrorState ? (
-                <div className="rounded-[28px] border border-[color-mix(in_srgb,var(--color-error)_35%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-error)_8%,var(--home-paper-alt))] px-5 py-6 text-center shadow-[var(--shadow-sm)]">
-                  <p className="text-sm font-semibold text-[var(--home-ink)]">
-                    Research data is temporarily unavailable.
-                  </p>
-                  <p className="mt-2 text-sm text-[var(--home-ink-muted)]">
-                    {getResearchErrorMessage(symbolError)}
-                  </p>
-                </div>
-              ) : (
-                <>
+              ) : null}
+
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={resolvedActiveTab}
+                  id={`research-panel-${resolvedActiveTab}`}
+                  role="tabpanel"
+                  aria-labelledby={`research-tab-${resolvedActiveTab}`}
+                  variants={v.fadeInVariants}
+                  initial="hidden"
+                  animate="visible"
+                  exit="hidden"
+                >
                   {resolvedActiveTab === "overview" && (
                     <ResearchOverview symbol={symbol} showNews={capabilities.news !== false} />
                   )}
@@ -279,12 +306,82 @@ export function StockResearch({
                   {resolvedActiveTab === "industry" && <IndustryPanel symbol={symbol} />}
                   {resolvedActiveTab === "dcf" && <DCFPanel symbol={symbol} />}
                   {resolvedActiveTab === "chart" && <PriceChartPanel symbol={symbol} />}
-                </>
-              )}
-            </motion.div>
-          </AnimatePresence>
+                </motion.div>
+              </AnimatePresence>
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function ResearchSidebar({ activeNavId }: { activeNavId: string }) {
+  return (
+    <aside className="invest-sidebar" aria-label="Investments navigation">
+      <div className="invest-brand">
+        <div className="invest-brand-iv" aria-hidden="true">IV</div>
+        <div className="invest-brand-name">
+          Isaac Vazquez
+          <small>Investments</small>
         </div>
       </div>
-    </section>
+
+      <nav className="flex flex-col gap-1.5" aria-label="Section navigation">
+        <a href="?view=portfolio#hero" className="invest-nav-link">
+          <IconHome size={18} aria-hidden="true" />
+          Portfolio home
+        </a>
+        <span
+          className="invest-nav-link is-active"
+          aria-current="true"
+        >
+          <IconReportMoney size={18} aria-hidden="true" />
+          Research
+        </span>
+        {NAV_ITEMS.filter((it) => it.id !== "overview").map((item) => {
+          const Icon = item.icon;
+          return (
+            <a key={item.id} href={item.href ?? "#"} className="invest-nav-link">
+              <Icon size={18} aria-hidden="true" />
+              {item.label}
+            </a>
+          );
+        })}
+      </nav>
+
+      <div className="invest-sidebar-footer">
+        <span>{activeNavId === "overview" ? "Curated snapshots" : "—"}</span>
+      </div>
+    </aside>
+  );
+}
+
+function ResearchTopbar({
+  symbol,
+  onSymbolChange,
+  crumbTrail,
+}: {
+  symbol: string;
+  onSymbolChange: (s: string) => void;
+  crumbTrail: string;
+}) {
+  return (
+    <div className="invest-topbar">
+      <div>
+        <p className="invest-crumbs">
+          Investments / Research / <strong>{crumbTrail}</strong>
+        </p>
+        <h1>Research</h1>
+      </div>
+
+      <div className="research-topbar-search">
+        <StockSearch value={symbol} onChange={onSymbolChange} />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="invest-avatar" aria-hidden="true">IV</span>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace `PortfolioSummary` with a hero balance card (live pulse, big balance, delta chip, periwinkle haze blur) followed by a dense 8-cell Gemini-style stats grid and a quick-link pill row.
- New stats are computed locally from `EnhancedHolding[]`: top holding, best performer, biggest day move, top-3 concentration. Day P/L, all-time return, cost basis, and position count keep their existing data sources.
- `PortfolioTracker` now passes `holdings` through to the summary and tags the performance/holdings/allocation sections with anchor IDs (`scroll-mt-28`) so the pill row can deep-link inside the page.
- Adapted from the design handoff at https://api.anthropic.com/v1/design/h/F_K06yZxmSiwetahRIcRvw — kept the editorial language and density without inventing features (no left-rail nav, no Buy/Sell/Convert panel, no Pro toggle — those aren't real on the tracker).

Out of scope (covered by the design source, separate PRs):
- Animated SVG balance chart (needs historical price data we don't fetch yet).
- Research single-asset deep-dive screen.
- Writing page redesign.

## Test plan
- [ ] `/investments` with seeded holdings renders the hero balance card with correct delta sign + color.
- [ ] Stats grid shows real values for Day P/L, all-time return, cost basis, position count, top holding %, best performer %, biggest day move %, top-3 concentration %.
- [ ] Empty state (no holdings) renders without errors.
- [ ] Pill row links scroll to performance chart, holdings list, and allocation chart with the right offset.
- [ ] No console errors or hydration warnings at 1280 / 700 / 375 px.
- [ ] Light + dark mode both pass.
- [ ] Reduced-motion preference suppresses the pulse animation.