### PR TITLE
feat(investments): retirement-planning module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,15 @@ This is intentional to avoid stacked closing CTAs.
   - `/api/investments/quotes`
   - `/api/investments/data/[symbol]`
 
+#### Retirement planner
+
+- Surfaced as the `#retirement` band inside the investments dashboard (`InvestmentsDashboard.tsx`); reachable from the sidebar nav. Offers the live portfolio value as a one-click starting balance.
+- **Pure engine:** `src/lib/retirement/*` — framework-free and unit-tested. `project(input)` / `projectCore(input)` return `{ deterministic, monteCarlo, levers, verdict, targetNestEgg, assumptions }`. Expected return + volatility are **derived from the allocation** via dated capital-market assumptions (`capitalMarketAssumptions.ts`), never a single hardcoded number. Two-phase projection (accumulation/decumulation), seeded Monte Carlo (1,000 trials) with confidence bands, coarse account-aware taxes + RMDs, Social Security claim mechanics, and fixed-real / guardrails / fixed-% withdrawal strategies.
+- **CMAs are illustrative and tagged for verification** (`CMA_VERIFIED = false` in `capitalMarketAssumptions.ts`). Re-pin them to a dated primary source before relying on the figures; the UI discloses the source + as-of date + unverified state.
+- **State:** browser-local via `useRetirementPlan` (localStorage key `retirement_plan`), mirroring `useInvestments`. The headline (verdict/chart) computes synchronously; the heavier lever sensitivity runs off the critical path and fills in after paint.
+- **UI:** `src/components/investments/retirement/*` — progressive-disclosure inputs, honest "N of 100 scenarios" framing, D3 confidence-band chart, levers panel, editable assumptions footer, and the educational disclaimer (all output is illustrative, not advice).
+- Output is **educational only** — keep the disclaimer and assumption disclosure intact (compliance, spec §9).
+
 ### NFL Dashboard
 
 `/nfl` is a snapshot-driven NFL dashboard following the same pattern as the Premier League and La Liga. Data comes from public NFLverse CSVs (no API key required) and is committed to the repo as TypeScript.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3602,3 +3602,701 @@ input[type="range"]:focus-visible::-moz-range-thumb {
     transition: none;
   }
 }
+
+/* ============================================================
+   Retirement planner (/investments #retirement)
+   Reuses the editorial palette + invest-research-band shell.
+   ============================================================ */
+
+.invest-retire-band {
+  scroll-margin-top: 7rem;
+}
+.invest-retire-band-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--home-ink-muted);
+  background: var(--home-paper-alt);
+  border: 1px solid var(--home-rule);
+  border-radius: 999px;
+  padding: 6px 12px;
+}
+.invest-retire-computing {
+  color: var(--home-acid, var(--home-ink-muted));
+  font-weight: 600;
+}
+.invest-retire-intro {
+  margin: 0;
+  max-width: 62ch;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--home-ink-muted);
+}
+
+.invest-retire-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 380px) minmax(0, 1fr);
+  gap: 22px;
+  align-items: start;
+}
+@media (max-width: 1024px) {
+  .invest-retire-layout {
+    grid-template-columns: 1fr;
+  }
+}
+.invest-retire-col-results {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+
+/* ── Inputs ── */
+.invest-retire-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border: 1px solid var(--home-rule);
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  padding: 18px;
+}
+.invest-retire-inputs-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.invest-retire-reset {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--home-rule);
+  background: transparent;
+  color: var(--home-ink-muted);
+  border-radius: 999px;
+  padding: 5px 11px;
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 32px;
+}
+.invest-retire-reset:hover {
+  color: var(--home-ink);
+  border-color: var(--home-ink-muted);
+}
+.invest-retire-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+@media (max-width: 420px) {
+  .invest-retire-grid-2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.invest-retire-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+.invest-retire-field-label {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--home-ink);
+}
+.invest-retire-field-hint {
+  font-size: 10.5px;
+  color: var(--home-ink-muted);
+  line-height: 1.3;
+}
+.invest-retire-input-wrap {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--home-rule);
+  border-radius: 12px;
+  background: var(--home-paper);
+  overflow: hidden;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.invest-retire-input-wrap:focus-within {
+  border-color: color-mix(in srgb, var(--home-acid, #2563eb) 60%, var(--home-rule));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--home-acid, #2563eb) 14%, transparent);
+}
+.invest-retire-input-wrap input,
+.invest-retire-input-wrap select {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--home-ink);
+  font: inherit;
+  font-size: 13px;
+  padding: 9px 10px;
+  min-height: 44px;
+}
+.invest-retire-input-wrap input:focus,
+.invest-retire-input-wrap select:focus {
+  outline: none;
+}
+.invest-retire-affix {
+  font-size: 12px;
+  color: var(--home-ink-muted);
+  padding: 0 2px 0 10px;
+}
+.invest-retire-affix-suffix {
+  padding: 0 10px 0 2px;
+}
+
+/* ── Collapsible advanced sections ── */
+.invest-retire-disclose {
+  border: 1px solid var(--home-rule);
+  border-radius: 14px;
+  background: var(--home-paper);
+  overflow: hidden;
+}
+.invest-retire-disclose > summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 14px;
+  cursor: pointer;
+  list-style: none;
+  min-height: 44px;
+}
+.invest-retire-disclose > summary::-webkit-details-marker {
+  display: none;
+}
+.invest-retire-disclose-title {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--home-ink);
+}
+.invest-retire-disclose-summary {
+  font-size: 11px;
+  color: var(--home-ink-muted);
+}
+.invest-retire-disclose-chevron {
+  margin-left: auto;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--home-ink-muted);
+  transition: transform 0.18s ease;
+}
+.invest-retire-disclose[open] > summary .invest-retire-disclose-chevron {
+  transform: rotate(45deg);
+}
+.invest-retire-disclose-body {
+  padding: 4px 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-top: 1px solid var(--home-rule);
+}
+
+.invest-retire-seed {
+  align-self: flex-start;
+  border: 1px dashed color-mix(in srgb, var(--home-acid, #2563eb) 50%, var(--home-rule));
+  background: color-mix(in srgb, var(--home-acid, #2563eb) 8%, var(--home-paper));
+  color: var(--home-ink);
+  border-radius: 12px;
+  padding: 8px 13px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 44px;
+}
+.invest-retire-seed:hover {
+  background: color-mix(in srgb, var(--home-acid, #2563eb) 14%, var(--home-paper));
+}
+
+.invest-retire-accounts,
+.invest-retire-lumpy {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.invest-retire-account {
+  border: 1px solid var(--home-rule);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--home-paper-alt);
+}
+.invest-retire-account-head {
+  display: flex;
+  align-items: end;
+  gap: 8px;
+}
+.invest-retire-account-head .invest-retire-field {
+  flex: 1 1 auto;
+}
+.invest-retire-icon-btn {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--home-rule);
+  border-radius: 10px;
+  background: var(--home-paper);
+  color: var(--home-ink-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.invest-retire-icon-btn:hover {
+  color: var(--color-error);
+  border-color: color-mix(in srgb, var(--color-error) 40%, var(--home-rule));
+}
+.invest-retire-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  border: 1px solid var(--home-rule);
+  background: var(--home-paper);
+  color: var(--home-ink);
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 44px;
+}
+.invest-retire-add:hover {
+  border-color: var(--home-ink-muted);
+}
+.invest-retire-lumpy-row {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 0.8fr auto;
+  gap: 8px;
+  align-items: end;
+}
+@media (max-width: 520px) {
+  .invest-retire-lumpy-row {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.invest-retire-lumpy-label {
+  border: 1px solid var(--home-rule);
+  border-radius: 12px;
+  background: var(--home-paper);
+  color: var(--home-ink);
+  font: inherit;
+  font-size: 13px;
+  padding: 9px 10px;
+  min-height: 44px;
+}
+.invest-retire-alloc-note {
+  margin: 0;
+  font-size: 11px;
+  color: var(--home-ink-muted);
+}
+.invest-retire-alloc-note.warn {
+  color: var(--color-warning);
+}
+
+/* ── Verdict ── */
+.invest-retire-verdict {
+  border: 1px solid var(--home-rule);
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.invest-retire-verdict-head {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.invest-retire-gauge {
+  --gauge: 0;
+  --gauge-tone: var(--home-ink);
+  width: 116px;
+  height: 116px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: conic-gradient(
+    var(--gauge-tone) calc(var(--gauge) * 1%),
+    color-mix(in srgb, var(--home-rule) 70%, transparent) 0
+  );
+  display: grid;
+  place-items: center;
+}
+.invest-retire-gauge-inner {
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  background: var(--home-paper);
+  display: grid;
+  place-items: center;
+  line-height: 1;
+}
+.invest-retire-gauge-num {
+  font-size: 30px;
+  font-weight: 700;
+  color: var(--home-ink);
+  letter-spacing: -0.03em;
+}
+.invest-retire-gauge-unit {
+  font-size: 10.5px;
+  color: var(--home-ink-muted);
+  margin-top: 2px;
+}
+.invest-retire-verdict-copy {
+  flex: 1 1 240px;
+  min-width: 0;
+}
+.invest-retire-verdict-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.invest-retire-verdict-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.invest-retire-verdict-line {
+  margin: 8px 0 0;
+  font-size: 15px;
+  line-height: 1.45;
+  color: var(--home-ink);
+}
+.invest-retire-verdict-sub {
+  margin: 6px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--home-ink-muted);
+}
+.invest-retire-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin: 0;
+}
+@media (max-width: 640px) {
+  .invest-retire-stats {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.invest-retire-stats > div {
+  border: 1px solid var(--home-rule);
+  border-radius: 14px;
+  background: var(--home-paper);
+  padding: 11px 12px;
+}
+.invest-retire-stats dt {
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--home-ink-muted);
+  margin: 0 0 4px;
+}
+.invest-retire-stats dd {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--home-ink);
+}
+.invest-retire-stat-meta {
+  display: block;
+  margin-top: 3px;
+  font-size: 10px;
+  color: var(--home-ink-muted);
+}
+.invest-retire-verdict-note {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--home-ink-muted);
+  border-top: 1px solid var(--home-rule);
+  padding-top: 12px;
+}
+
+/* ── Chart ── */
+.invest-retire-chart {
+  margin: 0;
+  border: 1px solid var(--home-rule);
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  padding: 16px 18px;
+}
+.invest-retire-chart-cap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--home-ink);
+  margin-bottom: 6px;
+}
+.invest-retire-chart-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--home-ink-muted);
+}
+.invest-retire-legend-band {
+  display: inline-block;
+  width: 16px;
+  height: 9px;
+  border-radius: 3px;
+  background: color-mix(in srgb, #2563eb 20%, transparent);
+  margin-right: 2px;
+}
+.invest-retire-legend-line {
+  display: inline-block;
+  width: 16px;
+  height: 0;
+  border-top: 2.5px solid #2563eb;
+  margin: 0 2px 0 8px;
+}
+
+/* ── Levers ── */
+.invest-retire-levers {
+  border: 1px solid var(--home-rule);
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  padding: 18px;
+}
+.invest-retire-levers-head h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--home-ink);
+}
+.invest-retire-levers-head p {
+  margin: 3px 0 14px;
+  font-size: 12px;
+  color: var(--home-ink-muted);
+}
+.invest-retire-lever-list {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+@media (max-width: 640px) {
+  .invest-retire-lever-list {
+    grid-template-columns: 1fr;
+  }
+}
+.invest-retire-lever {
+  border: 1px solid var(--home-rule);
+  border-radius: 14px;
+  background: var(--home-paper);
+  padding: 12px;
+}
+.invest-retire-lever-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+.invest-retire-lever-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--home-ink);
+}
+.invest-retire-lever-change {
+  display: block;
+  font-size: 11px;
+  color: var(--home-ink-muted);
+  margin-top: 1px;
+}
+.invest-retire-lever-delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 12.5px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.invest-retire-lever-desc {
+  margin: 8px 0 10px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--home-ink-muted);
+}
+.invest-retire-lever-bar {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--home-paper-alt);
+  border: 1px solid var(--home-rule);
+  overflow: hidden;
+}
+.invest-retire-lever-bar-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: 999px;
+}
+.invest-retire-lever-bar-target {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 2px;
+  background: var(--home-ink);
+  opacity: 0.5;
+}
+.invest-retire-lever-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--home-ink-muted);
+}
+.invest-retire-lever-target {
+  font-weight: 700;
+  color: var(--home-ink);
+}
+
+/* ── Assumptions footer ── */
+.invest-retire-assumptions {
+  border: 1px solid var(--home-rule);
+  border-radius: 20px;
+  background: var(--home-paper-alt);
+  padding: 18px;
+}
+.invest-retire-assumptions header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--home-ink);
+}
+.invest-retire-assumptions header p {
+  margin: 3px 0 14px;
+  font-size: 11.5px;
+  color: var(--home-ink-muted);
+}
+.invest-retire-assumption-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px 18px;
+  margin: 0 0 12px;
+}
+.invest-retire-assumption-grid > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  border-bottom: 1px dotted var(--home-rule);
+  padding-bottom: 6px;
+}
+.invest-retire-assumption-grid dt {
+  font-size: 11.5px;
+  color: var(--home-ink-muted);
+}
+.invest-retire-assumption-grid dd {
+  margin: 0;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--home-ink);
+  text-align: right;
+  white-space: nowrap;
+}
+.invest-retire-cma {
+  margin-top: 6px;
+}
+.invest-retire-cma > summary {
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--home-ink);
+  padding: 6px 0;
+}
+.invest-retire-cma table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 6px;
+}
+.invest-retire-cma th,
+.invest-retire-cma td {
+  text-align: left;
+  font-size: 11.5px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--home-rule);
+  color: var(--home-ink);
+}
+.invest-retire-cma th {
+  color: var(--home-ink-muted);
+  font-weight: 600;
+}
+.invest-retire-cma td:nth-child(2),
+.invest-retire-cma td:nth-child(3),
+.invest-retire-cma th:nth-child(2),
+.invest-retire-cma th:nth-child(3) {
+  text-align: right;
+}
+.invest-retire-cma-source {
+  margin: 12px 0 0;
+  font-size: 10.5px;
+  line-height: 1.5;
+  color: var(--home-ink-muted);
+}
+
+/* ── Disclaimer + loading ── */
+.invest-retire-disclaimer {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  border: 1px solid var(--home-rule);
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix));
+  padding: 14px 16px;
+  color: var(--home-ink-muted);
+}
+.invest-retire-disclaimer p {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.55;
+}
+.invest-retire-loading {
+  display: grid;
+  place-items: center;
+  min-height: 280px;
+  border: 1px dashed var(--home-rule);
+  border-radius: 24px;
+  color: var(--home-ink-muted);
+  font-size: 13px;
+}
+.invest-retire-lever-skeleton {
+  min-height: 118px;
+  background: linear-gradient(
+    100deg,
+    var(--home-paper) 30%,
+    var(--home-paper-alt) 50%,
+    var(--home-paper) 70%
+  );
+  background-size: 200% 100%;
+  animation: invest-retire-shimmer 1.4s ease-in-out infinite;
+}
+@keyframes invest-retire-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .invest-retire-lever-skeleton {
+    animation: none;
+  }
+}

