### PR TITLE
fantasy-football: tidy display copy, dead code, cache path, and CSV export

### DIFF
--- a/content/blog/fantasy-football-beginners-complete-guide.mdx
+++ b/content/blog/fantasy-football-beginners-complete-guide.mdx
@@ -31,7 +31,7 @@ The season runs parallel to the NFL regular season. Most leagues have playoffs i
 
 Touchdowns are worth 6 points regardless of how they're scored. Yardage is worth less, typically 1 point per 10 rushing or receiving yards, and 1 point per 25 passing yards for quarterbacks. So a receiver who catches 8 passes for 120 yards and a touchdown earns roughly 12 plus 6, or 18 points in a standard league.
 
-The format that changes everything is PPR, which stands for Point Per Reception. In PPR leagues, each catch is worth 1 additional point. This sounds small but it fundamentally shifts which players are valuable. A slot receiver who catches 100 passes for 900 yards isn't as exciting as one who catches 60 for 1,000 yards in a standard league, but in PPR they're roughly equivalent. Most modern leagues use either full PPR or half-PPR (0.5 points per catch). Check your league settings before you do anything else.
+The format that changes everything is PPR, which stands for Point Per Reception. In PPR leagues, each catch is worth 1 additional point. This sounds small but it fundamentally shifts which players are valuable. A slot receiver who catches 100 passes for 900 yards isn't as exciting as one who catches 60 for 1,000 yards in a standard league, but in PPR they're roughly equivalent. Most modern leagues use either full PPR or Half PPR (0.5 points per catch). Check your league settings before you do anything else.
 
 ## The Draft
 

--- a/content/blog/rb-vs-wr-draft-strategy-modeling-positional-value.mdx
+++ b/content/blog/rb-vs-wr-draft-strategy-modeling-positional-value.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Fantasy Football Draft Strategy: Modeling RB vs WR Value Across Scoring Systems"
-excerpt: "Five years of data on when running backs are actually more valuable than wide receivers, and where the breakeven points shift depending on whether your league uses standard, half-PPR, or full PPR scoring."
+excerpt: "Five years of data on when running backs are actually more valuable than wide receivers, and where the breakeven points shift depending on whether your league uses standard, Half PPR, or full PPR scoring."
 publishedAt: "2025-01-24"
 category: "Fantasy Football Analytics"
 tags: ["Fantasy Football", "Draft Strategy", "Running Backs", "Wide Receivers", "Positional Value", "VBD", "Scoring Systems", "Data Analysis"]
@@ -9,7 +9,7 @@ archiveBucket: "Sports & Fantasy"
 author: "Isaac Vazquez"
 seo:
   title: "RB vs WR Draft Strategy - Modeling Positional Value Across Scoring Systems"
-  description: "Data-driven analysis of running back vs wide receiver value in fantasy football drafts. Learn when positional value shifts across standard, half-PPR, and full PPR formats."
+  description: "Data-driven analysis of running back vs wide receiver value in fantasy football drafts. Learn when positional value shifts across standard, Half PPR, and full PPR formats."
   keywords: ["fantasy football RB vs WR", "positional value fantasy football", "value based drafting", "PPR draft strategy", "fantasy football scoring systems", "running back draft value"]
 ---
 
@@ -23,7 +23,7 @@ I've looked at five years of data from 2020 through 2024 to model where the posi
 
 In standard scoring, running backs maintain a meaningful advantage through approximately the 30th-ranked player at the position. The top 50 running backs in 2024 scored 7,780 total points versus 6,945 for the top 50 wide receivers, a 12 percent advantage for running backs. That's a real structural edge, and it shows up in the data most years in standard formats.
 
