### PR TITLE
ci(e2e): cut PR feedback time by ~5x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,11 @@ jobs:
           name: codecov-umbrella
         continue-on-error: true
 
-  e2e-tests:
-    name: E2E Tests
+  build:
+    name: Build
     runs-on: ubuntu-latest
+    outputs:
+      build-hash: ${{ steps.hash.outputs.value }}
 
     steps:
       - name: Checkout code
@@ -52,19 +54,153 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+      - name: Compute build hash
+        id: hash
+        run: echo "value=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      # Cache the .next build between jobs so the E2E job can run `next start`
+      # without recompiling. Keyed on commit SHA so it always matches the
+      # source the E2E job runs against.
+      - name: Cache .next build
+        id: next-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next
+            public
+          key: next-build-${{ github.sha }}
+
+      - name: Build application
+        if: steps.next-cache.outputs.cache-hit != 'true'
+        run: npm run build
+
+  e2e-tests:
+    name: E2E Tests (chromium)
+    runs-on: ubuntu-latest
+    needs: build
+    # Shard the spec files across N runners. Bump the matrix length to scale.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Reuse the build artifact produced by the `build` job. With the cache
+      # warm, `next start` boots immediately and pages render pre-compiled.
+      - name: Restore .next build
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next
+            public
+          key: next-build-${{ github.sha }}
+
+      # Cache Playwright browser binaries (~hundreds of MB) keyed on the
+      # @playwright/test version pinned in package-lock.json.
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          VERSION=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.value }}-chromium
+
+      - name: Install Playwright browsers (chromium only)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Run E2E tests
-        run: npm run test:e2e
+        run: npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: playwright-report/
-          retention-days: 30
+          retention-days: 14
+
+  # Run the full browser matrix only on pushes to main (not on every PR).
+  # Catches Safari/Firefox-specific regressions without slowing down PR feedback.
+  e2e-tests-full-matrix:
+    name: E2E Tests (full matrix)
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Restore .next build
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next
+            public
+          key: next-build-${{ github.sha }}
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          VERSION=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.value }}-full
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
+
+      - name: Run E2E tests (full matrix)
+        run: npm run test:e2e:full
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-full-matrix
+          path: playwright-report/
+          retention-days: 14
 
   lint:
     name: Lint
@@ -86,23 +222,3 @@ jobs:
       - name: Run ESLint
         run: npm run lint
         continue-on-error: true
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build application
-        run: npm run build

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:coverage": "jest --coverage",
     "test:ci": "jest --ci --coverage --maxWorkers=2",
     "test:e2e": "playwright test",
+    "test:e2e:full": "E2E_FULL_MATRIX=1 playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
     "test:all": "npm run test:coverage && npm run test:e2e",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,37 @@ import { defineConfig, devices } from '@playwright/test'
 
 /**
  * See https://playwright.dev/docs/test-configuration.
+ *
+ * CI defaults to chromium-only against `next start` so PR feedback is fast.
+ * Set `E2E_FULL_MATRIX=1` (or run `npm run test:e2e:full`) to run firefox /
+ * webkit / mobile projects too — used for main-branch / nightly coverage.
  */
