### PR TITLE
feat: add Food Map curated Austin restaurant project

### DIFF
--- a/src/app/food-map/__tests__/food-map-client.test.tsx
+++ b/src/app/food-map/__tests__/food-map-client.test.tsx
@@ -1,0 +1,80 @@
+import type { HTMLAttributes } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { FoodMapClient } from "../food-map-client";
+import { DEFAULT_FOOD_MAP_STATE } from "../food-map-state";
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+let currentSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: mockReplace,
+  }),
+  useSearchParams: () => currentSearchParams,
+}));
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  },
+  useReducedMotion: () => true,
+}));
+
+describe("FoodMapClient", () => {
+  beforeEach(() => {
+    currentSearchParams = new URLSearchParams();
+    mockReplace.mockReset();
+    mockPush.mockReset();
+  });
+
+  it("renders the default surface with all 12 spots and the empty pick panel", () => {
+    render(<FoodMapClient initialState={DEFAULT_FOOD_MAP_STATE} />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /the austin spots i send people to before they ask/i,
+      })
+    ).toBeVisible();
+    expect(screen.getByText(/Showing 12 of 12 spots\./i)).toBeVisible();
+    expect(
+      screen.getByText(/Tap a pin or a card to see why it earns the spot\./i)
+    ).toBeVisible();
+  });
+
+  it("toggles a cuisine chip into the URL", () => {
+    render(<FoodMapClient initialState={DEFAULT_FOOD_MAP_STATE} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^barbecue$/i }));
+
+    expect(mockReplace).toHaveBeenCalledWith("/food-map?cuisine=barbecue", {
+      scroll: false,
+    });
+  });
+
+  it("selects a place from the shortlist and clears it again", () => {
+    currentSearchParams = new URLSearchParams("pick=franklin-barbecue");
+
+    render(<FoodMapClient initialState={DEFAULT_FOOD_MAP_STATE} />);
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Franklin Barbecue" })
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: /clear pick/i }));
+
+    expect(mockReplace).toHaveBeenLastCalledWith("/food-map", { scroll: false });
+  });
+
+  it("shows the empty-state copy when filters exclude every spot", () => {
+    currentSearchParams = new URLSearchParams("cuisine=pizza&meal=breakfast");
+
+    render(<FoodMapClient initialState={DEFAULT_FOOD_MAP_STATE} />);
+
+    expect(
+      screen.getByText(/Nothing matches that combination yet\./i)
+    ).toBeVisible();
+  });
+});

--- a/src/app/food-map/__tests__/food-map-data.test.ts
+++ b/src/app/food-map/__tests__/food-map-data.test.ts
@@ -1,0 +1,73 @@
+import {
+  countPlacesByNeighborhood,
+  filterFoodMapPlaces,
+  FOOD_MAP_NEIGHBORHOODS,
+  FOOD_MAP_PLACES,
+  isFoodMapCuisineId,
+  isFoodMapMealId,
+  isFoodMapNeighborhoodId,
+  isFoodMapPlaceId,
+} from "../food-map-data";
+
+describe("food-map-data", () => {
+  it("places sit in known neighborhoods, cuisines, and meals", () => {
+    for (const place of FOOD_MAP_PLACES) {
+      expect(isFoodMapNeighborhoodId(place.neighborhood)).toBe(true);
+      expect(isFoodMapCuisineId(place.cuisine)).toBe(true);
+      expect(place.meals.length).toBeGreaterThan(0);
+      for (const meal of place.meals) {
+        expect(isFoodMapMealId(meal)).toBe(true);
+      }
+      expect(isFoodMapPlaceId(place.id)).toBe(true);
+      expect(place.x).toBeGreaterThanOrEqual(0);
+      expect(place.x).toBeLessThanOrEqual(100);
+      expect(place.y).toBeGreaterThanOrEqual(0);
+      expect(place.y).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("counts places per neighborhood for every defined neighborhood", () => {
+    const counts = countPlacesByNeighborhood(FOOD_MAP_PLACES);
+    for (const neighborhood of FOOD_MAP_NEIGHBORHOODS) {
+      expect(counts).toHaveProperty(neighborhood.id);
+    }
+    const total = Object.values(counts).reduce((acc, value) => acc + value, 0);
+    expect(total).toBe(FOOD_MAP_PLACES.length);
+  });
+
+  it("filterFoodMapPlaces returns the full list when filters are empty", () => {
+    const result = filterFoodMapPlaces(FOOD_MAP_PLACES, {
+      neighborhoods: [],
+      cuisines: [],
+      meal: "all",
+    });
+    expect(result).toHaveLength(FOOD_MAP_PLACES.length);
+  });
+
+  it("filterFoodMapPlaces narrows by meal and cuisine together", () => {
+    const result = filterFoodMapPlaces(FOOD_MAP_PLACES, {
+      neighborhoods: [],
+      cuisines: ["tacos"],
+      meal: "breakfast",
+    });
+
+    expect(result.length).toBeGreaterThan(0);
+    for (const place of result) {
+      expect(place.cuisine).toBe("tacos");
+      expect(place.meals).toContain("breakfast");
+    }
+  });
+
+  it("filterFoodMapPlaces narrows by neighborhood selection", () => {
+    const result = filterFoodMapPlaces(FOOD_MAP_PLACES, {
+      neighborhoods: ["south-lamar"],
+      cuisines: [],
+      meal: "all",
+    });
+
+    expect(result.length).toBeGreaterThan(0);
+    for (const place of result) {
+      expect(place.neighborhood).toBe("south-lamar");
+    }
+  });
+});

--- a/src/app/food-map/__tests__/food-map-state.test.ts
+++ b/src/app/food-map/__tests__/food-map-state.test.ts
@@ -1,0 +1,90 @@
+import {
+  buildFoodMapHref,
+  DEFAULT_FOOD_MAP_STATE,
+  normalizeFoodMapState,
+  resetFoodMapFilters,
+  setMeal,
+  setPick,
+  toggleCuisine,
+  toggleNeighborhood,
+} from "../food-map-state";
+
+describe("food-map-state", () => {
+  it("returns the default state when params are empty", () => {
+    expect(normalizeFoodMapState({})).toEqual(DEFAULT_FOOD_MAP_STATE);
+  });
+
+  it("drops invalid neighborhoods, cuisines, meal, and pick values", () => {
+    expect(
+      normalizeFoodMapState({
+        neighborhood: "east-austin,not-real,downtown",
+        cuisine: "tacos,nope",
+        meal: "midnight",
+        pick: "fake-place",
+      })
+    ).toEqual({
+      neighborhoods: ["east-austin", "downtown"],
+      cuisines: ["tacos"],
+      meal: "all",
+      pick: null,
+    });
+  });
+
+  it("dedupes repeated values inside a list parameter", () => {
+    expect(
+      normalizeFoodMapState({
+        cuisine: "tacos,tacos,coffee",
+      }).cuisines
+    ).toEqual(["tacos", "coffee"]);
+  });
+
+  it("omits default values when serializing the href", () => {
+    expect(buildFoodMapHref(DEFAULT_FOOD_MAP_STATE)).toBe("/food-map");
+    expect(
+      buildFoodMapHref({
+        neighborhoods: ["east-austin"],
+        cuisines: ["tacos", "coffee"],
+        meal: "breakfast",
+        pick: "veracruz-all-natural",
+      })
+    ).toBe(
+      "/food-map?neighborhood=east-austin&cuisine=tacos%2Ccoffee&meal=breakfast&pick=veracruz-all-natural"
+    );
+  });
+
+  it("toggles neighborhood and cuisine selections cleanly", () => {
+    const afterAdd = toggleNeighborhood(DEFAULT_FOOD_MAP_STATE, "east-austin");
+    expect(afterAdd.neighborhoods).toEqual(["east-austin"]);
+
+    const afterRemove = toggleNeighborhood(afterAdd, "east-austin");
+    expect(afterRemove.neighborhoods).toEqual([]);
+
+    const cuisineAdded = toggleCuisine(DEFAULT_FOOD_MAP_STATE, "tacos");
+    expect(cuisineAdded.cuisines).toEqual(["tacos"]);
+    expect(cuisineAdded.pick).toBeNull();
+  });
+
+  it("setMeal preserves filters and clears the pick", () => {
+    const base = setPick(DEFAULT_FOOD_MAP_STATE, "franklin-barbecue");
+    expect(base.pick).toBe("franklin-barbecue");
+
+    const next = setMeal(base, "lunch");
+    expect(next.meal).toBe("lunch");
+    expect(next.pick).toBeNull();
+  });
+
+  it("resetFoodMapFilters keeps the current pick", () => {
+    const filtered = {
+      neighborhoods: ["east-austin" as const],
+      cuisines: ["tacos" as const],
+      meal: "breakfast" as const,
+      pick: "veracruz-all-natural",
+    };
+
+    const reset = resetFoodMapFilters(filtered);
+    expect(reset).toEqual({
+      ...DEFAULT_FOOD_MAP_STATE,
+      pick: "veracruz-all-natural",
+    });
+  });
+});

--- a/src/app/food-map/__tests__/page.test.tsx
+++ b/src/app/food-map/__tests__/page.test.tsx
@@ -1,0 +1,47 @@
+import type { HTMLAttributes } from "react";
+import { render, screen } from "@testing-library/react";
+import FoodMapPage from "../page";
+
+let currentSearchParams = new URLSearchParams();
+
+jest.mock("@/components/StructuredData", () => ({
+  StructuredData: () => null,
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+  useSearchParams: () => currentSearchParams,
+}));
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  },
+  useReducedMotion: () => true,
+}));
+
+describe("FoodMapPage", () => {
+  beforeEach(() => {
+    currentSearchParams = new URLSearchParams();
+  });
+
+  it("renders one h1 and no nested main landmark", async () => {
+    const page = await FoodMapPage({ searchParams: Promise.resolve({}) });
+    const { container } = render(page);
+
+    expect(container.querySelectorAll("main")).toHaveLength(0);
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /the austin spots i send people to before they ask\./i,
+      })
+    ).toBeVisible();
+    expect(
+      screen.getByText(/I built this because I keep typing the same restaurant list/i)
+    ).toBeVisible();
+  });
+});

