### PR TITLE
feat(draft-tracker): tier-grouped position-column board view

### DIFF
--- a/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
@@ -2,11 +2,14 @@
 
 import { useMemo, useState, type CSSProperties } from "react";
 import { Player, TeamRoster } from "@/types";
+import type { FantasySnapshot } from "@/lib/fantasy";
 import { useDebounce } from "@/hooks/useDebounce";
 import { formatRange, formatRankValue, getPositionTone } from "@/lib/fantasyUtils";
+import { DraftTierColumns } from "./DraftTierColumns";
 
 interface DraftBoardProps {
   players: Player[];
+  snapshot: FantasySnapshot | null;
   draftedPlayerIds: Set<string>;
   onDraftPlayer: (player: Player) => void;
   currentPick: number;
@@ -17,6 +20,7 @@ interface DraftBoardProps {
 }
 
 type BoardFilter = "ALL" | "QB" | "RB" | "WR" | "TE" | "K" | "DST" | "FLEX";
+type BoardView = "list" | "columns";
 
 const POSITION_LABELS: { value: BoardFilter; label: string }[] = [
   { value: "ALL", label: "All" },
@@ -84,6 +88,7 @@ function getFilterStyle(active: boolean): CSSProperties {
 
 export function DraftBoard({
   players,
+  snapshot,
   draftedPlayerIds,
   onDraftPlayer,
   currentPick,
@@ -92,6 +97,7 @@ export function DraftBoard({
   isDraftComplete,
   userTeam,
 }: DraftBoardProps) {
+  const [boardView, setBoardView] = useState<BoardView>("list");
   const [selectedPosition, setSelectedPosition] = useState<BoardFilter>("ALL");
   const [searchQuery, setSearchQuery] = useState("");
   const debouncedSearch = useDebounce(searchQuery, 200);
@@ -125,19 +131,54 @@ export function DraftBoard({
       <div className="flex flex-col gap-3 border-b pb-4" style={{ borderColor: "var(--home-rule)" }}>
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <p className="home-kicker mb-1">Best Available</p>
+            <p className="home-kicker mb-1">Draft Board</p>
             <h2 className="text-2xl font-semibold">
               Pick #{currentPick} on the clock: Team {currentTeamNumber}
             </h2>
           </div>
-          <div
-            className="rounded-full border px-3 py-1.5 text-sm font-medium"
-            style={{
-              borderColor: "var(--home-rule)",
-              background: "color-mix(in srgb, var(--home-paper-alt) 52%, var(--home-elev-mix))",
-            }}
-          >
-            {isUserPick ? "Your pick is live" : "Log the room's next selection"}
+          <div className="flex flex-wrap items-center gap-3">
+            <div
+              className="flex rounded-full border p-1 text-sm font-semibold"
+              style={{
+                borderColor: "var(--home-rule)",
+                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+              }}
+              role="radiogroup"
+              aria-label="Draft board view"
+            >
+              {([
+                { value: "list", label: "Best available" },
+                { value: "columns", label: "Tier columns" },
+              ] as const).map((option) => {
+                const active = boardView === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={active}
+                    onClick={() => setBoardView(option.value)}
+                    className="inline-flex min-h-[40px] items-center rounded-full px-3.5 py-1.5 text-sm transition-colors duration-200"
+                    style={
+                      active
+                        ? { background: "var(--home-ink)", color: "var(--home-paper)" }
+                        : { color: "var(--home-ink-muted)" }
+                    }
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+            <div
+              className="rounded-full border px-3 py-1.5 text-sm font-medium"
+              style={{
+                borderColor: "var(--home-rule)",
+                background: "color-mix(in srgb, var(--home-paper-alt) 52%, var(--home-elev-mix))",
+              }}
+            >
+              {isUserPick ? "Your pick is live" : "Log the room's next selection"}
+            </div>
           </div>
         </div>
 
@@ -157,6 +198,15 @@ export function DraftBoard({
         </div>
       </div>
 
+      {boardView === "columns" ? (
+        <DraftTierColumns
+          snapshot={snapshot}
+          draftedPlayerIds={draftedPlayerIds}
+          onDraftPlayer={onDraftPlayer}
+          isDraftComplete={isDraftComplete}
+          rosterNeeds={rosterNeeds}
+        />
+      ) : (
       <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1fr)_17rem]">
         <div className="grid gap-4">
           <label className="grid gap-2 text-sm" htmlFor="draft-board-search">
@@ -343,6 +393,7 @@ export function DraftBoard({
           </div>
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/src/app/fantasy-football/draft-tracker/components/DraftTierColumns.test.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftTierColumns.test.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { DraftTierColumns } from "./DraftTierColumns";
+import type {
+  FantasySnapshot,
+  FantasySnapshotSliceMap,
+  FantasySnapshotSliceMetadata,
+} from "@/lib/fantasy";
+import type { Player } from "@/types";
+
+function makePlayer(
+  partial: Partial<Player> & Pick<Player, "id" | "name" | "team" | "position">
+): Player {
+  return {
+    averageRank: 1,
+    rankEcr: 1,
+    ...partial,
+  } as Player;
+}
+
+function availableSlice(playerCount: number): FantasySnapshotSliceMetadata {
+  return {
+    available: true,
+    sourceKind: "position_consensus",
+    rangeKind: "position",
+    playerCount,
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  };
+}
+
+function unavailableSlice(): FantasySnapshotSliceMetadata {
+  return { available: false, sourceKind: "unavailable", rangeKind: "none", playerCount: 0 };
+}
+
+function buildSnapshot(positions: {
+  QB?: Player[];
+  RB?: Player[];
+  WR?: Player[];
+  TE?: Player[];
+}): FantasySnapshot {
+  const sliceMetadata: FantasySnapshotSliceMap = {
+    overall: availableSlice(0),
+    qb: availableSlice(positions.QB?.length ?? 0),
+    rb: availableSlice(positions.RB?.length ?? 0),
+    wr: availableSlice(positions.WR?.length ?? 0),
+    te: availableSlice(positions.TE?.length ?? 0),
+    flex: unavailableSlice(),
+    k: unavailableSlice(),
+    dst: unavailableSlice(),
+  };
+
+  return {
+    schemaVersion: 1,
+    season: 2026,
+    week: 0,
+    generatedAt: "2026-06-01T00:00:00.000Z",
+    upstreamUpdatedAt: "2026-06-01T00:00:00.000Z",
+    scoringFormat: "PPR",
+    source: "test",
+    positions: {
+      QB: positions.QB ?? [],
+      RB: positions.RB ?? [],
+      WR: positions.WR ?? [],
+      TE: positions.TE ?? [],
+      FLEX: [],
+      K: [],
+      DST: [],
+    },
+    overall: [],
+    sliceMetadata,
+  };
+}
+
+const snapshot = buildSnapshot({
+  // RB: a 1-player top tier (a cliff) above a deeper tier 2.
+  RB: [
+    makePlayer({ id: "rb1", name: "Bijan Robinson", team: "ATL", position: "RB", tier: 1, positionRank: 1 }),
+    makePlayer({ id: "rb2", name: "Jahmyr Gibbs", team: "DET", position: "RB", tier: 2, positionRank: 2 }),
+    makePlayer({ id: "rb3", name: "Saquon Barkley", team: "PHI", position: "RB", tier: 2, positionRank: 3 }),
+  ],
+  // QB: a healthy top tier (no cliff).
+  QB: [
+    makePlayer({ id: "qb1", name: "Josh Allen", team: "BUF", position: "QB", tier: 1, positionRank: 1 }),
+    makePlayer({ id: "qb2", name: "Lamar Jackson", team: "BAL", position: "QB", tier: 1, positionRank: 2 }),
+    makePlayer({ id: "qb3", name: "Jayden Daniels", team: "WAS", position: "QB", tier: 1, positionRank: 3 }),
+  ],
+  WR: [makePlayer({ id: "wr1", name: "Ja'Marr Chase", team: "CIN", position: "WR", tier: 1, positionRank: 1 })],
+  TE: [makePlayer({ id: "te1", name: "Brock Bowers", team: "LV", position: "TE", tier: 1, positionRank: 1 })],
+});
+
+describe("DraftTierColumns", () => {
+  it("renders one column per skill position, grouped by tier", () => {
+    render(
+      <DraftTierColumns
+        snapshot={snapshot}
+        draftedPlayerIds={new Set()}
+        onDraftPlayer={jest.fn()}
+        isDraftComplete={false}
+        rosterNeeds={[]}
+      />
+    );
+
+    expect(screen.getByLabelText("QB tier column")).toBeInTheDocument();
+    expect(screen.getByLabelText("RB tier column")).toBeInTheDocument();
+    expect(screen.getByLabelText("WR tier column")).toBeInTheDocument();
+    expect(screen.getByLabelText("TE tier column")).toBeInTheDocument();
+
+    const rbColumn = screen.getByLabelText("RB tier column");
+    expect(within(rbColumn).getByText("Tier 1")).toBeInTheDocument();
+    expect(within(rbColumn).getByText("Tier 2")).toBeInTheDocument();
+    expect(within(rbColumn).getByText("Bijan Robinson")).toBeInTheDocument();
+  });
+
+  it("flags a tier cliff only when the current tier is nearly empty", () => {
+    render(
+      <DraftTierColumns
+        snapshot={snapshot}
+        draftedPlayerIds={new Set()}
+        onDraftPlayer={jest.fn()}
+        isDraftComplete={false}
+        rosterNeeds={[]}
+      />
+    );
+
+    // RB top tier has a single player left -> cliff. QB top tier has three.
+    expect(within(screen.getByLabelText("RB tier column")).getByText(/Tier 1 cliff/i)).toBeInTheDocument();
+    expect(within(screen.getByLabelText("QB tier column")).queryByText(/cliff/i)).not.toBeInTheDocument();
+  });
+
+  it("hides drafted players and logs a pick when a player is clicked", () => {
+    const onDraftPlayer = jest.fn();
+    render(
+      <DraftTierColumns
+        snapshot={snapshot}
+        draftedPlayerIds={new Set(["rb2"])}
+        onDraftPlayer={onDraftPlayer}
+        isDraftComplete={false}
+        rosterNeeds={[]}
+      />
+    );
+
+    // rb2 was drafted, so it should not appear on the board.
+    expect(screen.queryByText("Jahmyr Gibbs")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Draft Bijan Robinson/i }));
+    expect(onDraftPlayer).toHaveBeenCalledTimes(1);
+    expect(onDraftPlayer).toHaveBeenCalledWith(expect.objectContaining({ id: "rb1" }));
+  });
+
+  it("marks roster-need positions", () => {
+    render(
+      <DraftTierColumns
+        snapshot={snapshot}
+        draftedPlayerIds={new Set()}
+        onDraftPlayer={jest.fn()}
+        isDraftComplete={false}
+        rosterNeeds={["RB"]}
+      />
+    );
+
+    expect(within(screen.getByLabelText("RB tier column")).getByText("Need")).toBeInTheDocument();
+    expect(within(screen.getByLabelText("QB tier column")).queryByText("Need")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/fantasy-football/draft-tracker/components/DraftTierColumns.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftTierColumns.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useMemo } from "react";
+
+import {
+  getFantasyPlayersForPosition,
+  type FantasyRoutePosition,
+  type FantasySnapshot,
+} from "@/lib/fantasy";
+import { formatRankValue, getPositionTone } from "@/lib/fantasyUtils";
+import type { Player } from "@/types";
+
+interface DraftTierColumnsProps {
+  snapshot: FantasySnapshot | null;
+  draftedPlayerIds: Set<string>;
+  onDraftPlayer: (player: Player) => void;
+  isDraftComplete: boolean;
+  rosterNeeds: string[];
+}
+
+// Skill positions where tier scarcity actually drives draft-day decisions.
+// K/DST are intentionally omitted — they come off the board late and their
+// tiers carry little signal during the meaningful part of a draft.
+const COLUMN_POSITIONS: { route: FantasyRoutePosition; label: string }[] = [
+  { route: "qb", label: "QB" },
+  { route: "rb", label: "RB" },
+  { route: "wr", label: "WR" },
+  { route: "te", label: "TE" },
+];
+
+// How many available players to surface per column before collapsing the rest
+// into a "+N more" footer — enough to see the next tier or two without the
+// column running off the screen.
+const MAX_VISIBLE_PER_COLUMN = 10;
+
+// A current tier with this many or fewer players left is a "cliff": value drops
+// off after it, so the team on the clock should consider reaching now.
+const TIER_CLIFF_THRESHOLD = 2;
+
+type TierKey = number | "untiered";
+
+interface TierGroup {
+  tier: TierKey;
+  players: Player[];
+}
+
+function groupAvailableByTier(players: Player[]): TierGroup[] {
+  const buckets = new Map<TierKey, Player[]>();
+
+  for (const player of players) {
+    const key: TierKey =
+      typeof player.tier === "number" && Number.isFinite(player.tier) ? player.tier : "untiered";
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.push(player);
+    } else {
+      buckets.set(key, [player]);
+    }
+  }
+
+  const tiered: TierGroup[] = Array.from(buckets.entries())
+    .filter(([tier]) => tier !== "untiered")
+    .sort(([a], [b]) => (a as number) - (b as number))
+    .map(([tier, tierPlayers]) => ({ tier: tier as number, players: tierPlayers }));
+
+  const untiered = buckets.get("untiered");
+  if (untiered && untiered.length > 0) {
+    tiered.push({ tier: "untiered", players: untiered });
+  }
+
+  return tiered;
+}
+
+// Trim the grouped tiers down to MAX_VISIBLE_PER_COLUMN players while keeping
+// the tier boundaries intact, and report how many available players were left
+// out so the column can show a "+N more" footer.
+function takeVisibleGroups(groups: TierGroup[]): { groups: TierGroup[]; shown: number } {
+  const visible: TierGroup[] = [];
+  let shown = 0;
+
+  for (const group of groups) {
+    if (shown >= MAX_VISIBLE_PER_COLUMN) {
+      break;
+    }
+    const slice = group.players.slice(0, MAX_VISIBLE_PER_COLUMN - shown);
+    visible.push({ tier: group.tier, players: slice });
+    shown += slice.length;
+  }
+
+  return { groups: visible, shown };
+}
+
+export function DraftTierColumns({
+  snapshot,
+  draftedPlayerIds,
+  onDraftPlayer,
+  isDraftComplete,
+  rosterNeeds,
+}: DraftTierColumnsProps) {
+  const columns = useMemo(() => {
+    if (!snapshot) {
+      return [];
+    }
+
+    return COLUMN_POSITIONS.map(({ route, label }) => {
+      const available = getFantasyPlayersForPosition(snapshot, route).filter(
+        (player) => !draftedPlayerIds.has(player.id)
+      );
+      return { route, label, available, groups: groupAvailableByTier(available) };
+    });
+  }, [snapshot, draftedPlayerIds]);
+
+  if (columns.length === 0) {
+    return (
+      <div
+        className="mt-5 rounded-[1.5rem] border px-5 py-12 text-center"
+        style={{
+          borderColor: "var(--home-rule)",
+          background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
+        }}
+      >
+        <p className="text-sm" style={{ color: "var(--home-ink-muted)" }}>
+          Loading the position boards…
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-4" aria-label="Tier columns by position">
+      {columns.map((column) => {
+        const isNeed = rosterNeeds.includes(column.label);
+        const topGroup = column.groups[0];
+        const isCliff =
+          Boolean(topGroup) &&
+          topGroup.tier !== "untiered" &&
+          topGroup.players.length <= TIER_CLIFF_THRESHOLD &&
+          column.available.length > 0;
+        const { groups: visibleGroups, shown } = takeVisibleGroups(column.groups);
+        const hiddenCount = column.available.length - shown;
+
+        return (
+          <section
+            key={column.route}
+            className="flex flex-col rounded-[1.5rem] border p-4"
+            style={{
+              borderColor: isNeed
+                ? "color-mix(in srgb, var(--color-success) 30%, var(--home-rule))"
+                : "var(--home-rule)",
+              background: "color-mix(in srgb, var(--home-paper-alt) 42%, var(--home-elev-mix))",
+            }}
+            aria-label={`${column.label} tier column`}
+          >
+            <header
+              className="flex items-center justify-between gap-2 border-b pb-3"
+              style={{ borderColor: "var(--home-rule)" }}
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className="inline-flex min-h-[28px] items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em]"
+                  style={getPositionTone(column.label)}
+                >
+                  {column.label}
+                </span>
+                {isNeed && (
+                  <span
+                    className="inline-flex min-h-[28px] items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em]"
+                    style={{
+                      borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
+                      background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
+                    }}
+                  >
+                    Need
+                  </span>
+                )}
+              </div>
+              <span className="text-xs font-semibold tabular-nums" style={{ color: "var(--home-ink-muted)" }}>
+                {column.available.length} left
+              </span>
+            </header>
+
+            {isCliff && topGroup.tier !== "untiered" && (
+              <p
+                className="mt-3 inline-flex items-center self-start rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em]"
+                style={{
+                  borderColor: "color-mix(in srgb, var(--color-warning) 32%, var(--home-rule))",
+                  background: "color-mix(in srgb, var(--color-warning) 12%, var(--home-paper))",
+                  color: "var(--home-ink)",
+                }}
+              >
+                Tier {topGroup.tier} cliff · {topGroup.players.length} left
+              </p>
+            )}
+
+            {column.available.length === 0 ? (
+              <p className="mt-3 text-sm" style={{ color: "var(--home-ink-muted)" }}>
+                No {column.label} players left on the board.
+              </p>
+            ) : (
+              <div className="mt-3 grid gap-3">
+                {visibleGroups.map((group) => (
+                  <div key={String(group.tier)} className="grid gap-1.5">
+                    <p className="home-kicker mb-0">
+                      {group.tier === "untiered" ? "Unranked" : `Tier ${group.tier}`}
+                    </p>
+                    {group.players.map((player) => (
+                      <button
+                        key={player.id}
+                        type="button"
+                        onClick={() => onDraftPlayer(player)}
+                        disabled={isDraftComplete}
+                        title="Log this player to the team on the clock"
+                        aria-label={`Draft ${player.name}, ${column.label}${
+                          player.positionRank ? ` ${player.positionRank}` : ""
+                        }`}
+                        className="flex min-h-[40px] w-full items-center justify-between gap-2 rounded-[0.9rem] border px-3 py-2 text-left text-sm transition-[background-color,border-color,color] duration-200 hover:border-[var(--home-ink)] disabled:cursor-not-allowed disabled:opacity-60"
+                        style={{
+                          borderColor: "var(--home-rule)",
+                          background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+                          color: "var(--home-ink)",
+                        }}
+                      >
+                        <span className="min-w-0 truncate font-semibold">{player.name}</span>
+                        <span className="flex shrink-0 items-center gap-2">
+                          <span className="text-xs" style={{ color: "var(--home-ink-muted)" }}>
+                            {player.team}
+                          </span>
+                          <span
+                            className="tabular-nums text-xs font-semibold"
+                            style={{ color: "var(--home-ink-muted)" }}
+                          >
+                            {column.label}
+                            {formatRankValue(player.positionRank ?? player.rankEcr ?? player.averageRank)}
+                          </span>
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                ))}
+                {hiddenCount > 0 && (
+                  <p className="text-xs" style={{ color: "var(--home-ink-muted)" }}>
+                    +{hiddenCount} more available
+                  </p>
+                )}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
+++ b/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
@@ -253,6 +253,7 @@ export function DraftTrackerClient() {
             ) : (
               <DraftBoard
                 players={snapshot?.overall ?? []}
+                snapshot={snapshot}
                 draftedPlayerIds={draftedPlayerIds}
                 onDraftPlayer={draftPlayer}
                 currentPick={draftState.currentPick}


### PR DESCRIPTION
## Summary

Adds a **Tier columns** view to the `/fantasy-football/draft-tracker`, inspired by the Boris Chen–style "draftaid" board ([jayjzheng/draftaid-react](https://github.com/jayjzheng/draftaid-react)). Where the existing **Best available** list shows one flat, single-position-filtered board, the new view shows **QB / RB / WR / TE side by side, each grouped by tier**, so positional scarcity is visible across positions at a glance.

### What it does
- **Position columns by tier** — each column pulls its *position-specific* board via `getFantasyPlayersForPosition(snapshot, …)`, so tiers are real position tiers (RB Tier 1, etc.), not the overall tier.
- **Tier-cliff cue** — when the current tier of a position is down to its last couple of available players, the column flags `Tier N cliff · X left` — the signal to reach.
- **Roster-need marking** — columns matching the user's roster needs get a `Need` chip (reuses the existing `getRosterNeedOrder` logic).
- **Drafting** — clicking any player logs the pick to the team on the clock, via the same `onDraftPlayer` handler as the list view; drafted players drop off the board.
- **Non-destructive** — wired in as a view toggle in `DraftBoard`; **Best available stays the default**, so existing behavior is unchanged. Flipping the default later is a one-liner.

### Files
- `components/DraftTierColumns.tsx` — new view (tier grouping, cliff detection, per-column cap with "+N more").
- `components/DraftTierColumns.test.tsx` — covers tier grouping, the cliff cue, drafted filtering, the draft action, and roster-need marking.
- `components/DraftBoard.tsx` — adds the Best available / Tier columns toggle and passes through the snapshot.
- `draft-tracker-client.tsx` — passes `snapshot` to `DraftBoard`.

## Verification
- `npx tsc --noEmit` → clean
- `npx eslint` (all changed files) → clean
- `npx jest src/app/fantasy-football/` → 5 suites, 17 tests pass (4 new)

## Notes
- Branched from `main` and kept separate from #135 (rankings polish) per request, so the two reviews stay independent.
- K/DST columns are intentionally omitted — they go late and their tiers carry little draft-day signal.
- I couldn't fully read the reference's component source through the GitHub web view (only the file listing + README), so this is a from-scratch implementation of the *pattern* (tier columns + scarcity cues), not a port of its code.

https://claude.ai/code/session_01EwZa87SXzdL5SzPGGEQCLe

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwZa87SXzdL5SzPGGEQCLe)_