+const FULL_MATRIX = process.env.E2E_FULL_MATRIX === '1'
+const IS_CI = !!process.env.CI
+
+const allProjects = [
+  {
+    name: 'chromium',
+    use: { ...devices['Desktop Chrome'] },
+  },
+  {
+    name: 'firefox',
+    use: { ...devices['Desktop Firefox'] },
+  },
+  {
+    name: 'webkit',
+    use: { ...devices['Desktop Safari'] },
+  },
+  {
+    name: 'Mobile Chrome',
+    use: { ...devices['Pixel 5'] },
+  },
+  {
+    name: 'Mobile Safari',
+    use: { ...devices['iPhone 12'] },
+  },
+]
+
 export default defineConfig({
   testDir: './e2e',
 
@@ -10,75 +40,44 @@ export default defineConfig({
   fullyParallel: true,
 
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
+  forbidOnly: IS_CI,
 
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  /* Single retry on CI is enough to weed out true flakes without tripling
+     runtime when something is genuinely broken. */
+  retries: IS_CI ? 1 : 0,
 
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : 2,
+  /* On CI, run against `next start` (no on-demand compile), so workers can
+     run in parallel safely. Locally we keep 2 to match developer flow. */
+  workers: IS_CI ? 4 : 2,
 
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  /* Reporter: list output in CI logs (useful for triage), html locally. */
+  reporter: IS_CI
+    ? [['list'], ['html', { open: 'never' }]]
+    : [['html', { open: 'never' }]],
 
-  /* Global test timeout – Next.js dev server compiles pages on demand so give
-     each test enough headroom for a cold-start compilation. */
-  timeout: 60_000,
+  /* Test timeout — production server doesn't need the dev cold-start budget. */
+  timeout: IS_CI ? 30_000 : 60_000,
 
-  /* Increase the default expect/assertion timeout for the same reason. */
   expect: {
-    timeout: 15_000,
+    timeout: IS_CI ? 10_000 : 15_000,
   },
 
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:3000',
-
-    /* Allow enough time for client-side navigation + on-demand page compilation. */
-    navigationTimeout: 30_000,
-    actionTimeout: 15_000,
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    navigationTimeout: IS_CI ? 15_000 : 30_000,
+    actionTimeout: IS_CI ? 10_000 : 15_000,
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
   },
 
-  /* Configure projects for major browsers */
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
+  projects: FULL_MATRIX ? allProjects : [allProjects[0]],
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    /* Test against mobile viewports. */
-    {
-      name: 'Mobile Chrome',
-      use: { ...devices['Pixel 5'] },
-    },
-    {
-      name: 'Mobile Safari',
-      use: { ...devices['iPhone 12'] },
-    },
-  ],
-
-  /* Run your local dev server before starting the tests */
+  /* Run the production server before tests on CI (compiled, fast). Locally
+     fall back to `npm run dev` so iteration stays cheap. */
   webServer: {
-    command: 'npm run dev',
+    command: IS_CI ? 'npm run start' : 'npm run dev',
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !IS_CI,
     timeout: 120 * 1000,
   },
 })


### PR DESCRIPTION
## Summary
The E2E job is the long pole on every PR. Audit found four compounding slowdowns:

1. **Dev server, not prod** — webServer ran `npm run dev`, so every page navigation paid Next's on-demand-compile cost.
2. **Five browsers on every PR** — chromium + firefox + webkit + Mobile Chrome + Mobile Safari, each spec runs 5×.
3. **`workers: 1` on CI** — kills parallelism even with `fullyParallel: true`.
4. **Browsers redownloaded every run** — no Playwright cache; `--with-deps` adds minutes.

## Changes

**`playwright.config.ts`**
- CI webServer is `npm run start` against a pre-built `.next`. Local still uses `npm run dev`.
- Default project is chromium-only. `E2E_FULL_MATRIX=1` (or `npm run test:e2e:full`) opts into the full matrix.
- Workers bumped 1 → 4 on CI; retries 2 → 1; timeouts tightened.
- List + HTML reporter on CI so failing specs show up in the log.

**`.github/workflows/test.yml`**
- New `build` job runs `next build` once and caches `.next` keyed on the commit SHA.
- E2E job depends on `build`, restores `.next`, and runs `next start`.
- Playwright browser binaries cached at `~/.cache/ms-playwright`, keyed on the @playwright/test version. PR runs install chromium only; system deps re-applied on cache hits.
- E2E sharded across 2 runners (`--shard=1/2` + `--shard=2/2`).
- New `e2e-tests-full-matrix` job runs the firefox/webkit/mobile browsers **only on pushes to main**, not on every PR.

**`package.json`**
- New `test:e2e:full` script.

## Expected impact
- Dev-server cold-starts: gone.
- Browser matrix on PR: 5× → 1× (~80% test reduction).
- Parallelism within a runner: 4×.
- Work split across 2 runners (sharding): ~2×.
- Browser install: cache hits skip ~hundreds of MB.

Worst case: roughly **a quarter** of prior wall-clock. Cache hits cut further.

## Test plan
- [ ] First push: build job populates the .next cache; E2E shards 1 + 2 both pass on chromium.
- [ ] Second push (same SHA range): build job cache-hits, Playwright cache-hits, total time noticeably lower.
- [ ] Local `npm run test:e2e` still works against `npm run dev`.
- [ ] Local `npm run test:e2e:full` runs all 5 browsers.
- [ ] On merge to main, the `e2e-tests-full-matrix` job runs and posts a separate report artifact.