--- a/src/components/investments/InvestmentsDashboard.tsx
+++ b/src/components/investments/InvestmentsDashboard.tsx
@@ -9,6 +9,7 @@ import {
   IconHelp,
   IconHome,
   IconList,
+  IconPigMoney,
   IconReportMoney,
   IconSearch,
   IconWallet,
@@ -20,6 +21,7 @@ import { DataFreshnessIndicator } from "./DataFreshnessIndicator";
 import { HoldingsTable } from "./HoldingsTable";
 import { ResearchSection } from "./ResearchSection";
 import { StockSearch } from "./StockSearch";
+import { RetirementPlanner } from "./retirement/RetirementPlanner";
 import { useInvestments } from "@/hooks/useInvestments";
 import type { ResearchTab } from "@/app/investments/investments-state";
 
@@ -105,6 +107,7 @@ export function InvestmentsDashboard({
       { id: "stats", label: "Portfolio stats", href: "#portfolio-stats", icon: IconCircleHalf },
       { id: "performance", label: "Performance", href: "#hero", icon: IconChartLine },
       { id: "research", label: "Research", href: "#research-section", icon: IconReportMoney },
+      { id: "retirement", label: "Retirement", href: "#retirement", icon: IconPigMoney },
     ],
     [enhancedHoldings.length],
   );
@@ -346,6 +349,11 @@ export function InvestmentsDashboard({
         portfolioSymbols={portfolioSymbols}
       />
     </section>
+
+    {/* Retirement planner — projects whether the portfolio + savings last
+        through retirement, with allocation-derived Monte Carlo. Offers the
+        live portfolio value as a one-click starting balance. */}
+    <RetirementPlanner portfolioValue={summary.totalValue > 0 ? summary.totalValue : undefined} />
     </div>
   );
 }

--- a/src/components/investments/retirement/RetirementAssumptions.tsx
+++ b/src/components/investments/retirement/RetirementAssumptions.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React from "react";
+import type { RetirementResult } from "@/lib/retirement";
+import { CAPITAL_MARKET_ASSUMPTIONS, formatPercent } from "@/lib/retirement";
+import type { AssetClassId } from "@/lib/retirement";
+
+interface Props {
+  result: RetirementResult;
+}
+
+const STRATEGY_LABEL: Record<string, string> = {
+  "fixed-real": "Fixed real (4%-rule style)",
+  "fixed-percent": "Fixed % of balance",
+  guardrails: "Dynamic guardrails (Guyton-Klinger)",
+};
+
+/**
+ * Disclose every assumption on screen with its source + as-of date — both a UX
+ * best practice and a compliance requirement (spec §6.4, §9). Values are edited
+ * in the Assumptions section of the form; this is the always-visible record.
+ */
+export function RetirementAssumptions({ result }: Props) {
+  const { assumptions, input } = result;
+  const rows: { label: string; value: string }[] = [
+    { label: "Expected return (from allocation)", value: formatPercent(assumptions.expectedReturn, 1) + " nominal" },
+    { label: "Return volatility", value: formatPercent(assumptions.volatility, 1) },
+    { label: "Inflation", value: formatPercent(assumptions.inflation, 1) },
+    { label: "Healthcare inflation (pre-65)", value: formatPercent(input.assumptions.healthcareInflation, 1) },
+    { label: "Withdrawal strategy", value: STRATEGY_LABEL[input.assumptions.withdrawalStrategy] ?? input.assumptions.withdrawalStrategy },
+    { label: "Safe withdrawal rate (target #)", value: formatPercent(result.safeWithdrawalRate, 1) },
+    { label: "On-track threshold", value: formatPercent(assumptions.successThreshold, 0) },
+    { label: "Monte Carlo trials", value: result.monteCarlo.simulations.toLocaleString() },
+    { label: "Effective tax — traditional", value: formatPercent(input.assumptions.taxRates.traditional, 0) },
+    { label: "Effective tax — taxable", value: formatPercent(input.assumptions.taxRates.taxable, 0) },
+    { label: "RMD start age (SECURE 2.0)", value: String(assumptions.rmdStartAge) },
+  ];
+
+  return (
+    <section className="invest-retire-assumptions" aria-label="Assumptions used">
+      <header>
+        <h3>Assumptions</h3>
+        <p>
+          Editable in the form. Returns are derived from your allocation, never a single hardcoded
+          number.
+        </p>
+      </header>
+
+      <dl className="invest-retire-assumption-grid">
+        {rows.map((r) => (
+          <div key={r.label}>
+            <dt>{r.label}</dt>
+            <dd>{r.value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <details className="invest-retire-cma">
+        <summary>Per-asset-class capital market assumptions</summary>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Asset class</th>
+              <th scope="col">Exp. return</th>
+              <th scope="col">Std dev</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(Object.keys(CAPITAL_MARKET_ASSUMPTIONS) as AssetClassId[]).map((id) => {
+              const cma = CAPITAL_MARKET_ASSUMPTIONS[id];
+              return (
+                <tr key={id}>
+                  <td>{cma.label}</td>
+                  <td>{formatPercent(cma.expectedReturn, 1)}</td>
+                  <td>{formatPercent(cma.stdDev, 1)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </details>
+
+      <p className="invest-retire-cma-source">
+        Capital market assumptions: {assumptions.cmaSource} As of {assumptions.cmaAsOf}.{" "}
+        {assumptions.cmaVerified
+          ? "Pinned to a dated primary source."
+          : "Illustrative — re-verify against the latest primary source before relying on figures."}
+      </p>
+    </section>
+  );
+}

--- a/src/components/investments/retirement/RetirementDisclaimer.tsx
+++ b/src/components/investments/retirement/RetirementDisclaimer.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import React from "react";
+import { IconInfoCircle } from "@tabler/icons-react";
+
+/**
+ * Educational / general-information disclaimer (spec §9). Keeps the tool out of
+ * regulated personalized-advice territory. Final language should be reviewed
+ * before any production launch.
+ */
+export function RetirementDisclaimer() {
+  return (
+    <div className="invest-retire-disclaimer" role="note" aria-label="Important disclaimer">
+      <IconInfoCircle size={16} aria-hidden="true" className="shrink-0 mt-0.5" />
+      <p>
+        For illustrative and educational purposes only. Not investment, tax, or financial advice.
+        Projections are hypothetical, rely on the assumptions shown above, and do not guarantee
+        future results. Capital-market assumptions are estimates that change over time. Consult a
+        qualified financial professional before making decisions.
+      </p>
+    </div>
+  );
+}

--- a/src/components/investments/retirement/RetirementFields.tsx
+++ b/src/components/investments/retirement/RetirementFields.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import React, { useId, useState } from "react";
+
+// ─── Numeric field with optional prefix/suffix ───────────────────────────────
+
+interface NumberFieldProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  prefix?: string;
+  suffix?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  hint?: string;
+  /** Treat the value as a percent (display value × 100, store ÷ 100). */
+  asPercent?: boolean;
+}
+
+export function NumberField({
+  label,
+  value,
+  onChange,
+  prefix,
+  suffix,
+  min,
+  max,
+  step,
+  hint,
+  asPercent = false,
+}: NumberFieldProps) {
+  const id = useId();
+  // Local text buffer so the field can be cleared/typed without snapping.
+  const [text, setText] = useState(() => String(asPercent ? value * 100 : value));
+  const [syncedValue, setSyncedValue] = useState(value);
+
+  // Reflect *external* value changes (reset, portfolio seed) during render
+  // without clobbering in-progress typing such as a trailing decimal point.
+  if (value !== syncedValue) {
+    setSyncedValue(value);
+    const parsed = asPercent ? Number(text) / 100 : Number(text);
+    if (Number.isNaN(parsed) || Math.abs(parsed - value) > 1e-9) {
+      setText(String(asPercent ? value * 100 : value));
+    }
+  }
+
+  function commit(raw: string) {
+    setText(raw);
+    if (raw.trim() === "" || raw === "-") return;
+    const parsed = Number(raw);
+    if (Number.isNaN(parsed)) return;
+    let next = asPercent ? parsed / 100 : parsed;
+    if (min !== undefined) next = Math.max(asPercent ? min / 100 : min, next);
+    if (max !== undefined) next = Math.min(asPercent ? max / 100 : max, next);
+    onChange(next);
+  }
+
+  return (
+    <label className="invest-retire-field" htmlFor={id}>
+      <span className="invest-retire-field-label">{label}</span>
+      <span className="invest-retire-input-wrap">
+        {prefix ? <span className="invest-retire-affix">{prefix}</span> : null}
+        <input
+          id={id}
+          type="number"
+          inputMode="decimal"
+          value={text}
+          min={min}
+          max={max}
+          step={step}
+          onChange={(e) => commit(e.target.value)}
+          onBlur={() => setText(String(asPercent ? value * 100 : value))}
+        />
+        {suffix ? <span className="invest-retire-affix invest-retire-affix-suffix">{suffix}</span> : null}
+      </span>
+      {hint ? <span className="invest-retire-field-hint">{hint}</span> : null}
+    </label>
+  );
+}
+
+// ─── Select ──────────────────────────────────────────────────────────────────
+
+interface SelectFieldProps<T extends string> {
+  label: string;
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (value: T) => void;
+  hint?: string;
+}
+
+export function SelectField<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+  hint,
+}: SelectFieldProps<T>) {
+  const id = useId();
+  return (
+    <label className="invest-retire-field" htmlFor={id}>
+      <span className="invest-retire-field-label">{label}</span>
+      <span className="invest-retire-input-wrap">
+        <select id={id} value={value} onChange={(e) => onChange(e.target.value as T)}>
+          {options.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </span>
+      {hint ? <span className="invest-retire-field-hint">{hint}</span> : null}
+    </label>
+  );
+}
+
+// ─── Collapsible advanced section (progressive disclosure) ───────────────────
+
+interface CollapsibleProps {
+  title: string;
+  summary?: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+export function Collapsible({ title, summary, defaultOpen = false, children }: CollapsibleProps) {
+  return (
+    <details className="invest-retire-disclose" open={defaultOpen}>
+      <summary>
+        <span className="invest-retire-disclose-title">{title}</span>
+        {summary ? <span className="invest-retire-disclose-summary">{summary}</span> : null}
+        <span className="invest-retire-disclose-chevron" aria-hidden="true">＋</span>
+      </summary>
+      <div className="invest-retire-disclose-body">{children}</div>
+    </details>
+  );
+}

--- a/src/components/investments/retirement/RetirementInputs.tsx
+++ b/src/components/investments/retirement/RetirementInputs.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import React from "react";
+import { IconTrash, IconPlus, IconRefresh, IconWallet } from "@tabler/icons-react";
+import type { UseRetirementPlanReturn } from "@/hooks/useRetirementPlan";
+import type { AccountType, RetirementResult, WithdrawalStrategy } from "@/lib/retirement";
+import { formatCompactCurrency, formatPercent } from "@/lib/retirement";
+import { Collapsible, NumberField, SelectField } from "./RetirementFields";
+
+interface Props {
+  controller: UseRetirementPlanReturn;
+  result: RetirementResult | null;
+  /** Current portfolio value, if any, offered as a one-click balance seed. */
+  portfolioValue?: number;
+}
+
+const ACCOUNT_TYPES: { value: AccountType; label: string }[] = [
+  { value: "taxable", label: "Taxable brokerage" },
+  { value: "traditional", label: "Traditional 401k / IRA" },
+  { value: "roth", label: "Roth" },
+  { value: "hsa", label: "HSA" },
+];
+
+const STRATEGIES: { value: WithdrawalStrategy; label: string }[] = [
+  { value: "fixed-real", label: "Fixed real (4%-rule style)" },
+  { value: "guardrails", label: "Dynamic guardrails (smart)" },
+  { value: "fixed-percent", label: "Fixed % of balance" },
+];
+
+export function RetirementInputs({ controller, result, portfolioValue }: Props) {
+  const {
+    plan,
+    updatePlan,
+    updateAssumptions,
+    updateAllocation,
+    updateOtherIncome,
+    addAccount,
+    updateAccount,
+    removeAccount,
+    addLumpyExpense,
+    updateLumpyExpense,
+    removeLumpyExpense,
+    applyPortfolioBalance,
+    reset,
+  } = controller;
+
+  const primary = plan.accounts[0];
+  const totalBalance = plan.accounts.reduce((s, a) => s + (a.balance || 0), 0);
+  const totalContribution = plan.accounts.reduce(
+    (s, a) => s + (a.annualContribution || 0) + (a.employerMatch || 0),
+    0,
+  );
+  const allocTotal =
+    plan.allocation.stocks + plan.allocation.bonds + plan.allocation.cash + plan.allocation.other;
+
+  function setPrimaryBalance(value: number) {
+    if (primary) updateAccount(primary.id, { balance: value });
+    else updatePlan({ accounts: [{ id: "primary", type: "traditional", balance: value, annualContribution: 0, employerMatch: 0 }] });
+  }
+  function setPrimaryContribution(value: number) {
+    if (primary) updateAccount(primary.id, { annualContribution: value });
+    else updatePlan({ accounts: [{ id: "primary", type: "traditional", balance: 0, annualContribution: value, employerMatch: 0 }] });
+  }
+
+  return (
+    <div className="invest-retire-inputs">
+      <div className="invest-retire-inputs-head">
+        <p className="invest-rail-section-label">
+          <IconWallet size={12} aria-hidden="true" className="mr-1.5 inline align-middle" />
+          Your numbers
+        </p>
+        <button type="button" className="invest-retire-reset" onClick={reset}>
+          <IconRefresh size={13} aria-hidden="true" /> Reset
+        </button>
+      </div>
+
+      {/* ── Quick start — instant first number ── */}
+      <div className="invest-retire-grid-2">
+        <NumberField label="Current age" value={plan.currentAge} min={18} max={90}
+          onChange={(v) => updatePlan({ currentAge: Math.round(v) })} />
+        <NumberField label="Retirement age" value={plan.retirementAge} min={plan.currentAge + 1} max={90}
+          onChange={(v) => updatePlan({ retirementAge: Math.round(v) })} />
+        <NumberField label="Current balance" value={primary?.balance ?? 0} prefix="$" min={0} step={1000}
+          onChange={setPrimaryBalance}
+          hint={plan.accounts.length > 1 ? `Total across ${plan.accounts.length} accounts: ${formatCompactCurrency(totalBalance)}` : undefined} />
+        <NumberField label="Annual savings" value={primary?.annualContribution ?? 0} prefix="$" min={0} step={500}
+          onChange={setPrimaryContribution}
+          hint={plan.accounts.length > 1 ? `Total contributions: ${formatCompactCurrency(totalContribution)}` : undefined} />
+        <NumberField label="Desired annual spend" value={plan.desiredAnnualSpend} prefix="$" min={0} step={1000}
+          onChange={(v) => updatePlan({ desiredAnnualSpend: v })} hint="In today's dollars" />
+        <NumberField label="Plan to age" value={plan.horizonAge} min={plan.retirementAge + 1} max={110}
+          onChange={(v) => updatePlan({ horizonAge: Math.round(v) })} hint="Conservative life expectancy" />
+      </div>
+
+      {portfolioValue && portfolioValue > 0 ? (
+        <button type="button" className="invest-retire-seed" onClick={() => applyPortfolioBalance(portfolioValue)}>
+          Use my portfolio balance ({formatCompactCurrency(portfolioValue)})
+        </button>
+      ) : null}
+
+      {/* ── Accounts by tax type ── */}
+      <Collapsible title="Accounts by tax type" summary="taxable · traditional · Roth · HSA">
+        <div className="invest-retire-accounts">
+          {plan.accounts.map((account) => (
+            <div key={account.id} className="invest-retire-account">
+              <div className="invest-retire-account-head">
+                <SelectField label="Type" value={account.type} options={ACCOUNT_TYPES}
+                  onChange={(v) => updateAccount(account.id, { type: v })} />
+                <button type="button" className="invest-retire-icon-btn" aria-label="Remove account"
+                  onClick={() => removeAccount(account.id)}>
+                  <IconTrash size={15} aria-hidden="true" />
+                </button>
+              </div>
+              <div className="invest-retire-grid-2">
+                <NumberField label="Balance" value={account.balance} prefix="$" min={0} step={1000}
+                  onChange={(v) => updateAccount(account.id, { balance: v })} />
+                <NumberField label="Annual contribution" value={account.annualContribution} prefix="$" min={0} step={500}
+                  onChange={(v) => updateAccount(account.id, { annualContribution: v })} />
+                <NumberField label="Employer match" value={account.employerMatch} prefix="$" min={0} step={500}
+                  onChange={(v) => updateAccount(account.id, { employerMatch: v })} />
+                <NumberField label="Contribution growth" value={account.contributionGrowth ?? plan.assumptions.inflation}
+                  suffix="%" min={0} max={20} step={0.1} asPercent
+                  onChange={(v) => updateAccount(account.id, { contributionGrowth: v })} />
+              </div>
+            </div>
+          ))}
+          <button type="button" className="invest-retire-add" onClick={addAccount}>
+            <IconPlus size={14} aria-hidden="true" /> Add account
+          </button>
+        </div>
+      </Collapsible>
+
+      {/* ── Allocation ── */}
+      <Collapsible
+        title="Asset allocation"
+        summary={result ? `${formatPercent(result.expectedReturn, 1)} return · ${formatPercent(result.volatility, 1)} vol` : undefined}
+      >
+        <div className="invest-retire-grid-2">
+          <NumberField label="Stocks" value={plan.allocation.stocks} suffix="%" min={0} max={100} step={5}
+            onChange={(v) => updateAllocation({ stocks: v })} />
+          <NumberField label="Bonds" value={plan.allocation.bonds} suffix="%" min={0} max={100} step={5}
+            onChange={(v) => updateAllocation({ bonds: v })} />
+          <NumberField label="Cash" value={plan.allocation.cash} suffix="%" min={0} max={100} step={5}
+            onChange={(v) => updateAllocation({ cash: v })} />
+          <NumberField label="Other / real assets" value={plan.allocation.other} suffix="%" min={0} max={100} step={5}
+            onChange={(v) => updateAllocation({ other: v })} />
+        </div>
+        <p className={`invest-retire-alloc-note ${Math.abs(allocTotal - 100) > 0.5 ? "warn" : ""}`}>
+          Total: {allocTotal.toFixed(0)}% {Math.abs(allocTotal - 100) > 0.5 ? "(weights are normalized automatically)" : "✓"}
+        </p>
+      </Collapsible>
+
+      {/* ── Other income ── */}
+      <Collapsible title="Other retirement income" summary="Social Security · pension · part-time">
+        <div className="invest-retire-grid-2">
+          <NumberField label="Social Security / yr" value={plan.otherIncome.socialSecurityAnnual} prefix="$" min={0} step={500}
+            onChange={(v) => updateOtherIncome({ socialSecurityAnnual: v })} hint="FRA estimate from ssa.gov" />
+          <NumberField label="Claim age" value={plan.otherIncome.socialSecurityClaimAge} min={62} max={70}
+            onChange={(v) => updateOtherIncome({ socialSecurityClaimAge: Math.round(v) })} hint="62–70; delaying adds ~8%/yr" />
+          <NumberField label="Pension / yr" value={plan.otherIncome.pensionAnnual} prefix="$" min={0} step={500}
+            onChange={(v) => updateOtherIncome({ pensionAnnual: v })} />
+          <NumberField label="Pension start age" value={plan.otherIncome.pensionStartAge} min={50} max={90}
+            onChange={(v) => updateOtherIncome({ pensionStartAge: Math.round(v) })} />
+          <NumberField label="Part-time income / yr" value={plan.otherIncome.partTimeAnnual} prefix="$" min={0} step={500}
+            onChange={(v) => updateOtherIncome({ partTimeAnnual: v })} />
+          <NumberField label="Part-time until age" value={plan.otherIncome.partTimeEndAge} min={plan.retirementAge} max={90}
+            onChange={(v) => updateOtherIncome({ partTimeEndAge: Math.round(v) })} />
+        </div>
+      </Collapsible>
+
+      {/* ── Spending details ── */}
+      <Collapsible title="Spending details" summary="healthcare gap · one-time expenses">
+        <NumberField label="Extra healthcare before Medicare (65) / yr" value={plan.preMedicareHealthcare} prefix="$" min={0} step={500}
+          onChange={(v) => updatePlan({ preMedicareHealthcare: v })} hint="Modeled with faster healthcare inflation" />
+        <div className="invest-retire-lumpy">
+          <span className="invest-retire-field-label">One-time / lumpy expenses</span>
+          {plan.lumpyExpenses.map((expense) => (
+            <div key={expense.id} className="invest-retire-lumpy-row">
+              <input className="invest-retire-lumpy-label" value={expense.label}
+                onChange={(e) => updateLumpyExpense(expense.id, { label: e.target.value })} aria-label="Expense label" />
+              <NumberField label="Amount" value={expense.amount} prefix="$" min={0} step={1000}
+                onChange={(v) => updateLumpyExpense(expense.id, { amount: v })} />
+              <NumberField label="At age" value={expense.age} min={plan.currentAge} max={plan.horizonAge}
+                onChange={(v) => updateLumpyExpense(expense.id, { age: Math.round(v) })} />
+              <button type="button" className="invest-retire-icon-btn" aria-label="Remove expense"
+                onClick={() => removeLumpyExpense(expense.id)}>
+                <IconTrash size={15} aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+          <button type="button" className="invest-retire-add" onClick={addLumpyExpense}>
+            <IconPlus size={14} aria-hidden="true" /> Add expense
+          </button>
+        </div>
+      </Collapsible>
+
+      {/* ── Assumptions ── */}
+      <Collapsible title="Assumptions" summary="returns, inflation, taxes, withdrawal rule">
+        <div className="invest-retire-grid-2">
+          <SelectField label="Filing status" value={plan.filingStatus}
+            options={[{ value: "single", label: "Single" }, { value: "married", label: "Married" }]}
+            onChange={(v) => updatePlan({ filingStatus: v })} />
+          <SelectField label="Withdrawal strategy" value={plan.assumptions.withdrawalStrategy} options={STRATEGIES}
+            onChange={(v) => updateAssumptions({ withdrawalStrategy: v })} />
+          <NumberField label="Inflation" value={plan.assumptions.inflation} suffix="%" min={0} max={10} step={0.1} asPercent
+            onChange={(v) => updateAssumptions({ inflation: v })} />
+          <NumberField label="Healthcare inflation" value={plan.assumptions.healthcareInflation} suffix="%" min={0} max={15} step={0.1} asPercent
+            onChange={(v) => updateAssumptions({ healthcareInflation: v })} />
+          <NumberField label="Withdrawal rate (target #)" value={plan.assumptions.withdrawalRateOverride ?? 0.04}
+            suffix="%" min={1} max={10} step={0.1} asPercent
+            onChange={(v) => updateAssumptions({ withdrawalRateOverride: v })} hint="Default 4%; edit to your safe rate" />
+          <NumberField label="On-track threshold" value={plan.assumptions.successThreshold} suffix="%" min={50} max={99} step={1} asPercent
+            onChange={(v) => updateAssumptions({ successThreshold: v })} hint="85–90% is typical" />
+          <NumberField label="Tax — traditional withdrawals" value={plan.assumptions.taxRates.traditional} suffix="%" min={0} max={50} step={1} asPercent
+            onChange={(v) => updateAssumptions({ taxRates: { ...plan.assumptions.taxRates, traditional: v } })} />
+          <NumberField label="Tax — taxable withdrawals" value={plan.assumptions.taxRates.taxable} suffix="%" min={0} max={40} step={1} asPercent
+            onChange={(v) => updateAssumptions({ taxRates: { ...plan.assumptions.taxRates, taxable: v } })} />
+        </div>
+      </Collapsible>
+    </div>
+  );
+}

--- a/src/components/investments/retirement/RetirementLevers.tsx
+++ b/src/components/investments/retirement/RetirementLevers.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React from "react";
+import { IconArrowDownRight, IconArrowUpRight, IconMinus } from "@tabler/icons-react";
+import type { LeverEffect, RetirementResult } from "@/lib/retirement";
+import { formatPercent } from "@/lib/retirement";
+
+interface Props {
+  result: RetirementResult;
+}
+
+function deltaTone(delta: number): string {
+  if (delta > 0.005) return "var(--color-success)";
+  if (delta < -0.005) return "var(--color-error)";
+  return "var(--home-ink-muted)";
+}
+
+function DeltaIcon({ delta }: { delta: number }) {
+  if (delta > 0.005) return <IconArrowUpRight size={15} aria-hidden="true" />;
+  if (delta < -0.005) return <IconArrowDownRight size={15} aria-hidden="true" />;
+  return <IconMinus size={15} aria-hidden="true" />;
+}
+
+function LeverRow({ lever, threshold }: { lever: LeverEffect; threshold: number }) {
+  const tone = deltaTone(lever.delta);
+  const pp = Math.round(lever.delta * 100);
+  return (
+    <li className="invest-retire-lever">
+      <div className="invest-retire-lever-top">
+        <div>
+          <span className="invest-retire-lever-label">{lever.label}</span>
+          <span className="invest-retire-lever-change">{lever.changeLabel}</span>
+        </div>
+        <span className="invest-retire-lever-delta" style={{ color: tone }}>
+          <DeltaIcon delta={lever.delta} />
+          {pp > 0 ? "+" : ""}
+          {pp} pp
+        </span>
+      </div>
+      <p className="invest-retire-lever-desc">{lever.description}</p>
+      <div className="invest-retire-lever-bar" aria-hidden="true">
+        <div
+          className="invest-retire-lever-bar-fill"
+          style={{ width: `${Math.round(lever.newSuccessRate * 100)}%`, background: tone }}
+        />
+        <span
+          className="invest-retire-lever-bar-target"
+          style={{ left: `${Math.round(threshold * 100)}%` }}
+        />
+      </div>
+      <div className="invest-retire-lever-foot">
+        <span>→ {formatPercent(lever.newSuccessRate, 0)} success</span>
+        {lever.toReachTarget ? (
+          <span className="invest-retire-lever-target">
+            {lever.toReachTarget.value} {lever.toReachTarget.label}
+          </span>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Sensitivity to the four dials (spec §5.5): save more, retire later, spend
+ * less, change allocation. Shows the marginal effect of each, sorted by impact.
+ */
+export function RetirementLevers({ result }: Props) {
+  const threshold = result.input.assumptions.successThreshold;
+  const levers = [...result.levers].sort((a, b) => b.delta - a.delta);
+
+  return (
+    <section className="invest-retire-levers" aria-label="What moves the outcome">
+      <header className="invest-retire-levers-head">
+        <h3>What gets me to {formatPercent(threshold, 0)}?</h3>
+        <p>Each dial&apos;s marginal effect on your probability of success.</p>
+      </header>
+      {levers.length === 0 ? (
+        <ul className="invest-retire-lever-list" aria-hidden="true">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <li key={i} className="invest-retire-lever invest-retire-lever-skeleton" />
+          ))}
+        </ul>
+      ) : (
+        <ul className="invest-retire-lever-list">
+          {levers.map((lever) => (
+            <LeverRow key={lever.id} lever={lever} threshold={threshold} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/investments/retirement/RetirementPlanner.tsx
+++ b/src/components/investments/retirement/RetirementPlanner.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React from "react";
+import { IconChartHistogram } from "@tabler/icons-react";
+import { useRetirementPlan, type RetirementSeed } from "@/hooks/useRetirementPlan";
+import { RetirementInputs } from "./RetirementInputs";
+import { RetirementVerdict } from "./RetirementVerdict";
+import { RetirementProjectionChart } from "./RetirementProjectionChart";
+import { RetirementLevers } from "./RetirementLevers";
+import { RetirementAssumptions } from "./RetirementAssumptions";
+import { RetirementDisclaimer } from "./RetirementDisclaimer";
+
+interface Props {
+  /** Current portfolio value, offered as a one-click balance seed. */
+  portfolioValue?: number;
+  /** Derived allocation from the portfolio, used to seed a fresh plan. */
+  seedAllocation?: RetirementSeed["allocation"];
+}
+
+export function RetirementPlanner({ portfolioValue, seedAllocation }: Props) {
+  const seed: RetirementSeed = { portfolioValue, allocation: seedAllocation };
+  const controller = useRetirementPlan(seed);
+  const { result, ready, isComputing } = controller;
+
+  return (
+    <section
+      id="retirement"
+      className="invest-research-band invest-retire-band scroll-mt-28"
+      aria-label="Retirement planner"
+    >
+      <div className="invest-section-header">
+        <div>
+          <p className="invest-section-kicker">Plan ahead</p>
+          <h2 className="invest-section-title">Retirement planner</h2>
+        </div>
+        <span className="invest-retire-band-tag">
+          <IconChartHistogram size={14} aria-hidden="true" />
+          {result ? `${result.monteCarlo.simulations.toLocaleString()} Monte Carlo scenarios` : "Monte Carlo"}
+          {isComputing ? <span className="invest-retire-computing" aria-live="polite"> · updating…</span> : null}
+        </span>
+      </div>
+
+      <p className="invest-retire-intro">
+        Am I on track to retire — and what should I change? Start with five numbers for an instant
+        read, then open the advanced sections to refine accounts, allocation, income, and
+        assumptions.
+      </p>
+
+      <div className="invest-retire-layout">
+        <div className="invest-retire-col-inputs">
+          <RetirementInputs controller={controller} result={result} portfolioValue={portfolioValue} />
+        </div>
+
+        <div className="invest-retire-col-results">
+          {ready && result ? (
+            <>
+              <RetirementVerdict result={result} />
+              <RetirementProjectionChart result={result} />
+              <RetirementLevers result={result} />
+            </>
+          ) : (
+            <div className="invest-retire-loading" role="status">
+              Crunching scenarios…
+            </div>
+          )}
+        </div>
+      </div>
+
+      {ready && result ? (
+        <>
+          <RetirementAssumptions result={result} />
+          <RetirementDisclaimer />
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/investments/retirement/RetirementProjectionChart.tsx
+++ b/src/components/investments/retirement/RetirementProjectionChart.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import * as d3 from "d3";
+import type { RetirementResult } from "@/lib/retirement";
+import { formatCompactCurrency } from "@/lib/retirement";
+
+interface Props {
+  result: RetirementResult;
+}
+
+const W = 760;
+const H = 340;
+const MARGIN = { top: 16, right: 18, bottom: 36, left: 60 };
+const ACCENT = "#2563EB";
+
+/**
+ * Balance over time with a shaded 10th–90th percentile confidence band and a
+ * median line — communicating the *range* of outcomes, not a single false-
+ * precision line (spec §5.2, §6.2). All figures in today's dollars.
+ */
+export function RetirementProjectionChart({ result }: Props) {
+  const ref = useRef<SVGSVGElement>(null);
+  const bands = result.monteCarlo.bands;
+
+  useEffect(() => {
+    if (!ref.current || bands.length === 0) return;
+    const svg = d3.select(ref.current);
+    svg.selectAll("*").remove();
+
+    const innerW = W - MARGIN.left - MARGIN.right;
+    const innerH = H - MARGIN.top - MARGIN.bottom;
+
+    const x = d3
+      .scaleLinear()
+      .domain([bands[0].age, bands[bands.length - 1].age])
+      .range([0, innerW]);
+
+    const maxY = d3.max(bands, (b) => b.p90) ?? 1;
+    const y = d3.scaleLinear().domain([0, maxY * 1.05]).nice().range([innerH, 0]);
+
+    const g = svg.append("g").attr("transform", `translate(${MARGIN.left},${MARGIN.top})`);
+
+    // Gridlines + y axis.
+    const yTicks = y.ticks(5);
+    g.selectAll("line.grid")
+      .data(yTicks)
+      .join("line")
+      .attr("class", "grid")
+      .attr("x1", 0)
+      .attr("x2", innerW)
+      .attr("y1", (d) => y(d))
+      .attr("y2", (d) => y(d))
+      .attr("stroke", "var(--home-rule)")
+      .attr("stroke-dasharray", "2 3")
+      .attr("opacity", 0.6);
+
+    g.selectAll("text.ylabel")
+      .data(yTicks)
+      .join("text")
+      .attr("class", "ylabel")
+      .attr("x", -10)
+      .attr("y", (d) => y(d))
+      .attr("dy", "0.32em")
+      .attr("text-anchor", "end")
+      .attr("font-size", "10px")
+      .attr("fill", "var(--home-ink-muted)")
+      .text((d) => formatCompactCurrency(d));
+
+    // X axis (age) ticks.
+    const xTicks = x.ticks(6);
+    g.selectAll("text.xlabel")
+      .data(xTicks)
+      .join("text")
+      .attr("class", "xlabel")
+      .attr("x", (d) => x(d))
+      .attr("y", innerH + 22)
+      .attr("text-anchor", "middle")
+      .attr("font-size", "10px")
+      .attr("fill", "var(--home-ink-muted)")
+      .text((d) => `${d}`);
+
+    g.append("text")
+      .attr("x", innerW)
+      .attr("y", innerH + 22)
+      .attr("text-anchor", "end")
+      .attr("font-size", "9px")
+      .attr("fill", "var(--home-ink-muted)")
+      .attr("opacity", 0.7)
+      .text("age →");
+
+    // Outer band (p10–p90).
+    const outerArea = d3
+      .area<(typeof bands)[number]>()
+      .x((d) => x(d.age))
+      .y0((d) => y(d.p10))
+      .y1((d) => y(d.p90))
+      .curve(d3.curveMonotoneX);
+
+    // Inner band (p25–p75).
+    const innerArea = d3
+      .area<(typeof bands)[number]>()
+      .x((d) => x(d.age))
+      .y0((d) => y(d.p25))
+      .y1((d) => y(d.p75))
+      .curve(d3.curveMonotoneX);
+
+    g.append("path").datum(bands).attr("d", outerArea).attr("fill", ACCENT).attr("opacity", 0.12);
+    g.append("path").datum(bands).attr("d", innerArea).attr("fill", ACCENT).attr("opacity", 0.2);
+
+    // Median line.
+    const median = d3
+      .line<(typeof bands)[number]>()
+      .x((d) => x(d.age))
+      .y((d) => y(d.p50))
+      .curve(d3.curveMonotoneX);
+    g.append("path")
+      .datum(bands)
+      .attr("d", median)
+      .attr("fill", "none")
+      .attr("stroke", ACCENT)
+      .attr("stroke-width", 2.5);
+
+    // Retirement-age marker.
+    const retireAge = result.input.retirementAge;
+    if (retireAge >= bands[0].age && retireAge <= bands[bands.length - 1].age) {
+      g.append("line")
+        .attr("x1", x(retireAge))
+        .attr("x2", x(retireAge))
+        .attr("y1", 0)
+        .attr("y2", innerH)
+        .attr("stroke", "var(--home-ink)")
+        .attr("stroke-width", 1)
+        .attr("stroke-dasharray", "4 3")
+        .attr("opacity", 0.5);
+      g.append("text")
+        .attr("x", x(retireAge) + 4)
+        .attr("y", 12)
+        .attr("font-size", "9.5px")
+        .attr("font-weight", "600")
+        .attr("fill", "var(--home-ink)")
+        .text(`retire ${retireAge}`);
+    }
+  }, [bands, result.input.retirementAge]);
+
+  const summary = `Projected portfolio balance from age ${result.input.currentAge} to ${result.input.horizonAge}, today's dollars. Median at retirement ${formatCompactCurrency(result.monteCarlo.balanceAtRetirement.p50)}, with a 10th–90th percentile range.`;
+
+  return (
+    <figure className="invest-retire-chart" aria-label="Projected balance over time">
+      <figcaption className="invest-retire-chart-cap">
+        Projected balance · today&apos;s dollars
+        <span className="invest-retire-chart-legend">
+          <span className="invest-retire-legend-band" /> 10–90th percentile
+          <span className="invest-retire-legend-line" /> median
+        </span>
+      </figcaption>
+      <svg
+        ref={ref}
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        aria-label={summary}
+        style={{ width: "100%", height: "auto" }}
+      />
+    </figure>
+  );
+}

--- a/src/components/investments/retirement/RetirementVerdict.tsx
+++ b/src/components/investments/retirement/RetirementVerdict.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import React from "react";
+import type { RetirementResult, Verdict } from "@/lib/retirement";
+import { formatCompactCurrency, formatPercent, formatScenarioCount } from "@/lib/retirement";
+
+const VERDICT_COPY: Record<Verdict, { label: string; tone: string }> = {
+  "on-track": { label: "On track", tone: "var(--color-success)" },
+  good: { label: "Looking good", tone: "var(--color-success)" },
+  fair: { label: "Fair — worth a look", tone: "var(--color-warning)" },
+  "at-risk": { label: "Needs attention", tone: "var(--color-error)" },
+};
+
+interface Props {
+  result: RetirementResult;
+}
+
+export function RetirementVerdict({ result }: Props) {
+  const { monteCarlo, deterministic, targetNestEgg, input, verdict } = result;
+  const successPct = Math.round(monteCarlo.successRate * 100);
+  const copy = VERDICT_COPY[verdict];
+  const meetsThreshold = monteCarlo.successRate >= input.assumptions.successThreshold;
+
+  const projected = monteCarlo.balanceAtRetirement.p50;
+  const surplus = projected - targetNestEgg;
+  const depletion = monteCarlo.medianDepletionAge;
+
+  return (
+    <section className="invest-retire-verdict" aria-label="Retirement readiness verdict">
+      <div className="invest-retire-verdict-head">
+        <div
+          className="invest-retire-gauge"
+          style={
+            {
+              "--gauge": `${successPct}`,
+              "--gauge-tone": copy.tone,
+            } as React.CSSProperties
+          }
+          role="img"
+          aria-label={`${formatScenarioCount(monteCarlo.successRate)} simulated scenarios fund retirement through age ${input.horizonAge}`}
+        >
+          <div className="invest-retire-gauge-inner">
+            <span className="invest-retire-gauge-num">{successPct}</span>
+            <span className="invest-retire-gauge-unit">/ 100</span>
+          </div>
+        </div>
+
+        <div className="invest-retire-verdict-copy">
+          <span className="invest-retire-verdict-badge" style={{ color: copy.tone }}>
+            <span className="invest-retire-verdict-dot" style={{ background: copy.tone }} aria-hidden="true" />
+            {copy.label}
+          </span>
+          <p className="invest-retire-verdict-line">
+            About <strong>{formatScenarioCount(monteCarlo.successRate)}</strong> simulated scenarios
+            fund your spending through age <strong>{input.horizonAge}</strong>.
+          </p>
+          <p className="invest-retire-verdict-sub">
+            Your target is {formatPercent(input.assumptions.successThreshold, 0)}.{" "}
+            {meetsThreshold
+              ? "You're meeting it."
+              : "A “miss” usually just means a mid-course spending adjustment, not running out."}
+          </p>
+        </div>
+      </div>
+
+      <dl className="invest-retire-stats">
+        <div>
+          <dt>Projected at {input.retirementAge}</dt>
+          <dd>{formatCompactCurrency(projected)}</dd>
+          <span className="invest-retire-stat-meta">median, today&apos;s dollars</span>
+        </div>
+        <div>
+          <dt>Target nest egg</dt>
+          <dd>{formatCompactCurrency(targetNestEgg)}</dd>
+          <span className="invest-retire-stat-meta">
+            net spend ÷ {formatPercent(result.safeWithdrawalRate, 1)}
+          </span>
+        </div>
+        <div>
+          <dt>{surplus >= 0 ? "Surplus" : "Shortfall"}</dt>
+          <dd style={{ color: surplus >= 0 ? "var(--color-success)" : "var(--color-error)" }}>
+            {surplus >= 0 ? "+" : "−"}
+            {formatCompactCurrency(Math.abs(surplus))}
+          </dd>
+          <span className="invest-retire-stat-meta">vs. target at retirement</span>
+        </div>
+        <div>
+          <dt>If money runs out</dt>
+          <dd>{depletion ? `age ${depletion}` : "lasts"}</dd>
+          <span className="invest-retire-stat-meta">
+            {depletion ? "median of shortfall paths" : `funded to ${input.horizonAge}`}
+          </span>
+        </div>
+      </dl>
+
+      {deterministic.depletionAge ? (
+        <p className="invest-retire-verdict-note">
+          On a single average-return path the portfolio is exhausted around age{" "}
+          {deterministic.depletionAge}. Monte Carlo (above) is the more honest read — a range, not a
+          point estimate.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/investments/retirement/__tests__/RetirementPlanner.test.tsx
+++ b/src/components/investments/retirement/__tests__/RetirementPlanner.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+// The D3 chart manipulates SVG; stub it so the smoke test focuses on the flow.
+jest.mock("../RetirementProjectionChart", () => ({
+  RetirementProjectionChart: () => null,
+}));
+
+import { RetirementPlanner } from "../RetirementPlanner";
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+function flush() {
+  return act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0)); // deferred levers
+  });
+}
+
+describe("RetirementPlanner", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders a verdict and levers from the default plan", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<RetirementPlanner />);
+    });
+    await flush();
+
+    // Headline verdict paints from the fast core path.
+    expect(container.textContent).toContain("Retirement planner");
+    expect(container.textContent).toMatch(/scenarios\s+fund/i);
+    // Probability is framed as "N of 100", not a bare percent.
+    expect(container.textContent).toMatch(/\d+ of 100/);
+    // Levers fill in after the deferred computation.
+    expect(container.textContent).toContain("Save more");
+    // The compliance disclaimer is always present on output.
+    expect(container.textContent).toMatch(/educational purposes only/i);
+  });
+
+  it("offers the portfolio balance as a starting seed", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<RetirementPlanner portfolioValue={250000} />);
+    });
+    await flush();
+
+    expect(container.textContent).toMatch(/Use my portfolio balance/i);
+  });
+});

--- a/src/hooks/useRetirementPlan.ts
+++ b/src/hooks/useRetirementPlan.ts
@@ -1,0 +1,277 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  projectCore,
+  computeLevers,
+  createDefaultPlan,
+  type AllocationInput,
+  type LeverEffect,
+  type LumpyExpense,
+  type OtherIncomeInput,
+  type RetirementAccountInput,
+  type RetirementAssumptions,
+  type RetirementPlanInput,
+  type RetirementResult,
+} from "@/lib/retirement";
+
+const STORAGE_KEY = "retirement_plan";
+const STORAGE_VERSION = 1;
+const RECOMPUTE_DEBOUNCE_MS = 200;
+
+interface StoredPlan {
+  version: number;
+  plan: RetirementPlanInput;
+}
+
+/** Optional values used to seed a *fresh* plan from the user's portfolio. */
+export interface RetirementSeed {
+  portfolioValue?: number;
+  allocation?: AllocationInput;
+}
+
+function safeWrite(plan: RetirementPlanInput): void {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: StoredPlan = { version: STORAGE_VERSION, plan };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Quota exceeded or storage disabled — projection still works in-memory.
+  }
+}
+
+function loadPlan(): RetirementPlanInput | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredPlan;
+    if (!parsed || parsed.version !== STORAGE_VERSION || !parsed.plan) return null;
+    // Merge over defaults so newly-added fields are always present.
+    const base = createDefaultPlan();
+    return {
+      ...base,
+      ...parsed.plan,
+      otherIncome: { ...base.otherIncome, ...parsed.plan.otherIncome },
+      allocation: { ...base.allocation, ...parsed.plan.allocation },
+      assumptions: {
+        ...base.assumptions,
+        ...parsed.plan.assumptions,
+        taxRates: { ...base.assumptions.taxRates, ...parsed.plan.assumptions?.taxRates },
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+function seedFreshPlan(seed?: RetirementSeed): RetirementPlanInput {
+  const plan = createDefaultPlan();
+  if (seed?.portfolioValue && seed.portfolioValue > 0) {
+    // A brokerage portfolio is a taxable account; pre-fill it as a starting point.
+    plan.accounts = [
+      { id: "portfolio", type: "taxable", balance: Math.round(seed.portfolioValue), annualContribution: 0, employerMatch: 0 },
+      ...plan.accounts.map((a) => ({ ...a, balance: 0 })),
+    ];
+  }
+  if (seed?.allocation) {
+    plan.allocation = { ...plan.allocation, ...seed.allocation };
+  }
+  return plan;
+}
+
+let accountCounter = 0;
+function nextAccountId(): string {
+  accountCounter += 1;
+  return `acct-${Date.now()}-${accountCounter}`;
+}
+
+export interface UseRetirementPlanReturn {
+  plan: RetirementPlanInput;
+  result: RetirementResult | null;
+  ready: boolean;
+  /** True while the (debounced) projection catches up to the latest inputs. */
+  isComputing: boolean;
+  updatePlan: (updates: Partial<RetirementPlanInput>) => void;
+  updateAssumptions: (updates: Partial<RetirementAssumptions>) => void;
+  updateAllocation: (updates: Partial<AllocationInput>) => void;
+  updateOtherIncome: (updates: Partial<OtherIncomeInput>) => void;
+  addAccount: () => void;
+  updateAccount: (id: string, updates: Partial<RetirementAccountInput>) => void;
+  removeAccount: (id: string) => void;
+  addLumpyExpense: () => void;
+  updateLumpyExpense: (id: string, updates: Partial<LumpyExpense>) => void;
+  removeLumpyExpense: (id: string) => void;
+  applyPortfolioBalance: (value: number) => void;
+  reset: () => void;
+}
+
+export function useRetirementPlan(seed?: RetirementSeed): UseRetirementPlanReturn {
+  const [plan, setPlan] = useState<RetirementPlanInput>(() => createDefaultPlan());
+  const [debouncedPlan, setDebouncedPlan] = useState<RetirementPlanInput>(plan);
+  const [ready, setReady] = useState(false);
+  const seedRef = useRef(seed);
+
+  // Keep the latest seed in a ref for reset(), updated after render.
+  useEffect(() => {
+    seedRef.current = seed;
+  });
+
+  // Hydrate from localStorage on mount (SSR-safe — must run in an effect).
+  useEffect(() => {
+    const stored = loadPlan();
+    const initial = stored ?? seedFreshPlan(seedRef.current);
+    setPlan(initial);
+    setDebouncedPlan(initial);
+    setReady(true);
+  }, []);
+
+  // Persist + debounce the projection so typing stays responsive.
+  useEffect(() => {
+    if (!ready) return;
+    safeWrite(plan);
+    const handle = setTimeout(() => setDebouncedPlan(plan), RECOMPUTE_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [plan, ready]);
+
+  // Fast path — verdict, chart, and assumptions paint immediately.
+  const core = useMemo(() => {
+    if (!ready) return null;
+    try {
+      return projectCore(debouncedPlan);
+    } catch {
+      return null;
+    }
+  }, [debouncedPlan, ready]);
+
+  // Heavier lever sensitivity runs off the critical path, after the core paints.
+  // We track which plan the levers belong to so "computing" can be derived
+  // (no synchronous setState in the effect body).
+  const [leverState, setLeverState] = useState<{
+    plan: RetirementPlanInput | null;
+    levers: LeverEffect[];
+  }>({ plan: null, levers: [] });
+
+  useEffect(() => {
+    if (!core) return;
+    const handle = setTimeout(() => {
+      try {
+        setLeverState({ plan: debouncedPlan, levers: computeLevers(debouncedPlan) });
+      } catch {
+        setLeverState({ plan: debouncedPlan, levers: [] });
+      }
+    }, 0);
+    return () => clearTimeout(handle);
+  }, [debouncedPlan, core]);
+
+  const result = useMemo<RetirementResult | null>(() => {
+    if (!core) return null;
+    const levers = leverState.plan === debouncedPlan ? leverState.levers : [];
+    return { ...core, levers };
+  }, [core, leverState, debouncedPlan]);
+
+  const leversReady = leverState.plan === debouncedPlan;
+  const isComputing = ready && (debouncedPlan !== plan || !leversReady);
+
+  // ─── Mutators ──────────────────────────────────────────────────────────────
+
+  const updatePlan = useCallback((updates: Partial<RetirementPlanInput>) => {
+    setPlan((prev) => ({ ...prev, ...updates }));
+  }, []);
+
+  const updateAssumptions = useCallback((updates: Partial<RetirementAssumptions>) => {
+    setPlan((prev) => ({ ...prev, assumptions: { ...prev.assumptions, ...updates } }));
+  }, []);
+
+  const updateAllocation = useCallback((updates: Partial<AllocationInput>) => {
+    setPlan((prev) => ({ ...prev, allocation: { ...prev.allocation, ...updates } }));
+  }, []);
+
+  const updateOtherIncome = useCallback((updates: Partial<OtherIncomeInput>) => {
+    setPlan((prev) => ({ ...prev, otherIncome: { ...prev.otherIncome, ...updates } }));
+  }, []);
+
+  const addAccount = useCallback(() => {
+    setPlan((prev) => ({
+      ...prev,
+      accounts: [
+        ...prev.accounts,
+        { id: nextAccountId(), type: "taxable", balance: 0, annualContribution: 0, employerMatch: 0 },
+      ],
+    }));
+  }, []);
+
+  const updateAccount = useCallback((id: string, updates: Partial<RetirementAccountInput>) => {
+    setPlan((prev) => ({
+      ...prev,
+      accounts: prev.accounts.map((a) => (a.id === id ? { ...a, ...updates } : a)),
+    }));
+  }, []);
+
+  const removeAccount = useCallback((id: string) => {
+    setPlan((prev) => ({ ...prev, accounts: prev.accounts.filter((a) => a.id !== id) }));
+  }, []);
+
+  const addLumpyExpense = useCallback(() => {
+    setPlan((prev) => ({
+      ...prev,
+      lumpyExpenses: [
+        ...prev.lumpyExpenses,
+        { id: nextAccountId(), label: "One-time expense", amount: 10000, age: prev.retirementAge + 5 },
+      ],
+    }));
+  }, []);
+
+  const updateLumpyExpense = useCallback((id: string, updates: Partial<LumpyExpense>) => {
+    setPlan((prev) => ({
+      ...prev,
+      lumpyExpenses: prev.lumpyExpenses.map((e) => (e.id === id ? { ...e, ...updates } : e)),
+    }));
+  }, []);
+
+  const removeLumpyExpense = useCallback((id: string) => {
+    setPlan((prev) => ({ ...prev, lumpyExpenses: prev.lumpyExpenses.filter((e) => e.id !== id) }));
+  }, []);
+
+  const applyPortfolioBalance = useCallback((value: number) => {
+    setPlan((prev) => {
+      if (prev.accounts.length === 0) {
+        return {
+          ...prev,
+          accounts: [
+            { id: "portfolio", type: "taxable", balance: Math.round(value), annualContribution: 0, employerMatch: 0 },
+          ],
+        };
+      }
+      return {
+        ...prev,
+        accounts: prev.accounts.map((a, i) => (i === 0 ? { ...a, balance: Math.round(value) } : a)),
+      };
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    const fresh = seedFreshPlan(seedRef.current);
+    setPlan(fresh);
+    setDebouncedPlan(fresh);
+  }, []);
+
+  return {
+    plan,
+    result,
+    ready,
+    isComputing,
+    updatePlan,
+    updateAssumptions,
+    updateAllocation,
+    updateOtherIncome,
+    addAccount,
+    updateAccount,
+    removeAccount,
+    addLumpyExpense,
+    updateLumpyExpense,
+    removeLumpyExpense,
+    applyPortfolioBalance,
+    reset,
+  };
+}

--- a/src/lib/retirement/__tests__/retirement.test.ts
+++ b/src/lib/retirement/__tests__/retirement.test.ts
@@ -1,0 +1,290 @@
+import {
+  project,
+  createDefaultPlan,
+  computePortfolioAssumptions,
+  expandAllocation,
+  simulatePath,
+  runDeterministic,
+  socialSecurityClaimFactor,
+  rmdDivisor,
+  rmdStartAge,
+  rmdStartAgeFromCurrent,
+  type RetirementPlanInput,
+} from "../index";
+
+// Fixed reference year so RMD-age logic is deterministic across machines/dates.
+const REF_YEAR = 2026;
+
+function planWith(overrides: Partial<RetirementPlanInput>): RetirementPlanInput {
+  return { ...createDefaultPlan(), ...overrides };
+}
+
+function noTaxRates() {
+  return { taxable: 0, traditional: 0, roth: 0, hsa: 0 };
+}
+
+describe("allocation → expected return + volatility", () => {
+  it("returns the cash CMA for an all-cash portfolio", () => {
+    const { expectedReturn, volatility } = computePortfolioAssumptions({
+      stocks: 0,
+      bonds: 0,
+      cash: 100,
+      other: 0,
+    });
+    expect(expectedReturn).toBeCloseTo(0.037, 5);
+    expect(volatility).toBeCloseTo(0.01, 5);
+  });
+
+  it("normalizes weights that don't sum to 100", () => {
+    const weights = expandAllocation({ stocks: 50, bonds: 50, cash: 0, other: 0 });
+    const total = Object.values(weights).reduce((a, b) => a + b, 0);
+    expect(total).toBeCloseTo(1, 6);
+  });
+
+  it("gives a stock-heavy portfolio a higher return and volatility than a bond-heavy one", () => {
+    const stocky = computePortfolioAssumptions({ stocks: 90, bonds: 10, cash: 0, other: 0 });
+    const bondy = computePortfolioAssumptions({ stocks: 10, bonds: 90, cash: 0, other: 0 });
+    expect(stocky.expectedReturn).toBeGreaterThan(bondy.expectedReturn);
+    expect(stocky.volatility).toBeGreaterThan(bondy.volatility);
+  });
+});
+
+describe("Social Security claim mechanics", () => {
+  it("is unchanged at full retirement age", () => {
+    expect(socialSecurityClaimFactor(67)).toBeCloseTo(1, 6);
+  });
+
+  it("cuts the benefit ~30% at 62 and adds ~24% at 70", () => {
+    expect(socialSecurityClaimFactor(62)).toBeCloseTo(0.7, 2);
+    expect(socialSecurityClaimFactor(70)).toBeCloseTo(1.24, 2);
+  });
+});
+
+describe("RMD schedule", () => {
+  it("uses the IRS Uniform Lifetime Table divisors", () => {
+    expect(rmdDivisor(73)).toBe(26.5);
+    expect(rmdDivisor(75)).toBe(24.6);
+    expect(rmdDivisor(90)).toBe(12.2);
+  });
+
+  it("applies SECURE 2.0 start ages by birth year", () => {
+    expect(rmdStartAge(1949)).toBe(72);
+    expect(rmdStartAge(1955)).toBe(73);
+    expect(rmdStartAge(1965)).toBe(75);
+    // Born 1956 → RMD age 73.
+    expect(rmdStartAgeFromCurrent(70, REF_YEAR)).toBe(73);
+  });
+});
+
+describe("4% rule on a 60/40 portfolio over 30 years", () => {
+  const plan = planWith({
+    currentAge: 65,
+    retirementAge: 65,
+    horizonAge: 95,
+    desiredAnnualSpend: 40000,
+    preMedicareHealthcare: 0,
+    accounts: [
+      { id: "a", type: "taxable", balance: 1_000_000, annualContribution: 0, employerMatch: 0 },
+    ],
+    allocation: { stocks: 60, bonds: 40, cash: 0, other: 0 },
+    otherIncome: {
+      socialSecurityAnnual: 0,
+      socialSecurityClaimAge: 67,
+      socialSecurityCola: true,
+      pensionAnnual: 0,
+      pensionStartAge: 65,
+      pensionCola: false,
+      partTimeAnnual: 0,
+      partTimeStartAge: 65,
+      partTimeEndAge: 70,
+    },
+    assumptions: { ...createDefaultPlan().assumptions, taxRates: noTaxRates() },
+  });
+
+  it("lands near established safe-withdrawal results (high but not certain success)", () => {
+    const result = project(plan, REF_YEAR);
+    // Trinity/Bengen: a 4% inflation-adjusted withdrawal funds 30 years with
+    // high probability — but forward-looking CMAs keep it short of certainty.
+    expect(result.monteCarlo.successRate).toBeGreaterThan(0.6);
+    expect(result.monteCarlo.successRate).toBeLessThanOrEqual(1);
+  });
+
+  it("computes a target nest egg near 25× net spend", () => {
+    const result = project(plan, REF_YEAR);
+    // 40,000 / 0.04 = 1,000,000.
+    expect(result.targetNestEgg).toBeCloseTo(1_000_000, 0);
+  });
+});
+
+describe("edge cases — no divide by zero", () => {
+  it("handles zero balances and zero contributions", () => {
+    const plan = planWith({
+      accounts: [],
+      currentAge: 40,
+      retirementAge: 65,
+      horizonAge: 95,
+    });
+    const result = project(plan, REF_YEAR);
+    expect(Number.isFinite(result.targetNestEgg)).toBe(true);
+    result.deterministic.path.forEach((y) => {
+      expect(Number.isFinite(y.nominalBalance)).toBe(true);
+      expect(Number.isFinite(y.realBalance)).toBe(true);
+    });
+  });
+
+  it("guards the target number when the withdrawal rate is zero", () => {
+    const base = createDefaultPlan();
+    const plan = planWith({
+      assumptions: { ...base.assumptions, withdrawalRateOverride: 0 },
+    });
+    const result = project(plan, REF_YEAR);
+    expect(Number.isFinite(result.targetNestEgg)).toBe(true);
+    expect(result.targetNestEgg).toBe(0);
+  });
+
+  it("produces finite balances for a zero-return path", () => {
+    const plan = planWith({
+      currentAge: 60,
+      retirementAge: 60,
+      horizonAge: 62,
+      accounts: [
+        { id: "a", type: "taxable", balance: 100000, annualContribution: 0, employerMatch: 0 },
+      ],
+    });
+    const years = plan.horizonAge - plan.currentAge;
+    const path = simulatePath(plan, new Array(years + 1).fill(0), REF_YEAR);
+    path.years.forEach((y) => expect(Number.isFinite(y.nominalBalance)).toBe(true));
+  });
+});
+
+describe("inflation compounding", () => {
+  it("matches a hand-calculated spending row", () => {
+    const base = createDefaultPlan();
+    const plan = planWith({
+      currentAge: 60,
+      retirementAge: 60,
+      horizonAge: 63,
+      desiredAnnualSpend: 50000,
+      accounts: [
+        { id: "a", type: "taxable", balance: 5_000_000, annualContribution: 0, employerMatch: 0 },
+      ],
+      otherIncome: { ...base.otherIncome, socialSecurityAnnual: 0 },
+      assumptions: { ...base.assumptions, inflation: 0.03, taxRates: noTaxRates() },
+    });
+    const years = plan.horizonAge - plan.currentAge;
+    const path = simulatePath(plan, new Array(years + 1).fill(0.03), REF_YEAR);
+    expect(path.years[0].spending).toBeCloseTo(50000, 2);
+    expect(path.years[1].spending).toBeCloseTo(51500, 2);
+    expect(path.years[2].spending).toBeCloseTo(53045, 2);
+  });
+});
+
+describe("Monte Carlo determinism", () => {
+  it("returns identical success rates for a fixed seed", () => {
+    const plan = createDefaultPlan();
+    const a = project(plan, REF_YEAR);
+    const b = project(plan, REF_YEAR);
+    expect(a.monteCarlo.successRate).toBe(b.monteCarlo.successRate);
+    expect(a.monteCarlo.bands).toEqual(b.monteCarlo.bands);
+  });
+});
+
+describe("lumpy expense", () => {
+  it("reduces the balance starting in the expense year only", () => {
+    const base = createDefaultPlan();
+    const common = {
+      currentAge: 65,
+      retirementAge: 65,
+      horizonAge: 80,
+      desiredAnnualSpend: 30000,
+      accounts: [
+        { id: "a", type: "taxable" as const, balance: 1_000_000, annualContribution: 0, employerMatch: 0 },
+      ],
+      otherIncome: { ...base.otherIncome, socialSecurityAnnual: 0 },
+      assumptions: { ...base.assumptions, taxRates: noTaxRates() },
+    };
+    const without = planWith({ ...common, lumpyExpenses: [] });
+    const withExpense = planWith({
+      ...common,
+      lumpyExpenses: [{ id: "x", label: "Roof", amount: 50000, age: 70 }],
+    });
+
+    const years = common.horizonAge - common.currentAge;
+    const r = new Array(years + 1).fill(0.04);
+    const pa = simulatePath(without, r, REF_YEAR);
+    const pb = simulatePath(withExpense, r, REF_YEAR);
+
+    const expenseIdx = 70 - common.currentAge;
+    // Years before the expense are identical.
+    for (let t = 0; t < expenseIdx; t++) {
+      expect(pb.years[t].nominalBalance).toBeCloseTo(pa.years[t].nominalBalance, 2);
+    }
+    // The expense year spends the extra amount.
+    expect(pb.years[expenseIdx].spending - pa.years[expenseIdx].spending).toBeCloseTo(
+      50000 * Math.pow(1.025, expenseIdx),
+      0,
+    );
+    // And the balance is lower from that year onward.
+    expect(pb.years[expenseIdx].nominalBalance).toBeLessThan(pa.years[expenseIdx].nominalBalance);
+  });
+});
+
+describe("RMDs force tax-deferred withdrawals", () => {
+  it("draws the traditional balance starting at the RMD age", () => {
+    const base = createDefaultPlan();
+    const plan = planWith({
+      currentAge: 70, // born 1956 → RMD age 73
+      retirementAge: 70,
+      horizonAge: 85,
+      desiredAnnualSpend: 1000,
+      preMedicareHealthcare: 0,
+      accounts: [
+        { id: "t", type: "traditional", balance: 1_000_000, annualContribution: 0, employerMatch: 0 },
+      ],
+      allocation: { stocks: 0, bonds: 0, cash: 100, other: 0 },
+      otherIncome: { ...base.otherIncome, socialSecurityAnnual: 0 },
+      assumptions: { ...base.assumptions, inflation: 0 },
+    });
+    const years = plan.horizonAge - plan.currentAge;
+    const path = simulatePath(plan, new Array(years + 1).fill(0), REF_YEAR);
+
+    const at72 = path.years.find((y) => y.age === 72)!;
+    const at73 = path.years.find((y) => y.age === 73)!;
+    // Pre-RMD: only the small discretionary need is withdrawn.
+    expect(at72.withdrawal).toBeLessThan(5000);
+    // RMD year: a forced distribution far exceeding the spending need.
+    expect(at73.withdrawal).toBeGreaterThan(30000);
+  });
+});
+
+describe("money-runs-out case", () => {
+  it("reports the correct depletion age", () => {
+    const base = createDefaultPlan();
+    const plan = planWith({
+      currentAge: 60,
+      retirementAge: 60,
+      horizonAge: 90,
+      desiredAnnualSpend: 25000,
+      accounts: [
+        { id: "a", type: "taxable", balance: 100000, annualContribution: 0, employerMatch: 0 },
+      ],
+      otherIncome: { ...base.otherIncome, socialSecurityAnnual: 0 },
+      assumptions: { ...base.assumptions, inflation: 0, taxRates: noTaxRates() },
+    });
+    const years = plan.horizonAge - plan.currentAge;
+    // Zero return, zero tax, zero inflation: 100k / 25k = 4 years funded,
+    // depletes in year 4 (age 64).
+    const path = simulatePath(plan, new Array(years + 1).fill(0), REF_YEAR);
+    expect(path.depletionAge).toBe(64);
+  });
+});
+
+describe("deterministic projection shape", () => {
+  it("returns a value at every age through the horizon", () => {
+    const plan = createDefaultPlan();
+    const det = runDeterministic(plan, 0.06, REF_YEAR);
+    expect(det.path).toHaveLength(plan.horizonAge - plan.currentAge + 1);
+    expect(det.path[0].age).toBe(plan.currentAge);
+    expect(det.path[det.path.length - 1].age).toBe(plan.horizonAge);
+  });
+});

--- a/src/lib/retirement/assumptions.ts
+++ b/src/lib/retirement/assumptions.ts
@@ -1,0 +1,90 @@
+// ============================================================
+// Allocation → expected return + volatility (spec §4.2)
+//
+//   E[return] = Σ wᵢ · E[rᵢ]
+//   variance  = Σᵢ Σⱼ wᵢ wⱼ σᵢ σⱼ ρᵢⱼ
+//   σ_port    = √variance
+//
+// The UI collects four high-level buckets (stocks / bonds / cash / other);
+// here we expand them into the finer CMA asset classes so the per-class
+// figures stay defensible and citable.
+// ============================================================
+
+import type { AllocationInput } from "./types";
+import {
+  ASSET_ORDER,
+  CAPITAL_MARKET_ASSUMPTIONS,
+  correlation,
+  type AssetClassId,
+} from "./capitalMarketAssumptions";
+
+/**
+ * How each high-level bucket decomposes into CMA asset classes. Documented and
+ * intentionally simple; advanced per-class control is a future enhancement.
+ */
+const BUCKET_DECOMPOSITION: Record<keyof AllocationInput, Partial<Record<AssetClassId, number>>> = {
+  stocks: { usLargeCap: 0.55, intlDeveloped: 0.3, emergingMarkets: 0.15 },
+  bonds: { usBonds: 1 },
+  cash: { cash: 1 },
+  other: { realAssets: 1 },
+};
+
+export interface PortfolioAssumptions {
+  expectedReturn: number;
+  volatility: number;
+  /** Normalized weight per CMA asset class (sums to 1, or all-zero if empty). */
+  weights: Record<AssetClassId, number>;
+}
+
+/** Expand the four buckets into normalized per-asset-class weights. */
+export function expandAllocation(allocation: AllocationInput): Record<AssetClassId, number> {
+  const weights: Record<AssetClassId, number> = {
+    usLargeCap: 0,
+    intlDeveloped: 0,
+    emergingMarkets: 0,
+    usBonds: 0,
+    cash: 0,
+    realAssets: 0,
+  };
+
+  (Object.keys(BUCKET_DECOMPOSITION) as (keyof AllocationInput)[]).forEach((bucket) => {
+    const bucketWeight = Math.max(0, allocation[bucket] || 0);
+    const decomp = BUCKET_DECOMPOSITION[bucket];
+    (Object.keys(decomp) as AssetClassId[]).forEach((cls) => {
+      weights[cls] += bucketWeight * (decomp[cls] ?? 0);
+    });
+  });
+
+  const total = ASSET_ORDER.reduce((sum, cls) => sum + weights[cls], 0);
+  if (total > 0) {
+    ASSET_ORDER.forEach((cls) => {
+      weights[cls] = weights[cls] / total;
+    });
+  }
+  return weights;
+}
+
+/** Derive portfolio expected return and volatility from an allocation. */
+export function computePortfolioAssumptions(allocation: AllocationInput): PortfolioAssumptions {
+  const weights = expandAllocation(allocation);
+
+  const expectedReturn = ASSET_ORDER.reduce(
+    (sum, cls) => sum + weights[cls] * CAPITAL_MARKET_ASSUMPTIONS[cls].expectedReturn,
+    0,
+  );
+
+  let variance = 0;
+  for (const a of ASSET_ORDER) {
+    for (const b of ASSET_ORDER) {
+      variance +=
+        weights[a] *
+        weights[b] *
+        CAPITAL_MARKET_ASSUMPTIONS[a].stdDev *
+        CAPITAL_MARKET_ASSUMPTIONS[b].stdDev *
+        correlation(a, b);
+    }
+  }
+  const volatility = Math.sqrt(Math.max(0, variance));
+
+  return { expectedReturn, volatility, weights };
+}

--- a/src/lib/retirement/capitalMarketAssumptions.ts
+++ b/src/lib/retirement/capitalMarketAssumptions.ts
@@ -1,0 +1,83 @@
+// ============================================================
+// Capital Market Assumptions (CMAs)
+//
+// Per the spec (§4.2), expected return + volatility are DERIVED from the
+// allocation using a dated, citable published assumption set — never a single
+// hardcoded "stocks do 10%" number.
+//
+// ┌─────────────────────────────────────────────────────────────────────────┐
+// │ [verify @ build] — IMPORTANT                                              │
+// │ The figures below are ILLUSTRATIVE long-term (10–15yr) nominal estimates  │
+// │ shaped to align with publicly available 2025 assumption sets from major  │
+// │ firms (e.g. J.P. Morgan Long-Term Capital Market Assumptions, Research    │
+// │ Affiliates, Vanguard VCMM). CMAs drift year-to-year, so before relying on │
+// │ these in production they MUST be re-pinned to a current primary source —  │
+// │ update the numbers AND flip `CMA_VERIFIED` to true with the real source   │
+// │ string + as-of date. The UI surfaces the source + date and the           │
+// │ unverified state, as the spec (§4.2, §9) requires.                        │
+// └─────────────────────────────────────────────────────────────────────────┘
+//
+// Note the modern shape: US large-cap expected returns are historically *low*
+// (rich valuations) and international *higher* — do not bake in stale optimism.
+
+export type AssetClassId =
+  | "usLargeCap"
+  | "intlDeveloped"
+  | "emergingMarkets"
+  | "usBonds"
+  | "cash"
+  | "realAssets";
+
+export interface CapitalMarketAssumption {
+  id: AssetClassId;
+  label: string;
+  /** Expected nominal annual return (decimal). */
+  expectedReturn: number;
+  /** Annual return volatility / standard deviation (decimal). */
+  stdDev: number;
+}
+
+export const CMA_SOURCE =
+  "Illustrative long-term (10–15yr) capital market assumptions, aligned with published 2025 estimates from major firms (e.g. J.P. Morgan LTCMA).";
+export const CMA_AS_OF = "2026-06";
+/** Flip to true only once the figures are re-pinned to a dated primary source. */
+export const CMA_VERIFIED = false;
+
+export const CAPITAL_MARKET_ASSUMPTIONS: Record<AssetClassId, CapitalMarketAssumption> = {
+  usLargeCap: { id: "usLargeCap", label: "US large-cap equities", expectedReturn: 0.066, stdDev: 0.16 },
+  intlDeveloped: { id: "intlDeveloped", label: "Intl developed equities", expectedReturn: 0.08, stdDev: 0.175 },
+  emergingMarkets: { id: "emergingMarkets", label: "Emerging-market equities", expectedReturn: 0.085, stdDev: 0.205 },
+  usBonds: { id: "usBonds", label: "US aggregate bonds", expectedReturn: 0.047, stdDev: 0.06 },
+  cash: { id: "cash", label: "Cash / T-bills", expectedReturn: 0.037, stdDev: 0.01 },
+  realAssets: { id: "realAssets", label: "Real assets (REITs / commodities)", expectedReturn: 0.06, stdDev: 0.155 },
+};
+
+const ASSET_ORDER: AssetClassId[] = [
+  "usLargeCap",
+  "intlDeveloped",
+  "emergingMarkets",
+  "usBonds",
+  "cash",
+  "realAssets",
+];
+
+/**
+ * Pairwise correlation matrix between asset classes. Illustrative, long-run
+ * values consistent with the published CMA sets above — equities highly
+ * correlated with each other, bonds/cash near-uncorrelated to negatively
+ * correlated with equities. [verify @ build]
+ */
+const CORRELATIONS: Record<AssetClassId, Record<AssetClassId, number>> = {
+  usLargeCap: { usLargeCap: 1, intlDeveloped: 0.85, emergingMarkets: 0.75, usBonds: 0.1, cash: 0.0, realAssets: 0.6 },
+  intlDeveloped: { usLargeCap: 0.85, intlDeveloped: 1, emergingMarkets: 0.8, usBonds: 0.12, cash: 0.0, realAssets: 0.6 },
+  emergingMarkets: { usLargeCap: 0.75, intlDeveloped: 0.8, emergingMarkets: 1, usBonds: 0.1, cash: 0.0, realAssets: 0.6 },
+  usBonds: { usLargeCap: 0.1, intlDeveloped: 0.12, emergingMarkets: 0.1, usBonds: 1, cash: 0.3, realAssets: 0.2 },
+  cash: { usLargeCap: 0.0, intlDeveloped: 0.0, emergingMarkets: 0.0, usBonds: 0.3, cash: 1, realAssets: 0.0 },
+  realAssets: { usLargeCap: 0.6, intlDeveloped: 0.6, emergingMarkets: 0.6, usBonds: 0.2, cash: 0.0, realAssets: 1 },
+};
+
+export function correlation(a: AssetClassId, b: AssetClassId): number {
+  return CORRELATIONS[a]?.[b] ?? 0;
+}
+
+export { ASSET_ORDER };

--- a/src/lib/retirement/defaults.ts
+++ b/src/lib/retirement/defaults.ts
@@ -1,0 +1,66 @@
+// ============================================================
+// Sensible defaults (spec §6.3) — every advanced input has a defensible
+// default so the tool produces a first number before the user touches a single
+// assumption.
+// ============================================================
+
+import type { RetirementPlanInput, RetirementTaxRates } from "./types";
+
+export const DEFAULT_SAFE_WITHDRAWAL_RATE = 0.04;
+
+/**
+ * Coarse effective tax rates by account type (spec §4.7, v1 flat-rate approach):
+ *  - taxable: long-term cap gains (~15%) on roughly half the withdrawal (gains slice)
+ *  - traditional: a blended effective ordinary-income rate in retirement
+ *  - roth / hsa: tax-free
+ */
+export const DEFAULT_TAX_RATES: RetirementTaxRates = {
+  taxable: 0.08,
+  traditional: 0.18,
+  roth: 0,
+  hsa: 0,
+};
+
+export function createDefaultPlan(): RetirementPlanInput {
+  return {
+    currentAge: 35,
+    retirementAge: 65,
+    horizonAge: 95,
+    filingStatus: "single",
+    region: "",
+    desiredAnnualSpend: 60000,
+    preMedicareHealthcare: 0,
+    accounts: [
+      {
+        id: "primary",
+        type: "traditional",
+        balance: 50000,
+        annualContribution: 10000,
+        employerMatch: 0,
+      },
+    ],
+    allocation: { stocks: 80, bonds: 15, cash: 5, other: 0 },
+    otherIncome: {
+      socialSecurityAnnual: 24000,
+      socialSecurityClaimAge: 67,
+      socialSecurityCola: true,
+      pensionAnnual: 0,
+      pensionStartAge: 65,
+      pensionCola: false,
+      partTimeAnnual: 0,
+      partTimeStartAge: 65,
+      partTimeEndAge: 70,
+    },
+    lumpyExpenses: [],
+    assumptions: {
+      inflation: 0.025,
+      healthcareInflation: 0.05,
+      withdrawalStrategy: "fixed-real",
+      withdrawalRateOverride: null,
+      taxRates: { ...DEFAULT_TAX_RATES },
+      simulations: 1000,
+      seed: 20260608,
+      successThreshold: 0.85,
+    },
+  };
+}

--- a/src/lib/retirement/format.ts
+++ b/src/lib/retirement/format.ts
@@ -1,0 +1,30 @@
+// ============================================================
+// Formatting helpers shared by the engine (lever labels) and the UI.
+// ============================================================
+
+export function formatCurrency(value: number, maximumFractionDigits = 0): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits,
+  }).format(Math.round(value * 10 ** maximumFractionDigits) / 10 ** maximumFractionDigits);
+}
+
+export function formatCompactCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+export function formatPercent(value: number, fractionDigits = 1): string {
+  return `${(value * 100).toFixed(fractionDigits)}%`;
+}
+
+/** "≈85 of 100 scenarios" — the honest framing the spec (§6.2) asks for. */
+export function formatScenarioCount(successRate: number): string {
+  const n = Math.round(successRate * 100);
+  return `${n} of 100`;
+}

--- a/src/lib/retirement/index.ts
+++ b/src/lib/retirement/index.ts
@@ -1,0 +1,117 @@
+// ============================================================
+// Retirement planning engine — public entry point.
+//
+//   project(input) -> { deterministic, monteCarlo, levers, verdict, … }
+//
+// Pure and framework-free so it's unit-testable and reusable server-side
+// (spec §8). The UI never does math; it calls project() and renders.
+// ============================================================
+
+import type { RetirementPlanInput, RetirementResult, Verdict } from "./types";
+import { computePortfolioAssumptions } from "./assumptions";
+import { runDeterministic } from "./projection";
+import { runMonteCarlo } from "./monteCarlo";
+import { computeLevers } from "./levers";
+import { socialSecurityClaimFactor } from "./socialSecurity";
+import { rmdStartAgeFromCurrent } from "./tax";
+import { DEFAULT_SAFE_WITHDRAWAL_RATE } from "./defaults";
+import {
+  CMA_AS_OF,
+  CMA_SOURCE,
+  CMA_VERIFIED,
+} from "./capitalMarketAssumptions";
+
+function verdictFor(successRate: number): Verdict {
+  if (successRate >= 0.9) return "on-track";
+  if (successRate >= 0.8) return "good";
+  if (successRate >= 0.65) return "fair";
+  return "at-risk";
+}
+
+/**
+ * Real-dollar nest egg needed at retirement: the spend the portfolio must
+ * cover (after guaranteed income) divided by the safe withdrawal rate.
+ */
+function computeTargetNestEgg(input: RetirementPlanInput, swr: number): number {
+  const ss =
+    input.otherIncome.socialSecurityAnnual *
+    socialSecurityClaimFactor(input.otherIncome.socialSecurityClaimAge);
+  const guaranteed = ss + input.otherIncome.pensionAnnual;
+  const netSpend = Math.max(0, input.desiredAnnualSpend - guaranteed);
+  return swr > 0 ? netSpend / swr : 0;
+}
+
+/** Everything except the (heavier) lever sensitivity analysis. */
+export type RetirementCore = Omit<RetirementResult, "levers">;
+
+/**
+ * Fast path: deterministic projection + headline Monte Carlo + target/verdict.
+ * Excludes the lever solver so the UI can paint the verdict and chart instantly
+ * and compute levers off the critical path.
+ */
+export function projectCore(input: RetirementPlanInput, referenceYear?: number): RetirementCore {
+  const { expectedReturn, volatility } = computePortfolioAssumptions(input.allocation);
+  const swr = input.assumptions.withdrawalRateOverride ?? DEFAULT_SAFE_WITHDRAWAL_RATE;
+
+  const deterministic = runDeterministic(input, expectedReturn, referenceYear);
+  const monteCarlo = runMonteCarlo(input, { expectedReturn, volatility, referenceYear });
+
+  return {
+    input,
+    expectedReturn,
+    volatility,
+    targetNestEgg: computeTargetNestEgg(input, swr),
+    safeWithdrawalRate: swr,
+    deterministic,
+    monteCarlo,
+    verdict: verdictFor(monteCarlo.successRate),
+    assumptions: {
+      cmaSource: CMA_SOURCE,
+      cmaAsOf: CMA_AS_OF,
+      cmaVerified: CMA_VERIFIED,
+      expectedReturn,
+      volatility,
+      inflation: input.assumptions.inflation,
+      successThreshold: input.assumptions.successThreshold,
+      rmdStartAge: rmdStartAgeFromCurrent(input.currentAge, referenceYear),
+    },
+  };
+}
+
+/** Full projection including the lever sensitivity analysis. */
+export function project(input: RetirementPlanInput, referenceYear?: number): RetirementResult {
+  return { ...projectCore(input, referenceYear), levers: computeLevers(input, referenceYear) };
+}
+
+// Re-exports for consumers (hook, UI, tests).
+export * from "./types";
+export { createDefaultPlan, DEFAULT_TAX_RATES, DEFAULT_SAFE_WITHDRAWAL_RATE } from "./defaults";
+export { computePortfolioAssumptions, expandAllocation } from "./assumptions";
+export { simulatePath, runDeterministic } from "./projection";
+export { runMonteCarlo } from "./monteCarlo";
+export { computeLevers } from "./levers";
+export {
+  socialSecurityClaimFactor,
+  otherIncomeRealAtAge,
+  FULL_RETIREMENT_AGE,
+} from "./socialSecurity";
+export {
+  rmdDivisor,
+  rmdStartAge,
+  rmdStartAgeFromCurrent,
+  withdrawForYear,
+  DEFAULT_REFERENCE_YEAR,
+} from "./tax";
+export {
+  CAPITAL_MARKET_ASSUMPTIONS,
+  CMA_SOURCE,
+  CMA_AS_OF,
+  CMA_VERIFIED,
+  type AssetClassId,
+} from "./capitalMarketAssumptions";
+export {
+  formatCurrency,
+  formatCompactCurrency,
+  formatPercent,
+  formatScenarioCount,
+} from "./format";

--- a/src/lib/retirement/levers.ts
+++ b/src/lib/retirement/levers.ts
@@ -1,0 +1,206 @@
+// ============================================================
+// Levers / sensitivity analysis (spec §5.5)
+//
+// The four dials that move the outcome: save more, retire later, spend less,
+// change allocation. For each, report the marginal effect on the success rate
+// and — where it's a clean single dial — how far you'd have to push it to hit
+// the "on track" threshold.
+//
+// Lever recomputation uses a smaller simulation count for snappiness; the
+// baseline it's compared against is computed at the same count so deltas are
+// apples-to-apples.
+// ============================================================
+
+import type {
+  LeverEffect,
+  LeverId,
+  RetirementAccountInput,
+  RetirementPlanInput,
+} from "./types";
+import { computePortfolioAssumptions } from "./assumptions";
+import { runMonteCarlo } from "./monteCarlo";
+import { formatCurrency, formatPercent } from "./format";
+
+const LEVER_SIMS = 400;
+const TO_REACH_SIMS = 250;
+const SAVE_MORE_STEP = 5000;
+const RETIRE_LATER_STEP = 2;
+
+function successRate(input: RetirementPlanInput, referenceYear?: number, simulations = LEVER_SIMS): number {
+  const { expectedReturn, volatility } = computePortfolioAssumptions(input.allocation);
+  return runMonteCarlo(input, {
+    expectedReturn,
+    volatility,
+    referenceYear,
+    simulations,
+  }).successRate;
+}
+
+/**
+ * Smallest x in [lo, hi] where the (monotonic) predicate holds, or null if it
+ * never holds within range. Binary search keeps lever-solving cheap.
+ */
+function findMinContinuous(
+  lo: number,
+  hi: number,
+  iterations: number,
+  predicate: (x: number) => boolean,
+): number | null {
+  if (!predicate(hi)) return null;
+  if (predicate(lo)) return lo;
+  for (let i = 0; i < iterations; i++) {
+    const mid = (lo + hi) / 2;
+    if (predicate(mid)) hi = mid;
+    else lo = mid;
+  }
+  return hi;
+}
+
+/** Integer variant for ages: smallest integer age achieving the predicate. */
+function findMinInt(lo: number, hi: number, predicate: (x: number) => boolean): number | null {
+  if (lo > hi || !predicate(hi)) return null;
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (predicate(mid)) hi = mid;
+    else lo = mid + 1;
+  }
+  return lo;
+}
+
+function withExtraContribution(input: RetirementPlanInput, extra: number): RetirementPlanInput {
+  let accounts: RetirementAccountInput[];
+  if (input.accounts.length === 0) {
+    accounts = [
+      {
+        id: "lever-savings",
+        type: "traditional",
+        balance: 0,
+        annualContribution: extra,
+        employerMatch: 0,
+      },
+    ];
+  } else {
+    // Add the extra to whichever account already receives the most savings.
+    let targetIndex = 0;
+    for (let i = 1; i < input.accounts.length; i++) {
+      if (input.accounts[i].annualContribution > input.accounts[targetIndex].annualContribution) {
+        targetIndex = i;
+      }
+    }
+    accounts = input.accounts.map((a, i) =>
+      i === targetIndex ? { ...a, annualContribution: a.annualContribution + extra } : a,
+    );
+  }
+  return { ...input, accounts };
+}
+
+function withRetirementAge(input: RetirementPlanInput, age: number): RetirementPlanInput {
+  return { ...input, retirementAge: Math.min(age, input.horizonAge - 1) };
+}
+
+function withSpendMultiplier(input: RetirementPlanInput, mult: number): RetirementPlanInput {
+  return { ...input, desiredAnnualSpend: input.desiredAnnualSpend * mult };
+}
+
+/** Shift up to `points` percentage points from cash then bonds into stocks. */
+function withMoreStocks(input: RetirementPlanInput, points: number): RetirementPlanInput {
+  let remaining = points;
+  const allocation = { ...input.allocation };
+  const fromCash = Math.min(allocation.cash, remaining);
+  allocation.cash -= fromCash;
+  remaining -= fromCash;
+  const fromBonds = Math.min(allocation.bonds, remaining);
+  allocation.bonds -= fromBonds;
+  allocation.stocks += fromCash + fromBonds;
+  return { ...input, allocation };
+}
+
+export function computeLevers(input: RetirementPlanInput, referenceYear?: number): LeverEffect[] {
+  const threshold = input.assumptions.successThreshold;
+  const base = successRate(input, referenceYear);
+
+  const build = (
+    id: LeverId,
+    label: string,
+    description: string,
+    changeLabel: string,
+    variant: RetirementPlanInput,
+    toReachTarget: { label: string; value: string } | null,
+  ): LeverEffect => {
+    const newSuccessRate = successRate(variant, referenceYear);
+    return { id, label, description, changeLabel, newSuccessRate, delta: newSuccessRate - base, toReachTarget };
+  };
+
+  const reachLabel = `to reach ${formatPercent(threshold, 0)}`;
+
+  // ── Save more ────────────────────────────────────────────────────────────
+  let saveTarget: { label: string; value: string } | null = null;
+  if (base < threshold) {
+    const extra = findMinContinuous(0, 50000, 7, (x) =>
+      successRate(withExtraContribution(input, x), referenceYear, TO_REACH_SIMS) >= threshold,
+    );
+    if (extra !== null) {
+      const rounded = Math.ceil(extra / 500) * 500;
+      saveTarget = { label: reachLabel, value: `+${formatCurrency(rounded)}/yr` };
+    }
+  }
+
+  // ── Retire later ─────────────────────────────────────────────────────────
+  let retireTarget: { label: string; value: string } | null = null;
+  if (base < threshold) {
+    const maxAge = Math.min(input.retirementAge + 12, input.horizonAge - 1);
+    const age = findMinInt(input.retirementAge + 1, maxAge, (a) =>
+      successRate(withRetirementAge(input, a), referenceYear, TO_REACH_SIMS) >= threshold,
+    );
+    if (age !== null) retireTarget = { label: reachLabel, value: `retire at ${age}` };
+  }
+
+  // ── Spend less ───────────────────────────────────────────────────────────
+  let spendTarget: { label: string; value: string } | null = null;
+  if (base < threshold) {
+    const cut = findMinContinuous(0, 0.5, 7, (x) =>
+      successRate(withSpendMultiplier(input, 1 - x), referenceYear, TO_REACH_SIMS) >= threshold,
+    );
+    if (cut !== null) {
+      spendTarget = {
+        label: reachLabel,
+        value: `${formatCurrency(input.desiredAnnualSpend * (1 - cut))}/yr`,
+      };
+    }
+  }
+
+  return [
+    build(
+      "save-more",
+      "Save more",
+      "Increase your annual contributions.",
+      `+${formatCurrency(SAVE_MORE_STEP)}/yr`,
+      withExtraContribution(input, SAVE_MORE_STEP),
+      saveTarget,
+    ),
+    build(
+      "retire-later",
+      "Retire later",
+      "Push the retirement age back — more saving, fewer years to fund.",
+      `retire at ${Math.min(input.retirementAge + RETIRE_LATER_STEP, input.horizonAge - 1)}`,
+      withRetirementAge(input, input.retirementAge + RETIRE_LATER_STEP),
+      retireTarget,
+    ),
+    build(
+      "spend-less",
+      "Spend less",
+      "Trim the desired annual spend in retirement.",
+      "−10% spending",
+      withSpendMultiplier(input, 0.9),
+      spendTarget,
+    ),
+    build(
+      "more-stocks",
+      "Shift to stocks",
+      "Move 15 points from cash and bonds into equities — higher expected return, more volatility.",
+      "+15% stocks",
+      withMoreStocks(input, 15),
+      null,
+    ),
+  ];
+}

--- a/src/lib/retirement/monteCarlo.ts
+++ b/src/lib/retirement/monteCarlo.ts
@@ -1,0 +1,120 @@
+// ============================================================
+// Monte Carlo simulation (spec §4.3)
+//
+// Draw N return paths from the allocation's expected return + volatility,
+// report probability of success (% of paths funded through the horizon) and
+// per-year confidence bands. Deterministic for a fixed seed.
+// ============================================================
+
+import type {
+  MonteCarloResult,
+  PercentileBand,
+  PercentileTriple,
+  RetirementPlanInput,
+} from "./types";
+import { makeNormalSampler, mulberry32 } from "./random";
+import { simulatePath } from "./projection";
+
+/** Returns below −95% would imply an implausible near-total wipeout; floor there. */
+const MIN_ANNUAL_RETURN = -0.95;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const rank = p * (sorted.length - 1);
+  const low = Math.floor(rank);
+  const high = Math.ceil(rank);
+  if (low === high) return sorted[low];
+  return sorted[low] + (sorted[high] - sorted[low]) * (rank - low);
+}
+
+export interface MonteCarloOptions {
+  expectedReturn: number;
+  volatility: number;
+  referenceYear?: number;
+  /** Override the simulation count (e.g. fewer for lever sensitivity). */
+  simulations?: number;
+  /** Override the RNG seed. */
+  seed?: number;
+}
+
+export function runMonteCarlo(
+  input: RetirementPlanInput,
+  options: MonteCarloOptions,
+): MonteCarloResult {
+  const { expectedReturn, volatility, referenceYear } = options;
+  const simulations = Math.max(1, options.simulations ?? input.assumptions.simulations);
+  const seed = options.seed ?? input.assumptions.seed;
+  const infl = input.assumptions.inflation;
+
+  const uniform = mulberry32(seed);
+  const normal = makeNormalSampler(uniform);
+
+  const totalYears = Math.max(0, input.horizonAge - input.currentAge);
+  const tRetire = Math.max(0, input.retirementAge - input.currentAge);
+
+  // Per-year real balances across paths, for percentile bands.
+  const perYear: number[][] = Array.from({ length: totalYears + 1 }, () => []);
+  const retirementBalances: number[] = [];
+  const endingBalances: number[] = [];
+  const depletionAges: number[] = [];
+  let funded = 0;
+
+  // Reused scratch arrays so a run doesn't allocate per path.
+  const returns = new Array(totalYears + 1);
+  const realOut = new Array(totalYears + 1);
+
+  for (let s = 0; s < simulations; s++) {
+    for (let t = 0; t <= totalYears; t++) {
+      returns[t] = Math.max(MIN_ANNUAL_RETURN, expectedReturn + volatility * normal());
+    }
+
+    const path = simulatePath(input, returns, referenceYear, realOut);
+
+    for (let t = 0; t <= totalYears; t++) {
+      perYear[t].push(realOut[t]);
+    }
+    retirementBalances.push(
+      path.balanceAtRetirementNominal / Math.pow(1 + infl, tRetire),
+    );
+    endingBalances.push(path.endingBalanceNominal / Math.pow(1 + infl, totalYears));
+
+    if (path.depletionAge === null) funded += 1;
+    else depletionAges.push(path.depletionAge);
+  }
+
+  const bands: PercentileBand[] = perYear.map((values, t) => {
+    const sorted = [...values].sort((a, b) => a - b);
+    return {
+      age: input.currentAge + t,
+      yearIndex: t,
+      p10: percentile(sorted, 0.1),
+      p25: percentile(sorted, 0.25),
+      p50: percentile(sorted, 0.5),
+      p75: percentile(sorted, 0.75),
+      p90: percentile(sorted, 0.9),
+    };
+  });
+
+  const triple = (values: number[]): PercentileTriple => {
+    const sorted = [...values].sort((a, b) => a - b);
+    return {
+      p10: percentile(sorted, 0.1),
+      p50: percentile(sorted, 0.5),
+      p90: percentile(sorted, 0.9),
+    };
+  };
+
+  const sortedDepletion = [...depletionAges].sort((a, b) => a - b);
+  const medianDepletionAge =
+    sortedDepletion.length > 0 ? percentile(sortedDepletion, 0.5) : null;
+
+  return {
+    simulations,
+    successRate: funded / simulations,
+    bands,
+    balanceAtRetirement: triple(retirementBalances),
+    endingBalance: triple(endingBalances),
+    medianDepletionAge: medianDepletionAge === null ? null : Math.round(medianDepletionAge),
+  };
+}

--- a/src/lib/retirement/projection.ts
+++ b/src/lib/retirement/projection.ts
@@ -1,0 +1,227 @@
+// ============================================================
+// Single-path projection (spec §4.1)
+//
+// Two phases, computed in NOMINAL dollars with REAL values exposed alongside:
+//   balance[t+1] = (balance[t] + contribution[t] − withdrawal[t]) · (1 + r[t])
+// Contributions/withdrawals happen at the start of the year, then growth.
+// Used by both the deterministic projection and every Monte Carlo path.
+// ============================================================
+
+import type {
+  DeterministicResult,
+  RetirementPlanInput,
+  YearProjection,
+} from "./types";
+import { otherIncomeRealAtAge } from "./socialSecurity";
+import {
+  rmdStartAgeFromCurrent,
+  withdrawForYear,
+  type AccountBalances,
+} from "./tax";
+import { DEFAULT_SAFE_WITHDRAWAL_RATE } from "./defaults";
+
+const MEDICARE_AGE = 65;
+const DEFAULT_SWR = DEFAULT_SAFE_WITHDRAWAL_RATE;
+
+function emptyBalances(): AccountBalances {
+  return { taxable: 0, traditional: 0, roth: 0, hsa: 0 };
+}
+
+function totalBalance(b: AccountBalances): number {
+  return b.taxable + b.traditional + b.roth + b.hsa;
+}
+
+export function aggregateBalances(input: RetirementPlanInput): AccountBalances {
+  const balances = emptyBalances();
+  for (const account of input.accounts) {
+    balances[account.type] += Math.max(0, account.balance || 0);
+  }
+  return balances;
+}
+
+export interface PathResult {
+  years: YearProjection[];
+  balanceAtRetirementNominal: number;
+  endingBalanceNominal: number;
+  depletionAge: number | null;
+}
+
+/**
+ * Simulate one path given a per-year return series (`returns[t]`).
+ * Pure and allocation-agnostic — the caller supplies the returns (a constant
+ * E[r] for the deterministic run, sampled draws for Monte Carlo).
+ *
+ * Pass `realOut` (a reusable scratch array) to run in fast mode: per-year real
+ * balances are written into it and the heavyweight `years` records are skipped.
+ * Monte Carlo uses this to avoid allocating thousands of objects per run.
+ */
+export function simulatePath(
+  input: RetirementPlanInput,
+  returns: number[],
+  referenceYear?: number,
+  realOut?: number[],
+): PathResult {
+  const { currentAge, retirementAge, horizonAge, assumptions } = input;
+  const infl = assumptions.inflation;
+  const hcInfl = assumptions.healthcareInflation;
+  const strategy = assumptions.withdrawalStrategy;
+  const swr = assumptions.withdrawalRateOverride ?? DEFAULT_SWR;
+  const rmdAge = rmdStartAgeFromCurrent(currentAge, referenceYear);
+
+  const balances = aggregateBalances(input);
+  const totalYears = Math.max(0, horizonAge - currentAge);
+
+  const years: YearProjection[] = [];
+  let depletionAge: number | null = null;
+  let balanceAtRetirementNominal = totalBalance(balances);
+
+  // Guardrails carries spend forward year to year; initialized at retirement.
+  let guardrailSpend = 0;
+  let guardrailInitialRate = 0;
+
+  for (let t = 0; t <= totalYears; t++) {
+    const age = currentAge + t;
+    const r = returns[t] ?? returns[returns.length - 1] ?? 0;
+    const startBalance = totalBalance(balances);
+    const inflationFactor = Math.pow(1 + infl, t);
+
+    if (age === retirementAge) {
+      balanceAtRetirementNominal = startBalance;
+    }
+
+    let contribution = 0;
+    let spending = 0;
+    let taxes = 0;
+    let withdrawal = 0;
+    let otherIncome = 0;
+
+    if (age < retirementAge) {
+      // ── Accumulation ──────────────────────────────────────────────────────
+      for (const account of input.accounts) {
+        const growth = account.contributionGrowth ?? infl;
+        const annual =
+          (account.annualContribution + account.employerMatch) * Math.pow(1 + growth, t);
+        balances[account.type] += annual;
+        contribution += annual;
+      }
+    } else {
+      // ── Decumulation ──────────────────────────────────────────────────────
+      const real = otherIncomeRealAtAge(input.otherIncome, age);
+      const ss = input.otherIncome.socialSecurityCola
+        ? real.socialSecurity * inflationFactor
+        : real.socialSecurity;
+      const pension = input.otherIncome.pensionCola
+        ? real.pension * inflationFactor
+        : real.pension;
+      const partTime = real.partTime * inflationFactor;
+      otherIncome = ss + pension + partTime;
+
+      // Base spending by strategy (nominal).
+      let baseSpend: number;
+      if (strategy === "fixed-percent") {
+        baseSpend = swr * startBalance;
+      } else if (strategy === "guardrails") {
+        if (age === retirementAge) {
+          guardrailSpend = input.desiredAnnualSpend * inflationFactor;
+          guardrailInitialRate = startBalance > 0 ? guardrailSpend / startBalance : 0;
+        } else {
+          // Inflation rule: skip the raise after a down year if we're overspending.
+          const currentRate = startBalance > 0 ? guardrailSpend / startBalance : Infinity;
+          const overspending = currentRate > guardrailInitialRate;
+          if (!(r < 0 && overspending)) {
+            guardrailSpend *= 1 + infl;
+          }
+          // Capital-preservation and prosperity guardrails (±20% band, ±10% step).
+          if (startBalance > 0) {
+            const rate = guardrailSpend / startBalance;
+            if (rate > guardrailInitialRate * 1.2) guardrailSpend *= 0.9;
+            else if (rate < guardrailInitialRate * 0.8) guardrailSpend *= 1.1;
+          }
+        }
+        baseSpend = guardrailSpend;
+      } else {
+        // fixed-real (default)
+        baseSpend = input.desiredAnnualSpend * inflationFactor;
+      }
+
+      // Pre-Medicare healthcare gap (inflates faster than CPI).
+      if (age < MEDICARE_AGE && input.preMedicareHealthcare > 0) {
+        baseSpend += input.preMedicareHealthcare * Math.pow(1 + hcInfl, t);
+      }
+
+      // One-time lumpy expenses landing this year.
+      let lumpy = 0;
+      for (const expense of input.lumpyExpenses) {
+        if (expense.age === age) lumpy += expense.amount * inflationFactor;
+      }
+
+      spending = baseSpend + lumpy;
+      const netNeed = Math.max(0, spending - otherIncome);
+      const result = withdrawForYear(balances, netNeed, age, assumptions.taxRates, rmdAge);
+      withdrawal = result.gross;
+      taxes = result.taxes;
+      if (result.depleted && depletionAge === null) {
+        depletionAge = age;
+      }
+    }
+
+    // Apply this year's return after start-of-year cash flows.
+    for (const key of ["taxable", "traditional", "roth", "hsa"] as const) {
+      balances[key] = Math.max(0, balances[key] * (1 + r));
+    }
+
+    const endBalance = totalBalance(balances);
+    if (realOut) {
+      realOut[t] = endBalance / inflationFactor;
+    } else {
+      years.push({
+        age,
+        yearIndex: t,
+        phase: age < retirementAge ? "accumulation" : "decumulation",
+        nominalBalance: endBalance,
+        realBalance: endBalance / inflationFactor,
+        contribution,
+        withdrawal,
+        spending,
+        taxes,
+        otherIncome,
+      });
+    }
+  }
+
+  return {
+    years,
+    balanceAtRetirementNominal,
+    endingBalanceNominal: totalBalance(balances),
+    depletionAge,
+  };
+}
+
+/** Deterministic projection using a constant expected return each year. */
+export function runDeterministic(
+  input: RetirementPlanInput,
+  expectedReturn: number,
+  referenceYear?: number,
+): DeterministicResult {
+  const totalYears = Math.max(0, input.horizonAge - input.currentAge);
+  const returns = new Array(totalYears + 1).fill(expectedReturn);
+  const path = simulatePath(input, returns, referenceYear);
+
+  const infl = input.assumptions.inflation;
+  const tRetire = input.retirementAge - input.currentAge;
+  const retireFactor = Math.pow(1 + infl, Math.max(0, tRetire));
+  const endFactor = Math.pow(1 + infl, totalYears);
+
+  return {
+    path: path.years,
+    balanceAtRetirement: {
+      nominal: path.balanceAtRetirementNominal,
+      real: path.balanceAtRetirementNominal / retireFactor,
+    },
+    endingBalance: {
+      nominal: path.endingBalanceNominal,
+      real: path.endingBalanceNominal / endFactor,
+    },
+    depletionAge: path.depletionAge,
+  };
+}

--- a/src/lib/retirement/random.ts
+++ b/src/lib/retirement/random.ts
@@ -1,0 +1,35 @@
+// ============================================================
+// Seeded RNG + normal sampling for Monte Carlo.
+//
+// A deterministic generator is required so a given plan + seed always yields
+// the same success rate (spec §8 test case) and the headline number doesn't
+// jitter on every keystroke.
+// ============================================================
+
+/**
+ * mulberry32 — a small, fast, well-distributed 32-bit seeded PRNG.
+ * Returns a function producing uniforms in [0, 1).
+ */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Standard-normal sampler (Box-Muller) backed by a uniform generator.
+ * Avoids the log(0) singularity by flooring the uniform.
+ */
+export function makeNormalSampler(uniform: () => number): () => number {
+  return function nextNormal() {
+    let u1 = uniform();
+    const u2 = uniform();
+    if (u1 < 1e-12) u1 = 1e-12;
+    return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+  };
+}

--- a/src/lib/retirement/socialSecurity.ts
+++ b/src/lib/retirement/socialSecurity.ts
@@ -1,0 +1,53 @@
+// ============================================================
+// Social Security claiming mechanics (spec §4.6)
+//
+// v1 takes the user's benefit estimate and adjusts it for claim age — the
+// benefit figure they enter is assumed to be their Full Retirement Age (FRA)
+// benefit. Claiming early permanently reduces it; delaying past FRA earns
+// delayed retirement credits up to age 70.
+// ============================================================
+
+import type { OtherIncomeInput } from "./types";
+
+/** Full Retirement Age for those born 1960+ (SSA). */
+export const FULL_RETIREMENT_AGE = 67;
+
+/**
+ * Multiplier applied to the FRA benefit for a given claim age.
+ *  - Early (62 → FRA): ~6.67%/yr reduction for the first 3 years, 5%/yr beyond
+ *    (≈25–30% cut at 62 for an FRA of 67).
+ *  - Delayed (FRA → 70): +8%/yr delayed retirement credits; no gain past 70.
+ */
+export function socialSecurityClaimFactor(claimAge: number, fra: number = FULL_RETIREMENT_AGE): number {
+  const clamped = Math.max(62, Math.min(70, claimAge));
+  if (clamped >= fra) {
+    return 1 + 0.08 * (clamped - fra);
+  }
+  const monthsEarly = (fra - clamped) * 12;
+  const first36 = Math.min(36, monthsEarly);
+  const beyond36 = Math.max(0, monthsEarly - 36);
+  const reduction = first36 * (5 / 9 / 100) + beyond36 * (5 / 12 / 100);
+  return 1 - reduction;
+}
+
+/**
+ * Other income (today's dollars) received at a given age, before inflation.
+ * COLA-adjusted streams are inflated to nominal terms by the caller.
+ */
+export function otherIncomeRealAtAge(income: OtherIncomeInput, age: number): {
+  socialSecurity: number;
+  pension: number;
+  partTime: number;
+} {
+  const socialSecurity =
+    age >= income.socialSecurityClaimAge
+      ? income.socialSecurityAnnual * socialSecurityClaimFactor(income.socialSecurityClaimAge)
+      : 0;
+
+  const pension = age >= income.pensionStartAge ? income.pensionAnnual : 0;
+
+  const partTime =
+    age >= income.partTimeStartAge && age <= income.partTimeEndAge ? income.partTimeAnnual : 0;
+
+  return { socialSecurity, pension, partTime };
+}

--- a/src/lib/retirement/tax.ts
+++ b/src/lib/retirement/tax.ts
@@ -1,0 +1,116 @@
+// ============================================================
+// Coarse, account-aware taxes + Required Minimum Distributions (spec §4.7)
+//
+// v1 uses a flat effective rate per account type (acceptable per the spec).
+// Withdrawals follow the conventional sequence taxable → traditional → roth →
+// hsa, with RMDs force-drawing tax-deferred balances on the IRS schedule.
+// ============================================================
+
+import type { AccountType, RetirementTaxRates } from "./types";
+
+/** Reference "now" year — fixed so RMD-age logic stays deterministic in tests. */
+export const DEFAULT_REFERENCE_YEAR = 2026;
+
+/**
+ * RMD start age under SECURE 2.0, by birth year:
+ *  - born ≤ 1950: 72
+ *  - born 1951–1959: 73 (in effect 2023–2032)
+ *  - born ≥ 1960: 75 (effective 2033)
+ */
+export function rmdStartAge(birthYear: number): number {
+  if (birthYear <= 1950) return 72;
+  if (birthYear <= 1959) return 73;
+  return 75;
+}
+
+export function rmdStartAgeFromCurrent(currentAge: number, referenceYear = DEFAULT_REFERENCE_YEAR): number {
+  return rmdStartAge(referenceYear - currentAge);
+}
+
+/**
+ * IRS Uniform Lifetime Table (effective 2022) — distribution period by age.
+ * RMD = tax-deferred balance / divisor. Ages beyond the table clamp to the last.
+ */
+const UNIFORM_LIFETIME_TABLE: Record<number, number> = {
+  72: 27.4, 73: 26.5, 74: 25.5, 75: 24.6, 76: 23.7, 77: 22.9, 78: 22.0, 79: 21.1,
+  80: 20.2, 81: 19.4, 82: 18.5, 83: 17.7, 84: 16.8, 85: 16.0, 86: 15.2, 87: 14.4,
+  88: 13.7, 89: 12.9, 90: 12.2, 91: 11.5, 92: 10.8, 93: 10.1, 94: 9.5, 95: 8.9,
+  96: 8.4, 97: 7.8, 98: 7.3, 99: 6.8, 100: 6.4, 101: 6.0, 102: 5.6, 103: 5.2,
+  104: 4.9, 105: 4.6, 106: 4.3, 107: 4.1, 108: 3.9, 109: 3.7, 110: 3.5,
+};
+
+export function rmdDivisor(age: number): number {
+  if (age <= 72) return UNIFORM_LIFETIME_TABLE[72];
+  if (age >= 110) return UNIFORM_LIFETIME_TABLE[110];
+  return UNIFORM_LIFETIME_TABLE[age] ?? UNIFORM_LIFETIME_TABLE[110];
+}
+
+/** Mutable per-account balance map carried through a single simulated path. */
+export interface AccountBalances {
+  taxable: number;
+  traditional: number;
+  roth: number;
+  hsa: number;
+}
+
+export interface WithdrawalResult {
+  /** Gross amount pulled from the portfolio (reduces balances). */
+  gross: number;
+  /** Taxes paid on the withdrawals. */
+  taxes: number;
+  /** True if accounts couldn't cover the net need this year. */
+  depleted: boolean;
+}
+
+const SEQUENCE: AccountType[] = ["taxable", "traditional", "roth", "hsa"];
+
+/**
+ * Withdraw enough (after tax) to cover `netNeed`, mutating `balances`.
+ * Honors RMDs first (force-draw tax-deferred; reinvest any after-tax surplus
+ * into the taxable account), then the conventional withdrawal sequence.
+ */
+export function withdrawForYear(
+  balances: AccountBalances,
+  netNeed: number,
+  age: number,
+  rates: RetirementTaxRates,
+  rmdAge: number,
+): WithdrawalResult {
+  let gross = 0;
+  let taxes = 0;
+  let remaining = Math.max(0, netNeed);
+
+  // 1. Required Minimum Distribution from tax-deferred balances.
+  if (age >= rmdAge && balances.traditional > 0) {
+    const rmd = balances.traditional / rmdDivisor(age);
+    balances.traditional -= rmd;
+    gross += rmd;
+    const tax = rmd * rates.traditional;
+    taxes += tax;
+    const net = rmd - tax;
+    if (net >= remaining) {
+      // Forced distribution exceeds the spending need — reinvest the surplus.
+      balances.taxable += net - remaining;
+      remaining = 0;
+    } else {
+      remaining -= net;
+    }
+  }
+
+  // 2. Conventional sequence for any remaining need.
+  for (const type of SEQUENCE) {
+    if (remaining <= 1e-9) break;
+    const balance = balances[type];
+    if (balance <= 0) continue;
+    const rate = rates[type];
+    const grossNeeded = remaining / (1 - rate);
+    const take = Math.min(grossNeeded, balance);
+    balances[type] = balance - take;
+    gross += take;
+    const tax = take * rate;
+    taxes += tax;
+    remaining -= take - tax;
+  }
+
+  return { gross, taxes, depleted: remaining > 1e-6 };
+}

--- a/src/lib/retirement/types.ts
+++ b/src/lib/retirement/types.ts
@@ -1,0 +1,230 @@
+// ============================================================
+// Retirement planning — shared types
+//
+// The engine computes internally in NOMINAL dollars and exposes
+// REAL (today's-dollar) figures for display. See projection.ts.
+// ============================================================
+
+export type FilingStatus = "single" | "married";
+
+/** Tax treatment of an account drives how withdrawals are taxed. */
+export type AccountType = "taxable" | "traditional" | "roth" | "hsa";
+
+/**
+ * Withdrawal / decumulation strategies.
+ * - fixed-real:    spend a fixed real amount (4%-rule mental model). Default.
+ * - fixed-percent: spend a fixed % of the *current* balance each year (never
+ *                  depletes, income swings with the market).
+ * - guardrails:    Guyton-Klinger — inflation rule + capital-preservation and
+ *                  prosperity guardrails. The "smart" alternative.
+ */
+export type WithdrawalStrategy = "fixed-real" | "fixed-percent" | "guardrails";
+
+export interface RetirementAccountInput {
+  id: string;
+  type: AccountType;
+  /** Current balance, today's dollars. */
+  balance: number;
+  /** Annual contribution, today's dollars (accumulation phase only). */
+  annualContribution: number;
+  /** Employer match added to the contribution, today's dollars. */
+  employerMatch: number;
+  /** Contribution growth rate (decimal). Defaults to inflation when omitted. */
+  contributionGrowth?: number;
+}
+
+/**
+ * High-level allocation buckets collected from the UI. Expanded into the
+ * finer capital-market-assumption asset classes by assumptions.ts so we get
+ * defensible per-class returns without forcing the user through a 6-field form.
+ */
+export interface AllocationInput {
+  stocks: number;
+  bonds: number;
+  cash: number;
+  other: number;
+}
+
+export interface LumpyExpense {
+  id: string;
+  label: string;
+  /** Today's dollars. */
+  amount: number;
+  /** Age at which the expense occurs. */
+  age: number;
+}
+
+export interface OtherIncomeInput {
+  /** Social Security, today's dollars/yr (user-supplied estimate). */
+  socialSecurityAnnual: number;
+  socialSecurityClaimAge: number;
+  /** Whether Social Security receives an annual cost-of-living adjustment. */
+  socialSecurityCola: boolean;
+  pensionAnnual: number;
+  pensionStartAge: number;
+  pensionCola: boolean;
+  partTimeAnnual: number;
+  partTimeStartAge: number;
+  partTimeEndAge: number;
+}
+
+export interface RetirementTaxRates {
+  /** Effective tax on a taxable-account withdrawal (cap-gains on the gains slice). */
+  taxable: number;
+  /** Effective ordinary-income rate on traditional / tax-deferred withdrawals. */
+  traditional: number;
+  /** Roth withdrawals are tax-free. */
+  roth: number;
+  /** HSA qualified withdrawals are tax-free. */
+  hsa: number;
+}
+
+export interface RetirementAssumptions {
+  /** Long-run CPI (decimal). */
+  inflation: number;
+  /** Healthcare inflation (decimal) — runs hotter than CPI; applied to the pre-Medicare gap. */
+  healthcareInflation: number;
+  withdrawalStrategy: WithdrawalStrategy;
+  /** Optional safe-withdrawal-rate override (decimal). Pins the target-number math. */
+  withdrawalRateOverride: number | null;
+  taxRates: RetirementTaxRates;
+  /** Monte Carlo trial count. 1,000 is the industry norm. */
+  simulations: number;
+  /** RNG seed — fixed so results are stable per inputs and unit-testable. */
+  seed: number;
+  /** "On track" probability threshold (decimal). Default 0.85. */
+  successThreshold: number;
+}
+
+export interface RetirementPlanInput {
+  currentAge: number;
+  retirementAge: number;
+  /** Planning horizon / life expectancy. Plan to a conservative age. */
+  horizonAge: number;
+  filingStatus: FilingStatus;
+  region?: string;
+  /** Desired annual spend in retirement, today's dollars. */
+  desiredAnnualSpend: number;
+  /** Extra annual healthcare spend before Medicare (age < 65), today's dollars. */
+  preMedicareHealthcare: number;
+  accounts: RetirementAccountInput[];
+  allocation: AllocationInput;
+  otherIncome: OtherIncomeInput;
+  lumpyExpenses: LumpyExpense[];
+  assumptions: RetirementAssumptions;
+}
+
+// ─── Outputs ─────────────────────────────────────────────────────────────────
+
+export type Phase = "accumulation" | "decumulation";
+
+export interface YearProjection {
+  age: number;
+  /** Years from today (t). */
+  yearIndex: number;
+  phase: Phase;
+  /** Nominal end-of-year balance. */
+  nominalBalance: number;
+  /** Real (today's-dollar) end-of-year balance. */
+  realBalance: number;
+  /** Nominal contribution added this year (accumulation). */
+  contribution: number;
+  /** Nominal gross withdrawal from the portfolio this year (decumulation). */
+  withdrawal: number;
+  /** Nominal gross spending this year. */
+  spending: number;
+  /** Nominal taxes paid on withdrawals this year. */
+  taxes: number;
+  /** Nominal other income (Social Security, pension, part-time) this year. */
+  otherIncome: number;
+}
+
+export interface DeterministicResult {
+  path: YearProjection[];
+  balanceAtRetirement: MoneyPair;
+  endingBalance: MoneyPair;
+  /** Age at which the portfolio is exhausted, or null if it lasts. */
+  depletionAge: number | null;
+}
+
+export interface MoneyPair {
+  nominal: number;
+  real: number;
+}
+
+export interface PercentileBand {
+  age: number;
+  yearIndex: number;
+  // Real (today's) dollars for display.
+  p10: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  p90: number;
+}
+
+export interface PercentileTriple {
+  p10: number;
+  p50: number;
+  p90: number;
+}
+
+export interface MonteCarloResult {
+  simulations: number;
+  /** Fraction of paths funded through the horizon (0..1). */
+  successRate: number;
+  /** Per-year balance bands, real dollars. */
+  bands: PercentileBand[];
+  /** Real-dollar balance at retirement across paths. */
+  balanceAtRetirement: PercentileTriple;
+  /** Real-dollar ending balance across paths. */
+  endingBalance: PercentileTriple;
+  /** Median depletion age among paths that ran out, or null if none did. */
+  medianDepletionAge: number | null;
+}
+
+export type LeverId = "save-more" | "retire-later" | "spend-less" | "more-stocks";
+
+export interface LeverEffect {
+  id: LeverId;
+  label: string;
+  description: string;
+  /** Human-readable size of the nudge, e.g. "+$5,000/yr". */
+  changeLabel: string;
+  newSuccessRate: number;
+  /** newSuccessRate − baseline success rate. */
+  delta: number;
+  /** The magnitude of this lever needed to reach the success threshold, if solvable. */
+  toReachTarget: { label: string; value: string } | null;
+}
+
+export type Verdict = "on-track" | "good" | "fair" | "at-risk";
+
+export interface AssumptionsMeta {
+  cmaSource: string;
+  cmaAsOf: string;
+  /** Whether the shipped CMA figures have been re-pinned to a primary source. */
+  cmaVerified: boolean;
+  expectedReturn: number;
+  volatility: number;
+  inflation: number;
+  successThreshold: number;
+  rmdStartAge: number;
+}
+
+export interface RetirementResult {
+  input: RetirementPlanInput;
+  /** Annualized nominal expected return derived from the allocation. */
+  expectedReturn: number;
+  /** Annualized return volatility (std dev) derived from the allocation. */
+  volatility: number;
+  /** Real-dollar nest egg needed at retirement: netSpend / safe-withdrawal-rate. */
+  targetNestEgg: number;
+  /** Safe withdrawal rate used for the target number (decimal). */
+  safeWithdrawalRate: number;
+  deterministic: DeterministicResult;
+  monteCarlo: MonteCarloResult;
+  levers: LeverEffect[];
+  verdict: Verdict;
+  assumptions: AssumptionsMeta;
+}


### PR DESCRIPTION
## Retirement planning for the investment tool

Implements the retirement-planning spec (`docs/specs/retirementplanningspec.md`). Surfaced as a new **#retirement** band inside the investments dashboard, reachable from the sidebar nav, with the live portfolio value offered as a one-click starting balance.

Per direction, this **follows the spec but adapts to existing patterns** (browser-local state like `useInvestments`, `--home-*` editorial palette, D3 charts, co-located Jest tests). Deviations are noted below.

### Pure engine — `src/lib/retirement/*`
Framework-free and unit-tested so it's reusable server-side (spec §8). `project(input)` → `{ deterministic, monteCarlo, levers, verdict, targetNestEgg, assumptions }`.

- **Allocation-derived returns** (§4.2): expected return + volatility computed from per-asset-class capital market assumptions + a correlation matrix — never a single hardcoded "stocks do 10%" number.
- **Two-phase projection** (§4.1): accumulation → decumulation, nominal internally, **today's dollars** for display.
- **Monte Carlo** (§4.3): seeded (deterministic), 1,000 trials, probability of success + 10th–90th percentile confidence bands.
- **Withdrawal strategies** (§4.4): fixed-real (default) + Guyton-Klinger **guardrails** + fixed-%.
- **Taxes + RMDs** (§4.7): coarse account-aware effective rates; RMDs on the IRS Uniform Lifetime Table with SECURE 2.0 start ages (73 → 75).
- **Social Security** (§4.6): claim-age mechanics (62 cut ≈30%, +8%/yr delayed credits to 70).
- **Levers** (§5.5): save more / retire later / spend less / shift allocation, each with marginal Δ and "what gets me to target%".

> ⚠️ **CMAs are illustrative and flagged for verification** (`CMA_VERIFIED = false`). They're shaped to align with published 2025 long-term assumptions but **must be re-pinned to a dated primary source** before relying on the figures — the spec's `[verify @ build]` requirement. The UI discloses the source, as-of date, and unverified state.

### UI — `src/components/investments/retirement/*`
- **Progressive disclosure** (§6.1): five fields → an instant number; accounts, allocation, income, spending, and assumptions reveal on demand.
- **Honest probability framing** (§6.2): "**N of 100 scenarios**", confidence bands, plain language — not a lone false-precision figure.
- D3 confidence-band chart, levers panel, **editable assumptions footer** with source + as-of date, and the **educational-only disclaimer** (§9).
- State via `useRetirementPlan` (localStorage, SSR-safe). Headline paints synchronously; the heavier lever analysis runs off the critical path and fills in after paint.

### Decisions on the open questions (§10)
Defaulted per the spec's own recommendations (chose "follow but improve"): 85% on-track threshold, flat-rate taxes for v1, fixed-real + guardrails shipped, manual Social Security estimate, today's-dollars display, standard disclaimer language (flagged for review before launch).

### Tests
- `src/lib/retirement/__tests__/retirement.test.ts` — all spec §8 cases (4% rule on 60/40, zero-return/zero-contribution edges, inflation row, seed determinism, lumpy-expense isolation, RMD forcing, depletion age) plus CMA/SS/RMD helpers. **18 passing.**
- `RetirementPlanner.test.tsx` — UI smoke test (verdict + levers + disclaimer render; portfolio seed). **2 passing.**
- Existing investments suites still green (53 total). `tsc --noEmit` and `eslint` clean.

### Not in v1 (spec phasing §11)
Bracket-level taxes/Roth conversions, SSA PIA approximation, account aggregation, scenario comparison — left for v2/v3.

https://claude.ai/code/session_01N6hZobnQ8D1PBCExfwbPAp

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6hZobnQ8D1PBCExfwbPAp)_