### PR TITLE
feat(writing): editorial archive layout from design handoff

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1720,6 +1720,468 @@ img {
 }
 
 /* ==========================================================================
+ * Writing archive — editorial layout from the design handoff
+ * ========================================================================== */
+.wp-page { display: flex; flex-direction: column; gap: clamp(2rem, 4vw, 3rem); }
+
+/* Page heading row */
+.wp-pagehead {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: clamp(1.5rem, 3vw, 3rem);
+  align-items: end;
+  border-bottom: 1px solid var(--home-rule);
+  padding-bottom: clamp(1.5rem, 3vw, 2.5rem);
+}
+@media (max-width: 880px) {
+  .wp-pagehead { grid-template-columns: 1fr; align-items: start; }
+}
+.wp-pagehead-kicker {
+  font-family: var(--font-home-sans);
+  font-size: 0.72rem; font-weight: 600;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+  margin: 0 0 0.5rem;
+}
+.wp-pagehead-title {
+  font-family: var(--font-home-sans);
+  font-size: clamp(2.6rem, 6vw, 5rem);
+  font-weight: 600; line-height: 0.94; letter-spacing: -0.075em;
+  color: var(--home-ink);
+  margin: 0;
+  text-wrap: balance;
+  max-width: 14ch;
+}
+.wp-pagehead-title em {
+  font-family: var(--font-home-serif);
+  font-style: italic; font-weight: 500;
+  color: color-mix(in srgb, var(--home-ink) 72%, var(--home-ink-muted));
+}
+.wp-pagehead-stats {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: clamp(1.25rem, 2vw, 2.25rem);
+  justify-content: end;
+  font-family: var(--font-home-sans);
+}
+@media (max-width: 880px) {
+  .wp-pagehead-stats { justify-content: start; }
+}
+.wp-stat-label {
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+  display: block; margin-bottom: 4px;
+}
+.wp-stat-value {
+  font-size: 1.2rem; font-weight: 600; letter-spacing: -0.02em;
+  color: var(--home-ink); font-variant-numeric: tabular-nums;
+}
+
+/* Featured row */
+.wp-featured {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 18px;
+}
+@media (max-width: 880px) {
+  .wp-featured { grid-template-columns: 1fr; }
+}
+.wp-feat-big {
+  border-radius: 1.4rem;
+  border: 1px solid var(--home-rule);
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  box-shadow: var(--shadow-sm);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  display: flex; flex-direction: column; justify-content: space-between; gap: 1.25rem;
+  min-height: 28rem;
+  position: relative; overflow: hidden;
+  text-decoration: none; color: inherit;
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+}
+.wp-feat-big:hover {
+  transform: translateY(-2px); box-shadow: var(--shadow-md);
+  border-color: color-mix(in srgb, var(--home-ink) 18%, var(--home-stone));
+}
+.wp-feat-big::before {
+  content: ""; position: absolute; right: -60px; top: -60px;
+  width: 220px; height: 220px; border-radius: 999px;
+  background: radial-gradient(circle, var(--home-acid) 0%, transparent 65%);
+  opacity: 0.5; pointer-events: none;
+}
+.wp-feat-topline {
+  display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+  position: relative; z-index: 1;
+}
+.wp-feat-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 11px; border-radius: 999px;
+  background: var(--home-ink); color: var(--home-paper);
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+}
+.wp-feat-pill--editor {
+  background: color-mix(in srgb, var(--home-acid) 32%, transparent);
+  color: var(--home-ink);
+  border: 1px solid color-mix(in srgb, var(--home-ink) 14%, transparent);
+}
+.wp-feat-meta {
+  font-size: 11px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+}
+.wp-feat-meta--dark { color: color-mix(in srgb, var(--home-paper) 60%, transparent); }
+.wp-feat-big-title {
+  font-family: var(--font-home-sans);
+  font-size: clamp(2rem, 3.5vw, 3rem);
+  font-weight: 600; line-height: 0.98; letter-spacing: -0.055em;
+  color: var(--home-ink);
+  margin: 0; max-width: 24ch; text-wrap: balance;
+  position: relative; z-index: 1;
+}
+.wp-feat-big-title em {
+  font-family: var(--font-home-serif);
+  font-style: italic; font-weight: 500;
+}
+.wp-feat-dek {
+  font-size: 1.02rem; line-height: 1.6;
+  color: color-mix(in srgb, var(--home-ink) 72%, var(--home-ink-muted));
+  max-width: 42ch; margin: 0;
+  position: relative; z-index: 1;
+}
+.wp-feat-footrow {
+  display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--home-rule);
+  position: relative; z-index: 1;
+}
+.wp-feat-byline {
+  display: flex; align-items: center; gap: 10px;
+  font-size: 13px; color: var(--home-ink-muted);
+}
+.wp-feat-byline-name { color: var(--home-ink); font-weight: 600; }
+.wp-feat-avatar {
+  width: 32px; height: 32px; border-radius: 999px;
+  background:
+    radial-gradient(circle at 32% 36%, var(--home-acid) 0%, transparent 58%),
+    radial-gradient(circle at 70% 64%, var(--home-haze) 0%, transparent 60%),
+    var(--home-ink);
+  display: grid; place-items: center;
+  color: var(--home-paper); font-weight: 700; font-size: 11px; letter-spacing: -0.04em;
+}
+.wp-feat-readlink {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 13px; font-weight: 600; color: var(--home-ink);
+}
+
+.wp-feat-stack { display: grid; grid-template-rows: 1fr 1fr; gap: 18px; }
+.wp-feat-small {
+  border-radius: 1.4rem;
+  border: 1px solid var(--home-rule);
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  padding: clamp(1.1rem, 2vw, 1.5rem);
+  display: flex; flex-direction: column; gap: 0.75rem;
+  text-decoration: none; color: inherit;
+  position: relative; overflow: hidden;
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+}
+.wp-feat-small:hover {
+  transform: translateY(-2px); box-shadow: var(--shadow-md);
+  border-color: color-mix(in srgb, var(--home-ink) 18%, var(--home-stone));
+}
+.wp-feat-small--dark {
+  background: var(--home-ink);
+  color: var(--home-paper);
+  border-color: color-mix(in srgb, var(--home-ink) 90%, var(--home-paper));
+}
+.wp-feat-small--dark::before {
+  content: ""; position: absolute; left: -40px; bottom: -40px;
+  width: 180px; height: 180px; border-radius: 999px;
+  background: radial-gradient(circle, var(--home-haze) 0%, transparent 65%);
+  opacity: 0.22; pointer-events: none;
+}
+.wp-feat-small--dark .wp-feat-pill {
+  background: color-mix(in srgb, var(--home-acid) 16%, transparent);
+  color: var(--home-acid);
+  border: 1px solid color-mix(in srgb, var(--home-acid) 24%, transparent);
+}
+.wp-feat-small--dark .wp-feat-pill--editor {
+  background: color-mix(in srgb, var(--home-acid) 16%, transparent);
+  color: var(--home-acid);
+}
+.wp-feat-small-title {
+  font-family: var(--font-home-sans);
+  font-size: 1.4rem; font-weight: 600; line-height: 1.05; letter-spacing: -0.035em;
+  color: inherit;
+  margin: 0; text-wrap: balance;
+  position: relative; z-index: 1;
+}
+.wp-feat-small-title em {
+  font-family: var(--font-home-serif);
+  font-style: italic; font-weight: 500;
+}
+.wp-feat-small-footrow {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--home-rule);
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+  position: relative; z-index: 1;
+}
+.wp-feat-small-footrow--dark {
+  border-top-color: color-mix(in srgb, var(--home-paper) 22%, transparent);
+  color: color-mix(in srgb, var(--home-paper) 60%, transparent);
+}
+.wp-feat-small-readlink {
+  display: inline-flex; align-items: center; gap: 6px;
+  color: var(--home-ink);
+}
+.wp-feat-small--dark .wp-feat-small-readlink { color: var(--home-paper); }
+
+/* Archive section */
+.wp-archive-section {
+  display: flex; flex-direction: column; gap: 1.25rem;
+}
+.wp-archive-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 1rem; flex-wrap: wrap;
+}
+.wp-archive-title {
+  font-family: var(--font-home-sans);
+  font-size: clamp(1.6rem, 2.5vw, 2rem);
+  font-weight: 600; letter-spacing: -0.045em;
+  margin: 0;
+  color: var(--home-ink);
+}
+.wp-archive-count {
+  font-size: 12px; color: var(--home-ink-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.wp-filter-row {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--home-rule);
+}
+.wp-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--home-rule);
+  font-family: var(--font-home-sans);
+  font-size: 12px; font-weight: 600;
+  color: var(--home-ink-muted);
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+.wp-chip:hover {
+  background: color-mix(in srgb, var(--home-acid) 16%, transparent);
+  color: var(--home-ink);
+}
+.wp-chip--on {
+  background: var(--home-ink);
+  color: var(--home-paper);
+  border-color: var(--home-ink);
+}
+.wp-chip-count {
+  font-size: 11px; padding: 2px 7px; border-radius: 999px;
+  font-variant-numeric: tabular-nums;
+}
+.wp-chip:not(.wp-chip--on) .wp-chip-count {
+  background: var(--home-paper-alt);
+  color: var(--home-ink-muted);
+}
+.wp-chip--on .wp-chip-count {
+  background: color-mix(in srgb, var(--home-paper) 22%, transparent);
+  color: inherit;
+}
+.wp-sort {
+  margin-left: auto;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12px; color: var(--home-ink-muted);
+}
+.wp-sort-label { letter-spacing: 0.04em; }
+.wp-sort select {
+  font-family: var(--font-home-sans);
+  font-size: 12px; font-weight: 600;
+  padding: 7px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--home-rule);
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  color: var(--home-ink);
+  cursor: pointer;
+}
+
+/* Article grid */
+.wp-grid {
+  list-style: none;
+  margin: 0; padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+@media (max-width: 980px) { .wp-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 660px) { .wp-grid { grid-template-columns: 1fr; } }
+
+.wp-card {
+  border-radius: 1.1rem;
+  border: 1px solid var(--home-rule);
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  padding: 22px;
+  display: flex; flex-direction: column;
+  gap: 0.75rem;
+  text-decoration: none; color: inherit;
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+  min-height: 14rem;
+  position: relative;
+  height: 100%;
+}
+.wp-card:hover {
+  transform: translateY(-2px); box-shadow: var(--shadow-md);
+  border-color: color-mix(in srgb, var(--home-ink) 16%, var(--home-stone));
+}
+.wp-card-topline {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  font-size: 10.5px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+}
+.wp-card-cat { color: var(--home-ink); font-weight: 700; }
+.wp-card-dot {
+  width: 3px; height: 3px; border-radius: 999px; background: var(--home-stone);
+}
+.wp-card-title {
+  font-family: var(--font-home-sans);
+  font-size: 1.18rem; font-weight: 600; line-height: 1.18; letter-spacing: -0.035em;
+  color: var(--home-ink);
+  margin: 0; text-wrap: balance;
+}
+.wp-card-title em {
+  font-family: var(--font-home-serif);
+  font-style: italic; font-weight: 500;
+}
+.wp-card-dek {
+  font-size: 13.5px; line-height: 1.55;
+  color: color-mix(in srgb, var(--home-ink) 72%, var(--home-ink-muted));
+  margin: 0;
+}
+.wp-card-footrow {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid var(--home-rule);
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--home-ink-muted);
+}
+.wp-card-readlink {
+  color: var(--home-ink);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+
+/* Image-led card variants */
+.wp-card--has-image { padding: 0; overflow: hidden; }
+.wp-card-img {
+  aspect-ratio: 16 / 9;
+  background: linear-gradient(135deg,
+    color-mix(in srgb, var(--home-acid) 60%, transparent) 0%,
+    color-mix(in srgb, var(--home-haze) 50%, transparent) 50%,
+    color-mix(in srgb, var(--home-ink) 80%, transparent) 100%);
+  position: relative;
+  display: flex; align-items: flex-end;
+  padding: 14px;
+  color: var(--home-paper);
+}
+.wp-card-img::after {
+  content: ""; position: absolute; inset: 0;
+  background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--home-ink) 45%, transparent) 100%);
+  pointer-events: none;
+}
+.wp-card-img-pill {
+  position: relative; z-index: 1;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border-radius: 999px;
+  background: color-mix(in srgb, var(--home-paper) 18%, transparent);
+  backdrop-filter: blur(8px);
+  border: 1px solid color-mix(in srgb, var(--home-paper) 22%, transparent);
+  font-size: 10px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--home-paper);
+}
+.wp-card-body {
+  padding: 18px 22px 22px;
+  display: flex; flex-direction: column; gap: 0.6rem; flex: 1;
+}
+.wp-card-body--noimg { padding: 0; gap: 0.75rem; flex: 1; }
+.wp-card--var-acid .wp-card-img {
+  background: linear-gradient(135deg, var(--home-acid) 0%, var(--home-acid-soft) 60%, var(--home-paper-alt) 100%);
+  color: var(--home-ink);
+}
+.wp-card--var-acid .wp-card-img-pill {
+  background: color-mix(in srgb, var(--home-ink) 10%, transparent);
+  border-color: color-mix(in srgb, var(--home-ink) 18%, transparent);
+  color: var(--home-ink);
+}
+.wp-card--var-haze .wp-card-img {
+  background: linear-gradient(160deg,
+    var(--home-haze) 0%,
+    color-mix(in srgb, var(--home-haze) 40%, var(--home-ink)) 100%);
+}
+.wp-card--var-ink .wp-card-img {
+  background:
+    radial-gradient(circle at 70% 80%, color-mix(in srgb, var(--home-haze) 70%, transparent) 0%, transparent 55%),
+    radial-gradient(circle at 20% 30%, color-mix(in srgb, var(--home-acid) 50%, transparent) 0%, transparent 55%),
+    var(--home-ink);
+}
+
+/* Pager */
+.wp-pager {
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 1.5rem 0 0;
+}
+.wp-pager-btn {
+  min-width: 36px; height: 36px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid var(--home-rule);
+  background: transparent;
+  color: var(--home-ink-muted);
+  font-family: var(--font-home-sans);
+  font-size: 13px; font-weight: 600;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+}
+.wp-pager-btn:hover {
+  background: color-mix(in srgb, var(--home-acid) 18%, transparent);
+  color: var(--home-ink);
+}
+.wp-pager-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.wp-pager-btn--on {
+  background: var(--home-ink);
+  color: var(--home-paper);
+  border-color: var(--home-ink);
+}
+
+.wp-empty {
+  border: 1px dashed var(--home-rule);
+  border-radius: 1.4rem;
+  padding: 3rem 1.5rem;
+  text-align: center;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+}
+.wp-empty-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--home-ink);
+}
+.wp-empty-body {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--home-ink-muted);
+}
+
+/* ==========================================================================
  * Investments dashboard — three-column shell adapted from the design handoff
  * ========================================================================== */
 .invest-page-stack {

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,5 +1,3 @@
-import Image from "next/image";
-import Link from "next/link";
 import {
   getAllBlogPostPreviews,
   getArchiveBlogPostPreviewsByBucket,
@@ -11,12 +9,9 @@ import {
   BLOG_ARCHIVE_BUCKET_ORDER,
   BLOG_CLUSTER_DETAILS,
   BLOG_CLUSTER_ORDER,
-  type BlogArchiveBucket,
-  type BlogCluster,
 } from "@/lib/blog-config";
 import { generateBreadcrumbStructuredData, constructMetadata } from "@/lib/seo";
-import { Clock, ArrowRight } from "@/components/ui/ServerIcons";
-import { publishedDateFormatter } from "@/lib/utils";
+import { WritingArchiveClient } from "@/components/writing/WritingArchiveClient";
 
 export const metadata = constructMetadata({
   title: "Writing",
@@ -50,258 +45,37 @@ export const metadata = constructMetadata({
   },
 });
 
-type WritingCardPost = ReturnType<typeof getAllBlogPostPreviews>[number];
-
-function toSectionId(label: string) {
-  return label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
-}
-
-function WritingCardFooter({ post }: { post: WritingCardPost }) {
-  const footerTags = post.tags.slice(0, 2);
-
-  return (
-    <div
-      className="mt-auto flex items-center justify-between gap-4 pt-4"
-      style={{ borderTop: "1px solid var(--home-rule)" }}
-    >
-      <div className="min-w-0 flex items-center gap-3 overflow-hidden whitespace-nowrap">
-        <div
-          className="flex items-center gap-1"
-          style={{
-            fontFamily: "var(--font-home-sans)",
-            fontSize: "0.8rem",
-            color: "var(--home-ink-muted)",
-          }}
-        >
-          <Clock className="h-3.5 w-3.5" />
-          <span>{post.readingTime}</span>
-        </div>
-
-        {footerTags.length > 0 ? (
-          <div className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap">
-            {footerTags.map((tag) => (
-              <span key={tag} className="resume-chip shrink-0">
-                {tag}
-              </span>
-            ))}
-          </div>
-        ) : null}
-      </div>
-
-      <ArrowRight
-        className="h-4 w-4 flex-shrink-0 transition-transform group-hover:translate-x-1"
-        style={{ color: "var(--home-haze)" }}
-      />
-    </div>
-  );
-}
-
-function CuratedWritingCard({ post }: { post: WritingCardPost }) {
-  return (
-    <Link key={post.slug} href={`/writing/${post.slug}`} className="group block h-full">
-      <article className="home-card flex h-full flex-col" style={{ padding: "1.5rem" }}>
-        <div className="relative aspect-[1200/630] overflow-hidden rounded-[1.2rem] border border-[var(--home-rule)] bg-[var(--home-paper-alt)]">
-          <Image
-            src={post.coverImage}
-            alt={post.title}
-            fill
-            sizes="(min-width: 1280px) 30vw, (min-width: 768px) 45vw, 100vw"
-            className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
-          />
-        </div>
-
-        <div className="mt-5 flex flex-1 flex-col gap-4">
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <span className="home-kicker">{post.category}</span>
-            <time dateTime={post.publishedAt} className="home-meta mb-0">
-              {publishedDateFormatter.format(new Date(post.publishedAt))}
-            </time>
-          </div>
-
-          <h2
-            className="transition-colors group-hover:opacity-70"
-            style={{
-              fontFamily: "var(--font-home-sans)",
-              fontSize: "1.35rem",
-              fontWeight: 700,
-              letterSpacing: "-0.03em",
-              lineHeight: 1.12,
-              color: "var(--home-ink)",
-            }}
-          >
-            {post.title}
-          </h2>
-
-          <p className="home-body mb-0 flex-1 line-clamp-4 text-sm leading-6">{post.excerpt}</p>
-
-          <WritingCardFooter post={post} />
-        </div>
-      </article>
-    </Link>
-  );
-}
-
-function ArchiveWritingCard({ post }: { post: WritingCardPost }) {
-  return (
-    <Link key={post.slug} href={`/writing/${post.slug}`} className="group block h-full">
-      <article
-        className="flex h-full flex-col rounded-[1.5rem] border"
-        style={{
-          padding: "1.25rem",
-          borderColor: "color-mix(in srgb, var(--home-rule) 78%, var(--home-elev-mix))",
-          background:
-            "color-mix(in srgb, var(--home-paper) 82%, var(--home-paper-alt) 18%)",
-        }}
-      >
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <span className="home-kicker">{post.category}</span>
-          <time dateTime={post.publishedAt} className="home-meta mb-0">
-            {publishedDateFormatter.format(new Date(post.publishedAt))}
-          </time>
-        </div>
-
-        <div className="mt-4 flex flex-1 flex-col gap-3">
-          <h2
-            className="transition-colors group-hover:opacity-70"
-            style={{
-              fontFamily: "var(--font-home-sans)",
-              fontSize: "1.05rem",
-              fontWeight: 700,
-              letterSpacing: "-0.03em",
-              lineHeight: 1.18,
-              color: "var(--home-ink)",
-            }}
-          >
-            {post.title}
-          </h2>
-
-          <p
-            className="mb-0 flex-1 line-clamp-4 text-sm leading-6"
-            style={{ color: "var(--home-ink-muted)" }}
-          >
-            {post.excerpt}
-          </p>
-
-          <WritingCardFooter post={post} />
-        </div>
-      </article>
-    </Link>
-  );
-}
-
-function WritingClusterSection({
-  cluster,
-  posts,
-}: {
-  cluster: BlogCluster;
-  posts: ReturnType<typeof getAllBlogPostPreviews>;
-}) {
-  if (posts.length === 0) {
-    return null;
-  }
-
-  const details = BLOG_CLUSTER_DETAILS[cluster];
-
-  return (
-    <section
-      id={toSectionId(cluster)}
-      data-testid={`writing-cluster-${toSectionId(cluster)}`}
-      className="space-y-6 scroll-mt-28"
-    >
-      <div className="space-y-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <p className="home-kicker mb-0">Lead pillar</p>
-          <span className="resume-chip">{posts.length} articles</span>
-        </div>
-        <h2
-          style={{
-            fontFamily: "var(--font-home-sans)",
-            fontSize: "clamp(1.9rem, 4vw, 2.8rem)",
-            fontWeight: 600,
-            lineHeight: 0.98,
-            letterSpacing: "-0.05em",
-            color: "var(--home-ink)",
-          }}
-        >
-          {cluster}
-        </h2>
-        <p className="home-body max-w-[52rem]">{details.description}</p>
-      </div>
-
-      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-        {posts.map((post) => (
-          <CuratedWritingCard key={post.slug} post={post} />
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function ArchiveBucketSection({
-  bucket,
-  posts,
-}: {
-  bucket: BlogArchiveBucket;
-  posts: ReturnType<typeof getAllBlogPostPreviews>;
-}) {
-  if (posts.length === 0) {
-    return null;
-  }
-
-  const details = BLOG_ARCHIVE_BUCKET_DETAILS[bucket];
-
-  return (
-    <section
-      id={toSectionId(bucket)}
-      data-testid={`writing-archive-${toSectionId(bucket)}`}
-      className="rounded-[2rem] border p-6 md:p-7"
-      style={{
-        borderColor: "color-mix(in srgb, var(--home-rule) 74%, var(--home-elev-mix))",
-        background:
-          "color-mix(in srgb, var(--home-paper) 76%, var(--home-paper-alt) 24%)",
-      }}
-    >
-      <div className="space-y-2">
-        <div className="flex flex-wrap items-center gap-3">
-          <p className="home-kicker mb-0">Archive bucket</p>
-          <span className="resume-chip">{posts.length} articles</span>
-        </div>
-        <h3
-          style={{
-            fontFamily: "var(--font-home-sans)",
-            fontSize: "1.4rem",
-            fontWeight: 700,
-            lineHeight: 1.02,
-            letterSpacing: "-0.04em",
-            color: "var(--home-ink)",
-          }}
-        >
-          {bucket}
-        </h3>
-        <p className="home-body text-sm">{details.description}</p>
-      </div>
-
-      <div className="mt-6 grid gap-4">
-        {posts.map((post) => (
-          <ArchiveWritingCard key={post.slug} post={post} />
-        ))}
-      </div>
-    </section>
-  );
+function readingMinutes(rt: string): number {
+  const m = rt.match(/(\d+)/);
+  return m ? parseInt(m[1], 10) : 0;
 }
 
 export default function WritingPage() {
   const posts = getAllBlogPostPreviews();
   const curatedSections = getCuratedBlogPostPreviewsByCluster();
   const archiveSections = getArchiveBlogPostPreviewsByBucket();
-  const leadCount = BLOG_CLUSTER_ORDER.reduce(
-    (count, cluster) => count + curatedSections[cluster].length,
-    0
-  );
-  const archiveCount = BLOG_ARCHIVE_BUCKET_ORDER.reduce(
-    (count, bucket) => count + archiveSections[bucket].length,
-    0
-  );
+
+  const clusters = BLOG_CLUSTER_ORDER.map((c) => ({
+    id: c,
+    label: c,
+    description: BLOG_CLUSTER_DETAILS[c].description,
+    count: curatedSections[c].length,
+  }));
+  const buckets = BLOG_ARCHIVE_BUCKET_ORDER.map((b) => ({
+    id: b,
+    label: b,
+    description: BLOG_ARCHIVE_BUCKET_DETAILS[b].description,
+    count: archiveSections[b].length,
+  }));
+
+  const totalNotes = posts.filter((p) => readingMinutes(p.readingTime) <= 5).length;
+  const totalEssays = posts.length - totalNotes;
+
+  const earliestDate = posts.length
+    ? [...posts].sort(
+        (a, b) => new Date(a.publishedAt).getTime() - new Date(b.publishedAt).getTime(),
+      )[0]?.publishedAt
+    : undefined;
 
   const breadcrumbs = [
     { name: "Home", url: "/" },
@@ -340,178 +114,15 @@ export default function WritingPage() {
       ))}
 
       <section className="home-page min-h-screen">
-        <div className="home-shell home-section space-y-14">
-          <header className="space-y-6 pt-4">
-            <div className="space-y-4 text-center">
-              <p className="home-kicker">Writing</p>
-              <h1
-                className="mx-auto w-full max-w-5xl"
-                style={{
-                  fontFamily: "var(--font-home-sans)",
-                  fontSize: "clamp(2.6rem, 6vw, 5rem)",
-                  fontWeight: 600,
-                  lineHeight: 0.94,
-                  letterSpacing: "-0.07em",
-                  color: "var(--home-ink)",
-                }}
-              >
-                I keep the writing organized around the work I want to do more of.
-              </h1>
-              <p className="home-body mx-auto max-w-[54rem] text-center">
-                The first layer is PM workflows, agentic AI, fintech product
-                thinking, and systems work. The broader archive is still here,
-                but it lives in smaller buckets instead of one undifferentiated
-                feed.
-              </p>
-            </div>
-
-            <div
-              className="grid gap-4 rounded-[2rem] border p-5 md:grid-cols-[minmax(0,1.35fr)_minmax(0,0.9fr)] md:p-7"
-              style={{
-                borderColor: "var(--home-rule)",
-                background:
-                  "linear-gradient(135deg, color-mix(in srgb, var(--home-paper-alt) 84%, var(--home-elev-mix)) 0%, color-mix(in srgb, var(--home-paper) 88%, var(--home-paper-alt) 12%) 100%)",
-              }}
-            >
-              <div className="space-y-3">
-                <p className="home-kicker mb-0">Start with the pillar that matches the question</p>
-                <p
-                  style={{
-                    fontFamily: "var(--font-home-sans)",
-                    fontSize: "clamp(1.3rem, 3vw, 1.85rem)",
-                    fontWeight: 600,
-                    lineHeight: 1.02,
-                    letterSpacing: "-0.04em",
-                    color: "var(--home-ink)",
-                  }}
-                >
-                  The top of the archive is meant to be a faster scan. You
-                  should know where to start before you read a single card.
-                </p>
-              </div>
-
-              <div className="grid grid-cols-3 gap-3">
-                {[
-                  { label: "Lead pillars", value: BLOG_CLUSTER_ORDER.length },
-                  { label: "Lead pieces", value: leadCount },
-                  { label: "Archive pieces", value: archiveCount },
-                ].map((stat) => (
-                  <div
-                    key={stat.label}
-                    className="rounded-[1.35rem] border px-4 py-4 text-center"
-                    style={{
-                      borderColor: "color-mix(in srgb, var(--home-rule) 82%, var(--home-elev-mix))",
-                      background:
-                        "color-mix(in srgb, var(--home-paper) 72%, var(--home-paper-alt) 28%)",
-                    }}
-                  >
-                    <p className="home-meta mb-1">{stat.label}</p>
-                    <p
-                      className="mb-0"
-                      style={{
-                        fontFamily: "var(--font-home-sans)",
-                        fontSize: "1.8rem",
-                        fontWeight: 700,
-                        letterSpacing: "-0.05em",
-                        lineHeight: 1,
-                        color: "var(--home-ink)",
-                      }}
-                    >
-                      {stat.value}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </header>
-
-          <nav
-            aria-label="Writing pillars"
-            className="rounded-[1.8rem] border p-3"
-            style={{
-              borderColor: "var(--home-rule)",
-              background:
-                "color-mix(in srgb, var(--home-paper) 82%, var(--home-paper-alt) 18%)",
-            }}
-          >
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-              {BLOG_CLUSTER_ORDER.map((cluster) => {
-                const sectionId = toSectionId(cluster);
-
-                return (
-                  <Link
-                    key={cluster}
-                    href={`#${sectionId}`}
-                    className="group flex min-h-[56px] items-center justify-between gap-3 rounded-[1.2rem] border px-4 py-3 transition-[border-color,background-color,color]"
-                    style={{
-                      borderColor: "color-mix(in srgb, var(--home-rule) 84%, var(--home-elev-mix))",
-                      background:
-                        "color-mix(in srgb, var(--home-paper-alt) 76%, var(--home-elev-mix))",
-                    }}
-                  >
-                    <div className="space-y-1">
-                      <p className="home-kicker mb-0">{cluster}</p>
-                      <p
-                        className="mb-0 text-sm"
-                        style={{ color: "var(--home-ink-muted)" }}
-                      >
-                        {curatedSections[cluster].length} articles
-                      </p>
-                    </div>
-                    <ArrowRight
-                      className="h-4 w-4 flex-shrink-0 transition-transform group-hover:translate-x-1"
-                      style={{ color: "var(--home-haze)" }}
-                    />
-                  </Link>
-                );
-              })}
-            </div>
-          </nav>
-
-          <div className="space-y-14">
-            {BLOG_CLUSTER_ORDER.map((cluster) => (
-              <WritingClusterSection
-                key={cluster}
-                cluster={cluster}
-                posts={curatedSections[cluster]}
-              />
-            ))}
-          </div>
-
-          {archiveCount > 0 ? (
-            <section className="space-y-6" data-testid="writing-archive-root">
-              <div className="space-y-3">
-                <p className="home-kicker">Archive</p>
-                <h2
-                  style={{
-                    fontFamily: "var(--font-home-sans)",
-                    fontSize: "clamp(1.9rem, 4vw, 2.8rem)",
-                    fontWeight: 600,
-                    lineHeight: 0.98,
-                    letterSpacing: "-0.05em",
-                    color: "var(--home-ink)",
-                  }}
-                >
-                  Broader archive
-                </h2>
-                <p className="home-body max-w-[52rem]">
-                  Sports and fantasy work, weekly signals, and the side-path
-                  experiments are still fully available. They are just grouped
-                  by what they are instead of competing with the lead library.
-                </p>
-              </div>
-
-              <div className="grid gap-6 xl:grid-cols-3">
-                {BLOG_ARCHIVE_BUCKET_ORDER.map((bucket) => (
-                  <ArchiveBucketSection
-                    key={bucket}
-                    bucket={bucket}
-                    posts={archiveSections[bucket]}
-                  />
-                ))}
-              </div>
-            </section>
-          ) : null}
+        <div className="home-shell home-section">
+          <WritingArchiveClient
+            posts={posts}
+            clusters={clusters}
+            buckets={buckets}
+            totalEssays={totalEssays}
+            totalNotes={totalNotes}
+            earliestDate={earliestDate}
+          />
         </div>
       </section>
     </>

--- a/src/components/writing/WritingArchiveClient.tsx
+++ b/src/components/writing/WritingArchiveClient.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { IconArrowRight, IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import { publishedDateFormatter } from "@/lib/utils";
+
+export interface WritingArchivePost {
+  slug: string;
+  title: string;
+  excerpt: string;
+  publishedAt: string;
+  readingTime: string;
+  category: string;
+  cluster?: string;
+  archiveBucket?: string;
+  coverImage?: string;
+  tags?: string[];
+}
+
+interface FilterChip {
+  id: string;
+  label: string;
+  count: number;
+  match?: (post: WritingArchivePost) => boolean;
+}
+
+interface Props {
+  posts: WritingArchivePost[];
+  clusters: { id: string; label: string; description?: string; count: number }[];
+  buckets: { id: string; label: string; description?: string; count: number }[];
+  totalEssays: number;
+  totalNotes: number;
+  earliestDate?: string;
+}
+
+const PAGE_SIZE = 12;
+
+function readingMinutes(rt: string): number {
+  const m = rt.match(/(\d+)/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+function isNote(post: WritingArchivePost): boolean {
+  return readingMinutes(post.readingTime) <= 5;
+}
+
+function categoryLabel(post: WritingArchivePost): string {
+  return post.cluster ?? post.archiveBucket ?? post.category ?? "Other";
+}
+
+function postKind(post: WritingArchivePost): "Note" | "Essay" {
+  return isNote(post) ? "Note" : "Essay";
+}
+
+function pickCoverVariant(post: WritingArchivePost, index: number): "acid" | "haze" | "ink" | null {
+  // Sprinkle image-led card variants every ~5th card so the grid breathes,
+  // matching the design's visual breakpoints.
+  if (post.coverImage) return null;
+  if (index % 5 === 1) return "acid";
+  if (index % 5 === 3) return "haze";
+  if (index % 11 === 7) return "ink";
+  return null;
+}
+
+export function WritingArchiveClient({
+  posts,
+  clusters,
+  buckets,
+  totalEssays,
+  totalNotes,
+  earliestDate,
+}: Props) {
+  const [activeFilter, setActiveFilter] = useState<string>("all");
+  const [sort, setSort] = useState<"newest" | "shortest" | "longest">("newest");
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    setPage(1);
+  }, [activeFilter, sort]);
+
+  const filterChips: FilterChip[] = useMemo(() => {
+    const chips: FilterChip[] = [
+      { id: "all", label: "All", count: posts.length },
+    ];
+    clusters.forEach((c) =>
+      chips.push({
+        id: `cluster:${c.id}`,
+        label: c.label,
+        count: c.count,
+        match: (p) => p.cluster === c.id,
+      }),
+    );
+    if (totalNotes > 0) {
+      chips.push({
+        id: "kind:notes",
+        label: "Notes (short)",
+        count: totalNotes,
+        match: (p) => isNote(p),
+      });
+    }
+    if (totalEssays > 0) {
+      chips.push({
+        id: "kind:essays",
+        label: "Essays (long)",
+        count: totalEssays,
+        match: (p) => !isNote(p),
+      });
+    }
+    buckets.forEach((b) =>
+      chips.push({
+        id: `bucket:${b.id}`,
+        label: b.label,
+        count: b.count,
+        match: (p) => p.archiveBucket === b.id,
+      }),
+    );
+    return chips.filter((c) => c.count > 0);
+  }, [posts.length, clusters, buckets, totalEssays, totalNotes]);
+
+  const filtered = useMemo(() => {
+    const chip = filterChips.find((c) => c.id === activeFilter);
+    let list = chip?.match ? posts.filter(chip.match) : posts;
+    if (sort === "shortest") {
+      list = [...list].sort(
+        (a, b) => readingMinutes(a.readingTime) - readingMinutes(b.readingTime),
+      );
+    } else if (sort === "longest") {
+      list = [...list].sort(
+        (a, b) => readingMinutes(b.readingTime) - readingMinutes(a.readingTime),
+      );
+    }
+    return list;
+  }, [posts, filterChips, activeFilter, sort]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const visible = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+  const showingFrom = filtered.length === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const showingTo = Math.min(page * PAGE_SIZE, filtered.length);
+
+  // Featured row uses the first three posts (most recent) — big + 2 stacked.
+  const [featBig, featSmallA, featSmallB] = posts;
+
+  const sinceLabel = useMemo(() => {
+    if (!earliestDate) return "—";
+    const d = new Date(earliestDate);
+    if (Number.isNaN(d.getTime())) return earliestDate;
+    return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+  }, [earliestDate]);
+
+  return (
+    <div className="wp-page">
+      <section className="wp-pagehead">
+        <div>
+          <p className="wp-pagehead-kicker">The archive</p>
+          <h1 className="wp-pagehead-title">
+            Writing on <em>product</em>, AI, and judgment.
+          </h1>
+        </div>
+        <div className="wp-pagehead-stats">
+          <div>
+            <span className="wp-stat-label">Essays</span>
+            <span className="wp-stat-value">{totalEssays}</span>
+          </div>
+          <div>
+            <span className="wp-stat-label">Notes</span>
+            <span className="wp-stat-value">{totalNotes}</span>
+          </div>
+          <div>
+            <span className="wp-stat-label">Since</span>
+            <span className="wp-stat-value">{sinceLabel}</span>
+          </div>
+        </div>
+      </section>
+
+      {featBig ? (
+        <section className="wp-featured">
+          <Link href={`/writing/${featBig.slug}`} className="wp-feat-big group">
+            <div className="wp-feat-topline">
+              <span className="wp-feat-pill">Most recent</span>
+              <span className="wp-feat-meta">
+                {postKind(featBig)} · {featBig.readingTime}
+              </span>
+            </div>
+            <h2 className="wp-feat-big-title">{featBig.title}</h2>
+            <p className="wp-feat-dek">{featBig.excerpt}</p>
+            <div className="wp-feat-footrow">
+              <div className="wp-feat-byline">
+                <div className="wp-feat-avatar" aria-hidden="true">IV</div>
+                <span>
+                  <span className="wp-feat-byline-name">Isaac Vazquez</span>
+                  {" · "}
+                  {publishedDateFormatter.format(new Date(featBig.publishedAt))}
+                </span>
+              </div>
+              <span className="wp-feat-readlink">
+                Read essay <IconArrowRight size={14} aria-hidden="true" />
+              </span>
+            </div>
+          </Link>
+
+          <div className="wp-feat-stack">
+            {featSmallA ? (
+              <Link
+                href={`/writing/${featSmallA.slug}`}
+                className="wp-feat-small wp-feat-small--dark"
+              >
+                <div className="wp-feat-topline">
+                  <span className="wp-feat-pill">New · this week</span>
+                  <span className="wp-feat-meta wp-feat-meta--dark">
+                    {postKind(featSmallA)} · {featSmallA.readingTime}
+                  </span>
+                </div>
+                <h3 className="wp-feat-small-title">{featSmallA.title}</h3>
+                <div className="wp-feat-small-footrow wp-feat-small-footrow--dark">
+                  <span>{publishedDateFormatter.format(new Date(featSmallA.publishedAt))}</span>
+                  <span className="wp-feat-small-readlink">
+                    Read {postKind(featSmallA).toLowerCase()} <IconArrowRight size={12} />
+                  </span>
+                </div>
+              </Link>
+            ) : null}
+            {featSmallB ? (
+              <Link href={`/writing/${featSmallB.slug}`} className="wp-feat-small">
+                <div className="wp-feat-topline">
+                  <span className="wp-feat-pill wp-feat-pill--editor">Editor's pick</span>
+                  <span className="wp-feat-meta">
+                    {postKind(featSmallB)} · {featSmallB.readingTime}
+                  </span>
+                </div>
+                <h3 className="wp-feat-small-title">{featSmallB.title}</h3>
+                <div className="wp-feat-small-footrow">
+                  <span>{publishedDateFormatter.format(new Date(featSmallB.publishedAt))}</span>
+                  <span className="wp-feat-small-readlink">
+                    Read {postKind(featSmallB).toLowerCase()} <IconArrowRight size={12} />
+                  </span>
+                </div>
+              </Link>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="wp-archive-section">
+        <div className="wp-archive-head">
+          <h2 className="wp-archive-title">All articles</h2>
+          <span className="wp-archive-count">
+            Showing {showingFrom}–{showingTo} of {filtered.length}
+          </span>
+        </div>
+
+        <div className="wp-filter-row" role="tablist" aria-label="Filter articles">
+          {filterChips.map((chip) => (
+            <button
+              key={chip.id}
+              type="button"
+              role="tab"
+              aria-selected={activeFilter === chip.id}
+              onClick={() => setActiveFilter(chip.id)}
+              className={`wp-chip ${activeFilter === chip.id ? "wp-chip--on" : ""}`}
+            >
+              {chip.label}
+              <span className="wp-chip-count">{chip.count}</span>
+            </button>
+          ))}
+          <span className="wp-sort">
+            <span className="wp-sort-label">Sort</span>
+            <select
+              value={sort}
+              onChange={(e) => setSort(e.target.value as typeof sort)}
+              aria-label="Sort articles"
+            >
+              <option value="newest">Newest first</option>
+              <option value="shortest">Shortest first</option>
+              <option value="longest">Longest first</option>
+            </select>
+          </span>
+        </div>
+
+        {visible.length === 0 ? (
+          <div className="wp-empty">
+            <p className="wp-empty-title">No articles match that filter yet.</p>
+            <p className="wp-empty-body">
+              Try a different category or check back later — the archive grows weekly.
+            </p>
+          </div>
+        ) : (
+          <ul className="wp-grid">
+            {visible.map((post, i) => {
+              const coverVariant = pickCoverVariant(post, i);
+              const cardClass = coverVariant
+                ? `wp-card wp-card--has-image wp-card--var-${coverVariant}`
+                : "wp-card";
+              return (
+                <li key={post.slug}>
+                  <Link href={`/writing/${post.slug}`} className={cardClass}>
+                    {coverVariant ? (
+                      <div className="wp-card-img">
+                        <span className="wp-card-img-pill">{postKind(post)}</span>
+                      </div>
+                    ) : null}
+                    <div className={coverVariant ? "wp-card-body" : "wp-card-body wp-card-body--noimg"}>
+                      <div className="wp-card-topline">
+                        <span className="wp-card-cat">{postKind(post)}</span>
+                        <span className="wp-card-dot" aria-hidden="true" />
+                        <span>{post.readingTime}</span>
+                        <span className="wp-card-dot" aria-hidden="true" />
+                        <span>{publishedDateFormatter.format(new Date(post.publishedAt))}</span>
+                      </div>
+                      <h3 className="wp-card-title">{post.title}</h3>
+                      <p className="wp-card-dek">{post.excerpt}</p>
+                      <div className="wp-card-footrow">
+                        <span>{categoryLabel(post)}</span>
+                        <span className="wp-card-readlink">
+                          Read <IconArrowRight size={12} />
+                        </span>
+                      </div>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {totalPages > 1 ? (
+          <nav className="wp-pager" aria-label="Article pagination">
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="wp-pager-btn"
+            >
+              <IconChevronLeft size={14} aria-hidden="true" />
+              Prev
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setPage(n)}
+                className={`wp-pager-btn ${n === page ? "wp-pager-btn--on" : ""}`}
+                aria-current={n === page ? "page" : undefined}
+              >
+                {n}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="wp-pager-btn"
+            >
+              Next
+              <IconChevronRight size={14} aria-hidden="true" />
+            </button>
+          </nav>
+        ) : null}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the cluster/archive-bucket stack on `/writing` with the editorial archive layout from the design handoff: page heading + featured row + chip filter + 3-col grid + pagination.
- New `WritingArchiveClient` owns the interactivity (filter, sort, pagination). All filter chips include real counts pulled from the existing blog data layer.
- Featured row uses the most-recent post as the big card and the next two posts as the stacked pair (one dark variant). Cards default to a text-led layout but rotate in acid/haze/ink gradient cover variants every few rows for posts without a `coverImage`.
- Heading uses the design's display size and serif-italic emphasis on "product"; a 3-column stats strip surfaces Essays / Notes / Since {month year} pulled from the post list.
- Reading time is parsed to classify Note vs Essay so the totals and per-card kind chip stay consistent. Backwards-compatible: BreadcrumbList + first-12 Article structured data still render server-side, MDX layer unchanged.

Out of scope (design source had them but they aren't real product features yet):
- Most-cited pull-quote section (no citation data).
- Newsletter CTA (no signup integration).

## Test plan
- [ ] `/writing` renders the new heading, featured row, and full 12-card grid with the right total counts.
- [ ] Filter chips switch the grid (All / each cluster / Notes / Essays / each archive bucket) and reset pagination to page 1.
- [ ] Sort dropdown reorders by newest / shortest / longest.
- [ ] Pagination prev/next + page numbers work with PAGE_SIZE=12.
- [ ] Image-led card variants render at the expected positions when posts lack a `coverImage`.
- [ ] Light + dark mode both pass; serif-italic emphasis renders.
- [ ] `/writing/[slug]` and OG/structured-data tests still pass.
- [ ] No console errors at 1440 / 1280 / 700.