### PR TITLE
Fantasy football: findability, honest framing, and data robustness

### DIFF
--- a/.github/workflows/update-fantasy.yml
+++ b/.github/workflows/update-fantasy.yml
@@ -42,8 +42,11 @@ jobs:
 
       # Quality gate: a partial scrape (e.g. FantasyPros throttling some
       # positions) can produce a snapshot with mostly empty boards and slip
-      # past `git diff` because the file does change. Refuse to commit if any
-      # of the three scoring formats has fewer than the minimum player count.
+      # past `git diff` because the file does change. Refuse to commit unless
+      # every scoring format has a healthy overall board AND every individual
+      # position board (QB/RB/WR/TE/K/DST) clears a conservative floor. The
+      # floors sit well below normal counts so they only trip on a genuinely
+      # degraded or empty board, not on routine week-to-week churn.
       - name: Verify fantasy snapshot quality
         id: verify_quality
         run: |
@@ -51,7 +54,8 @@ jobs:
           const fs = require('fs');
           const path = require('path');
 
-          const MIN_PLAYERS = 100;
+          const MIN_OVERALL = 100;
+          const MIN_POSITION = { QB: 20, RB: 40, WR: 40, TE: 20, K: 10, DST: 10 };
           const DATA_DIR = path.join('public', 'data', 'fantasy');
           const formats = ['ppr', 'half_ppr', 'standard'];
           const failures = [];
@@ -61,9 +65,20 @@ jobs:
             try {
               const snapshot = JSON.parse(fs.readFileSync(filePath, 'utf8'));
               const overallCount = Array.isArray(snapshot.overall) ? snapshot.overall.length : 0;
-              console.log(format + ': overall=' + overallCount);
-              if (overallCount < MIN_PLAYERS) {
-                failures.push(format + ' overall has ' + overallCount + ' players (need >= ' + MIN_PLAYERS + ')');
+              const positions = snapshot.positions || {};
+              const counts = Object.keys(MIN_POSITION)
+                .map((pos) => pos + '=' + ((positions[pos] || []).length))
+                .join(' ');
+              console.log(format + ': overall=' + overallCount + ' ' + counts);
+
+              if (overallCount < MIN_OVERALL) {
+                failures.push(format + ' overall has ' + overallCount + ' players (need >= ' + MIN_OVERALL + ')');
+              }
+              for (const [pos, min] of Object.entries(MIN_POSITION)) {
+                const count = Array.isArray(positions[pos]) ? positions[pos].length : 0;
+                if (count < min) {
+                  failures.push(format + ' ' + pos + ' board has ' + count + ' players (need >= ' + min + ')');
+                }
               }
             } catch (err) {
               failures.push(format + ' failed to parse: ' + err.message);
@@ -77,7 +92,7 @@ jobs:
             }
             process.exit(1);
           }
-          console.log('All scoring formats have at least ' + MIN_PLAYERS + ' players. Quality gate passed.');
+          console.log('All scoring formats cleared the overall and per-position floors. Quality gate passed.');
           "
 
       - name: Check for snapshot changes
@@ -166,7 +181,7 @@ jobs:
               `Check the run logs to diagnose. Common causes:`,
               `- FantasyPros HTML structure changed (\`var ecrData\` extraction failed)`,
               `- Sustained 429s exceeded retry budget`,
-              `- Quality gate caught a degraded snapshot (< 100 players in a scoring format)`,
+              `- Quality gate caught a degraded snapshot (thin overall board or an empty/short position board)`,
               ``,
               `This issue will be updated if the next run also fails, and auto-closed on the first successful run.`
             ].join('\n');

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Redirects:
 
 `src/components/StaticHeader.tsx` uses `src/constants/navlinks.tsx`.
 
