### PR TITLE
Align legacy blog SEO descriptions with Isaac's voice; review article dates

### DIFF
--- a/content/blog/2025-fantasy-football-draft-strategy.mdx
+++ b/content/blog/2025-fantasy-football-draft-strategy.mdx
@@ -9,7 +9,7 @@ archiveBucket: "Sports & Fantasy"
 author: "Isaac Vazquez"
 seo:
   title: "2025 Fantasy Football Draft Strategy - Data-Driven Approach | Analytics Guide"
-  description: "Dominate your fantasy football draft with advanced analytics and tier-based strategies. Expert insights on data-driven draft approaches for 2025."
+  description: "How I prepare for a fantasy draft using tier-based drafting, value-based calculations, and format-specific strategy, so you stop reaching and start taking the players who matter."
   keywords: ["fantasy football draft 2025", "fantasy draft strategy", "fantasy football analytics", "draft tiers", "fantasy football data", "NFL draft strategy"]
 ---
 

--- a/content/blog/ai-in-software-testing-future-of-qa.mdx
+++ b/content/blog/ai-in-software-testing-future-of-qa.mdx
@@ -9,7 +9,7 @@ cluster: "Systems & Quality"
 author: "Isaac Vazquez"
 seo:
   title: "AI in Software Testing - The Future of QA Engineering | Isaac Vazquez"
-  description: "Learn how AI is transforming software testing and QA engineering. Explore automated test generation, intelligent bug detection, and the future of quality assurance in 2025."
+  description: "AI is changing what QA engineers spend their time on, shifting from routine execution toward judgment. What that looks like in practice and what it means for the field."
   keywords: ["AI software testing", "artificial intelligence QA", "automated test generation", "machine learning testing", "AI QA tools", "future of software testing", "intelligent testing", "AI test automation"]
 ---
 

--- a/content/blog/building-ai-powered-analytics-fantasy-football-to-enterprise.mdx
+++ b/content/blog/building-ai-powered-analytics-fantasy-football-to-enterprise.mdx
@@ -9,7 +9,7 @@ cluster: "Systems & Quality"
 author: "Isaac Vazquez"
 seo:
   title: "Building AI-Powered Analytics Systems - From Fantasy Football to Enterprise"
-  description: "Master AI analytics implementation with real-world case studies. Learn data pipeline architecture, ML model deployment, and scaling strategies from fantasy football to enterprise systems."
+  description: "What I learned building a fantasy football analytics platform mapped onto enterprise problems more directly than expected, from pipeline tradeoffs to architecture decisions."
   keywords: ["AI analytics", "machine learning systems", "data pipeline architecture", "AI implementation", "enterprise analytics", "real-time AI", "ML model deployment", "analytics scaling"]
 ---
 

--- a/content/blog/building-reliable-software-systems.mdx
+++ b/content/blog/building-reliable-software-systems.mdx
@@ -16,7 +16,7 @@ cta:
   actionLabel: "Open the resume"
 seo:
   title: "Building Reliable Software Systems - Strategic Business & Technical Guide | Isaac Vazquez"
-  description: "Learn to build reliable, maintainable software systems with proven quality principles from Austin civic tech and Silicon Valley innovation. Strategic business insights from UC Berkeley MBA perspective."
+  description: "Reliability isn't something you bolt on after the fact. It's a product of the decisions you make throughout development, and the patterns that actually hold up at scale."
   keywords: ["software quality", "reliable software", "system architecture", "software testing", "best practices", "Austin software engineer", "Bay Area engineering", "business strategy software", "product management quality", "UC Berkeley MBA tech"]
 ---
 

--- a/content/blog/complete-guide-qa-engineering.mdx
+++ b/content/blog/complete-guide-qa-engineering.mdx
@@ -16,7 +16,7 @@ cta:
   actionLabel: "Open the resume"
 seo:
   title: "Complete Guide to QA Engineering - Business Strategy & Testing Best Practices | Isaac Vazquez"
-  description: "Master QA engineering with strategic business insights from Austin civic tech and Silicon Valley innovation. Comprehensive guide covering testing strategies, automation, and quality processes that drive business value."
+  description: "QA engineering is less about finding bugs than building the conditions where bugs don't survive to production, across testing strategy, automation, and team integration."
   keywords: ["QA engineering", "software testing", "quality assurance", "test automation", "Austin QA engineer", "Bay Area QA", "business strategy QA", "product management testing", "UC Berkeley MBA QA", "strategic testing practices"]
 ---
 
