### PR TITLE
fix: anchor league snapshot quality gate on `= {` to skip import line

### DIFF
--- a/.github/workflows/update-la-liga.yml
+++ b/.github/workflows/update-la-liga.yml
@@ -56,13 +56,16 @@ jobs:
           const SNAPSHOT_PATH = path.join('src', 'data', 'laLigaSnapshot.ts');
           const raw = fs.readFileSync(SNAPSHOT_PATH, 'utf8');
           // The snapshot is an exported object literal — extract the JSON-ish
-          // payload between the first '{' and the trailing '};'.
-          const start = raw.indexOf('{');
+          // payload between the assignment '= {' and the trailing '};'.
+          // Anchoring on '= {' avoids matching the '{' inside the
+          // 'import type { … }' line at the top of the file.
+          const assign = raw.indexOf('= {');
           const end = raw.lastIndexOf('};');
-          if (start === -1 || end === -1 || end <= start) {
+          if (assign === -1 || end === -1 || end <= assign) {
             console.error('::error::Could not locate snapshot object in laLigaSnapshot.ts');
             process.exit(1);
           }
+          const start = assign + 2;
           let snapshot;
           try {
             snapshot = JSON.parse(raw.slice(start, end + 1));

--- a/.github/workflows/update-premier-league.yml
+++ b/.github/workflows/update-premier-league.yml
@@ -56,13 +56,16 @@ jobs:
           const SNAPSHOT_PATH = path.join('src', 'data', 'premierLeagueSnapshot.ts');
           const raw = fs.readFileSync(SNAPSHOT_PATH, 'utf8');
           // The snapshot is an exported object literal — extract the JSON-ish
-          // payload between the first '{' and the trailing '};'.
-          const start = raw.indexOf('{');
+          // payload between the assignment '= {' and the trailing '};'.
+          // Anchoring on '= {' avoids matching the '{' inside the
+          // 'import type { … }' line at the top of the file.
+          const assign = raw.indexOf('= {');
           const end = raw.lastIndexOf('};');
-          if (start === -1 || end === -1 || end <= start) {
+          if (assign === -1 || end === -1 || end <= assign) {
             console.error('::error::Could not locate snapshot object in premierLeagueSnapshot.ts');
             process.exit(1);
           }
+          const start = assign + 2;
           let snapshot;
           try {
             snapshot = JSON.parse(raw.slice(start, end + 1));


### PR DESCRIPTION
## Summary

The Premier League and La Liga refresh workflows have failed every day since the snapshot quality gate was added on 2026-05-03 (commit `251c1e2`). The first scheduled run on 2026-05-04 failed and every run since has filed a follow-up comment on issues #122 / #123.

**Root cause:** the verify step uses `raw.indexOf('{')` to locate the start of the snapshot object literal. The first `{` in the file is actually inside the `import type { PremierLeagueSnapshot }` header on line 1, so `raw.slice(start, end + 1)` returns junk and `JSON.parse` throws `Expected property name or '}' in JSON at position 2`. The refresh script itself was succeeding; only the quality gate was broken.

Reproduced locally against the current snapshots — `indexOf('{')` matches `{ PremierLeagueSnapshot }` (position 12) and parsing fails. With the fix (`indexOf('= {') + 2`), both snapshots parse and report 20 PL clubs / 20 La Liga clubs, passing the ≥18 gate.

## Changes

- `.github/workflows/update-premier-league.yml`: anchor parse on `= {` instead of the first `{`.
- `.github/workflows/update-la-liga.yml`: same fix.

## Test plan

- [x] Reproduced original failure locally (`JSON.parse` throws `Expected property name`).
- [x] Verified fix parses both `src/data/premierLeagueSnapshot.ts` and `src/data/laLigaSnapshot.ts`.
- [x] Verified both snapshots still satisfy the ≥18 quality gate (20 PL standings, 20 La Liga clubs).
- [ ] Confirm the next scheduled run (or manual `workflow_dispatch`) of both workflows passes and auto-closes issues #122 and #123.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BswQwPGUtVhLqgiR45uWGM)_