-All 7 links are active in the nav: Home, About, Projects, Writing, Investments, Resume, Contact.
+All 8 links are active in the nav: Home, About, Projects, Writing, Investments, Fantasy, Resume, Contact. The Fantasy link points to `/fantasy-football`.
 
 ### Layout
 

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -161,13 +161,13 @@ async function getAllSearchableContent(): Promise<SearchableContent[]> {
       id: 'page-fantasy-football',
       title: 'Fantasy Football Analytics Platform',
       excerpt:
-        'Advanced fantasy football analytics with tier charts, clustering, and draft tooling.',
+        'Snapshot-backed fantasy football rankings with consensus tiers, scoring toggles, and a manual draft assistant.',
       content:
-        'Fantasy football analytics data visualization D3 React TypeScript clustering tier charts draft tools waiver wire',
+        'Fantasy football rankings FantasyPros consensus tiers PPR half PPR standard scoring overall position QB RB WR TE draft assistant snake draft waiver',
       url: '/fantasy-football',
       type: 'project',
       category: 'Fantasy Football Analytics',
-      tags: ['Fantasy Football', 'Analytics', 'Data Visualization', 'React', 'TypeScript'],
+      tags: ['Fantasy Football', 'Rankings', 'Draft Tools', 'Next.js', 'TypeScript'],
     },
     {
       id: 'page-news-pulse',

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -663,8 +663,10 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                         </div>
 
                         <div>
-                          <p className={cellLabelClassName}>Availability</p>
-                          <p className="text-sm font-semibold">{formatOwnership(player.ownership)}</p>
+                          <p className={cellLabelClassName}>Rostered</p>
+                          <p className="text-sm font-semibold" title="Share of leagues where this player is on a roster">
+                            {formatOwnership(player.ownership)}
+                          </p>
                           <p className="mt-1 text-xs" style={{ color: "var(--home-ink-muted)" }}>
                             {player.byeWeek ? `Bye ${player.byeWeek}` : "Bye not listed"}
                           </p>

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -163,7 +163,7 @@ export function StructuredData({ type = "Person", data = {} }: StructuredDataPro
           ...baseData,
           "@type": "SoftwareApplication",
           "name": data.name || "Fantasy Football Analytics Tools",
-          "description": data.description || "Advanced fantasy football analytics and visualization platform",
+          "description": data.description || "Snapshot-backed fantasy football rankings and a manual draft assistant sourced from FantasyPros consensus pages",
           "applicationCategory": "SportsApplication",
           "operatingSystem": "Any",
           "url": siteConfig.url,
@@ -182,11 +182,11 @@ export function StructuredData({ type = "Person", data = {} }: StructuredDataPro
             "audienceType": "Fantasy Football Players"
           },
           "featureList": [
-            "Interactive tier visualizations",
-            "Real-time player data",
-            "Clustering algorithms",
-            "Mobile-optimized interface",
-            "Draft assistance tools"
+            "Overall and position-specific rankings",
+            "PPR, Half PPR, and Standard scoring",
+            "FantasyPros consensus tiers and expert ranges",
+            "Published snapshot freshness metadata",
+            "Manual draft assistant with local persistence"
           ],
           "screenshot": `${siteConfig.url}${siteConfig.ogImage}`,
           "offers": {

--- a/src/constants/caseStudies.ts
+++ b/src/constants/caseStudies.ts
@@ -93,11 +93,11 @@ export const caseStudiesData: Record<string, CaseStudyData> = {
     slug: "fantasy-football-analytics",
     title: "Fantasy Football Analytics Platform",
     description:
-      "Full-stack fantasy football platform with live tier rankings, D3 visualizations, and an automated data pipeline.",
+      "Fantasy football platform with snapshot-backed consensus rankings, tier views, scoring toggles, and a manual draft assistant fed by an automated weekly data pipeline.",
     role: "Solo Builder",
-    timeline: "2024–2025",
-    tools: ["Next.js", "D3.js", "TypeScript", "SQLite"],
-    metrics: "Live platform · 2026 season coming soon",
+    timeline: "2024–2026",
+    tools: ["Next.js", "TypeScript", "React", "GitHub Actions"],
+    metrics: "Live · Weekly FantasyPros snapshots · PPR / Half / Standard",
     github: "https://github.com/IsaacAVazquez",
     link: "/fantasy-football",
     featured: true,
@@ -105,9 +105,9 @@ export const caseStudiesData: Record<string, CaseStudyData> = {
 
     overview: {
       summary:
-        "I built a fantasy football platform that combines tier rankings, visualizations, and automated data refreshes into a single weekly workflow.",
+        "I built a fantasy football platform that combines consensus rankings, tier views, and an automated weekly data refresh into a single workflow.",
       impact:
-        "Gives players one place to move from raw rankings to lineup and waiver decisions with less tab-hopping.",
+        "Gives players one place to move from raw rankings to draft decisions with less tab-hopping, and keeps data freshness explicit instead of implied.",
     },
     problem: {
       context:

--- a/src/constants/navlinks.tsx
+++ b/src/constants/navlinks.tsx
@@ -4,6 +4,7 @@ import {
   Briefcase,
   Article,
   ChartBar,
+  Target,
   FileText,
   Mail,
 } from "@/components/ui/ServerIcons";
@@ -34,6 +35,11 @@ export const navLinks: Navlink[] = [
     href: "/investments",
     label: "Investments",
     icon: ChartBar,
+  },
+  {
+    href: "/fantasy-football",
+    label: "Fantasy",
+    icon: Target,
   },
   {
     href: "/resume",

--- a/src/lib/__tests__/fantasySnapshotBuilder.test.ts
+++ b/src/lib/__tests__/fantasySnapshotBuilder.test.ts
@@ -2,7 +2,31 @@
  * @jest-environment node
  */
 import { FANTASY_SNAPSHOT_SCHEMA_VERSION } from "@/lib/fantasy";
-import { buildFantasySnapshot } from "@/lib/fantasySnapshotBuilder";
+import { buildFantasySnapshot, getNflRegularSeasonWeek } from "@/lib/fantasySnapshotBuilder";
+
+const NFL_WEEKS = 18;
+
+describe("getNflRegularSeasonWeek", () => {
+  it("reports week 0 during the offseason and before Week 1 kickoff", () => {
+    expect(getNflRegularSeasonWeek(2026, new Date(Date.UTC(2026, 5, 8)))).toBe(0); // June
+    expect(getNflRegularSeasonWeek(2026, new Date(Date.UTC(2026, 8, 1)))).toBe(0); // Sep 1, before kickoff
+  });
+
+  it("counts up through the regular season", () => {
+    const earlyOctober = getNflRegularSeasonWeek(2026, new Date(Date.UTC(2026, 9, 1)));
+    const lateNovember = getNflRegularSeasonWeek(2026, new Date(Date.UTC(2026, 10, 25)));
+
+    expect(earlyOctober).toBeGreaterThanOrEqual(3);
+    expect(earlyOctober).toBeLessThanOrEqual(6);
+    expect(lateNovember).toBeGreaterThan(earlyOctober);
+    expect(lateNovember).toBeLessThanOrEqual(NFL_WEEKS);
+  });
+
+  it("caps at the final regular-season week through the playoffs and offseason rollover", () => {
+    expect(getNflRegularSeasonWeek(2026, new Date(Date.UTC(2026, 11, 25)))).toBeGreaterThanOrEqual(15); // late December
+    expect(getNflRegularSeasonWeek(2026, new Date(Date.UTC(2027, 1, 1)))).toBe(NFL_WEEKS); // following February
+  });
+});
 
 describe("fantasySnapshotBuilder", () => {
   it("publishes sourced overall and position availability for every scoring format", () => {

--- a/src/lib/fantasySnapshotBuilder.ts
+++ b/src/lib/fantasySnapshotBuilder.ts
@@ -19,7 +19,38 @@ import {
 import { Player } from "@/types";
 
 export const SNAPSHOT_SEASON = new Date().getUTCFullYear();
-export const SNAPSHOT_WEEK = 0;
+
+const MS_PER_DAY = 86_400_000;
+const NFL_REGULAR_SEASON_WEEKS = 18;
+
+/**
+ * Derives the NFL regular-season week for a season from the calendar so a
+ * snapshot built mid-season isn't perpetually stamped "Preseason" (week 0).
+ *
+ * Week 1 kicks off the Thursday after Labor Day (the first Monday of
+ * September). Before that we're in the offseason/preseason and report week 0;
+ * after kickoff we count regular-season weeks and hold at the final week
+ * through the playoffs until the next season opens. This is calendar-derived,
+ * not schedule-aware, so it can be off by a day or two around week
+ * boundaries — close enough for a freshness label, and self-contained.
+ */
+export function getNflRegularSeasonWeek(season: number, now: Date = new Date()): number {
+  // First Monday of September (Labor Day), evaluated in UTC.
+  const septFirst = new Date(Date.UTC(season, 8, 1));
+  const offsetToMonday = (8 - septFirst.getUTCDay()) % 7;
+  const laborDay = new Date(Date.UTC(season, 8, 1 + offsetToMonday));
+  // Week 1's Thursday opener is three days after the Labor Day Monday.
+  const week1Kickoff = laborDay.getTime() + 3 * MS_PER_DAY;
+
+  if (now.getTime() < week1Kickoff) {
+    return 0;
+  }
+
+  const weeksElapsed = Math.floor((now.getTime() - week1Kickoff) / (7 * MS_PER_DAY));
+  return Math.min(NFL_REGULAR_SEASON_WEEKS, weeksElapsed + 1);
+}
+
+export const SNAPSHOT_WEEK = getNflRegularSeasonWeek(SNAPSHOT_SEASON);
 export const SNAPSHOT_SOURCE = DEFAULT_FANTASY_SNAPSHOT_SOURCE;
 export const FANTASY_SNAPSHOT_POSITION_ORDER = ["QB", "RB", "WR", "TE", "K", "DST"] as const;
 

--- a/src/lib/fantasyUtils.ts
+++ b/src/lib/fantasyUtils.ts
@@ -74,7 +74,7 @@ export function formatOwnership(ownership: number | undefined): string {
     return "Not listed";
   }
 
-  return `${ownership?.toFixed(1)}% rostered`;
+  return `${ownership?.toFixed(1)}%`;
 }
 
 export function getPositionTone(position: string): CSSProperties {


### PR DESCRIPTION
## Why

A pass over the fantasy football surface to make it more usable, findable, and honest. The pages themselves are already well-built (good a11y, tier-cliff cues, density toggle, honest "we don't fake ADP/projections" framing) — the real gaps were in **discoverability**, **how the feature is advertised vs. what it actually is**, and a couple of **data/robustness** seams.

## Changes

### Findability
- **Add `Fantasy` to the primary header nav.** It was previously invisible in human-facing navigation — not in the header, footer, or homepage, reachable only via the portfolio card and two blog posts (crawlers found it via sitemap/redirects; people browsing the site basically couldn't). Updated the nav note in `CLAUDE.md` (7 → 8 links).

### Accuracy / honest framing
The case study, the site **search index**, and the `SportsApplication` **structured data** all advertised **"D3 visualizations," "clustering algorithms," and SQLite** — none of which exist anywhere in this surface (it's snapshot-backed FantasyPros consensus rankings + tier chips + a manual draft tracker). Ironically the page itself brags about *not* faking data. Realigned all three to reality:
- `src/constants/caseStudies.ts` — description, tools, timeline, metrics, overview copy.
- `src/app/api/search/route.ts` — excerpt/content/tags (kept `title` + `category` so the search deep-link e2e still passes).
- `src/components/StructuredData.tsx` — `SportsApplication` default description + featureList.

### Robustness / data
- **Harden the weekly refresh CI gate** (`update-fantasy.yml`): it only checked `overall >= 100`, so a partial scrape that emptied a position board would still commit. Now validates every board (QB/RB/WR/TE/K/DST) against a conservative floor well below normal counts.
- **Derive the snapshot NFL week from the calendar** (`getNflRegularSeasonWeek`) instead of hardcoding week 0, so in-season snapshots stop being perpetually labeled "Preseason." Self-contained, with unit tests. No data churn now (June = offseason = week 0, unchanged); takes effect on the next in-season scrape.

### UX
- Relabel the rankings **"Availability" → "Rostered"** — high rostered % meant *low* availability, so the label was backwards — and drop the redundant "rostered" suffix from the value (with a tooltip explaining it).

## Testing
- `jest` — all fantasy + search + header suites pass (50 tests across affected suites), including new `getNflRegularSeasonWeek` tests.
- `eslint src/...` on changed files — clean.
- `tsc --noEmit` — no new errors from these changes (one pre-existing error in the untouched `fantasy-formula-1` surface; the build sets `ignoreBuildErrors`).

## Notes / not done
- Left the FantasyPros scrape on its single `var ecrData` regex (it already opens a GitHub issue on failure); a JSON-API fallback would be a larger, separate change.


---
_Generated by [Claude Code](https://claude.ai/code/session_011du4GdS3Pdi1c3czdaBktJ)_