### PR TITLE
fix(ci): retry refresh-snapshot push on race with main

### DIFF
--- a/.github/workflows/update-fantasy.yml
+++ b/.github/workflows/update-fantasy.yml
@@ -60,7 +60,24 @@ jobs:
             public/data/fantasy/half_ppr.json \
             public/data/fantasy/standard.json
           git commit -m "chore: update fantasy football snapshots [automated]"
-          git push
+          # Retry on push rejection — main can move during the multi-minute
+          # snapshot refresh. Rebase the single snapshot commit onto the
+          # latest origin/main and try again. Bail on a real conflict.
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push attempt $attempt rejected. Rebasing onto latest origin/main…"
+            git fetch origin main
+            if ! git rebase origin/main; then
+              git rebase --abort
+              echo "Rebase conflict — failing the run."
+              exit 1
+            fi
+            sleep $((attempt * 3))
+          done
+          echo "Push failed after 5 attempts."
+          exit 1
 
       - name: Create job summary
         if: always()

--- a/.github/workflows/update-investments.yml
+++ b/.github/workflows/update-investments.yml
@@ -89,7 +89,24 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add public/data/investments
           git commit -m "chore: refresh investments snapshots [automated]"
-          git push
+          # Retry on push rejection — main can move during the multi-minute
+          # snapshot refresh. Rebase the single snapshot commit onto the
+          # latest origin/main and try again. Bail on a real conflict.
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push attempt $attempt rejected. Rebasing onto latest origin/main…"
+            git fetch origin main
+            if ! git rebase origin/main; then
+              git rebase --abort
+              echo "Rebase conflict — failing the run."
+              exit 1
+            fi
+            sleep $((attempt * 3))
+          done
+          echo "Push failed after 5 attempts."
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-la-liga.yml
+++ b/.github/workflows/update-la-liga.yml
@@ -52,7 +52,24 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add src/data/laLigaSnapshot.ts
           git commit -m "chore: refresh la liga snapshot [automated]"
-          git push
+          # Retry on push rejection — main can move during the multi-minute
+          # snapshot refresh. Rebase the single snapshot commit onto the
+          # latest origin/main and try again. Bail on a real conflict.
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push attempt $attempt rejected. Rebasing onto latest origin/main…"
+            git fetch origin main
+            if ! git rebase origin/main; then
+              git rebase --abort
+              echo "Rebase conflict — failing the run."
+              exit 1
+            fi
+            sleep $((attempt * 3))
+          done
+          echo "Push failed after 5 attempts."
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-premier-league.yml
+++ b/.github/workflows/update-premier-league.yml
@@ -52,7 +52,24 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add src/data/premierLeagueSnapshot.ts
           git commit -m "chore: refresh premier league snapshot [automated]"
-          git push
+          # Retry on push rejection — main can move during the multi-minute
+          # snapshot refresh. Rebase the single snapshot commit onto the
+          # latest origin/main and try again. Bail on a real conflict.
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push attempt $attempt rejected. Rebasing onto latest origin/main…"
+            git fetch origin main
+            if ! git rebase origin/main; then
+              git rebase --abort
+              echo "Rebase conflict — failing the run."
+              exit 1
+            fi
+            sleep $((attempt * 3))
+          done
+          echo "Push failed after 5 attempts."
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Why
The La Liga refresh failed on 2026-04-26:
\`\`\`
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'https://github.com/IsaacAVazquez/Website'
\`\`\`

The job ran for 8 minutes; main moved during that window, so the bare \`git push\` got rejected. All four refresh workflows (la-liga, premier-league, fantasy, investments) have the same naive push and the same race window — la-liga happened to lose this time.

## Fix
Wrap each push in a retry-with-rebase loop:

\`\`\`bash
for attempt in 1..5:
  if git push origin HEAD:main: success
  else: fetch origin main, rebase the single snapshot commit, sleep, retry
  on rebase conflict: abort + fail visibly
\`\`\`

Every refresh commit touches a single snapshot file (or the fantasy data dir), and snapshots aren't human-edited, so real conflicts should be near-zero. Almost every retry will fast-forward cleanly.

Applied identically to all four refresh workflows so the next race takes whichever workflow is running, not just la-liga.

## Out of scope (separate PRs / settings)
- **#100** (\`chore/cheaper-investments-refresh\`) cuts the investments cron 5×/week → 2× and caches the venv to reduce Actions minutes.
- The billing block (*"recent account payments have failed or your spending limit needs to be increased"*) is account-level. Resolve in **Settings → Billing & plans**.

## Test plan
- [ ] Manually \`workflow_dispatch\` la-liga while a PR merges to main during the run; push should succeed after rebase.
- [ ] Sanity check: existing scheduled runs land cleanly when no race occurs.
- [ ] If the rebase fails (unlikely — only happens if someone manually edits the same snapshot file), the run fails visibly so a human can intervene.