### PR TITLE
fix(investments): keep holdings rail reachable below 1280px + honor reduced motion

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2414,7 +2414,19 @@ img {
 }
 @media (max-width: 1280px) {
   .invest-shell { grid-template-columns: 200px minmax(0, 1fr); }
-  .invest-rail { display: none !important; }
+  /* The rail holds the "Add a holding" form, allocation chart, and movers.
+     Don't hide it on narrower screens — reflow it into a full-width band below
+     the main column, otherwise there is no way to add a holding on tablet or
+     mobile and the empty-state instructions point at nothing. */
+  .invest-rail {
+    grid-column: 1 / -1;
+    border-left: 0;
+    border-top: 1px solid var(--home-rule);
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 22px 26px;
+    align-items: start;
+  }
 }
 @media (max-width: 900px) {
   .invest-shell { grid-template-columns: 1fr; border-radius: 20px; }
@@ -4298,5 +4310,11 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 @media (prefers-reduced-motion: reduce) {
   .invest-retire-lever-skeleton {
     animation: none;
+  }
+  /* Stop the looping skeleton/spinner animations across the investments
+     surface for motion-sensitive users (the static state stays legible). */
+  .invest-page-stack .animate-pulse,
+  .invest-page-stack .animate-spin {
+    animation: none !important;
   }
 }

--- a/src/components/investments/InvestmentsDashboard.tsx
+++ b/src/components/investments/InvestmentsDashboard.tsx
@@ -251,7 +251,7 @@ export function InvestmentsDashboard({
                 No positions yet
               </p>
               <p className="mx-auto max-w-xs text-sm text-[color-mix(in_srgb,var(--home-ink)_45%,var(--home-paper))]">
-                Add your first stock using the form on the right. Holdings are saved in your browser and persist across visits.
+                Add your first stock with the Add a holding form. Holdings are saved in your browser and persist across visits.
               </p>
             </div>
           )}

--- a/src/components/investments/PortfolioHeroCard.tsx
+++ b/src/components/investments/PortfolioHeroCard.tsx
@@ -219,18 +219,25 @@ export function PortfolioHeroCard({
       .attr("fill", "none")
       .attr("stroke", "var(--home-haze)")
       .attr("stroke-opacity", 0.5);
-    pulse
-      .append("animate")
-      .attr("attributeName", "r")
-      .attr("values", "6;14;6")
-      .attr("dur", "2.4s")
-      .attr("repeatCount", "indefinite");
-    pulse
-      .append("animate")
-      .attr("attributeName", "stroke-opacity")
-      .attr("values", "0.55;0;0.55")
-      .attr("dur", "2.4s")
-      .attr("repeatCount", "indefinite");
+    // SMIL animations can't be disabled via CSS, so honor reduced-motion here.
+    const prefersReducedMotion =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (!prefersReducedMotion) {
+      pulse
+        .append("animate")
+        .attr("attributeName", "r")
+        .attr("values", "6;14;6")
+        .attr("dur", "2.4s")
+        .attr("repeatCount", "indefinite");
+      pulse
+        .append("animate")
+        .attr("attributeName", "stroke-opacity")
+        .attr("values", "0.55;0;0.55")
+        .attr("dur", "2.4s")
+        .attr("repeatCount", "indefinite");
+    }
 
     const yAxisG = d3
       .select(svg)


### PR DESCRIPTION
## Summary

Fixes design issues on the `/investments` surface. The most serious was a responsive bug that made the portfolio unusable on anything narrower than a wide desktop.

### Critical: holdings rail was hidden on tablet/mobile

`.invest-rail` was set to `display: none !important` at `max-width: 1280px`. That rail contains:

- the **Add a holding** form
- the **Allocation** donut
- **Today's movers**

So on every tablet and phone (and narrow laptops < 1280px) there was **no way to add a holding at all** — and the empty state still told users to *"add your first stock using the form on the right,"* pointing at a form that wasn't rendered.

**Fix:** instead of hiding the rail, reflow it into a full-width band below the main column using an auto-fit grid (`repeat(auto-fit, minmax(240px, 1fr))`). On tablets the three rail sections sit side by side; on phones they stack. The form, allocation chart, and movers are now reachable at every width.

### Also in this PR

- **Empty-state copy** no longer says *"the form on the right"* (inaccurate once the rail reflows below) — it now references the **Add a holding** form by name, which is correct in every layout.
- **Reduced motion:** the looping skeleton (`animate-pulse`) and refresh-spinner (`animate-spin`) animations across the investments surface now stop under `prefers-reduced-motion`, and the hero chart's infinite SMIL pulse ring is gated in JS (CSS can't disable SMIL). This completes the pattern the retirement module already followed for its own skeleton.

## Notes on scope

I audited the whole investments surface for design issues. Token usage is actually clean — no legacy `--surface-*`/`--text-*`/`--color-primary` tokens, and `--neutral-*` is defined and dark-mode-aware. The `text-white` cases sit on the `--home-haze` accent (a legitimate pattern). So this PR focuses on the genuine, verifiable problems above rather than churning token names.

## Verification

- `npx jest src/components/investments src/app/investments` → 5 suites / 14 tests pass
- `npx tsc --noEmit` → no new type errors (one pre-existing error in unrelated `fantasy-formula-1-state.ts`)
- Allocation chart is a fixed 220×220 donut, so it renders correctly in the reflowed cell

https://claude.ai/code/session_01Gg2uu3cp6YdMnzYh1J46Mt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gg2uu3cp6YdMnzYh1J46Mt)_