### PR TITLE
feat(fantasy): list density toggle, sticky board header, compact rows

### DIFF
--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useEffect, useMemo, useState, type CSSProperties } from "react";
+import { startTransition, useEffect, useMemo, useState, useSyncExternalStore, type CSSProperties } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
@@ -85,22 +85,67 @@ function getPublishedBoardRank(player: Player, position: FantasyRoutePosition): 
 
 function getPlayerDescriptor(player: Player, position: FantasyRoutePosition): string {
   const parts = [player.team];
+  const isOverallView = position === "overall" || position === "flex";
 
-  if (position === "overall" || position === "flex") {
-    if (player.positionRank) {
-      parts.push(`${player.position}${player.positionRank}`);
-    } else {
-      parts.push(player.position);
-    }
-  } else if (Number.isFinite(player.rankAverage)) {
-    parts.push(`Avg ${Number(player.rankAverage).toFixed(2)}`);
+  // Overall/flex boards lead with the player's position rank (e.g. "RB3");
+  // position boards skip it because the column already implies the position.
+  if (isOverallView) {
+    parts.push(player.positionRank ? `${player.position}${player.positionRank}` : player.position);
   }
 
-  if (Number.isFinite(player.rankAverage) && (position === "overall" || position === "flex")) {
+  if (Number.isFinite(player.rankAverage)) {
     parts.push(`Avg ${Number(player.rankAverage).toFixed(2)}`);
   }
 
   return parts.filter(Boolean).join(" • ");
+}
+
+type FantasyBoardDensity = "comfortable" | "compact";
+
+const FANTASY_DENSITY_STORAGE_KEY = "fantasy-board-density";
+
+// The list density is a client-only preference backed by localStorage. We read
+// it through useSyncExternalStore (matching useBudgetPlanner / useWineCellar) so
+// the server and first client paint agree on the default, then the real value
+// resolves on the client without a hydration mismatch.
+const densityListeners = new Set<() => void>();
+
+function subscribeDensityChange(listener: () => void) {
+  densityListeners.add(listener);
+
+  function handleStorage(event: StorageEvent) {
+    if (event.key === null || event.key === FANTASY_DENSITY_STORAGE_KEY) {
+      listener();
+    }
+  }
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("storage", handleStorage);
+  }
+
+  return () => {
+    densityListeners.delete(listener);
+    if (typeof window !== "undefined") {
+      window.removeEventListener("storage", handleStorage);
+    }
+  };
+}
+
+function getDensitySnapshot(): FantasyBoardDensity {
+  if (typeof window === "undefined") return "comfortable";
+  return window.localStorage.getItem(FANTASY_DENSITY_STORAGE_KEY) === "compact"
+    ? "compact"
+    : "comfortable";
+}
+
+function persistDensity(next: FantasyBoardDensity) {
+  try {
+    window.localStorage.setItem(FANTASY_DENSITY_STORAGE_KEY, next);
+  } catch {
+    // Persistence is best-effort (private mode, blocked storage); the listener
+    // notification below still updates this tab's UI even if the write fails.
+  }
+  densityListeners.forEach((listener) => listener());
 }
 
 export function FantasyFootballClient({ initialState }: FantasyFootballClientProps) {
@@ -109,6 +154,12 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
   const shouldReduceMotion = useReducedMotion();
   const variants = shouldReduceMotion ? noMotion : fadeIn;
   const [searchQuery, setSearchQuery] = useState("");
+  const density = useSyncExternalStore(
+    subscribeDensityChange,
+    getDensitySnapshot,
+    () => "comfortable" as FantasyBoardDensity
+  );
+
   const hasManagedParams = searchParams.get("position") !== null || searchParams.get("scoring") !== null;
   const routeState = useMemo<FantasySearchState>(
     () => (hasManagedParams ? normalizeFantasyState(searchParams) : initialState),
@@ -238,6 +289,19 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
       sub: "Snapshot generated",
     },
   ];
+
+  const isCompact = density === "compact";
+  // Compact trims vertical rhythm and, on desktop where the columns are
+  // self-evident, drops the per-cell kicker labels. Mobile keeps the labels
+  // since the cells stack into a single column.
+  const rowClassName = isCompact
+    ? "grid gap-x-4 gap-y-1 rounded-[1.25rem] border px-4 py-2.5 md:grid-cols-[56px_minmax(0,1.6fr)_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1fr)] md:items-center"
+    : "grid gap-4 rounded-[1.5rem] border px-4 py-4 md:grid-cols-[64px_minmax(0,1.6fr)_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1fr)] md:items-center";
+  const rankValueClassName = isCompact
+    ? "text-xl font-semibold tabular-nums"
+    : "text-2xl font-semibold tabular-nums";
+  const cellLabelClassName = isCompact ? "home-kicker mb-1 md:hidden" : "home-kicker mb-1";
+  const skeletonHeightClass = isCompact ? "h-[68px]" : "h-[104px]";
 
   return (
     <section
@@ -413,7 +477,13 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
             </article>
 
             <article className="home-card p-5 sm:p-6" aria-labelledby="rankings-board-heading">
-              <div className="flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-end sm:justify-between" style={{ borderColor: "var(--home-rule)" }}>
+              <div
+                className="sticky top-20 z-20 flex flex-col gap-3 border-b pb-4 pt-1 sm:flex-row sm:items-end sm:justify-between"
+                style={{
+                  borderColor: "var(--home-rule)",
+                  background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+                }}
+              >
                 <div>
                   <p className="home-kicker mb-1">Rankings Board</p>
                   <h2 id="rankings-board-heading" className="text-2xl font-semibold">
@@ -421,6 +491,39 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                   </h2>
                 </div>
                 <div className="flex flex-wrap items-center gap-3">
+                  {routeState.view === "list" && (
+                    <div
+                      className="flex rounded-full border p-1 text-sm font-semibold"
+                      style={{
+                        borderColor: "var(--home-rule)",
+                        background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+                      }}
+                      role="radiogroup"
+                      aria-label="List density"
+                    >
+                      {(["comfortable", "compact"] as const).map((option) => {
+                        const active = density === option;
+                        return (
+                          <button
+                            key={option}
+                            type="button"
+                            role="radio"
+                            aria-checked={active}
+                            onClick={() => persistDensity(option)}
+                            disabled={currentSliceUnavailable}
+                            className="inline-flex min-h-[40px] items-center rounded-full px-3.5 py-1.5 text-sm transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+                            style={
+                              active
+                                ? { background: "var(--home-ink)", color: "var(--home-paper)" }
+                                : { color: "var(--home-ink-muted)" }
+                            }
+                          >
+                            {option === "comfortable" ? "Comfortable" : "Compact"}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
                   <div
                     className="flex rounded-full border p-1 text-sm font-semibold"
                     style={{
@@ -472,7 +575,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                     {Array.from({ length: 10 }).map((_, index) => (
                       <div
                         key={`loading-${index}`}
-                        className="h-[104px] animate-pulse rounded-[1.5rem] border"
+                        className={`${skeletonHeightClass} animate-pulse rounded-[1.5rem] border`}
                         style={{
                           borderColor: "var(--home-rule)",
                           background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
@@ -520,7 +623,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                     {filteredPlayers.map((player) => (
                       <li
                         key={player.id}
-                        className="grid gap-4 rounded-[1.5rem] border px-4 py-4 md:grid-cols-[64px_minmax(0,1.6fr)_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1fr)] md:items-center"
+                        className={rowClassName}
                         style={{
                           borderColor: "var(--home-rule)",
                           background: "color-mix(in srgb, var(--home-paper-alt) 42%, var(--home-elev-mix))",
@@ -528,8 +631,8 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                         aria-label={`${player.name}, ${player.position}, rank ${getPublishedBoardRank(player, routeState.position)}`}
                       >
                         <div>
-                          <p className="home-kicker mb-1">Rank</p>
-                          <p className="text-2xl font-semibold tabular-nums">
+                          <p className={cellLabelClassName}>Rank</p>
+                          <p className={rankValueClassName}>
                             {getPublishedBoardRank(player, routeState.position)}
                           </p>
                         </div>
@@ -550,17 +653,17 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                         </div>
 
                         <div>
-                          <p className="home-kicker mb-1">Tier</p>
+                          <p className={cellLabelClassName}>Tier</p>
                           <p className="text-sm font-semibold">{player.tier ? `Tier ${player.tier}` : "Not listed"}</p>
                         </div>
 
                         <div>
-                          <p className="home-kicker mb-1">Expert range</p>
+                          <p className={cellLabelClassName}>Expert range</p>
                           <p className="text-sm font-semibold tabular-nums">{formatRange(player)}</p>
                         </div>
 
                         <div>
-                          <p className="home-kicker mb-1">Availability</p>
+                          <p className={cellLabelClassName}>Availability</p>
                           <p className="text-sm font-semibold">{formatOwnership(player.ownership)}</p>
                           <p className="mt-1 text-xs" style={{ color: "var(--home-ink-muted)" }}>
                             {player.byeWeek ? `Bye ${player.byeWeek}` : "Bye not listed"}


### PR DESCRIPTION
## Summary

Polish + density pass on the `/fantasy-football` rankings board (no data or behavior changes to what's displayed — purely presentation/UX refinement on the existing structure).

- **List density toggle** — a `Comfortable` / `Compact` control in the board header (list view only), persisted in `localStorage` via `useSyncExternalStore`. This matches the existing hydration-safe client-preference pattern in `useBudgetPlanner` / `useWineCellar` (constant server snapshot → no hydration mismatch, no `setState`-in-effect).
- **Compact mode** — tightens row padding and gap, shrinks the rank value, and hides the per-cell kicker labels on desktop (where the column layout already implies each field). Labels stay on mobile, where cells stack into a single column.
- **Sticky board header** — the header (board title, view/density controls, player count) now sticks below the global nav so controls stay reachable while scrolling a 100+ player board. Tucks under the `sticky top-0 z-50` site header at `top-20 z-20`; background uses the theme-aware `--home-paper`/`--home-elev-mix` mix so it matches the card in light and dark.
- **`getPlayerDescriptor` tidy** — collapsed redundant branching into one path. Output is identical for every position/scoring combination.

## Verification

- `npx jest src/app/fantasy-football/__tests__/fantasy-football-client.test.tsx` → 3/3 pass
- `npx eslint src/app/fantasy-football/fantasy-football-client.tsx` → clean (incl. the strict `react-hooks/set-state-in-effect` rule)
- `npx tsc --noEmit` → clean

## Notes

This session could not refresh the data snapshots directly — the remote environment's network policy blocks the data-provider hosts (`fantasypros.com`, ESPN, MLB, football-data.org all return `host_not_allowed`), and the session's GitHub integration lacks `actions: write` to dispatch the refresh workflow. The scheduled `update-fantasy.yml` cron (Wednesdays) keeps the snapshot current; a manual "Run workflow" is the on-demand path.

https://claude.ai/code/session_01EwZa87SXzdL5SzPGGEQCLe

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwZa87SXzdL5SzPGGEQCLe)_