@@ -350,7 +350,7 @@ function processPayment(amount) {
   return amount * 1.08; // tax calculation
 }
 
-// After QA review — input validation added, tax rate made configurable,
+// After QA review, input validation added, tax rate made configurable,
 // floating-point precision handled
 function processPayment(amount, taxRate = 0.08) {
   if (typeof amount !== 'number' || amount < 0) {

--- a/content/blog/cybersecurity-in-age-of-ai-software-engineer-perspective.mdx
+++ b/content/blog/cybersecurity-in-age-of-ai-software-engineer-perspective.mdx
@@ -9,7 +9,7 @@ cluster: "Systems & Quality"
 author: "Isaac Vazquez"
 seo:
   title: "Cybersecurity in the Age of AI - Software Engineer's Security Guide | Isaac Vazquez"
-  description: "Master AI cybersecurity challenges with practical insights for software engineers. Comprehensive guide covering AI-powered threats, defense strategies, and secure development practices for the AI era."
+  description: "AI is changing both sides of the security equation at once, making attackers and defenders more capable. What that shift means for engineers building and testing systems."
   keywords: ["AI cybersecurity", "artificial intelligence security", "AI-powered attacks", "machine learning security", "software security engineering", "AI threat detection", "secure AI development", "cybersecurity software engineer", "AI security best practices", "intelligent security systems"]
 ---
 

--- a/content/blog/evolution-software-architecture-monoliths-ai-native-systems.mdx
+++ b/content/blog/evolution-software-architecture-monoliths-ai-native-systems.mdx
@@ -9,7 +9,7 @@ cluster: "Systems & Quality"
 author: "Isaac Vazquez"
 seo:
   title: "Software Architecture Evolution - From Monoliths to AI Systems | Isaac Vazquez"
-  description: "Master the evolution of software architecture with strategic insights from Austin to Silicon Valley. Comprehensive guide covering monoliths, microservices, and AI-native system design patterns."
+  description: "How software architecture evolved from monoliths to microservices to AI-native systems, and what each shift means for the decisions engineers face today."
   keywords: ["software architecture evolution", "monolithic vs microservices", "AI-native systems", "distributed systems design", "cloud architecture patterns", "system design principles", "enterprise architecture", "software architecture patterns", "Austin software architecture", "Silicon Valley system design"]
 ---
 

--- a/content/blog/fantasy-football-beginners-complete-guide.mdx
+++ b/content/blog/fantasy-football-beginners-complete-guide.mdx
@@ -9,7 +9,7 @@ archiveBucket: "Sports & Fantasy"
 author: "Isaac Vazquez"
 seo:
   title: "Fantasy Football Beginner Guide 2025 - Complete Starter Guide"
-  description: "Complete fantasy football guide for beginners. Learn how to play, draft strategy, scoring systems, and everything you need to start winning in 2025."
+  description: "What a first-time fantasy player needs to know before their draft, from how scoring and positions work to the mistakes that sink most beginners in their first season."
   keywords: ["fantasy football beginners", "how to play fantasy football", "fantasy football guide 2025", "fantasy football for dummies", "fantasy football basics", "fantasy football tutorial"]
 ---
 

--- a/content/blog/getting-started-with-automated-testing.mdx
+++ b/content/blog/getting-started-with-automated-testing.mdx
@@ -9,7 +9,7 @@ cluster: "Systems & Quality"
 author: "Isaac Vazquez"
 seo:
   title: "Automated Testing Guide - Strategic QA Engineering & Business Practices | Isaac Vazquez"
-  description: "Complete guide to automated testing strategies from Austin civic tech and Silicon Valley perspectives. Business-focused QA practices with UC Berkeley MBA insights."
+  description: "Where to start with automated testing, what the testing pyramid actually means in practice, which tools hold up, and why flaky tests destroy trust in a suite."
   keywords: ["automated testing", "QA engineering", "test automation", "software testing", "quality assurance", "Austin QA engineer", "Bay Area testing", "business strategy QA", "product management testing", "UC Berkeley MBA QA"]
 ---
 

--- a/content/blog/low-code-no-code-vs-traditional-development-when-to-choose.mdx
+++ b/content/blog/low-code-no-code-vs-traditional-development-when-to-choose.mdx
@@ -9,7 +9,7 @@ cluster: "Systems & Quality"
 author: "Isaac Vazquez"
 seo:
   title: "Low-Code vs Traditional Development Strategy Guide | Isaac Vazquez"
-  description: "Make strategic technology decisions with insights from Austin and Silicon Valley. Comprehensive guide to choosing between low-code, no-code, and traditional development approaches for maximum business impact."
+  description: "The low-code versus traditional development question isn't about which approach is better. It's about which constraints matter most for the problem in front of you."
   keywords: ["low-code vs traditional development", "no-code platforms", "software development strategy", "technology decision framework", "digital transformation", "platform engineering", "development methodology", "business technology strategy", "Austin software development", "Silicon Valley development practices"]
 ---
 

--- a/content/blog/mastering-fantasy-football-analytics.mdx
+++ b/content/blog/mastering-fantasy-football-analytics.mdx
@@ -9,7 +9,7 @@ archiveBucket: "Sports & Fantasy"
 author: "Isaac Vazquez"
 seo:
   title: "Fantasy Football Analytics Guide - Data-Driven Strategies & Tools"
-  description: "Master fantasy football through data analytics, visualization, and machine learning. Build advanced tools and gain competitive advantages with data science techniques."
+  description: "Which fantasy football metrics are actually predictive, where the data comes from, and how to apply analytics without overcomplicating your decisions."
   keywords: ["fantasy football analytics", "sports data science", "fantasy football tools", "data visualization", "machine learning fantasy", "Austin fantasy football"]
 ---
 

--- a/content/blog/mba-ai-misuse-how-to-stand-out.mdx
+++ b/content/blog/mba-ai-misuse-how-to-stand-out.mdx
@@ -9,7 +9,7 @@ cluster: "PM Workflows"
 author: "Isaac Vazquez"
 seo:
   title: "How MBAs Misuse AI and How to Stand Out Instead"
-  description: "The predictable patterns of AI misuse in MBA programs and recruiting — and what it actually looks like to use AI in ways that sharpen your thinking rather than substitute for it."
+  description: "The predictable patterns of AI misuse in MBA programs and recruiting, and what it actually looks like to use AI in ways that sharpen your thinking rather than substitute for it."
   keywords: ["MBA AI misuse", "how MBAs use AI", "AI MBA recruiting", "AI for MBA students", "standing out MBA AI", "MBA AI tools", "AI overuse MBA"]
 ---
 

--- a/content/blog/qa-engineer-guide-testing-ai-systems.mdx
+++ b/content/blog/qa-engineer-guide-testing-ai-systems.mdx
@@ -16,7 +16,7 @@ cta:
   actionLabel: "Open the resume"
 seo:
   title: "Testing AI Systems - Complete QA Guide for Machine Learning | Isaac Vazquez"
-  description: "Master AI system testing with comprehensive QA strategies. Learn model validation, bias detection, performance testing, and quality assurance for machine learning applications."
+  description: "Testing AI systems takes different instincts than deterministic software. What I've learned about data validation, model performance, bias detection, and production monitoring."
   keywords: ["AI testing", "machine learning testing", "AI QA", "model testing", "bias testing", "ML quality assurance", "AI validation", "testing AI systems", "QA for AI"]
 ---
 
@@ -45,7 +45,7 @@ def predict_customer_churn(customer_data):
 
 prediction = predict_customer_churn(customer_data)
 assert 0.0 <= prediction <= 1.0  # Range validation
-assert prediction > 0.8           # Threshold validation — may be flaky
+assert prediction > 0.8           # Threshold validation, may be flaky
 ```
 
 The threshold assertion in that second example is the problem. Whether a prediction crosses 0.8 can change when the model retrains, when the input data distribution shifts, or when the model sees input that's slightly outside its training distribution. Tests that were passing yesterday start failing today, not because something broke but because the model learned something new. That's a different kind of test maintenance problem than anything in conventional software testing.

--- a/content/blog/qa-engineering-silicon-valley-uc-berkeley-mba-perspective.mdx
+++ b/content/blog/qa-engineering-silicon-valley-uc-berkeley-mba-perspective.mdx
@@ -9,7 +9,7 @@ cluster: "Systems & Quality"
 author: "Isaac Vazquez"
 seo:
   title: "QA Engineering in Silicon Valley - UC Berkeley MBA Insights | Isaac Vazquez"
-  description: "Deep dive into Silicon Valley QA engineering practices from a UC Berkeley Haas MBA perspective. Strategic insights on quality assurance in Bay Area innovation culture."
+  description: "What changes about QA engineering when you work in Silicon Valley and pursue an MBA at the same time, and why the stakeholder problem turns out harder than the technical one."
   keywords: ["Silicon Valley QA engineering", "UC Berkeley MBA", "Bay Area software testing", "California QA professional", "Haas business strategy", "Silicon Valley tech culture"]
 ---
 

--- a/content/blog/understanding-fantasy-football-analytics.mdx
+++ b/content/blog/understanding-fantasy-football-analytics.mdx
@@ -9,7 +9,7 @@ archiveBucket: "Sports & Fantasy"
 author: "Isaac Vazquez"
 seo:
   title: "Fantasy Football Analytics Guide - Essential Metrics & Advanced Stats"
-  description: "Master fantasy football analytics with this comprehensive guide to the metrics that matter. Learn to evaluate players using advanced statistics and data-driven insights."
+  description: "Most fantasy football metrics just describe what already happened. The ones worth tracking predict what happens next, and the difference changes how you evaluate players."
   keywords: ["fantasy football analytics", "fantasy football metrics", "advanced fantasy stats", "fantasy football data analysis", "player evaluation metrics", "fantasy statistics guide"]
 ---
 

--- a/content/blog/waiver-wire-mastery-hidden-gems.mdx
+++ b/content/blog/waiver-wire-mastery-hidden-gems.mdx
@@ -9,7 +9,7 @@ archiveBucket: "Sports & Fantasy"
 author: "Isaac Vazquez"
 seo:
   title: "Fantasy Football Waiver Wire Strategy - Analytics Guide to Finding Hidden Gems"
-  description: "Dominate your fantasy football waiver wire with data-driven strategies. Learn to identify breakout candidates and sustainable value using advanced analytics."
+  description: "How I read the waiver wire using snap counts, target trends, and sustainability signals to find players worth claiming before they become obvious."
   keywords: ["fantasy football waiver wire", "waiver wire strategy", "fantasy football breakouts", "waiver wire analytics", "fantasy football hidden gems", "weekly waiver wire"]
 ---
 


### PR DESCRIPTION
## What this does

A voice-and-date QA pass over all 78 articles in `content/blog/`.

### Voice

The April 2026 voice rewrite updated article **bodies** and **excerpts**, but a batch of legacy posts kept their original `seo.description` fields, which were keyword-stuffed marketing copy that violates `WRITING_VOICE.md` (which explicitly governs page descriptions):

- `Master fantasy football through data analytics…`
- `Comprehensive guide covering monoliths, microservices…`
- `Dominate your fantasy football waiver wire…`
- `Deep dive into Silicon Valley QA engineering practices…`

This rewrites **15** of those descriptions into Isaac's actual voice, each derived from the post's existing in-voice excerpt, while keeping them descriptive and keyword-relevant for search. It also removes **3** stray em dashes (one in the `mba-ai-misuse` description, two in example-code comments) so the content is fully compliant with the no-em-dash rule.

The `rb-vs-wr` description was already clean (it's the doc's cited "good" example) and was left untouched. Article titles/H1s with "Complete Guide" were left intact — the hard rule targets listicle openers and section headers, not descriptive titles, and changing them would break permalinks and cross-links.

### Dates

Reviewed every post's `publishedAt`/`updatedAt`. No changes were needed:

- **The shared `2025-01-24` date on 16 legacy posts** matches the site-wide batch-dating convention (~16 posts on `2026-04-07`, 8 on `2026-04-29`, 5 on `2026-04-02`, etc.). None of the legacy posts forward-reference 2026, so there are no internal contradictions.
- **The future-dated World Cup posts** (`2026-06-10` → `2026-06-18`) are a deliberate one-per-day countdown, which the hub article explicitly frames ("over the next few weeks I am going to count down… starting at number ten"). The sequence is internally coherent.
- No `updatedAt` precedes its `publishedAt`; weekly-series dates align with their slugs.

### Verification

- Zero em dashes remain anywhere in `content/blog/`.
- Zero marketing-speak remains in any `description` or `excerpt`.
- Diff is 18 line changes across 16 files; no article body prose was altered beyond the three em-dash removals; all frontmatter remains valid YAML.

https://claude.ai/code/session_01NqQPheEqWFJySt2sSyV66v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqQPheEqWFJySt2sSyV66v)_