-In half-PPR, the gap essentially closes. The same 2024 comparison shows running backs at 8,664 points versus wide receivers at 8,782, a less than two percent difference. That's statistical noise. The breakeven point (where wide receivers become more valuable pick for pick) moves to around the 24th player.
+In Half PPR, the gap essentially closes. The same 2024 comparison shows running backs at 8,664 points versus wide receivers at 8,782, a less than two percent difference. That's statistical noise. The breakeven point (where wide receivers become more valuable pick for pick) moves to around the 24th player.
 
 In full PPR, wide receivers hold the advantage. The 2024 numbers show 9,548 points for the top 50 running backs versus 10,639 for the top 50 wide receivers, an 11 percent edge in the other direction. The breakeven point in full PPR is around the 18th player.
 
@@ -47,7 +47,7 @@ This doesn't invalidate the long-term structural argument for waiting on running
 
 The practical application is that I enter every draft knowing which format I'm in and letting that drive my early-round approach. In standard scoring, I'm aggressively prioritizing running backs in rounds one through three. The data supports it, and the position is scarce enough that waiting creates real risk. In full PPR, I'm more willing to start with elite wide receivers and come back for running backs in the middle rounds, because the positional advantage of receivers in that format is large enough to justify the approach.
 
-In half-PPR (which is where many leagues have settled), I think a balanced approach makes the most sense. One or two running backs in the first three picks, with a genuine willingness to take a wide receiver at any point where a clear tier break exists. The advantage is too thin in half-PPR to commit rigidly to either position.
+In Half PPR (which is where many leagues have settled), I think a balanced approach makes the most sense. One or two running backs in the first three picks, with a genuine willingness to take a wide receiver at any point where a clear tier break exists. The advantage is too thin in Half PPR to commit rigidly to either position.
 
 The other thing I track closely is positional runs during the draft. When four or five teams draft receivers consecutively in rounds three and four, the remaining receivers become artificially scarce while running back value sits on the board. The inverse happens too. Reading when a position is being overdrafted relative to its actual value tier is one of the more useful live-draft skills, and it comes from knowing the breakeven points going in rather than just following your pre-draft rankings.
 

--- a/src/app/fantasy-football/draft-tracker/hooks/useDraftState.test.tsx
+++ b/src/app/fantasy-football/draft-tracker/hooks/useDraftState.test.tsx
@@ -50,6 +50,60 @@ describe("useDraftState", () => {
     expect(result.current.currentTeamNumber).toBe(2);
   });
 
