### PR TITLE
feat: add /travel planner for trips, itineraries, and journaling

### DIFF
--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable react-refresh/only-export-components */
+import { StructuredData } from "@/components/StructuredData";
+import { constructMetadata, generateBreadcrumbStructuredData } from "@/lib/seo";
+import { TravelPlannerClient } from "./travel-planner-client";
+
+export const metadata = constructMetadata({
+  title: "Travel Planner",
+  description:
+    "Plan trips, track day-by-day itineraries, and journal as you go. Browser-persisted, no account required.",
+  canonicalUrl: "/travel",
+  dateModified: "2026-05-04",
+  aiMetadata: {
+    profession: "Product Manager",
+    specialty: "Travel planning UX, itinerary tracking, and trip journaling",
+    expertise: [
+      "Trip Planning",
+      "Itinerary Management",
+      "Travel Journaling",
+      "Client-side Persistence",
+      "Next.js",
+    ],
+    industry: ["Travel", "Personal Productivity", "Product Management"],
+    topics: [
+      "Trip planning",
+      "Itinerary tracking",
+      "Travel journaling",
+      "Browser-persisted travel notes",
+    ],
+    contentType: "Software Application",
+    context:
+      "Standalone travel planner tool that lets you draft trips, lay out a day-by-day itinerary, check off stops, and keep a per-trip journal. State is saved in your browser.",
+    summary:
+      "Travel planner for trip dates, day-by-day activities, and per-day journal entries.",
+    primaryFocus:
+      "Trip planning, itinerary tracking, and reflective travel journaling",
+  },
+});
+
+export default function TravelPlannerPage() {
+  const breadcrumbs = [
+    { name: "Home", url: "/" },
+    { name: "Travel Planner", url: "/travel" },
+  ];
+
+  return (
+    <>
+      <StructuredData
+        type="BreadcrumbList"
+        data={{
+          items: (generateBreadcrumbStructuredData(breadcrumbs) as { itemListElement: object[] })
+            .itemListElement,
+        }}
+      />
+      <StructuredData
+        type="SoftwareApplication"
+        data={{
+          name: "Travel Planner",
+          description:
+            "Browser-persisted travel planner for trip dates, day-by-day itineraries, and trip journaling.",
+          url: "https://isaacavazquez.com/travel",
+          applicationCategory: "TravelApplication",
+          programmingLanguage: ["TypeScript", "Next.js"],
+          author: "Isaac Vazquez",
+          keywords: [
+            "travel planner",
+            "trip itinerary",
+            "travel journal",
+            "vacation planning",
+            "trip tracker",
+          ],
+        }}
+      />
+      <TravelPlannerClient />
+    </>
+  );
+}

