### PR TITLE
ci: bring la-liga / premier-league / fantasy up to investments hygiene

### DIFF
--- a/.github/workflows/update-fantasy.yml
+++ b/.github/workflows/update-fantasy.yml
@@ -5,10 +5,17 @@ on:
     - cron: "0 17 * * 3"
   workflow_dispatch:
 
+# Don't stack a manual dispatch on top of a scheduled run.
+concurrency:
+  group: update-fantasy
+  cancel-in-progress: false
+
 jobs:
   update-fantasy-snapshots:
     name: Update Fantasy Football Snapshots
     runs-on: ubuntu-latest
+    # FantasyPros scrape with retries can run long; cap at 30 min.
+    timeout-minutes: 30
     permissions:
       contents: write
 
@@ -16,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -25,7 +32,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --fund=false
 
       - name: Build fantasy snapshots
         run: npm run update:fantasy

--- a/.github/workflows/update-la-liga.yml
+++ b/.github/workflows/update-la-liga.yml
@@ -5,10 +5,17 @@ on:
     - cron: "30 6 * * *"
   workflow_dispatch:
 
+# Don't stack a manual dispatch on top of a scheduled run.
+concurrency:
+  group: refresh-la-liga
+  cancel-in-progress: false
+
 jobs:
   refresh-la-liga:
     name: Refresh La Liga Snapshot
     runs-on: ubuntu-latest
+    # Cap a hung football-data.org call so we don't burn 6 hours of runner.
+    timeout-minutes: 20
 
     permissions:
       contents: write
@@ -17,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -26,7 +33,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --fund=false
 
       - name: Refresh La Liga snapshot
         run: npm run update:la-liga

--- a/.github/workflows/update-premier-league.yml
+++ b/.github/workflows/update-premier-league.yml
@@ -5,10 +5,17 @@ on:
     - cron: "15 6 * * *"
   workflow_dispatch:
 
+# Don't stack a manual dispatch on top of a scheduled run.
+concurrency:
+  group: refresh-premier-league
+  cancel-in-progress: false
+
 jobs:
   refresh-premier-league:
     name: Refresh Premier League Snapshot
     runs-on: ubuntu-latest
+    # Cap a hung football-data.org call so we don't burn 6 hours of runner.
+    timeout-minutes: 20
 
     permissions:
       contents: write
@@ -17,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -26,7 +33,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --fund=false
 
       - name: Refresh Premier League snapshot
         run: npm run update:premier-league


### PR DESCRIPTION
## Why
PR #100 added timeout-minutes, a concurrency group, fetch-depth: 1, and lighter npm ci flags to the investments refresh. The other three refresh workflows (la-liga, premier-league, fantasy) didn't get the same treatment, so they still:

- could hang for 6 hours if upstream stalled (no \`timeout-minutes\`),
- could double-run if a workflow_dispatch fired while a scheduled run was queued (no \`concurrency\` group),
- pulled the entire git history every run (\`fetch-depth: 0\`),
- ran \`npm ci\` without the offline / no-audit / no-fund flags.

This commit was authored on the PR #101 branch but landed *after* the merge commit, so it never reached main. Cleanly cherry-picked here.

## Changes
- \`timeout-minutes: 20\` for la-liga / premier-league, \`30\` for fantasy (its FantasyPros scrape has built-in retries that legitimately take longer).
- \`concurrency.group\` per workflow.
- \`fetch-depth: 1\` on the checkout step.
- \`npm ci --prefer-offline --no-audit --fund=false\`.

No behavior changes for the happy path — schedules and refresh scripts untouched. Pure bounded-failure-mode hygiene: faster checkout, no double-runs, capped wall-clock if upstream APIs stall.

## Test plan
- [ ] Next scheduled la-liga run cleanly checks out at depth 1, completes within 20-min cap.
- [ ] \`workflow_dispatch\` while a scheduled run is queued lands one job, not two.
- [ ] No regression in commit/push behavior (covered by PR #101's retry loop, already on main).