+  it("quotes CSV fields that contain commas", async () => {
+    // Capture the CSV payload from the Blob constructor — jsdom's Blob here
+    // does not implement text(), and the download path (createObjectURL/click)
+    // needs stubbing in the test DOM.
+    const csvParts: string[] = [];
+    const OriginalBlob = global.Blob;
+    class MockBlob {
+      constructor(parts: BlobPart[]) {
+        csvParts.push(String(parts[0]));
+      }
+    }
+    global.Blob = MockBlob as unknown as typeof Blob;
+    const originalCreate = URL.createObjectURL;
+    const originalRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = jest.fn(() => "blob:mock") as unknown as typeof URL.createObjectURL;
+    URL.revokeObjectURL = jest.fn() as unknown as typeof URL.revokeObjectURL;
+    const clickSpy = jest
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    try {
+      const { result } = renderHook(() => useDraftState());
+      await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+      act(() => {
+        result.current.draftPlayer({
+          ...SAMPLE_PLAYER,
+          id: "player-comma",
+          name: "Smith, Jr.",
+          tier: 2,
+          minRank: 1,
+          maxRank: 3,
+          rankEcr: 1,
+        });
+      });
+
+      act(() => {
+        result.current.exportDraftResults("csv");
+      });
+
+      const csvText = csvParts[0];
+
+      expect(csvText).toContain('"Smith, Jr."');
+      // The comma inside the quoted name must not create an extra column.
+      const dataRow = csvText.split("\n")[1];
+      expect(dataRow.startsWith("1,1,Team 1,\"Smith, Jr.\",RB,ATL,1,Tier 2,1-3")).toBe(true);
+    } finally {
+      global.Blob = OriginalBlob;
+      URL.createObjectURL = originalCreate;
+      URL.revokeObjectURL = originalRevoke;
+      clickSpy.mockRestore();
+    }
+  });
+
   it("persists the draft to localStorage", async () => {
     const { result, unmount } = renderHook(() => useDraftState());
 

--- a/src/app/fantasy-football/draft-tracker/hooks/useDraftState.ts
+++ b/src/app/fantasy-football/draft-tracker/hooks/useDraftState.ts
@@ -97,6 +97,15 @@ const generateDraftId = (): string => {
   return `draft_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 };
 
+// Escape a single CSV field per RFC 4180: wrap in quotes and double any
+// embedded quotes when the value contains a comma, quote, or newline. NFL
+// player names are usually comma-free, but this keeps the export from breaking
+// on the occasional edge case.
+const escapeCsvValue = (value: string | number): string => {
+  const stringValue = String(value);
+  return /[",\n\r]/.test(stringValue) ? `"${stringValue.replace(/"/g, '""')}"` : stringValue;
+};
+
 export const useDraftState = () => {
   const [draftState, setDraftState] = useState<DraftState>(() => {
     // Initialize with default state
@@ -340,7 +349,7 @@ export const useDraftState = () => {
       ]);
 
       const csvContent = [csvHeaders, ...csvRows]
-        .map(row => row.join(','))
+        .map(row => row.map(escapeCsvValue).join(','))
         .join('\n');
 
       const blob = new Blob([csvContent], { type: 'text/csv' });

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -563,7 +563,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                     {isLoading
                       ? "Loading players..."
                       : currentSliceUnavailable
-                        ? "Unavailable"
+                        ? "Board unavailable"
                         : `${filteredPlayers.length} players shown`}
                   </p>
                 </div>

--- a/src/components/fantasy/TierBreakdown.tsx
+++ b/src/components/fantasy/TierBreakdown.tsx
@@ -86,7 +86,7 @@ export function TierBreakdown({ players, position, getPublishedRank }: TierBreak
       {groups.map((group, index) => {
         const isUntiered = group.tier === "untiered";
         const accent = isUntiered ? "6%" : tierAccent(index, Math.max(tieredGroups.length, 1));
-        const label = isUntiered ? "Unranked" : `Tier ${group.tier}`;
+        const label = isUntiered ? "Untiered" : `Tier ${group.tier}`;
         const description = isUntiered
           ? "Players without an assigned tier"
           : `${group.players.length} ${group.players.length === 1 ? "player" : "players"}`;

--- a/src/hooks/useFantasySnapshot.ts
+++ b/src/hooks/useFantasySnapshot.ts
@@ -86,7 +86,10 @@ async function loadFantasySnapshot(scoring: FantasyRouteScoring): Promise<Fantas
   const cacheKey = getFantasySnapshotCacheKey(scoring);
   const cachedSnapshot = snapshotCache.get(cacheKey);
   if (cachedSnapshot) {
-    return cacheNormalizedFantasySnapshot(scoring, cachedSnapshot);
+    // The cache only ever holds normalized snapshots (the sole writer is
+    // cacheNormalizedFantasySnapshot), so return the hit directly instead of
+    // re-normalizing it on every read.
+    return cachedSnapshot;
   }
 
   const inflightRequest = inflightSnapshotRequests.get(cacheKey);
@@ -124,8 +127,7 @@ export function useFantasySnapshot({
 }: UseFantasySnapshotOptions): UseFantasySnapshotResult {
   const cacheKey = getFantasySnapshotCacheKey(scoring);
   const [snapshot, setSnapshot] = useState<FantasySnapshot | null>(() => {
-    const cachedSnapshot = snapshotCache.get(cacheKey);
-    return cachedSnapshot ? cacheNormalizedFantasySnapshot(scoring, cachedSnapshot) : null;
+    return snapshotCache.get(cacheKey) ?? null;
   });
   const [isLoading, setIsLoading] = useState(snapshotCache.get(cacheKey) === undefined);
   const [error, setError] = useState<string | null>(null);
@@ -136,7 +138,7 @@ export function useFantasySnapshot({
     async function loadSnapshot() {
       const cachedSnapshot = snapshotCache.get(cacheKey);
       if (cachedSnapshot) {
-        setSnapshot(cacheNormalizedFantasySnapshot(scoring, cachedSnapshot));
+        setSnapshot(cachedSnapshot);
         setIsLoading(false);
         setError(null);
         return;

--- a/src/lib/fantasy.ts
+++ b/src/lib/fantasy.ts
@@ -21,7 +21,6 @@ export type FantasyRouteScoring = (typeof FANTASY_ROUTE_SCORING)[number];
 export type FantasySnapshotPosition = Extract<Position, "QB" | "RB" | "WR" | "TE" | "K" | "DST" | "FLEX">;
 export type FantasySnapshotSliceSourceKind =
   | "overall_consensus"
-  | "derived_overall"
   | "position_consensus"
   | "shared_position_consensus"
   | "derived_flex"

--- a/src/lib/fantasyUtils.ts
+++ b/src/lib/fantasyUtils.ts
@@ -129,8 +129,6 @@ export function getSourceKindLabel(
       return "Shared consensus";
     case "derived_flex":
       return "Derived flex board";
-    case "derived_overall":
-      return "Derived overall board";
     default:
       return "Unavailable";
   }


### PR DESCRIPTION
## What this does

A focused review-and-polish pass over the fantasy football surface (`/fantasy-football`, the draft tracker, the tier breakdown, the data layer, and the related articles). The feature is well-maintained, so this is cleanup, not a rewrite.

### Display / copy
- **`TierBreakdown`** — the no-tier group was labeled **"Unranked"**, which is misleading (those players *are* ranked, just untiered). Now **"Untiered"**, matching the adjacent "Players without an assigned tier" description.
- **Rankings board** — the unavailable status pill said a bare **"Unavailable"** while the sibling stat already said **"Board unavailable"**. Standardized to "Board unavailable".

### Code correctness / hygiene
- **Removed the dead `derived_overall` source kind.** The snapshot builder never emits it, so the union member (`fantasy.ts`) and its label case (`fantasyUtils.ts`) were unreachable.
- **`useFantasySnapshot`** — stopped re-running `normalizeFantasySnapshot` on snapshots that are already cached/normalized on every cache hit. The cache's only writer is `cacheNormalizedFantasySnapshot`, so cache hits now return the stored snapshot directly.
- **Draft tracker CSV export** — fields were joined with a bare `,` and no escaping. Added RFC 4180 escaping (quote + double internal quotes) so a value containing a comma/quote/newline can't corrupt the file. Added a regression test asserting a comma-containing name stays quoted.

### Articles
- Normalized **"half-PPR" → "Half PPR"** in two fantasy posts so prose matches the app's consistent label.

## Verification
- `npx tsc --noEmit` — no new type errors (one pre-existing, unrelated error in `fantasy-formula-1-state.ts` remains).
- `npx jest` over the fantasy suites — **18/18 passing**, including the new CSV-escaping test.
- `eslint` clean on all touched files.

## Notes / deliberately out of scope
Two agent-flagged "bugs" were rejected after verifying the code: the `sliceMetadataMap` "re-render" concern (`snapshot?.sliceMetadata` is a stable reference) and the flex "wrong rank" concern (the UI reads `rankEcr` for the flex board, so the `averageRank` override never surfaces). The flex board intentionally shows overall ranks, per the snapshot source description.

https://claude.ai/code/session_01FApL82mFQjdYZxCELXewgs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FApL82mFQjdYZxCELXewgs)_