--- a/src/app/food-map/food-map-client.tsx
+++ b/src/app/food-map/food-map-client.tsx
@@ -1,0 +1,741 @@
+"use client";
+
+import { startTransition, useEffect, useMemo, type CSSProperties } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  FOOD_MAP_CUISINES,
+  FOOD_MAP_MEALS,
+  FOOD_MAP_NEIGHBORHOODS,
+  FOOD_MAP_PLACES,
+  countPlacesByNeighborhood,
+  filterFoodMapPlaces,
+  getFoodMapCuisine,
+  getFoodMapNeighborhood,
+  getFoodMapPlace,
+  type FoodMapCuisineId,
+  type FoodMapMealId,
+  type FoodMapNeighborhoodId,
+  type FoodMapPlace,
+} from "./food-map-data";
+import {
+  buildFoodMapHref,
+  DEFAULT_FOOD_MAP_STATE,
+  FOOD_MAP_ROUTE,
+  normalizeFoodMapState,
+  resetFoodMapFilters,
+  setMeal,
+  setPick,
+  toggleCuisine,
+  toggleNeighborhood,
+  type FoodMapState,
+} from "./food-map-state";
+
+interface FoodMapClientProps {
+  initialState: FoodMapState;
+}
+
+const fadeIn = {
+  hidden: { opacity: 0, y: 12 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.35 } },
+};
+
+const noMotion = {
+  hidden: { opacity: 1, y: 0 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0 } },
+};
+
+function getPanelStyle(): CSSProperties {
+  return {
+    background: "color-mix(in srgb, var(--home-paper-alt) 74%, var(--home-elev-mix))",
+    border: "1px solid var(--home-rule)",
+    boxShadow: "var(--shadow-sm)",
+  };
+}
+
+function NeighborhoodChips({
+  state,
+  onToggle,
+}: {
+  state: FoodMapState;
+  onToggle: (id: FoodMapNeighborhoodId) => void;
+}) {
+  const counts = countPlacesByNeighborhood(FOOD_MAP_PLACES);
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {FOOD_MAP_NEIGHBORHOODS.map((neighborhood) => {
+        const isActive = state.neighborhoods.includes(neighborhood.id);
+        return (
+          <button
+            key={neighborhood.id}
+            type="button"
+            onClick={() => onToggle(neighborhood.id)}
+            aria-pressed={isActive}
+            className="resume-chip min-h-touch transition-[transform,border-color,background-color,box-shadow] duration-200 ease"
+            style={{
+              borderColor: isActive
+                ? `color-mix(in srgb, ${neighborhood.accent} 45%, var(--home-rule))`
+                : "var(--home-rule)",
+              background: isActive
+                ? `color-mix(in srgb, ${neighborhood.accent} 18%, var(--home-paper))`
+                : "color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))",
+              color: "var(--home-ink)",
+            }}
+          >
+            {neighborhood.name}
+            <span
+              className="ml-2 text-[0.7rem] uppercase tracking-[0.12em]"
+              style={{ color: "var(--home-ink-muted)" }}
+            >
+              {counts[neighborhood.id] ?? 0}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function CuisineChips({
+  state,
+  onToggle,
+}: {
+  state: FoodMapState;
+  onToggle: (id: FoodMapCuisineId) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {FOOD_MAP_CUISINES.map((cuisine) => {
+        const isActive = state.cuisines.includes(cuisine.id);
+        return (
+          <button
+            key={cuisine.id}
+            type="button"
+            onClick={() => onToggle(cuisine.id)}
+            aria-pressed={isActive}
+            className="resume-chip min-h-touch transition-[transform,border-color,background-color,box-shadow] duration-200 ease"
+            style={{
+              borderColor: isActive
+                ? "color-mix(in srgb, var(--home-haze) 38%, var(--home-rule))"
+                : "var(--home-rule)",
+              background: isActive
+                ? "color-mix(in srgb, var(--home-haze) 14%, var(--home-paper))"
+                : "color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))",
+              color: "var(--home-ink)",
+            }}
+          >
+            {cuisine.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function MealSegmented({
+  state,
+  onChange,
+}: {
+  state: FoodMapState;
+  onChange: (meal: FoodMapMealId) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Filter by meal"
+      className="flex flex-wrap gap-1 rounded-full p-1"
+      style={getPanelStyle()}
+    >
+      {FOOD_MAP_MEALS.map((meal) => {
+        const isActive = state.meal === meal.id;
+        return (
+          <button
+            key={meal.id}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            onClick={() => onChange(meal.id)}
+            className="min-h-touch rounded-full px-4 py-2 text-sm font-semibold transition-[transform,border-color,background-color,color] duration-200 ease"
+            style={{
+              background: isActive
+                ? "color-mix(in srgb, var(--home-haze) 18%, var(--home-paper))"
+                : "transparent",
+              color: "var(--home-ink)",
+              fontFamily: "var(--font-home-sans)",
+              border: isActive
+                ? "1px solid color-mix(in srgb, var(--home-haze) 35%, var(--home-rule))"
+                : "1px solid transparent",
+            }}
+          >
+            {meal.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function FoodMapSvg({
+  state,
+  visiblePlaces,
+  onSelectPlace,
+  onToggleNeighborhood,
+}: {
+  state: FoodMapState;
+  visiblePlaces: ReadonlyArray<FoodMapPlace>;
+  onSelectPlace: (id: string) => void;
+  onToggleNeighborhood: (id: FoodMapNeighborhoodId) => void;
+}) {
+  const visibleIds = useMemo(
+    () => new Set(visiblePlaces.map((place) => place.id)),
+    [visiblePlaces]
+  );
+
+  return (
+    <div
+      className="home-card overflow-hidden p-4 sm:p-5"
+      style={getPanelStyle()}
+    >
+      <svg
+        viewBox="0 0 100 100"
+        role="img"
+        aria-label="Stylized Austin food map showing curated restaurant pins by neighborhood"
+        className="block h-auto w-full"
+      >
+        <rect
+          x={0}
+          y={0}
+          width={100}
+          height={100}
+          fill="color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))"
+        />
+
+        {FOOD_MAP_NEIGHBORHOODS.map((neighborhood) => {
+          const isActive = state.neighborhoods.includes(neighborhood.id);
+          const fillStrength = isActive ? 24 : 12;
+          const strokeStrength = isActive ? 55 : 25;
+
+          return (
+            <g
+              key={neighborhood.id}
+              className="cursor-pointer"
+              onClick={() => onToggleNeighborhood(neighborhood.id)}
+            >
+              <rect
+                x={neighborhood.shape.x}
+                y={neighborhood.shape.y}
+                width={neighborhood.shape.width}
+                height={neighborhood.shape.height}
+                rx={2.4}
+                fill={`color-mix(in srgb, ${neighborhood.accent} ${fillStrength}%, var(--home-paper))`}
+                stroke={`color-mix(in srgb, ${neighborhood.accent} ${strokeStrength}%, var(--home-rule))`}
+                strokeWidth={0.5}
+              />
+              <text
+                x={neighborhood.labelX}
+                y={neighborhood.labelY}
+                textAnchor="middle"
+                style={{
+                  fill: "var(--home-ink-muted)",
+                  fontFamily: "var(--font-home-sans)",
+                  fontSize: "2.4px",
+                  fontWeight: 700,
+                  letterSpacing: "0.16em",
+                  textTransform: "uppercase",
+                }}
+              >
+                {neighborhood.name}
+              </text>
+            </g>
+          );
+        })}
+
+        <path
+          d="M 6 51 Q 22 47 38 51 Q 54 55 70 51 Q 86 47 96 53 L 96 56 Q 86 50 70 54 Q 54 58 38 54 Q 22 50 6 54 Z"
+          fill="color-mix(in srgb, var(--home-haze) 32%, var(--home-paper))"
+          stroke="color-mix(in srgb, var(--home-haze) 45%, var(--home-rule))"
+          strokeWidth={0.4}
+        />
+        <text
+          x={50}
+          y={54}
+          textAnchor="middle"
+          style={{
+            fill: "var(--home-ink-muted)",
+            fontFamily: "var(--font-home-sans)",
+            fontSize: "1.9px",
+            fontWeight: 600,
+            letterSpacing: "0.18em",
+            textTransform: "uppercase",
+          }}
+        >
+          Lady Bird Lake
+        </text>
+
+        {FOOD_MAP_PLACES.map((place) => {
+          const isVisible = visibleIds.has(place.id);
+          const isSelected = state.pick === place.id;
+          const radius = isSelected ? 2.4 : 1.6;
+          const fill = isSelected
+            ? "var(--home-haze)"
+            : isVisible
+              ? "var(--home-ink)"
+              : "color-mix(in srgb, var(--home-ink) 28%, var(--home-paper))";
+          const stroke = isSelected ? "var(--home-paper)" : "transparent";
+          const strokeWidth = isSelected ? 0.7 : 0;
+
+          return (
+            <g
+              key={place.id}
+              className="cursor-pointer"
+              onClick={() => isVisible && onSelectPlace(place.id)}
+              aria-label={`Select ${place.name}`}
+              role="button"
+              opacity={isVisible ? 1 : 0.45}
+            >
+              <circle
+                cx={place.x}
+                cy={place.y}
+                r={radius}
+                fill={fill}
+                stroke={stroke}
+                strokeWidth={strokeWidth}
+              />
+              {isSelected ? (
+                <text
+                  x={place.x}
+                  y={place.y - 3.4}
+                  textAnchor="middle"
+                  style={{
+                    fill: "var(--home-ink)",
+                    fontFamily: "var(--font-home-sans)",
+                    fontSize: "2px",
+                    fontWeight: 700,
+                    letterSpacing: "0.06em",
+                  }}
+                >
+                  {place.name}
+                </text>
+              ) : null}
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+function PlaceCard({
+  place,
+  isSelected,
+  onSelect,
+}: {
+  place: FoodMapPlace;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const neighborhood = getFoodMapNeighborhood(place.neighborhood);
+  const cuisine = getFoodMapCuisine(place.cuisine);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(place.id)}
+      aria-pressed={isSelected}
+      className="home-card min-h-touch w-full rounded-[1.25rem] p-4 text-left transition-[transform,border-color,background-color,box-shadow] duration-200 ease"
+      style={{
+        ...getPanelStyle(),
+        background: isSelected
+          ? `color-mix(in srgb, ${neighborhood.accent} 14%, var(--home-paper))`
+          : "color-mix(in srgb, var(--home-paper-alt) 70%, var(--home-elev-mix))",
+        borderColor: isSelected
+          ? `color-mix(in srgb, ${neighborhood.accent} 35%, var(--home-rule))`
+          : "var(--home-rule)",
+        boxShadow: isSelected ? "var(--shadow-md)" : "var(--shadow-sm)",
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="home-kicker mb-1">{cuisine.label}</p>
+          <p
+            className="mb-1 text-base font-semibold tracking-[-0.03em]"
+            style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
+          >
+            {place.name}
+          </p>
+          <p
+            className="mb-0 text-sm leading-relaxed"
+            style={{ color: "var(--home-ink-muted)" }}
+          >
+            {neighborhood.name}
+          </p>
+        </div>
+        <span
+          className="resume-chip"
+          style={{
+            borderColor: "var(--home-rule)",
+            background: "color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))",
+          }}
+        >
+          {place.price}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+function PlaceDetail({
+  place,
+  onClear,
+}: {
+  place: FoodMapPlace;
+  onClear: () => void;
+}) {
+  const neighborhood = getFoodMapNeighborhood(place.neighborhood);
+  const cuisine = getFoodMapCuisine(place.cuisine);
+  const mealLabels = place.meals.map((meal) =>
+    meal.charAt(0).toUpperCase() + meal.slice(1)
+  );
+
+  return (
+    <div
+      className="home-card h-full p-5 sm:p-6"
+      style={{
+        ...getPanelStyle(),
+        background: `color-mix(in srgb, ${neighborhood.accent} 12%, var(--home-paper))`,
+        borderColor: `color-mix(in srgb, ${neighborhood.accent} 30%, var(--home-rule))`,
+      }}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="home-kicker mb-1">{cuisine.label}</p>
+          <h2
+            className="text-[1.45rem] font-semibold tracking-[-0.04em]"
+            style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
+          >
+            {place.name}
+          </h2>
+          <p
+            className="mb-0 mt-1 text-sm leading-relaxed"
+            style={{ color: "var(--home-ink-muted)" }}
+          >
+            {neighborhood.name} · {place.price}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClear}
+          className="min-h-touch rounded-full px-4 py-2 text-sm font-semibold transition-[transform,border-color,background-color,color] duration-200 ease"
+          style={{
+            ...getPanelStyle(),
+            color: "var(--home-ink)",
+            fontFamily: "var(--font-home-sans)",
+          }}
+        >
+          Clear pick
+        </button>
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-[1.2rem] px-4 py-4" style={getPanelStyle()}>
+          <p className="home-kicker mb-1">Order</p>
+          <p
+            className="mb-0 text-base font-semibold tracking-[-0.03em]"
+            style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
+          >
+            {place.signature}
+          </p>
+        </div>
+        <div className="rounded-[1.2rem] px-4 py-4" style={getPanelStyle()}>
+          <p className="home-kicker mb-1">Best for</p>
+          <p
+            className="mb-0 text-base font-semibold tracking-[-0.03em]"
+            style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
+          >
+            {mealLabels.join(" · ")}
+          </p>
+        </div>
+      </div>
+
+      <p
+        className="mt-5 text-[1rem] leading-relaxed"
+        style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
+      >
+        {place.why}
+      </p>
+    </div>
+  );
+}
+
+function FoodMapWorkbench({
+  routeState,
+  variants,
+  onCommit,
+}: {
+  routeState: FoodMapState;
+  variants: typeof fadeIn;
+  onCommit: (next: FoodMapState) => void;
+}) {
+  const visiblePlaces = useMemo(
+    () =>
+      filterFoodMapPlaces(FOOD_MAP_PLACES, {
+        neighborhoods: routeState.neighborhoods,
+        cuisines: routeState.cuisines,
+        meal: routeState.meal,
+      }),
+    [routeState.neighborhoods, routeState.cuisines, routeState.meal]
+  );
+
+  const selectedPlace = routeState.pick ? getFoodMapPlace(routeState.pick) : undefined;
+
+  const hasFilters =
+    routeState.neighborhoods.length > 0 ||
+    routeState.cuisines.length > 0 ||
+    routeState.meal !== DEFAULT_FOOD_MAP_STATE.meal;
+
+  function handleToggleNeighborhood(id: FoodMapNeighborhoodId) {
+    onCommit(toggleNeighborhood(routeState, id));
+  }
+
+  function handleToggleCuisine(id: FoodMapCuisineId) {
+    onCommit(toggleCuisine(routeState, id));
+  }
+
+  function handleSetMeal(meal: FoodMapMealId) {
+    onCommit(setMeal(routeState, meal));
+  }
+
+  function handleSelectPlace(id: string) {
+    onCommit(setPick(routeState, id));
+  }
+
+  function handleClearPick() {
+    onCommit(setPick(routeState, null));
+  }
+
+  function handleResetFilters() {
+    onCommit(resetFoodMapFilters(routeState));
+  }
+
+  return (
+    <section
+      className="home-page min-h-screen"
+      aria-label="Food Map"
+      data-testid="food-map-shell"
+    >
+      <div className="home-shell home-section space-y-6 sm:space-y-8">
+        <motion.div variants={variants} initial="hidden" animate="visible">
+          <div className="space-y-4">
+            <p className="home-kicker">Food Map</p>
+            <h1
+              className="max-w-4xl text-balance"
+              style={{
+                color: "var(--home-ink)",
+                fontFamily: "var(--font-home-sans)",
+                fontSize: "clamp(2.6rem, 6vw, 5rem)",
+                fontWeight: 600,
+                lineHeight: 0.94,
+                letterSpacing: "-0.08em",
+              }}
+            >
+              The Austin spots I send people to before they ask.
+            </h1>
+            <p className="home-body max-w-[42rem]">
+              I built this because I keep typing the same restaurant list into
+              text threads. The map keeps my actual go-tos in one place, sorted
+              by neighborhood, cuisine, and what time of day I would actually be
+              there. It is opinionated on purpose. I would rather give a short,
+              honest list than a long one I do not stand behind.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <span className="resume-chip">{FOOD_MAP_PLACES.length} curated stops</span>
+              <span className="resume-chip">4 neighborhoods</span>
+              <span className="resume-chip">Deep-linkable filters</span>
+            </div>
+          </div>
+        </motion.div>
+
+        <motion.div variants={variants} initial="hidden" animate="visible">
+          <div
+            className="home-card p-5 sm:p-6"
+            style={getPanelStyle()}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p className="home-kicker mb-1">Filters</p>
+                <h2
+                  className="text-[1.2rem] font-semibold tracking-[-0.04em]"
+                  style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
+                >
+                  Narrow the map by neighborhood, cuisine, or meal
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={handleResetFilters}
+                disabled={!hasFilters}
+                className="min-h-touch rounded-full px-4 py-2 text-sm font-semibold transition-[transform,border-color,background-color,color,box-shadow] duration-200 ease disabled:cursor-not-allowed disabled:opacity-55"
+                style={{
+                  ...getPanelStyle(),
+                  color: "var(--home-ink)",
+                  fontFamily: "var(--font-home-sans)",
+                }}
+              >
+                Reset filters
+              </button>
+            </div>
+
+            <div className="mt-5 space-y-4">
+              <div>
+                <p className="home-kicker mb-2">Neighborhood</p>
+                <NeighborhoodChips
+                  state={routeState}
+                  onToggle={handleToggleNeighborhood}
+                />
+              </div>
+              <div>
+                <p className="home-kicker mb-2">Cuisine</p>
+                <CuisineChips state={routeState} onToggle={handleToggleCuisine} />
+              </div>
+              <div>
+                <p className="home-kicker mb-2">Meal</p>
+                <MealSegmented state={routeState} onChange={handleSetMeal} />
+              </div>
+            </div>
+          </div>
+        </motion.div>
+
+        <motion.div variants={variants} initial="hidden" animate="visible">
+          <div className="grid gap-5 xl:grid-cols-[1.05fr_0.95fr]">
+            <FoodMapSvg
+              state={routeState}
+              visiblePlaces={visiblePlaces}
+              onSelectPlace={handleSelectPlace}
+              onToggleNeighborhood={handleToggleNeighborhood}
+            />
+
+            {selectedPlace ? (
+              <PlaceDetail place={selectedPlace} onClear={handleClearPick} />
+            ) : (
+              <div
+                className="home-card flex h-full flex-col justify-between p-5 sm:p-6"
+                style={getPanelStyle()}
+              >
+                <div>
+                  <p className="home-kicker mb-2">Pick</p>
+                  <h2
+                    className="text-[1.2rem] font-semibold tracking-[-0.04em]"
+                    style={{
+                      color: "var(--home-ink)",
+                      fontFamily: "var(--font-home-sans)",
+                    }}
+                  >
+                    Tap a pin or a card to see why it earns the spot.
+                  </h2>
+                  <p
+                    className="mt-3 text-sm leading-relaxed"
+                    style={{ color: "var(--home-ink-muted)" }}
+                  >
+                    Each entry has the order I land on, the meal I would
+                    actually go for, and a short note on what makes the room
+                    work. Filters and picks both encode in the URL, so the
+                    shortlist I send a friend is just a link.
+                  </p>
+                </div>
+                <p
+                  className="mb-0 mt-5 text-sm"
+                  style={{ color: "var(--home-ink-muted)" }}
+                >
+                  Showing {visiblePlaces.length} of {FOOD_MAP_PLACES.length} spots.
+                </p>
+              </div>
+            )}
+          </div>
+        </motion.div>
+
+        <motion.div variants={variants} initial="hidden" animate="visible">
+          <div
+            className="home-card p-5 sm:p-6"
+            style={getPanelStyle()}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p className="home-kicker mb-1">Shortlist</p>
+                <h2
+                  className="text-[1.2rem] font-semibold tracking-[-0.04em]"
+                  style={{
+                    color: "var(--home-ink)",
+                    fontFamily: "var(--font-home-sans)",
+                  }}
+                >
+                  {visiblePlaces.length === 0
+                    ? "Nothing matches that combination yet."
+                    : `${visiblePlaces.length} ${visiblePlaces.length === 1 ? "spot" : "spots"} on this filter`}
+                </h2>
+              </div>
+            </div>
+
+            {visiblePlaces.length === 0 ? (
+              <p
+                className="mt-4 mb-0 text-sm leading-relaxed"
+                style={{ color: "var(--home-ink-muted)" }}
+              >
+                The list intentionally stays short, so a few filters can rule it
+                out entirely. Reset to see the full map.
+              </p>
+            ) : (
+              <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                {visiblePlaces.map((place) => (
+                  <PlaceCard
+                    key={place.id}
+                    place={place}
+                    isSelected={routeState.pick === place.id}
+                    onSelect={handleSelectPlace}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+export function FoodMapClient({ initialState }: FoodMapClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const shouldReduceMotion = useReducedMotion();
+  const variants = shouldReduceMotion ? noMotion : fadeIn;
+
+  const normalizedRouteState = normalizeFoodMapState(searchParams);
+  const currentQuery = searchParams.toString();
+  const currentHref = currentQuery ? `${FOOD_MAP_ROUTE}?${currentQuery}` : FOOD_MAP_ROUTE;
+  const canonicalHref = buildFoodMapHref(normalizedRouteState);
+  const hasManagedParams =
+    searchParams.get("neighborhood") !== null ||
+    searchParams.get("cuisine") !== null ||
+    searchParams.get("meal") !== null ||
+    searchParams.get("pick") !== null;
+  const routeState = hasManagedParams ? normalizedRouteState : initialState;
+
+  useEffect(() => {
+    if (hasManagedParams && currentHref !== canonicalHref) {
+      startTransition(() => {
+        router.replace(canonicalHref, { scroll: false });
+      });
+    }
+  }, [canonicalHref, currentHref, hasManagedParams, router]);
+
+  return (
+    <FoodMapWorkbench
+      key={buildFoodMapHref(routeState)}
+      routeState={routeState}
+      variants={variants}
+      onCommit={(next) =>
+        router.replace(buildFoodMapHref(next), { scroll: false })
+      }
+    />
+  );
+}

--- a/src/app/food-map/food-map-data.ts
+++ b/src/app/food-map/food-map-data.ts
@@ -1,0 +1,371 @@
+export const FOOD_MAP_NEIGHBORHOOD_IDS = [
+  "east-austin",
+  "downtown",
+  "south-congress",
+  "south-lamar",
+] as const;
+
+export type FoodMapNeighborhoodId = (typeof FOOD_MAP_NEIGHBORHOOD_IDS)[number];
+
+export const FOOD_MAP_CUISINE_IDS = [
+  "barbecue",
+  "tacos",
+  "mexican",
+  "japanese",
+  "asian",
+  "pizza",
+  "american",
+  "seafood",
+  "coffee",
+] as const;
+
+export type FoodMapCuisineId = (typeof FOOD_MAP_CUISINE_IDS)[number];
+
+export const FOOD_MAP_MEAL_IDS = [
+  "all",
+  "breakfast",
+  "lunch",
+  "dinner",
+  "coffee",
+] as const;
+
+export type FoodMapMealId = (typeof FOOD_MAP_MEAL_IDS)[number];
+
+export interface FoodMapNeighborhood {
+  id: FoodMapNeighborhoodId;
+  name: string;
+  blurb: string;
+  shape: { x: number; y: number; width: number; height: number };
+  labelX: number;
+  labelY: number;
+  accent: string;
+}
+
+export interface FoodMapCuisine {
+  id: FoodMapCuisineId;
+  label: string;
+}
+
+export interface FoodMapMeal {
+  id: FoodMapMealId;
+  label: string;
+}
+
+export interface FoodMapPlace {
+  id: string;
+  name: string;
+  neighborhood: FoodMapNeighborhoodId;
+  cuisine: FoodMapCuisineId;
+  meals: ReadonlyArray<Exclude<FoodMapMealId, "all">>;
+  price: "$" | "$$" | "$$$";
+  signature: string;
+  why: string;
+  x: number;
+  y: number;
+}
+
+export const FOOD_MAP_NEIGHBORHOODS: readonly FoodMapNeighborhood[] = [
+  {
+    id: "east-austin",
+    name: "East Austin",
+    blurb:
+      "I send people here first. The density of barbecue, taquerias, and dinner rooms doing their own thing is hard to match anywhere else in town.",
+    shape: { x: 56, y: 22, width: 32, height: 26 },
+    labelX: 72,
+    labelY: 19,
+    accent: "var(--home-haze)",
+  },
+  {
+    id: "downtown",
+    name: "Downtown",
+    blurb:
+      "I think of downtown as the workday option. It is more about a reliable hotel-bar dinner than a spot I would drive across town for.",
+    shape: { x: 30, y: 30, width: 22, height: 18 },
+    labelX: 41,
+    labelY: 27,
+    accent: "var(--home-moss)",
+  },
+  {
+    id: "south-congress",
+    name: "South Congress",
+    blurb:
+      "South Congress is where I take visitors when they want the all-day version of Austin food, from breakfast through oysters at night.",
+    shape: { x: 36, y: 58, width: 24, height: 22 },
+    labelX: 48,
+    labelY: 84,
+    accent: "var(--home-acid)",
+  },
+  {
+    id: "south-lamar",
+    name: "South Lamar",
+    blurb:
+      "South Lamar is the one I pick when I want a longer dinner. The rooms feel a little more grown up and the cooking has more reps behind it.",
+    shape: { x: 14, y: 58, width: 22, height: 22 },
+    labelX: 25,
+    labelY: 84,
+    accent: "var(--home-ink)",
+  },
+] as const;
+
+export const FOOD_MAP_CUISINES: readonly FoodMapCuisine[] = [
+  { id: "barbecue", label: "Barbecue" },
+  { id: "tacos", label: "Tacos" },
+  { id: "mexican", label: "Mexican" },
+  { id: "japanese", label: "Japanese" },
+  { id: "asian", label: "Asian smokehouse" },
+  { id: "pizza", label: "Pizza" },
+  { id: "american", label: "American" },
+  { id: "seafood", label: "Seafood" },
+  { id: "coffee", label: "Coffee" },
+] as const;
+
+export const FOOD_MAP_MEALS: readonly FoodMapMeal[] = [
+  { id: "all", label: "All meals" },
+  { id: "breakfast", label: "Breakfast" },
+  { id: "lunch", label: "Lunch" },
+  { id: "dinner", label: "Dinner" },
+  { id: "coffee", label: "Coffee" },
+] as const;
+
+export const FOOD_MAP_PLACES: readonly FoodMapPlace[] = [
+  {
+    id: "franklin-barbecue",
+    name: "Franklin Barbecue",
+    neighborhood: "east-austin",
+    cuisine: "barbecue",
+    meals: ["lunch"],
+    price: "$$",
+    signature: "Brisket, fatty end",
+    why: "The line is the price of admission, and I think it still earns it. I plan a Franklin lunch like an event, not a casual stop.",
+    x: 64,
+    y: 32,
+  },
+  {
+    id: "la-barbecue",
+    name: "La Barbecue",
+    neighborhood: "east-austin",
+    cuisine: "barbecue",
+    meals: ["lunch"],
+    price: "$$",
+    signature: "Brisket plate with the sausage add-on",
+    why: "I rotate La Barbecue in when I want the same caliber of brisket without committing the whole morning to a queue.",
+    x: 71,
+    y: 41,
+  },
+  {
+    id: "veracruz-all-natural",
+    name: "Veracruz All Natural",
+    neighborhood: "east-austin",
+    cuisine: "tacos",
+    meals: ["breakfast", "lunch"],
+    price: "$",
+    signature: "Migas taco",
+    why: "I think the migas taco is the single best argument for Austin breakfast. I order two and never feel like that was a mistake.",
+    x: 60,
+    y: 38,
+  },
+  {
+    id: "suerte",
+    name: "Suerte",
+    neighborhood: "east-austin",
+    cuisine: "mexican",
+    meals: ["dinner"],
+    price: "$$$",
+    signature: "Suadero tacos",
+    why: "Suerte is where I take dinners that need to land. The masa work alone makes it the most distinctive Mexican kitchen in town.",
+    x: 75,
+    y: 35,
+  },
+  {
+    id: "kemuri-tatsu-ya",
+    name: "Kemuri Tatsu-ya",
+    neighborhood: "east-austin",
+    cuisine: "japanese",
+    meals: ["dinner"],
+    price: "$$",
+    signature: "Brisket ramen",
+    why: "I love that Kemuri does not pretend Texas and Japan are separate ideas. The brisket ramen reads as a real dish, not a gimmick.",
+    x: 80,
+    y: 28,
+  },
+  {
+    id: "cuvee-coffee",
+    name: "Cuvée Coffee",
+    neighborhood: "east-austin",
+    cuisine: "coffee",
+    meals: ["coffee", "breakfast"],
+    price: "$",
+    signature: "Black & Blue nitro",
+    why: "I write here when I need a long, quiet morning. The nitro is the one I miss when I am out of town.",
+    x: 58,
+    y: 44,
+  },
+  {
+    id: "uchi",
+    name: "Uchi",
+    neighborhood: "south-lamar",
+    cuisine: "japanese",
+    meals: ["dinner"],
+    price: "$$$",
+    signature: "Hama chili",
+    why: "Uchi is the dinner I send out-of-town friends to when they want the full version. The hama chili still sets the bar.",
+    x: 25,
+    y: 64,
+  },
+  {
+    id: "loro",
+    name: "Loro",
+    neighborhood: "south-lamar",
+    cuisine: "asian",
+    meals: ["lunch", "dinner"],
+    price: "$$",
+    signature: "Oak-grilled hamachi",
+    why: "Loro is my answer when someone wants smoke and a patio without the Franklin commitment. I usually start with the hamachi and a slushie.",
+    x: 31,
+    y: 71,
+  },
+  {
+    id: "home-slice-pizza",
+    name: "Home Slice Pizza",
+    neighborhood: "south-congress",
+    cuisine: "pizza",
+    meals: ["lunch", "dinner"],
+    price: "$",
+    signature: "Cheese slice, doubled up",
+    why: "I think Home Slice is the most honest pizza in town. I order two cheese slices and walk South Congress like a tourist on purpose.",
+    x: 45,
+    y: 70,
+  },
+  {
+    id: "junes-all-day",
+    name: "June's All Day",
+    neighborhood: "south-congress",
+    cuisine: "american",
+    meals: ["breakfast", "lunch", "dinner"],
+    price: "$$",
+    signature: "Breakfast sandwich",
+    why: "June's is my default when I cannot tell what meal I am in the mood for. The room flexes between brunch and dinner without losing the thread.",
+    x: 51,
+    y: 64,
+  },
+  {
+    id: "perlas",
+    name: "Perla's",
+    neighborhood: "south-congress",
+    cuisine: "seafood",
+    meals: ["dinner"],
+    price: "$$$",
+    signature: "Oyster tower",
+    why: "Perla's is the patio I pick when the night needs to feel like a proper Austin evening. Oysters first, then whatever the chalkboard says.",
+    x: 49,
+    y: 78,
+  },
+  {
+    id: "eberly",
+    name: "Eberly",
+    neighborhood: "downtown",
+    cuisine: "american",
+    meals: ["dinner"],
+    price: "$$",
+    signature: "Cedar Tavern bar snacks",
+    why: "Eberly is my downtown move when the night is part work, part dinner. The Cedar Tavern bar still feels like the city's living room.",
+    x: 39,
+    y: 43,
+  },
+] as const;
+
+const neighborhoodMap = new Map(
+  FOOD_MAP_NEIGHBORHOODS.map((entry) => [entry.id, entry])
+);
+const cuisineMap = new Map(FOOD_MAP_CUISINES.map((entry) => [entry.id, entry]));
+const mealMap = new Map(FOOD_MAP_MEALS.map((entry) => [entry.id, entry]));
+const placeMap = new Map(FOOD_MAP_PLACES.map((entry) => [entry.id, entry]));
+
+export function isFoodMapNeighborhoodId(
+  value: string | null | undefined
+): value is FoodMapNeighborhoodId {
+  return Boolean(value && neighborhoodMap.has(value as FoodMapNeighborhoodId));
+}
+
+export function isFoodMapCuisineId(
+  value: string | null | undefined
+): value is FoodMapCuisineId {
+  return Boolean(value && cuisineMap.has(value as FoodMapCuisineId));
+}
+
+export function isFoodMapMealId(
+  value: string | null | undefined
+): value is FoodMapMealId {
+  return Boolean(value && mealMap.has(value as FoodMapMealId));
+}
+
+export function isFoodMapPlaceId(value: string | null | undefined): boolean {
+  return Boolean(value && placeMap.has(value));
+}
+
+export function getFoodMapNeighborhood(
+  id: FoodMapNeighborhoodId
+): FoodMapNeighborhood {
+  return neighborhoodMap.get(id) ?? FOOD_MAP_NEIGHBORHOODS[0];
+}
+
+export function getFoodMapCuisine(id: FoodMapCuisineId): FoodMapCuisine {
+  return cuisineMap.get(id) ?? FOOD_MAP_CUISINES[0];
+}
+
+export function getFoodMapPlace(id: string): FoodMapPlace | undefined {
+  return placeMap.get(id);
+}
+
+export interface FoodMapFilters {
+  neighborhoods: ReadonlyArray<FoodMapNeighborhoodId>;
+  cuisines: ReadonlyArray<FoodMapCuisineId>;
+  meal: FoodMapMealId;
+}
+
+export function filterFoodMapPlaces(
+  places: ReadonlyArray<FoodMapPlace>,
+  filters: FoodMapFilters
+): FoodMapPlace[] {
+  return places.filter((place) => {
+    if (
+      filters.neighborhoods.length > 0 &&
+      !filters.neighborhoods.includes(place.neighborhood)
+    ) {
+      return false;
+    }
+
+    if (
+      filters.cuisines.length > 0 &&
+      !filters.cuisines.includes(place.cuisine)
+    ) {
+      return false;
+    }
+
+    if (
+      filters.meal !== "all" &&
+      !place.meals.includes(filters.meal as Exclude<FoodMapMealId, "all">)
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+export function countPlacesByNeighborhood(
+  places: ReadonlyArray<FoodMapPlace>
+): Record<FoodMapNeighborhoodId, number> {
+  const counts = FOOD_MAP_NEIGHBORHOODS.reduce<
+    Record<FoodMapNeighborhoodId, number>
+  >((acc, neighborhood) => {
+    acc[neighborhood.id] = 0;
+    return acc;
+  }, {} as Record<FoodMapNeighborhoodId, number>);
+
+  for (const place of places) {
+    counts[place.neighborhood] = (counts[place.neighborhood] ?? 0) + 1;
+  }
+
+  return counts;
+}

--- a/src/app/food-map/food-map-state.ts
+++ b/src/app/food-map/food-map-state.ts
@@ -1,0 +1,146 @@
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import {
+  isFoodMapCuisineId,
+  isFoodMapMealId,
+  isFoodMapNeighborhoodId,
+  isFoodMapPlaceId,
+  type FoodMapCuisineId,
+  type FoodMapMealId,
+  type FoodMapNeighborhoodId,
+} from "./food-map-data";
+
+type SearchParamInput =
+  | URLSearchParams
+  | ReadonlyURLSearchParams
+  | Record<string, string | string[] | undefined | null>;
+
+export interface FoodMapState {
+  neighborhoods: ReadonlyArray<FoodMapNeighborhoodId>;
+  cuisines: ReadonlyArray<FoodMapCuisineId>;
+  meal: FoodMapMealId;
+  pick: string | null;
+}
+
+export const FOOD_MAP_ROUTE = "/food-map";
+
+export const DEFAULT_FOOD_MAP_STATE: FoodMapState = {
+  neighborhoods: [],
+  cuisines: [],
+  meal: "all",
+  pick: null,
+};
+
+function readParam(input: SearchParamInput, key: string): string | null {
+  if ("get" in input && typeof input.get === "function") {
+    return (input as URLSearchParams).get(key);
+  }
+
+  const rawValue = (input as Record<string, string | string[] | undefined | null>)[key];
+  if (Array.isArray(rawValue)) {
+    return rawValue[0] ?? null;
+  }
+  return rawValue ?? null;
+}
+
+function parseList(raw: string | null): string[] {
+  if (!raw) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const piece of raw.split(",")) {
+    const trimmed = piece.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+
+  return result;
+}
+
+export function normalizeFoodMapState(input: SearchParamInput): FoodMapState {
+  const neighborhoods = parseList(readParam(input, "neighborhood")).filter(
+    isFoodMapNeighborhoodId
+  );
+  const cuisines = parseList(readParam(input, "cuisine")).filter(
+    isFoodMapCuisineId
+  );
+
+  const rawMeal = readParam(input, "meal");
+  const meal: FoodMapMealId = isFoodMapMealId(rawMeal)
+    ? rawMeal
+    : DEFAULT_FOOD_MAP_STATE.meal;
+
+  const rawPick = readParam(input, "pick");
+  const pick = isFoodMapPlaceId(rawPick) ? rawPick : null;
+
+  return {
+    neighborhoods,
+    cuisines,
+    meal,
+    pick,
+  };
+}
+
+export function buildFoodMapHref(state: FoodMapState): string {
+  const params = new URLSearchParams();
+
+  if (state.neighborhoods.length > 0) {
+    params.set("neighborhood", state.neighborhoods.join(","));
+  }
+
+  if (state.cuisines.length > 0) {
+    params.set("cuisine", state.cuisines.join(","));
+  }
+
+  if (state.meal !== DEFAULT_FOOD_MAP_STATE.meal) {
+    params.set("meal", state.meal);
+  }
+
+  if (state.pick) {
+    params.set("pick", state.pick);
+  }
+
+  const query = params.toString();
+  return query ? `${FOOD_MAP_ROUTE}?${query}` : FOOD_MAP_ROUTE;
+}
+
+export function toggleNeighborhood(
+  state: FoodMapState,
+  neighborhood: FoodMapNeighborhoodId
+): FoodMapState {
+  const exists = state.neighborhoods.includes(neighborhood);
+  const next = exists
+    ? state.neighborhoods.filter((entry) => entry !== neighborhood)
+    : [...state.neighborhoods, neighborhood];
+
+  return { ...state, neighborhoods: next, pick: null };
+}
+
+export function toggleCuisine(
+  state: FoodMapState,
+  cuisine: FoodMapCuisineId
+): FoodMapState {
+  const exists = state.cuisines.includes(cuisine);
+  const next = exists
+    ? state.cuisines.filter((entry) => entry !== cuisine)
+    : [...state.cuisines, cuisine];
+
+  return { ...state, cuisines: next, pick: null };
+}
+
+export function setMeal(state: FoodMapState, meal: FoodMapMealId): FoodMapState {
+  return { ...state, meal, pick: null };
+}
+
+export function setPick(state: FoodMapState, pick: string | null): FoodMapState {
+  return { ...state, pick };
+}
+
+export function resetFoodMapFilters(state: FoodMapState): FoodMapState {
+  return { ...DEFAULT_FOOD_MAP_STATE, pick: state.pick };
+}

--- a/src/app/food-map/page.tsx
+++ b/src/app/food-map/page.tsx
@@ -1,0 +1,84 @@
+import { StructuredData } from "@/components/StructuredData";
+import { constructMetadata, generateBreadcrumbStructuredData } from "@/lib/seo";
+import { FoodMapClient } from "./food-map-client";
+import { normalizeFoodMapState } from "./food-map-state";
+
+export const metadata = constructMetadata({
+  title: "Food Map | Isaac Vazquez",
+  description:
+    "A curated, deep-linkable map of the Austin restaurants I send people to first, filterable by neighborhood, cuisine, and meal.",
+  canonicalUrl: "/food-map",
+  dateModified: "2026-04-28",
+  aiMetadata: {
+    profession: "Product Manager",
+    specialty: "Editorial product surfaces, deep-linkable filtering, and curated city guides",
+    expertise: [
+      "Next.js",
+      "Editorial UI",
+      "Deep-linkable state",
+      "Curated content design",
+    ],
+    industry: ["Food & Beverage", "Travel", "Local Guides"],
+    topics: [
+      "austin restaurants",
+      "austin food map",
+      "curated city guide",
+      "neighborhood food map",
+    ],
+    contentType: "Software Application",
+    context:
+      "Standalone food map by Isaac Vazquez that turns a personal Austin shortlist into a deep-linkable product surface.",
+    summary:
+      "Curated Austin restaurant map with neighborhood, cuisine, and meal filters and a shareable URL state.",
+    primaryFocus:
+      "Curated city guides, editorial product UX, and deep-linkable filtering models",
+  },
+});
+
+interface FoodMapPageProps {
+  searchParams: Promise<{
+    neighborhood?: string;
+    cuisine?: string;
+    meal?: string;
+    pick?: string;
+  }>;
+}
+
+export default async function FoodMapPage({ searchParams }: FoodMapPageProps) {
+  const initialState = normalizeFoodMapState(await searchParams);
+  const breadcrumbs = [
+    { name: "Home", url: "/" },
+    { name: "Food Map", url: "/food-map" },
+  ];
+
+  return (
+    <>
+      <StructuredData
+        type="BreadcrumbList"
+        data={{
+          items: (generateBreadcrumbStructuredData(breadcrumbs) as { itemListElement: object[] })
+            .itemListElement,
+        }}
+      />
+      <StructuredData
+        type="SoftwareApplication"
+        data={{
+          name: "Food Map",
+          description:
+            "Curated Austin restaurant map with neighborhood, cuisine, and meal filters and a shareable URL state.",
+          url: "https://isaacavazquez.com/food-map",
+          applicationCategory: "LifestyleApplication",
+          programmingLanguage: ["TypeScript", "Next.js"],
+          author: "Isaac Vazquez",
+          keywords: [
+            "austin food map",
+            "austin restaurants",
+            "curated guide",
+            "deep-linkable filters",
+          ],
+        }}
+      />
+      <FoodMapClient initialState={initialState} />
+    </>
+  );
+}

--- a/src/components/ConditionalLayout.tsx
+++ b/src/components/ConditionalLayout.tsx
@@ -21,6 +21,7 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
     "/fantasy-football",
     "/fantasy-football/draft-tracker",
     "/fintech-tools/budget-planner",
+    "/food-map",
     "/formula-1",
     "/golf",
     "/investments",

--- a/src/constants/__tests__/caseStudies.test.ts
+++ b/src/constants/__tests__/caseStudies.test.ts
@@ -9,6 +9,7 @@ describe("caseStudies helpers", () => {
       "interchange-iq",
       "news-pulse-dashboard",
       "decision-lab",
+      "food-map",
       "budget-planner",
       "mba-role-tracker",
       "spacex-mission-control",

--- a/src/constants/caseStudies.ts
+++ b/src/constants/caseStudies.ts
@@ -255,6 +255,39 @@ export const caseStudiesData: Record<string, CaseStudyData> = {
     retrospective: "",
   },
 
+  "food-map": {
+    slug: "food-map",
+    title: "Food Map",
+    description:
+      "Curated Austin restaurant map for sending friends to the right neighborhood, cuisine, and meal with a single deep-linkable shortlist.",
+    role: "Product Builder & Designer",
+    timeline: "2026",
+    tools: ["Next.js", "TypeScript", "SVG", "Editorial UX"],
+    metrics: "12 curated stops · 4 neighborhoods · Deep-linkable filters",
+    github: "https://github.com/IsaacAVazquez",
+    link: "/food-map",
+    featured: true,
+
+    overview: {
+      summary:
+        "I built a curated Austin food map that turns my actual go-to restaurant shortlist into a single deep-linkable product surface.",
+      impact:
+        "Replaces the same restaurant text-thread I keep retyping with one shareable link that already filters by neighborhood, cuisine, and meal.",
+    },
+    problem: {
+      context:
+        "Most food guides are either too long to be useful or too generic to be honest. A friend asking where to eat usually wants a short, opinionated answer, not a list of forty options.",
+      painPoints: [],
+      stakes: "",
+    },
+    process: { approach: "", methodology: [], decisions: [] },
+    result: { outcomes: [], lessonsLearned: [] },
+    userSegments: [],
+    northStarMetric: "",
+    tradeoffs: [],
+    retrospective: "",
+  },
+
   "march-madness-2026": {
     slug: "march-madness-2026",
     title: "March Madness 2026 Bracket Analysis",
@@ -432,6 +465,7 @@ const PORTFOLIO_PROJECT_ORDER = [
   "interchange-iq",
   "news-pulse-dashboard",
   "decision-lab",
+  "food-map",
   "budget-planner",
   "mba-role-tracker",
   "spacex-mission-control",

--- a/src/lib/sitemap.js
+++ b/src/lib/sitemap.js
@@ -31,6 +31,7 @@ const STATIC_ROUTE_LASTMOD = {
   "/fantasy-football/tiers/flex": readFantasyLastmod(),
   "/fintech-tools/budget-planner": "2026-04-03",
   "/fintech-tools/interchange-iq": "2026-04-02",
+  "/food-map": "2026-04-28",
   "/portfolio/investment-analytics-platform": "2026-04-04",
   "/portfolio/interchange-iq": "2026-04-04",
   "/portfolio/news-pulse-dashboard": "2026-04-04",
@@ -40,6 +41,7 @@ const STATIC_ROUTE_LASTMOD = {
   "/portfolio/fantasy-football-analytics": "2026-04-04",
   "/portfolio/la-liga-pulse": "2026-04-04",
   "/portfolio/march-madness-2026": "2026-04-04",
+  "/portfolio/food-map": "2026-04-28",
 };
 
 function readFile(filePath) {


### PR DESCRIPTION
## Summary

- Adds a new `/food-map` route: a curated Austin food map with a stylized SVG of neighborhoods + Lady Bird Lake and 12 hand-picked restaurants.
- Filters (neighborhood, cuisine, meal) and the selected pin all encode in the URL, so the shortlist becomes a single shareable link.
- Wires the project into `caseStudies.ts` (portfolio + featured), `ConditionalLayout` (self-shell route), and the sitemap.

## What's included

- `src/app/food-map/food-map-data.ts` — neighborhoods, cuisines, meals, and 12 restaurant entries with SVG coordinates.
- `src/app/food-map/food-map-state.ts` — URL state normalization, href builder, and toggle helpers.
- `src/app/food-map/food-map-client.tsx` — editorial layout with map, filter chips, segmented meal control, shortlist grid, and detail panel. Reduced-motion aware.
- `src/app/food-map/page.tsx` — server page with metadata, breadcrumbs, and SoftwareApplication structured data.
- Tests for state normalization, data integrity, page rendering, and client interactions (17 tests, all passing).

## Test plan

- [x] `npx jest src/app/food-map` (17/17 passing)
- [x] `npx eslint src/app/food-map ...` (clean except for the same pre-existing fast-refresh warning that decision-lab has)
- [x] `npx tsc --noEmit` produces no new production-code errors for food-map files
- [ ] Manual smoke test in the browser (open `/food-map`, toggle filters, share a deep link, select a pin)
- [ ] Confirm the new project card renders correctly on `/portfolio`

https://claude.ai/code/session_014XbkNdUngnSSRct1JG6dFo

---
_Generated by [Claude Code](https://claude.ai/code/session_014XbkNdUngnSSRct1JG6dFo)_