--- a/src/app/travel/travel-planner-client.tsx
+++ b/src/app/travel/travel-planner-client.tsx
@@ -1,0 +1,1089 @@
+"use client";
+
+import { type FormEvent, useMemo, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import {
+  BookOpen,
+  Bookmark,
+  CalendarDays,
+  CheckCircle2,
+  Circle,
+  Compass,
+  ListChecks,
+  Map,
+  MapPin,
+  NotebookPen,
+  Plane,
+  Plus,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
+import { getReducedMotionVariants, fadeInVariants } from "@/components/investments/animations";
+import {
+  ACTIVITY_CATEGORIES,
+  ACTIVITY_CATEGORY_LABELS,
+  JOURNAL_MOODS,
+  JOURNAL_MOOD_LABELS,
+  formatActivityTime,
+  formatDayHeading,
+  formatTripDateRange,
+  getDefaultActivityDate,
+  getTodayKey,
+} from "@/lib/travelPlanner";
+import {
+  type ActivityDraft,
+  type JournalDraft,
+  useTravelPlanner,
+} from "@/hooks/useTravelPlanner";
+import { HomeStatsPanel, type HomeStatsCell } from "@/components/home/HomeStatsPanel";
+import type { JournalEntry, Trip, TripActivity } from "@/types/travel";
+
+const NAV_ITEMS = [
+  { id: "overview", label: "Overview", icon: Compass, href: "#section-overview" },
+  { id: "itinerary", label: "Itinerary", icon: ListChecks, href: "#section-itinerary" },
+  { id: "journal", label: "Journal", icon: BookOpen, href: "#section-journal" },
+  { id: "trips", label: "All trips", icon: Map, href: "#section-trips" },
+] as const;
+
+const STATUS_LABELS = {
+  planned: "Planned",
+  active: "On the road",
+  completed: "Completed",
+} as const;
+
+const MOOD_TONE: Record<JournalEntry["mood"], string> = {
+  amazing: "var(--color-success, #2f7d4f)",
+  good: "var(--home-haze)",
+  neutral: "var(--home-ink-muted)",
+  rough: "var(--color-warning, #b8860b)",
+  tired: "var(--color-error, #b3322c)",
+};
+
+function emptyActivityDraft(date: string): ActivityDraft {
+  return {
+    date,
+    time: "",
+    title: "",
+    location: "",
+    category: "activity",
+    notes: "",
+  };
+}
+
+function emptyJournalDraft(date: string): JournalDraft {
+  return {
+    date,
+    title: "",
+    body: "",
+    mood: "good",
+  };
+}
+
+function formatBudget(value: number) {
+  if (!value) return "$0";
+  return value.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: value % 1 === 0 ? 0 : 2,
+  });
+}
+
+const fieldLabel =
+  "block text-[10.5px] font-semibold uppercase tracking-[0.16em] text-[color-mix(in_srgb,var(--home-ink)_45%,var(--home-paper))]";
+const fieldInput =
+  "mt-1.5 w-full min-h-touch rounded-xl border border-[var(--home-rule)] bg-[var(--home-paper)] px-3 py-2 text-[13px] text-[var(--home-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2";
+const textareaInput = `${fieldInput} min-h-[88px] resize-y`;
+
+export function TravelPlannerClient() {
+  const planner = useTravelPlanner();
+  const {
+    trips,
+    activeTrip,
+    activeTripId,
+    summary,
+    selectTrip,
+    addTrip,
+    removeTrip,
+    updateTripFields,
+    addActivity,
+    updateActivity,
+    toggleActivity,
+    removeActivity,
+    addJournal,
+    updateJournal,
+    removeJournal,
+  } = planner;
+
+  const shouldReduceMotion = useReducedMotion();
+  const motionVariants = shouldReduceMotion
+    ? getReducedMotionVariants().fadeInVariants
+    : fadeInVariants;
+
+  const today = getTodayKey();
+
+  const [tripDraft, setTripDraft] = useState({
+    name: "",
+    destination: "",
+    startDate: today,
+    endDate: today,
+  });
+  const [showTripForm, setShowTripForm] = useState(false);
+
+  const defaultActivityDate = useMemo(
+    () => (activeTrip ? getDefaultActivityDate(activeTrip, today) : today),
+    [activeTrip, today]
+  );
+
+  const [activityDraft, setActivityDraft] = useState<ActivityDraft>(() =>
+    emptyActivityDraft(defaultActivityDate)
+  );
+  const [editingActivityId, setEditingActivityId] = useState<string | null>(null);
+
+  const [journalDraft, setJournalDraft] = useState<JournalDraft>(() =>
+    emptyJournalDraft(defaultActivityDate)
+  );
+  const [editingJournalId, setEditingJournalId] = useState<string | null>(null);
+
+  const [lastTripContext, setLastTripContext] = useState({
+    tripId: activeTripId,
+    date: defaultActivityDate,
+  });
+  if (
+    lastTripContext.tripId !== activeTripId ||
+    lastTripContext.date !== defaultActivityDate
+  ) {
+    setLastTripContext({ tripId: activeTripId, date: defaultActivityDate });
+    setEditingActivityId(null);
+    setEditingJournalId(null);
+    setActivityDraft((draft) =>
+      draft.title || draft.location || draft.notes || draft.time
+        ? draft
+        : emptyActivityDraft(defaultActivityDate)
+    );
+    setJournalDraft((draft) =>
+      draft.title || draft.body ? draft : emptyJournalDraft(defaultActivityDate)
+    );
+  }
+
+  function resetActivityDraft() {
+    setEditingActivityId(null);
+    setActivityDraft(emptyActivityDraft(defaultActivityDate));
+  }
+
+  function resetJournalDraft() {
+    setEditingJournalId(null);
+    setJournalDraft(emptyJournalDraft(defaultActivityDate));
+  }
+
+  function handleEditActivity(activity: TripActivity) {
+    setEditingActivityId(activity.id);
+    setActivityDraft({
+      date: activity.date,
+      time: activity.time,
+      title: activity.title,
+      location: activity.location,
+      category: activity.category,
+      notes: activity.notes,
+    });
+  }
+
+  function handleEditJournal(entry: JournalEntry) {
+    setEditingJournalId(entry.id);
+    setJournalDraft({
+      date: entry.date,
+      title: entry.title,
+      body: entry.body,
+      mood: entry.mood,
+    });
+  }
+
+  function handleCreateTrip(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!tripDraft.name.trim() || !tripDraft.startDate) return;
+    addTrip({
+      name: tripDraft.name.trim(),
+      destination: tripDraft.destination.trim(),
+      startDate: tripDraft.startDate,
+      endDate: tripDraft.endDate || tripDraft.startDate,
+    });
+    setTripDraft({ name: "", destination: "", startDate: today, endDate: today });
+    setShowTripForm(false);
+  }
+
+  function handleSubmitActivity(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!activeTrip) return;
+    if (!activityDraft.title.trim() || !activityDraft.date) return;
+
+    if (editingActivityId) {
+      updateActivity(activeTrip.id, editingActivityId, activityDraft);
+    } else {
+      addActivity(activeTrip.id, activityDraft);
+    }
+    resetActivityDraft();
+  }
+
+  function handleSubmitJournal(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!activeTrip) return;
+    if (!journalDraft.title.trim() && !journalDraft.body.trim()) return;
+
+    if (editingJournalId) {
+      updateJournal(activeTrip.id, editingJournalId, journalDraft);
+    } else {
+      addJournal(activeTrip.id, journalDraft);
+    }
+    resetJournalDraft();
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-[1280px] px-4 pb-14 pt-8 sm:px-6 sm:pb-16 sm:pt-10 lg:px-8">
+      <motion.div
+        variants={motionVariants}
+        initial="hidden"
+        animate="visible"
+        className="tool-page-stack"
+        data-testid="travel-planner-shell"
+      >
+        <div className="tool-shell">
+          <aside className="tool-sidebar" aria-label="Travel planner navigation">
+            <div className="tool-brand">
+              <div className="tool-brand-mark" aria-hidden="true">
+                <Plane className="h-4 w-4" />
+              </div>
+              <div className="tool-brand-name">
+                Travel Planner
+                <small>Plan · Track · Journal</small>
+              </div>
+            </div>
+
+            <nav className="flex flex-col gap-1.5" aria-label="Section navigation">
+              {NAV_ITEMS.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <a key={item.id} href={item.href} className="tool-nav-link">
+                    <Icon size={18} aria-hidden="true" />
+                    <span>{item.label}</span>
+                  </a>
+                );
+              })}
+            </nav>
+
+            <div className="tool-sidebar-footer">
+              <Bookmark size={14} aria-hidden="true" />
+              <span>Saved in your browser</span>
+            </div>
+          </aside>
+
+          <main className="tool-main">
+            <div className="tool-topbar">
+              <div className="min-w-0">
+                <p className="tool-crumbs">
+                  Travel Planner /{" "}
+                  <strong>{activeTrip ? activeTrip.name : "No trip selected"}</strong>
+                </p>
+                <h1>Travel Planner</h1>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                {trips.length > 0 ? (
+                  <label className="flex items-center gap-2 rounded-full border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_92%,var(--home-elev-mix))] px-3 py-1.5 text-[12px] font-semibold text-[var(--home-ink)] shadow-[var(--shadow-sm)]">
+                    <CalendarDays className="h-3.5 w-3.5 text-[var(--home-haze)]" aria-hidden="true" />
+                    <span className="sr-only">Active trip</span>
+                    <select
+                      aria-label="Active trip"
+                      value={activeTripId ?? ""}
+                      onChange={(event) => selectTrip(event.target.value)}
+                      className="border-0 bg-transparent p-0 text-[12px] font-semibold text-[var(--home-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                    >
+                      {trips.map((trip) => (
+                        <option key={trip.id} value={trip.id}>
+                          {trip.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => setShowTripForm((open) => !open)}
+                  className="inline-flex min-h-touch items-center justify-center gap-1.5 rounded-full bg-[var(--home-ink)] px-3 text-[12.5px] font-semibold text-[var(--home-paper)] shadow-[var(--shadow-sm)] transition hover:bg-[color-mix(in_srgb,var(--home-ink)_88%,var(--home-haze))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                  aria-expanded={showTripForm}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  New trip
+                </button>
+              </div>
+            </div>
+
+            {showTripForm ? (
+              <section
+                aria-label="Create a new trip"
+                className="tool-card mb-5 border-dashed"
+              >
+                <form className="grid gap-3 sm:grid-cols-2" onSubmit={handleCreateTrip}>
+                  <label className="block sm:col-span-2">
+                    <span className={fieldLabel}>Trip name</span>
+                    <input
+                      type="text"
+                      autoFocus
+                      value={tripDraft.name}
+                      onChange={(event) =>
+                        setTripDraft((draft) => ({ ...draft, name: event.target.value }))
+                      }
+                      placeholder="Lisbon long weekend"
+                      className={fieldInput}
+                      required
+                    />
+                  </label>
+                  <label className="block sm:col-span-2">
+                    <span className={fieldLabel}>Destination</span>
+                    <input
+                      type="text"
+                      value={tripDraft.destination}
+                      onChange={(event) =>
+                        setTripDraft((draft) => ({ ...draft, destination: event.target.value }))
+                      }
+                      placeholder="Lisbon, Portugal"
+                      className={fieldInput}
+                    />
+                  </label>
+                  <label className="block">
+                    <span className={fieldLabel}>Start date</span>
+                    <input
+                      type="date"
+                      value={tripDraft.startDate}
+                      onChange={(event) =>
+                        setTripDraft((draft) => ({
+                          ...draft,
+                          startDate: event.target.value,
+                          endDate:
+                            !draft.endDate || draft.endDate < event.target.value
+                              ? event.target.value
+                              : draft.endDate,
+                        }))
+                      }
+                      className={fieldInput}
+                      required
+                    />
+                  </label>
+                  <label className="block">
+                    <span className={fieldLabel}>End date</span>
+                    <input
+                      type="date"
+                      value={tripDraft.endDate}
+                      min={tripDraft.startDate}
+                      onChange={(event) =>
+                        setTripDraft((draft) => ({ ...draft, endDate: event.target.value }))
+                      }
+                      className={fieldInput}
+                      required
+                    />
+                  </label>
+                  <div className="flex flex-wrap gap-2 sm:col-span-2">
+                    <button
+                      type="submit"
+                      className="inline-flex min-h-touch items-center justify-center gap-1.5 rounded-lg bg-[var(--home-ink)] px-4 text-[13px] font-semibold text-[var(--home-paper)] shadow-[var(--shadow-sm)] transition hover:bg-[color-mix(in_srgb,var(--home-ink)_88%,var(--home-haze))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      Save trip
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setShowTripForm(false)}
+                      className="inline-flex min-h-touch items-center justify-center rounded-lg border border-[var(--home-rule)] bg-[var(--home-paper)] px-4 text-[12.5px] font-semibold text-[var(--home-ink-muted)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              </section>
+            ) : null}
+
+            {activeTrip && summary ? (
+              <ActiveTripView
+                trip={activeTrip}
+                summary={summary}
+                onUpdateField={(fields) => updateTripFields(activeTrip.id, fields)}
+                onToggleActivity={(activityId) => toggleActivity(activeTrip.id, activityId)}
+                onRemoveActivity={(activityId) => {
+                  removeActivity(activeTrip.id, activityId);
+                  if (editingActivityId === activityId) resetActivityDraft();
+                }}
+                onEditActivity={handleEditActivity}
+                onRemoveJournal={(entryId) => {
+                  removeJournal(activeTrip.id, entryId);
+                  if (editingJournalId === entryId) resetJournalDraft();
+                }}
+                onEditJournal={handleEditJournal}
+                onSelectTrip={selectTrip}
+                onRemoveTrip={removeTrip}
+                trips={trips}
+              />
+            ) : (
+              <EmptyState onStart={() => setShowTripForm(true)} />
+            )}
+          </main>
+
+          <aside className="tool-rail" aria-label="Quick actions">
+            <section aria-labelledby="rail-add-activity">
+              <p className="tool-rail-label" id="rail-add-activity">
+                <Plus size={12} aria-hidden="true" />
+                {editingActivityId ? "Edit stop" : "Add stop"}
+              </p>
+              <form
+                onSubmit={handleSubmitActivity}
+                className="flex flex-col gap-3 rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_94%,var(--home-elev-mix))] p-3 shadow-[var(--shadow-sm)]"
+              >
+                <fieldset disabled={!activeTrip} className="contents">
+                  <label className="block">
+                    <span className={fieldLabel}>Title</span>
+                    <input
+                      type="text"
+                      value={activityDraft.title}
+                      onChange={(event) =>
+                        setActivityDraft((draft) => ({ ...draft, title: event.target.value }))
+                      }
+                      placeholder="Sunset at Miradouro"
+                      className={fieldInput}
+                    />
+                  </label>
+                  <div className="grid grid-cols-2 gap-2">
+                    <label className="block">
+                      <span className={fieldLabel}>Date</span>
+                      <input
+                        type="date"
+                        value={activityDraft.date}
+                        min={activeTrip?.startDate}
+                        max={activeTrip?.endDate}
+                        onChange={(event) =>
+                          setActivityDraft((draft) => ({ ...draft, date: event.target.value }))
+                        }
+                        className={fieldInput}
+                      />
+                    </label>
+                    <label className="block">
+                      <span className={fieldLabel}>Time</span>
+                      <input
+                        type="time"
+                        value={activityDraft.time}
+                        onChange={(event) =>
+                          setActivityDraft((draft) => ({ ...draft, time: event.target.value }))
+                        }
+                        className={fieldInput}
+                      />
+                    </label>
+                  </div>
+                  <label className="block">
+                    <span className={fieldLabel}>Category</span>
+                    <select
+                      value={activityDraft.category}
+                      onChange={(event) =>
+                        setActivityDraft((draft) => ({
+                          ...draft,
+                          category: event.target.value as ActivityDraft["category"],
+                        }))
+                      }
+                      className={fieldInput}
+                    >
+                      {ACTIVITY_CATEGORIES.map((category) => (
+                        <option key={category} value={category}>
+                          {ACTIVITY_CATEGORY_LABELS[category]}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="block">
+                    <span className={fieldLabel}>Location</span>
+                    <input
+                      type="text"
+                      value={activityDraft.location}
+                      onChange={(event) =>
+                        setActivityDraft((draft) => ({ ...draft, location: event.target.value }))
+                      }
+                      placeholder="Alfama"
+                      className={fieldInput}
+                    />
+                  </label>
+                  <label className="block">
+                    <span className={fieldLabel}>Notes</span>
+                    <textarea
+                      value={activityDraft.notes}
+                      onChange={(event) =>
+                        setActivityDraft((draft) => ({ ...draft, notes: event.target.value }))
+                      }
+                      placeholder="Reservation, what to bring, etc."
+                      className={textareaInput}
+                    />
+                  </label>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="submit"
+                      className="inline-flex min-h-touch flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--home-ink)] px-3 text-[13px] font-semibold text-[var(--home-paper)] shadow-[var(--shadow-sm)] transition hover:bg-[color-mix(in_srgb,var(--home-ink)_88%,var(--home-haze))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      {editingActivityId ? "Save stop" : "Add stop"}
+                    </button>
+                    {editingActivityId ? (
+                      <button
+                        type="button"
+                        onClick={resetActivityDraft}
+                        className="inline-flex min-h-touch items-center justify-center rounded-lg border border-[var(--home-rule)] bg-[var(--home-paper)] px-3 text-[12.5px] font-semibold text-[var(--home-ink-muted)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                      >
+                        Cancel
+                      </button>
+                    ) : null}
+                  </div>
+                </fieldset>
+              </form>
+            </section>
+
+            <section aria-labelledby="rail-add-journal">
+              <p className="tool-rail-label" id="rail-add-journal">
+                <NotebookPen size={12} aria-hidden="true" />
+                {editingJournalId ? "Edit entry" : "Journal entry"}
+              </p>
+              <form
+                onSubmit={handleSubmitJournal}
+                className="flex flex-col gap-3 rounded-2xl border border-[var(--home-rule)] bg-[color-mix(in_srgb,var(--home-paper)_94%,var(--home-elev-mix))] p-3 shadow-[var(--shadow-sm)]"
+              >
+                <fieldset disabled={!activeTrip} className="contents">
+                  <div className="grid grid-cols-2 gap-2">
+                    <label className="block">
+                      <span className={fieldLabel}>Date</span>
+                      <input
+                        type="date"
+                        value={journalDraft.date}
+                        min={activeTrip?.startDate}
+                        max={activeTrip?.endDate}
+                        onChange={(event) =>
+                          setJournalDraft((draft) => ({ ...draft, date: event.target.value }))
+                        }
+                        className={fieldInput}
+                      />
+                    </label>
+                    <label className="block">
+                      <span className={fieldLabel}>Mood</span>
+                      <select
+                        value={journalDraft.mood}
+                        onChange={(event) =>
+                          setJournalDraft((draft) => ({
+                            ...draft,
+                            mood: event.target.value as JournalDraft["mood"],
+                          }))
+                        }
+                        className={fieldInput}
+                      >
+                        {JOURNAL_MOODS.map((mood) => (
+                          <option key={mood} value={mood}>
+                            {JOURNAL_MOOD_LABELS[mood]}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+                  <label className="block">
+                    <span className={fieldLabel}>Title</span>
+                    <input
+                      type="text"
+                      value={journalDraft.title}
+                      onChange={(event) =>
+                        setJournalDraft((draft) => ({ ...draft, title: event.target.value }))
+                      }
+                      placeholder="A long walk in Alfama"
+                      className={fieldInput}
+                    />
+                  </label>
+                  <label className="block">
+                    <span className={fieldLabel}>Notes</span>
+                    <textarea
+                      value={journalDraft.body}
+                      onChange={(event) =>
+                        setJournalDraft((draft) => ({ ...draft, body: event.target.value }))
+                      }
+                      placeholder="What stood out today…"
+                      className={textareaInput}
+                    />
+                  </label>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="submit"
+                      className="inline-flex min-h-touch flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--home-ink)] px-3 text-[13px] font-semibold text-[var(--home-paper)] shadow-[var(--shadow-sm)] transition hover:bg-[color-mix(in_srgb,var(--home-ink)_88%,var(--home-haze))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      {editingJournalId ? "Save entry" : "Add entry"}
+                    </button>
+                    {editingJournalId ? (
+                      <button
+                        type="button"
+                        onClick={resetJournalDraft}
+                        className="inline-flex min-h-touch items-center justify-center rounded-lg border border-[var(--home-rule)] bg-[var(--home-paper)] px-3 text-[12.5px] font-semibold text-[var(--home-ink-muted)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                      >
+                        Cancel
+                      </button>
+                    ) : null}
+                  </div>
+                </fieldset>
+              </form>
+            </section>
+
+            <p className="tool-rail-foot">
+              <Sparkles size={14} aria-hidden="true" />
+              Saved in your browser — no account, no server.
+            </p>
+          </aside>
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+interface ActiveTripViewProps {
+  trip: Trip;
+  summary: NonNullable<ReturnType<typeof useTravelPlanner>["summary"]>;
+  trips: Trip[];
+  onUpdateField: (
+    fields: Partial<Pick<Trip, "name" | "destination" | "startDate" | "endDate" | "notes" | "budget">>
+  ) => void;
+  onToggleActivity: (activityId: string) => void;
+  onRemoveActivity: (activityId: string) => void;
+  onEditActivity: (activity: TripActivity) => void;
+  onRemoveJournal: (entryId: string) => void;
+  onEditJournal: (entry: JournalEntry) => void;
+  onSelectTrip: (id: string) => void;
+  onRemoveTrip: (id: string) => void;
+}
+
+function ActiveTripView({
+  trip,
+  summary,
+  trips,
+  onUpdateField,
+  onToggleActivity,
+  onRemoveActivity,
+  onEditActivity,
+  onRemoveJournal,
+  onEditJournal,
+  onSelectTrip,
+  onRemoveTrip,
+}: ActiveTripViewProps) {
+  const journalSorted = useMemo(
+    () =>
+      [...trip.journal].sort((left, right) => {
+        if (left.date !== right.date) return right.date.localeCompare(left.date);
+        return right.id.localeCompare(left.id);
+      }),
+    [trip.journal]
+  );
+
+  const stats: HomeStatsCell[] = [
+    {
+      label: "Status",
+      value: STATUS_LABELS[summary.status],
+      tone: summary.status === "active" ? "good" : "default",
+    },
+    {
+      label: "Days",
+      value: `${summary.daysElapsed} / ${summary.daysTotal}`,
+      sub:
+        summary.status === "planned"
+          ? `${summary.daysUntilStart} day${summary.daysUntilStart === 1 ? "" : "s"} away`
+          : summary.status === "active"
+            ? "Trip in progress"
+            : "Trip wrapped",
+    },
+    {
+      label: "Stops",
+      value: `${summary.activitiesCompleted} / ${summary.activitiesTotal}`,
+      sub: summary.activitiesTotal === 0 ? "Add your first stop" : "Completed",
+    },
+    {
+      label: "Journal",
+      value: summary.journalCount.toString(),
+      sub: summary.journalCount === 1 ? "entry" : "entries",
+    },
+    {
+      label: "Destination",
+      value: trip.destination || "—",
+    },
+    {
+      label: "Dates",
+      value: formatTripDateRange(trip.startDate, trip.endDate),
+    },
+    {
+      label: "Budget",
+      value: formatBudget(trip.budget),
+    },
+    {
+      label: "Trips saved",
+      value: trips.length.toString(),
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div id="section-overview" className="scroll-mt-28">
+        <HomeStatsPanel
+          id="travel-stats"
+          title="Trip at a glance"
+          meta={STATUS_LABELS[summary.status]}
+          hideLiveDot={summary.status !== "active"}
+          cells={stats}
+          pills={[
+            { label: "Itinerary", href: "#section-itinerary" },
+            { label: "Journal", href: "#section-journal" },
+            { label: "Trips", href: "#section-trips" },
+          ]}
+        />
+      </div>
+
+      <section className="tool-card" aria-label="Trip details">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="tool-section-kicker">Trip</p>
+            <h2 className="tool-section-title">{trip.name}</h2>
+          </div>
+          {trip.destination ? (
+            <p className="inline-flex items-center gap-1.5 text-[12px] text-[var(--home-ink-muted)]">
+              <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+              {trip.destination}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <label className="block">
+            <span className={fieldLabel}>Trip name</span>
+            <input
+              type="text"
+              value={trip.name}
+              onChange={(event) => onUpdateField({ name: event.target.value })}
+              className={fieldInput}
+            />
+          </label>
+          <label className="block">
+            <span className={fieldLabel}>Destination</span>
+            <input
+              type="text"
+              value={trip.destination}
+              onChange={(event) => onUpdateField({ destination: event.target.value })}
+              className={fieldInput}
+            />
+          </label>
+          <label className="block">
+            <span className={fieldLabel}>Start date</span>
+            <input
+              type="date"
+              value={trip.startDate}
+              onChange={(event) => onUpdateField({ startDate: event.target.value })}
+              className={fieldInput}
+            />
+          </label>
+          <label className="block">
+            <span className={fieldLabel}>End date</span>
+            <input
+              type="date"
+              value={trip.endDate}
+              min={trip.startDate}
+              onChange={(event) => onUpdateField({ endDate: event.target.value })}
+              className={fieldInput}
+            />
+          </label>
+          <label className="block">
+            <span className={fieldLabel}>Budget (USD)</span>
+            <input
+              type="number"
+              min="0"
+              step="50"
+              value={String(trip.budget)}
+              onChange={(event) => onUpdateField({ budget: Number(event.target.value) || 0 })}
+              className={`${fieldInput} [font-variant-numeric:tabular-nums]`}
+            />
+          </label>
+          <label className="block sm:col-span-2">
+            <span className={fieldLabel}>Trip notes</span>
+            <textarea
+              value={trip.notes}
+              onChange={(event) => onUpdateField({ notes: event.target.value })}
+              placeholder="Hotels, packing list, must-see places…"
+              className={textareaInput}
+            />
+          </label>
+        </div>
+      </section>
+
+      <section
+        id="section-itinerary"
+        className="tool-card scroll-mt-28"
+        aria-label="Day-by-day itinerary"
+      >
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="tool-section-kicker">Day by day</p>
+            <h2 className="tool-section-title">Itinerary</h2>
+          </div>
+          <p className="text-[12px] text-[var(--home-ink-muted)] [font-variant-numeric:tabular-nums]">
+            {summary.activitiesCompleted}/{summary.activitiesTotal} stops checked off
+          </p>
+        </div>
+
+        {summary.activitiesTotal === 0 ? (
+          <div className="tool-empty mt-4">
+            <p className="text-[13.5px] font-semibold text-[var(--home-ink)]">No stops yet</p>
+            <p>Add the first stop using the "Add stop" panel on the right.</p>
+          </div>
+        ) : (
+          <div className="mt-4 flex flex-col gap-4">
+            {summary.dayBuckets.map((bucket) => (
+              <div key={bucket.date} className="flex flex-col gap-2">
+                <header className="flex items-baseline justify-between gap-2">
+                  <h3 className="text-[13px] font-semibold uppercase tracking-[0.14em] text-[var(--home-ink-muted)]">
+                    {formatDayHeading(bucket.date)}
+                  </h3>
+                  <span className="text-[11.5px] text-[var(--home-ink-muted)] [font-variant-numeric:tabular-nums]">
+                    {bucket.activities.length}{" "}
+                    {bucket.activities.length === 1 ? "stop" : "stops"}
+                  </span>
+                </header>
+                {bucket.activities.length === 0 ? (
+                  <p className="rounded-xl border border-dashed border-[var(--home-rule)] px-3 py-2 text-[12px] text-[var(--home-ink-muted)]">
+                    Nothing planned yet.
+                  </p>
+                ) : (
+                  <ul className="divide-y divide-[var(--home-rule)] rounded-xl border border-[var(--home-rule)] bg-[var(--home-paper)]">
+                    {bucket.activities.map((activity) => (
+                      <li key={activity.id} className="flex items-start gap-3 px-3 py-2.5">
+                        <button
+                          type="button"
+                          onClick={() => onToggleActivity(activity.id)}
+                          aria-label={
+                            activity.completed
+                              ? `Mark ${activity.title} as not done`
+                              : `Mark ${activity.title} as done`
+                          }
+                          className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full text-[var(--home-ink-muted)] transition hover:text-[var(--home-haze)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                        >
+                          {activity.completed ? (
+                            <CheckCircle2 className="h-5 w-5 text-[var(--color-success,#2f7d4f)]" />
+                          ) : (
+                            <Circle className="h-5 w-5" />
+                          )}
+                        </button>
+                        <div className="min-w-0 flex-1">
+                          <p
+                            className={`text-[13.5px] font-semibold text-[var(--home-ink)] ${
+                              activity.completed ? "line-through opacity-60" : ""
+                            }`}
+                          >
+                            {activity.title}
+                          </p>
+                          <p className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] uppercase tracking-[0.12em] text-[var(--home-ink-muted)]">
+                            <span>{ACTIVITY_CATEGORY_LABELS[activity.category]}</span>
+                            {activity.time ? (
+                              <>
+                                <span aria-hidden="true">·</span>
+                                <span>{formatActivityTime(activity.time)}</span>
+                              </>
+                            ) : null}
+                            {activity.location ? (
+                              <>
+                                <span aria-hidden="true">·</span>
+                                <span className="normal-case tracking-normal">
+                                  {activity.location}
+                                </span>
+                              </>
+                            ) : null}
+                          </p>
+                          {activity.notes ? (
+                            <p className="mt-1 text-[12.5px] text-[var(--home-ink-muted)] whitespace-pre-line">
+                              {activity.notes}
+                            </p>
+                          ) : null}
+                        </div>
+                        <div className="flex flex-col gap-1.5">
+                          <button
+                            type="button"
+                            onClick={() => onEditActivity(activity)}
+                            className="inline-flex min-h-touch items-center justify-center rounded-lg border border-[var(--home-rule)] bg-[var(--home-paper)] px-2.5 text-[11.5px] font-medium text-[var(--home-ink-muted)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onRemoveActivity(activity.id)}
+                            className="inline-flex min-h-touch items-center justify-center rounded-lg border border-[var(--home-rule)] bg-[var(--home-paper)] px-2.5 text-[11.5px] font-medium text-[var(--home-ink-muted)] transition hover:border-[var(--color-error)] hover:text-[var(--color-error)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                            aria-label={`Delete ${activity.title}`}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section
+        id="section-journal"
+        className="tool-card scroll-mt-28"
+        aria-label="Trip journal"
+      >
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="tool-section-kicker">Reflection</p>
+            <h2 className="tool-section-title">Journal</h2>
+          </div>
+          <p className="text-[12px] text-[var(--home-ink-muted)] [font-variant-numeric:tabular-nums]">
+            {trip.journal.length} {trip.journal.length === 1 ? "entry" : "entries"}
+          </p>
+        </div>
+
+        {journalSorted.length === 0 ? (
+          <div className="tool-empty mt-4">
+            <p className="text-[13.5px] font-semibold text-[var(--home-ink)]">
+              Journal is empty
+            </p>
+            <p>Capture a moment using the journal panel on the right.</p>
+          </div>
+        ) : (
+          <ul className="mt-4 flex flex-col gap-3">
+            {journalSorted.map((entry) => (
+              <li
+                key={entry.id}
+                className="rounded-2xl border border-[var(--home-rule)] bg-[var(--home-paper)] px-4 py-3"
+              >
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <div>
+                    <p className="text-[13.5px] font-semibold text-[var(--home-ink)]">
+                      {entry.title}
+                    </p>
+                    <p className="mt-0.5 flex items-center gap-2 text-[11px] uppercase tracking-[0.14em] text-[var(--home-ink-muted)]">
+                      <span>{formatDayHeading(entry.date)}</span>
+                      <span aria-hidden="true">·</span>
+                      <span
+                        className="inline-flex items-center gap-1.5"
+                        style={{ color: MOOD_TONE[entry.mood] }}
+                      >
+                        <span
+                          aria-hidden="true"
+                          className="inline-block h-1.5 w-1.5 rounded-full"
+                          style={{ backgroundColor: MOOD_TONE[entry.mood] }}
+                        />
+                        {JOURNAL_MOOD_LABELS[entry.mood]}
+                      </span>
+                    </p>
+                  </div>
+                  <div className="flex gap-1.5">
+                    <button
+                      type="button"
+                      onClick={() => onEditJournal(entry)}
+                      className="inline-flex min-h-touch items-center justify-center rounded-lg border border-[var(--home-rule)] bg-[var(--home-paper)] px-3 text-[12px] font-medium text-[var(--home-ink-muted)] transition hover:border-[var(--home-haze)] hover:text-[var(--home-haze)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onRemoveJournal(entry.id)}
+                      aria-label={`Delete journal entry ${entry.title}`}
+                      className="inline-flex min-h-touch items-center justify-center rounded-lg border border-[var(--home-rule)] bg-[var(--home-paper)] px-3 text-[12px] font-medium text-[var(--home-ink-muted)] transition hover:border-[var(--color-error)] hover:text-[var(--color-error)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+                {entry.body ? (
+                  <p className="mt-2 whitespace-pre-line text-[13px] leading-6 text-[var(--home-ink)]">
+                    {entry.body}
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section
+        id="section-trips"
+        className="tool-card scroll-mt-28"
+        aria-label="All saved trips"
+      >
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="tool-section-kicker">Library</p>
+            <h2 className="tool-section-title">All trips</h2>
+          </div>
+          <p className="text-[12px] text-[var(--home-ink-muted)] [font-variant-numeric:tabular-nums]">
+            {trips.length} {trips.length === 1 ? "trip" : "trips"}
+          </p>
+        </div>
+        <ul className="mt-4 divide-y divide-[var(--home-rule)]">
+          {trips.map((other) => {
+            const isActive = other.id === trip.id;
+            return (
+              <li
+                key={other.id}
+                className="flex flex-wrap items-center justify-between gap-3 py-2.5"
+              >
+                <button
+                  type="button"
+                  onClick={() => onSelectTrip(other.id)}
+                  className="min-w-0 flex-1 text-left"
+                >
+                  <p className="truncate text-[13.5px] font-semibold text-[var(--home-ink)]">
+                    {other.name} {isActive ? <span className="text-[11px] font-medium text-[var(--home-haze)]">· active</span> : null}
+                  </p>
+                  <p className="mt-0.5 truncate text-[11.5px] text-[var(--home-ink-muted)]">
+                    {other.destination || "No destination"} ·{" "}
+                    {formatTripDateRange(other.startDate, other.endDate)}
+                  </p>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (
+                      typeof window !== "undefined" &&
+                      !window.confirm(`Delete "${other.name}"? This can't be undone.`)
+                    ) {
+                      return;
+                    }
+                    onRemoveTrip(other.id);
+                  }}
+                  aria-label={`Delete trip ${other.name}`}
+                  className="inline-flex min-h-touch items-center justify-center rounded-lg border border-[var(--home-rule)] bg-[var(--home-paper)] px-3 text-[12px] font-medium text-[var(--home-ink-muted)] transition hover:border-[var(--color-error)] hover:text-[var(--color-error)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function EmptyState({ onStart }: { onStart: () => void }) {
+  return (
+    <div className="tool-empty mt-2">
+      <p className="text-[14.5px] font-semibold text-[var(--home-ink)]">
+        No trips yet
+      </p>
+      <p className="mb-4 mt-1">
+        Start a trip to plan a day-by-day itinerary, track stops, and keep a journal as you go.
+      </p>
+      <button
+        type="button"
+        onClick={onStart}
+        className="inline-flex min-h-touch items-center justify-center gap-1.5 rounded-lg bg-[var(--home-ink)] px-4 text-[13px] font-semibold text-[var(--home-paper)] shadow-[var(--shadow-sm)] transition hover:bg-[color-mix(in_srgb,var(--home-ink)_88%,var(--home-haze))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-haze)] focus-visible:ring-offset-2"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Start a trip
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useTravelPlanner.ts
+++ b/src/hooks/useTravelPlanner.ts
@@ -1,0 +1,221 @@
+"use client";
+
+import { useMemo, useState, useSyncExternalStore } from "react";
+import {
+  TRAVEL_PLANNER_STORAGE_KEY,
+  calculateTripSummary,
+  createActivity,
+  createJournalEntry,
+  createTrip,
+  loadTrips,
+  parseTrips,
+  saveTrips,
+} from "@/lib/travelPlanner";
+import type { JournalEntry, Trip, TripActivity } from "@/types/travel";
+
+const travelListeners = new Set<() => void>();
+
+function emit() {
+  travelListeners.forEach((listener) => listener());
+}
+
+function subscribe(listener: () => void) {
+  travelListeners.add(listener);
+
+  function handleStorage(event: StorageEvent) {
+    if (event.key === null || event.key === TRAVEL_PLANNER_STORAGE_KEY) {
+      listener();
+    }
+  }
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("storage", handleStorage);
+  }
+
+  return () => {
+    travelListeners.delete(listener);
+    if (typeof window !== "undefined") {
+      window.removeEventListener("storage", handleStorage);
+    }
+  };
+}
+
+function getSnapshot() {
+  if (typeof window === "undefined") return "[]";
+  return window.localStorage.getItem(TRAVEL_PLANNER_STORAGE_KEY) ?? "[]";
+}
+
+export interface NewTripInput {
+  name: string;
+  destination: string;
+  startDate: string;
+  endDate: string;
+}
+
+export interface ActivityDraft {
+  date: string;
+  time: string;
+  title: string;
+  location: string;
+  category: TripActivity["category"];
+  notes: string;
+}
+
+export interface JournalDraft {
+  date: string;
+  title: string;
+  body: string;
+  mood: JournalEntry["mood"];
+}
+
+export function useTravelPlanner() {
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, () => "[]");
+  const trips = useMemo(() => parseTrips(snapshot), [snapshot]);
+
+  const [requestedTripId, setRequestedTripId] = useState<string | null>(null);
+
+  const activeTripId = useMemo(() => {
+    if (trips.length === 0) return null;
+    if (requestedTripId && trips.some((trip) => trip.id === requestedTripId)) {
+      return requestedTripId;
+    }
+    return trips[0].id;
+  }, [trips, requestedTripId]);
+
+  const activeTrip = trips.find((trip) => trip.id === activeTripId) ?? null;
+  const summary = useMemo(
+    () => (activeTrip ? calculateTripSummary(activeTrip) : null),
+    [activeTrip]
+  );
+
+  function commit(nextTrips: Trip[]) {
+    saveTrips(nextTrips);
+    emit();
+  }
+
+  function updateTrip(tripId: string, updater: (trip: Trip) => Trip) {
+    const current = loadTrips();
+    const next = current.map((trip) => (trip.id === tripId ? updater(trip) : trip));
+    commit(next);
+  }
+
+  function addTrip(input: NewTripInput) {
+    const trip = createTrip(input);
+    const current = loadTrips();
+    commit([...current, trip]);
+    setRequestedTripId(trip.id);
+    return trip;
+  }
+
+  function removeTrip(tripId: string) {
+    const current = loadTrips();
+    const next = current.filter((trip) => trip.id !== tripId);
+    commit(next);
+    if (requestedTripId === tripId) {
+      setRequestedTripId(next[0]?.id ?? null);
+    }
+  }
+
+  function updateTripFields(
+    tripId: string,
+    fields: Partial<Pick<Trip, "name" | "destination" | "startDate" | "endDate" | "notes" | "budget">>
+  ) {
+    updateTrip(tripId, (trip) => {
+      const next: Trip = { ...trip, ...fields };
+      if (next.endDate < next.startDate) next.endDate = next.startDate;
+      return next;
+    });
+  }
+
+  function addActivity(tripId: string, draft: ActivityDraft) {
+    const activity = createActivity(draft);
+    updateTrip(tripId, (trip) => ({
+      ...trip,
+      activities: [...trip.activities, activity],
+    }));
+  }
+
+  function updateActivity(tripId: string, activityId: string, draft: ActivityDraft) {
+    updateTrip(tripId, (trip) => ({
+      ...trip,
+      activities: trip.activities.map((activity) =>
+        activity.id === activityId
+          ? {
+              ...activity,
+              ...draft,
+              title: draft.title.trim() || "Untitled stop",
+              location: draft.location.trim(),
+              notes: draft.notes.trim(),
+            }
+          : activity
+      ),
+    }));
+  }
+
+  function toggleActivity(tripId: string, activityId: string) {
+    updateTrip(tripId, (trip) => ({
+      ...trip,
+      activities: trip.activities.map((activity) =>
+        activity.id === activityId
+          ? { ...activity, completed: !activity.completed }
+          : activity
+      ),
+    }));
+  }
+
+  function removeActivity(tripId: string, activityId: string) {
+    updateTrip(tripId, (trip) => ({
+      ...trip,
+      activities: trip.activities.filter((activity) => activity.id !== activityId),
+    }));
+  }
+
+  function addJournal(tripId: string, draft: JournalDraft) {
+    const entry = createJournalEntry(draft);
+    updateTrip(tripId, (trip) => ({
+      ...trip,
+      journal: [...trip.journal, entry],
+    }));
+  }
+
+  function updateJournal(tripId: string, entryId: string, draft: JournalDraft) {
+    updateTrip(tripId, (trip) => ({
+      ...trip,
+      journal: trip.journal.map((entry) =>
+        entry.id === entryId
+          ? {
+              ...entry,
+              ...draft,
+              title: draft.title.trim() || "Untitled entry",
+              body: draft.body.trim(),
+            }
+          : entry
+      ),
+    }));
+  }
+
+  function removeJournal(tripId: string, entryId: string) {
+    updateTrip(tripId, (trip) => ({
+      ...trip,
+      journal: trip.journal.filter((entry) => entry.id !== entryId),
+    }));
+  }
+
+  return {
+    trips,
+    activeTrip,
+    activeTripId,
+    summary,
+    selectTrip: setRequestedTripId,
+    addTrip,
+    removeTrip,
+    updateTripFields,
+    addActivity,
+    updateActivity,
+    toggleActivity,
+    removeActivity,
+    addJournal,
+    updateJournal,
+    removeJournal,
+  };
+}

--- a/src/lib/travelPlanner.ts
+++ b/src/lib/travelPlanner.ts
@@ -1,0 +1,376 @@
+import type {
+  ActivityCategory,
+  JournalEntry,
+  JournalMood,
+  Trip,
+  TripActivity,
+  TripDayBucket,
+  TripStatus,
+  TripSummary,
+} from "@/types/travel";
+
+export const TRAVEL_PLANNER_STORAGE_KEY = "travel_planner_trips_v1";
+
+export const ACTIVITY_CATEGORIES: ActivityCategory[] = [
+  "transit",
+  "lodging",
+  "food",
+  "sight",
+  "activity",
+  "other",
+];
+
+export const ACTIVITY_CATEGORY_LABELS: Record<ActivityCategory, string> = {
+  transit: "Transit",
+  lodging: "Lodging",
+  food: "Food",
+  sight: "Sight",
+  activity: "Activity",
+  other: "Other",
+};
+
+export const JOURNAL_MOODS: JournalMood[] = [
+  "amazing",
+  "good",
+  "neutral",
+  "rough",
+  "tired",
+];
+
+export const JOURNAL_MOOD_LABELS: Record<JournalMood, string> = {
+  amazing: "Amazing",
+  good: "Good",
+  neutral: "Neutral",
+  rough: "Rough",
+  tired: "Tired",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isIsoDate(value: unknown): value is string {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function isHourMinute(value: unknown): value is string {
+  return typeof value === "string" && /^\d{2}:\d{2}$/.test(value);
+}
+
+function createId(prefix: "trip" | "act" | "jrn") {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function clampString(value: unknown, max: number, fallback = ""): string {
+  if (typeof value !== "string") return fallback;
+  return value.trim().slice(0, max);
+}
+
+function sanitizeNumber(value: unknown): number {
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return 0;
+  return Math.round(numeric * 100) / 100;
+}
+
+export function getTodayKey(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function parseDateKey(value: string): Date | null {
+  if (!isIsoDate(value)) return null;
+  const date = new Date(`${value}T00:00`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function diffDaysInclusive(startKey: string, endKey: string): number {
+  const start = parseDateKey(startKey);
+  const end = parseDateKey(endKey);
+  if (!start || !end) return 0;
+  const ms = end.getTime() - start.getTime();
+  return Math.max(1, Math.round(ms / 86400000) + 1);
+}
+
+function diffDaysSigned(fromKey: string, toKey: string): number {
+  const from = parseDateKey(fromKey);
+  const to = parseDateKey(toKey);
+  if (!from || !to) return 0;
+  return Math.round((to.getTime() - from.getTime()) / 86400000);
+}
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+const DATE_FORMATTER_SHORT = new Intl.DateTimeFormat("en-US", {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+});
+
+const TIME_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+export function formatTripDateRange(startKey: string, endKey: string): string {
+  const start = parseDateKey(startKey);
+  const end = parseDateKey(endKey);
+  if (!start || !end) return "—";
+  if (startKey === endKey) return DATE_FORMATTER.format(start);
+  return `${DATE_FORMATTER.format(start)} – ${DATE_FORMATTER.format(end)}`;
+}
+
+export function formatDayHeading(dateKey: string): string {
+  const date = parseDateKey(dateKey);
+  if (!date) return dateKey;
+  return DATE_FORMATTER_SHORT.format(date);
+}
+
+export function formatActivityTime(time: string): string {
+  if (!isHourMinute(time)) return "";
+  const [hours, minutes] = time.split(":").map(Number);
+  const date = new Date();
+  date.setHours(hours, minutes, 0, 0);
+  return TIME_FORMATTER.format(date);
+}
+
+export function getTripStatus(trip: Pick<Trip, "startDate" | "endDate">, today = getTodayKey()): TripStatus {
+  if (today < trip.startDate) return "planned";
+  if (today > trip.endDate) return "completed";
+  return "active";
+}
+
+export function getDayKeysBetween(startKey: string, endKey: string): string[] {
+  const start = parseDateKey(startKey);
+  const end = parseDateKey(endKey);
+  if (!start || !end || end.getTime() < start.getTime()) return [];
+
+  const keys: string[] = [];
+  const cursor = new Date(start);
+  while (cursor.getTime() <= end.getTime()) {
+    keys.push(getTodayKey(cursor));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return keys;
+}
+
+function sanitizeActivity(input: unknown): TripActivity | null {
+  if (!isRecord(input)) return null;
+  if (!isIsoDate(input.date)) return null;
+
+  const category =
+    typeof input.category === "string" &&
+    (ACTIVITY_CATEGORIES as string[]).includes(input.category)
+      ? (input.category as ActivityCategory)
+      : "other";
+
+  return {
+    id: typeof input.id === "string" && input.id ? input.id : createId("act"),
+    date: input.date,
+    time: isHourMinute(input.time) ? input.time : "",
+    title: clampString(input.title, 140, "Untitled stop"),
+    location: clampString(input.location, 140),
+    category,
+    notes: clampString(input.notes, 500),
+    completed: input.completed === true,
+  };
+}
+
+function sanitizeJournalEntry(input: unknown): JournalEntry | null {
+  if (!isRecord(input)) return null;
+  if (!isIsoDate(input.date)) return null;
+
+  const mood =
+    typeof input.mood === "string" && (JOURNAL_MOODS as string[]).includes(input.mood)
+      ? (input.mood as JournalMood)
+      : "neutral";
+
+  return {
+    id: typeof input.id === "string" && input.id ? input.id : createId("jrn"),
+    date: input.date,
+    title: clampString(input.title, 160, "Untitled entry"),
+    body: clampString(input.body, 4000),
+    mood,
+  };
+}
+
+function sanitizeTrip(input: unknown): Trip | null {
+  if (!isRecord(input)) return null;
+  if (!isIsoDate(input.startDate) || !isIsoDate(input.endDate)) return null;
+
+  const startDate = input.startDate;
+  const endDate =
+    input.endDate >= startDate ? (input.endDate as string) : startDate;
+
+  const activities = Array.isArray(input.activities)
+    ? input.activities
+        .map(sanitizeActivity)
+        .filter((activity): activity is TripActivity => activity !== null)
+    : [];
+
+  const journal = Array.isArray(input.journal)
+    ? input.journal
+        .map(sanitizeJournalEntry)
+        .filter((entry): entry is JournalEntry => entry !== null)
+    : [];
+
+  return {
+    id: typeof input.id === "string" && input.id ? input.id : createId("trip"),
+    name: clampString(input.name, 140, "Untitled trip"),
+    destination: clampString(input.destination, 140),
+    startDate,
+    endDate,
+    notes: clampString(input.notes, 1000),
+    budget: sanitizeNumber(input.budget),
+    activities,
+    journal,
+  };
+}
+
+export function parseTrips(raw: string | null): Trip[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map(sanitizeTrip)
+      .filter((trip): trip is Trip => trip !== null);
+  } catch {
+    return [];
+  }
+}
+
+export function loadTrips(storage?: Pick<Storage, "getItem">): Trip[] {
+  if (storage) return parseTrips(storage.getItem(TRAVEL_PLANNER_STORAGE_KEY));
+  if (typeof window === "undefined") return [];
+  return parseTrips(window.localStorage.getItem(TRAVEL_PLANNER_STORAGE_KEY));
+}
+
+export function saveTrips(trips: Trip[], storage?: Pick<Storage, "setItem">) {
+  const payload = JSON.stringify(trips);
+  if (storage) {
+    storage.setItem(TRAVEL_PLANNER_STORAGE_KEY, payload);
+    return;
+  }
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(TRAVEL_PLANNER_STORAGE_KEY, payload);
+}
+
+interface CreateTripInput {
+  name: string;
+  destination: string;
+  startDate: string;
+  endDate: string;
+}
+
+export function createTrip(input: CreateTripInput): Trip {
+  const startDate = isIsoDate(input.startDate) ? input.startDate : getTodayKey();
+  const rawEnd = isIsoDate(input.endDate) ? input.endDate : startDate;
+  const endDate = rawEnd >= startDate ? rawEnd : startDate;
+
+  return {
+    id: createId("trip"),
+    name: clampString(input.name, 140, "Untitled trip"),
+    destination: clampString(input.destination, 140),
+    startDate,
+    endDate,
+    notes: "",
+    budget: 0,
+    activities: [],
+    journal: [],
+  };
+}
+
+export function createActivity(input: Omit<TripActivity, "id" | "completed">): TripActivity {
+  return {
+    id: createId("act"),
+    date: isIsoDate(input.date) ? input.date : getTodayKey(),
+    time: isHourMinute(input.time) ? input.time : "",
+    title: clampString(input.title, 140, "Untitled stop"),
+    location: clampString(input.location, 140),
+    category: input.category,
+    notes: clampString(input.notes, 500),
+    completed: false,
+  };
+}
+
+export function createJournalEntry(input: Omit<JournalEntry, "id">): JournalEntry {
+  return {
+    id: createId("jrn"),
+    date: isIsoDate(input.date) ? input.date : getTodayKey(),
+    title: clampString(input.title, 160, "Untitled entry"),
+    body: clampString(input.body, 4000),
+    mood: input.mood,
+  };
+}
+
+function sortActivities(activities: TripActivity[]): TripActivity[] {
+  return [...activities].sort((left, right) => {
+    if (left.date !== right.date) return left.date.localeCompare(right.date);
+    if (left.time && right.time) return left.time.localeCompare(right.time);
+    if (left.time) return -1;
+    if (right.time) return 1;
+    return left.title.localeCompare(right.title);
+  });
+}
+
+export function calculateTripSummary(trip: Trip, today = getTodayKey()): TripSummary {
+  const status = getTripStatus(trip, today);
+  const daysTotal = diffDaysInclusive(trip.startDate, trip.endDate);
+  const daysUntilStart = Math.max(0, diffDaysSigned(today, trip.startDate));
+
+  let daysElapsed = 0;
+  if (today >= trip.startDate) {
+    daysElapsed = Math.min(daysTotal, diffDaysSigned(trip.startDate, today) + 1);
+  }
+
+  const sortedActivities = sortActivities(trip.activities);
+  const dayKeys = getDayKeysBetween(trip.startDate, trip.endDate);
+
+  const dayLookup = new Map<string, TripActivity[]>();
+  for (const key of dayKeys) dayLookup.set(key, []);
+  for (const activity of sortedActivities) {
+    const list = dayLookup.get(activity.date);
+    if (list) {
+      list.push(activity);
+    } else {
+      dayLookup.set(activity.date, [activity]);
+    }
+  }
+
+  const dayBuckets: TripDayBucket[] = Array.from(dayLookup.entries())
+    .sort((left, right) => left[0].localeCompare(right[0]))
+    .map(([date, activities]) => ({ date, activities }));
+
+  const upcomingActivities = sortedActivities
+    .filter((activity) => !activity.completed && activity.date >= today)
+    .slice(0, 4);
+
+  const activitiesCompleted = sortedActivities.filter((activity) => activity.completed).length;
+
+  return {
+    status,
+    daysTotal,
+    daysElapsed,
+    daysUntilStart,
+    activitiesTotal: sortedActivities.length,
+    activitiesCompleted,
+    journalCount: trip.journal.length,
+    dayBuckets,
+    upcomingActivities,
+  };
+}
+
+export function getDefaultActivityDate(trip: Pick<Trip, "startDate" | "endDate">, today = getTodayKey()): string {
+  if (today < trip.startDate) return trip.startDate;
+  if (today > trip.endDate) return trip.endDate;
+  return today;
+}

--- a/src/types/travel.ts
+++ b/src/types/travel.ts
@@ -1,0 +1,64 @@
+export type TripStatus = "planned" | "active" | "completed";
+
+export type ActivityCategory =
+  | "transit"
+  | "lodging"
+  | "food"
+  | "sight"
+  | "activity"
+  | "other";
+
+export interface TripActivity {
+  id: string;
+  date: string;
+  time: string;
+  title: string;
+  location: string;
+  category: ActivityCategory;
+  notes: string;
+  completed: boolean;
+}
+
+export type JournalMood =
+  | "amazing"
+  | "good"
+  | "neutral"
+  | "rough"
+  | "tired";
+
+export interface JournalEntry {
+  id: string;
+  date: string;
+  title: string;
+  body: string;
+  mood: JournalMood;
+}
+
+export interface Trip {
+  id: string;
+  name: string;
+  destination: string;
+  startDate: string;
+  endDate: string;
+  notes: string;
+  budget: number;
+  activities: TripActivity[];
+  journal: JournalEntry[];
+}
+
+export interface TripDayBucket {
+  date: string;
+  activities: TripActivity[];
+}
+
+export interface TripSummary {
+  status: TripStatus;
+  daysTotal: number;
+  daysElapsed: number;
+  daysUntilStart: number;
+  activitiesTotal: number;
+  activitiesCompleted: number;
+  journalCount: number;
+  dayBuckets: TripDayBucket[];
+  upcomingActivities: TripActivity[];
+}


### PR DESCRIPTION
## Summary

- New `/travel` route: a browser-persisted travel planner that combines trip planning, itinerary tracking, and journaling in one shell.
- Mirrors the existing budget-planner shell (sidebar nav, main content, quick-action rail) and uses the editorial `--home-*` palette / `tool-*` helpers so it fits the rest of the tool surface.
- localStorage-backed via `useTravelPlanner` (`useSyncExternalStore`), following the same persistence pattern as `useBudgetPlanner`.

## What's in it

- **Overview**: stats panel (status, days elapsed/total, stops checked off, journal count, dates, budget) plus inline editing of trip name / destination / dates / budget / notes.
- **Itinerary**: day-by-day buckets between the trip's start and end. Each stop has a category (transit / lodging / food / sight / activity / other), optional time and location, freeform notes, and a check-off toggle for tracking.
- **Journal**: per-trip entries with date, title, body, and a mood tag (amazing / good / neutral / rough / tired). Sorted newest first.
- **All trips**: switch between saved trips or delete one (confirmed). New-trip form opens in a dashed card from the topbar.
- **Rail**: quick-add forms for stops and journal entries, with edit/cancel states.

## Files

- `src/types/travel.ts` — `Trip`, `TripActivity`, `JournalEntry`, `TripSummary`, etc.
- `src/lib/travelPlanner.ts` — sanitization, persistence (`travel_planner_trips_v1`), date helpers, `calculateTripSummary`.
- `src/hooks/useTravelPlanner.ts` — single hook exposing trip + activity + journal mutations.
- `src/app/travel/page.tsx` — server page with metadata + structured data.
- `src/app/travel/travel-planner-client.tsx` — client UI.

## Test plan

- [ ] `npm run dev` and visit `/travel` — empty state shows, "Start a trip" opens the new-trip form.
- [ ] Create a 3-day trip; itinerary shows 3 day buckets.
- [ ] Add a stop with a time and location; verify it appears in the right day, can be checked off, edited, and deleted.
- [ ] Add a journal entry; verify it appears with mood tag and is editable/deletable.
- [ ] Reload the page — trips, stops, and journal entries persist.
- [ ] Create a second trip; switch via the topbar selector and via the "All trips" list.
- [ ] Delete a trip from "All trips" — confirms before removing, switches active trip if it was the deleted one.
- [ ] `npx tsc --noEmit` and `npx eslint src/app/travel src/hooks/useTravelPlanner.ts src/lib/travelPlanner.ts src/types/travel.ts` both clean (verified).


---
_Generated by [Claude Code](https://claude.ai/code/session_015SUQKjhy66jtj82rGV5s7Z)_