### PR TITLE
feat(footer): use the updated contact CTA across all pages

### DIFF
--- a/PAGES.md
+++ b/PAGES.md
@@ -136,16 +136,13 @@ These routes manage more of their own spacing and width:
 - `/writing/[slug]`
 - `/resume`
 - `/spacex-mission-control`
-<<<<<<< HEAD
 - `/wine-cellar`
-=======
 - `/world-cup-2026`
->>>>>>> deb110b23d963f2ced13f361fb9f660c3cb6ecc7
 
 ### Footer variants
 
 - `/` and `/contact` use the compact footer
-- most other routes use the full `Thanks for taking a look.` footer
+- most other routes use the full footer, which closes with the shared contact CTA (`ContactCta`, headline `Building something that needs judgment and follow-through?`) — the same updated CTA used at the bottom of the home page
 
 ---
 

--- a/docs/dashboard-spatial-system.md
+++ b/docs/dashboard-spatial-system.md
@@ -244,7 +244,7 @@ Inside tool mode, an empty state is one card, not a marketing landing page.
 
 ## Footer / page CTA
 
-Tool pages still get the project's standard footer (the "Thanks for taking a look" CTA + site footer). That sits **outside** the shell, in `tool-page-stack` as the last sibling. It is editorial, not tool — that's intentional. Once the user finishes interacting with the tool, the footer pivots back to the portfolio frame.
+Tool pages still get the project's standard footer (the shared contact CTA + site footer). That sits **outside** the shell, in `tool-page-stack` as the last sibling. It is editorial, not tool — that's intentional. Once the user finishes interacting with the tool, the footer pivots back to the portfolio frame.
 
 ---
 
@@ -256,7 +256,7 @@ Tool pages still get the project's standard footer (the "Thanks for taking a loo
 4. Main: topbar (crumbs + small H1 + optional search/refresh) → freshness/meta chip → hero card → stats grid card → list/table card.
 5. Rail: primary "create/add" form → secondary breakdown/chart → recent activity → pinned help.
 6. Below the shell, only break out a separate band if there's a deep-dive view that needs full width.
-7. Keep the editorial site footer and "Thanks for taking a look" CTA at the bottom of `tool-page-stack` (outside the shell).
+7. Keep the editorial site footer and shared contact CTA at the bottom of `tool-page-stack` (outside the shell).
 
 The visible difference vs. the old layout: roughly **30-40% less vertical real estate** for the same content, and a clear sense that the user is operating a product rather than scrolling through a marketing page.
 

--- a/e2e/footer-cta.spec.ts
+++ b/e2e/footer-cta.spec.ts
@@ -14,7 +14,7 @@ test.describe("Footer CTA cleanup", () => {
     const footer = page.getByRole("contentinfo");
     await expect(footer).toHaveAttribute("data-footer-variant", "compact");
     await expect(
-      footer.getByRole("heading", { name: /thanks for taking a look\./i })
+      footer.getByRole("heading", { name: /building something that needs judgment and follow-through/i })
     ).toHaveCount(0);
   });
 
@@ -29,7 +29,7 @@ test.describe("Footer CTA cleanup", () => {
     const footer = page.getByRole("contentinfo");
     await expect(footer).toHaveAttribute("data-footer-variant", "compact");
     await expect(
-      footer.getByRole("heading", { name: /thanks for taking a look\./i })
+      footer.getByRole("heading", { name: /building something that needs judgment and follow-through/i })
     ).toHaveCount(0);
   });
 
@@ -43,7 +43,7 @@ test.describe("Footer CTA cleanup", () => {
     const footer = page.getByRole("contentinfo");
     await expect(footer).toHaveAttribute("data-footer-variant", "full");
     await expect(
-      footer.getByRole("heading", { name: /thanks for taking a look\./i })
+      footer.getByRole("heading", { name: /building something that needs judgment and follow-through/i })
     ).toBeVisible();
   });
 
@@ -58,7 +58,7 @@ test.describe("Footer CTA cleanup", () => {
     const footer = page.getByRole("contentinfo");
     await expect(footer).toHaveAttribute("data-footer-variant", "full");
     await expect(
-      footer.getByRole("heading", { name: /thanks for taking a look\./i })
+      footer.getByRole("heading", { name: /building something that needs judgment and follow-through/i })
     ).toBeVisible();
   });
 });

--- a/src/components/ContactCta.module.css
+++ b/src/components/ContactCta.module.css
@@ -1,0 +1,146 @@
+/* Shared closing contact CTA — the dark inverse panel with the acid-green
+   diagonal, lifted from the home page's updated CTA so every full-footer page
+   shares the same call to action. Uses the global --home-* editorial tokens
+   (not the home page's module-scoped --h-* namespace) so it renders correctly
+   wherever it is mounted, including inside the site footer. */
+
+.cta {
+  background: var(--home-ink);
+  color: var(--home-paper);
+  padding: clamp(2.5rem, 5vw, 4.5rem) 0;
+  position: relative;
+  overflow: hidden;
+}
+.cta::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 42%;
+  background: var(--home-acid);
+  clip-path: polygon(20% 0, 100% 0, 100% 100%, 0 100%);
+  opacity: 0.92;
+}
+
+.shell {
+  max-width: 92rem;
+  margin: 0 auto;
+  padding: 0 clamp(1.25rem, 2.5vw, 2.5rem);
+  position: relative;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: clamp(2rem, 4vw, 4rem);
+  align-items: center;
+  position: relative;
+}
+@media (max-width: 880px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.kicker {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--home-acid);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 1.25rem;
+}
+.kicker::before {
+  content: "";
+  width: 18px;
+  height: 1px;
+  background: var(--home-acid);
+}
+
+.heading {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--home-paper);
+  margin: 0;
+  max-width: 22ch;
+  text-wrap: balance;
+  font-variation-settings: "opsz" 72;
+}
+.heading em {
+  font-family: var(--font-instrument-serif);
+  font-style: italic;
+  font-weight: 400;
+  color: var(--home-acid);
+}
+
+.copy {
+  margin: 1.25rem 0 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--home-stone);
+  max-width: 44ch;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: relative;
+  z-index: 1;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px 22px;
+  min-height: 44px;
+  border: 1px solid var(--home-ink);
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+
+/* The acid diagonal lands behind the actions column, so the primary button
+   becomes solid ink (dark on green, high contrast) and the ghost variants use
+   ink type + ink border to stay legible on the green surface. */
+.btnAcid {
+  background: var(--home-ink);
+  color: var(--home-paper);
+  border-color: var(--home-ink);
+}
+.btnAcid:hover {
+  background: var(--home-paper);
+  color: var(--home-ink);
+  border-color: var(--home-paper);
+}
+
+.btnGhost {
+  background: transparent;
+  color: var(--home-ink);
+  border-color: var(--home-ink);
+}
+.btnGhost:hover {
+  background: var(--home-ink);
+  color: var(--home-paper);
+  border-color: var(--home-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn {
+    transition: none;
+  }
+}

--- a/src/components/ContactCta.tsx
+++ b/src/components/ContactCta.tsx
@@ -1,0 +1,109 @@
+import Link from "next/link";
+import styles from "./ContactCta.module.css";
+
+function MailIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 7a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-10z" />
+      <path d="M3 7l9 6l9 -6" />
+    </svg>
+  );
+}
+
+function DocIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+      <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+    </svg>
+  );
+}
+
+function LinkedInIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4 4m0 2a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2z" />
+      <path d="M8 11l0 5" />
+      <path d="M8 8l0 .01" />
+      <path d="M12 16l0 -5" />
+      <path d="M16 16v-3a2 2 0 0 0 -4 0" />
+    </svg>
+  );
+}
+
+/**
+ * The site-wide closing contact CTA. Mirrors the updated CTA at the bottom of
+ * the home page so every full-footer page surfaces the same call to action.
+ */
+export function ContactCta() {
+  return (
+    <section className={styles.cta} id="contact" aria-labelledby="home-cta-heading">
+      <div className={styles.shell}>
+        <div className={styles.grid}>
+          <div>
+            <span className={styles.kicker}>Contact &middot; Currently open</span>
+            <h2 id="home-cta-heading" className={styles.heading}>
+              Building something that needs <em>judgment</em> and follow-through?
+            </h2>
+            <p className={styles.copy}>
+              Especially interested in product, analytics, fintech, and workflow tools where
+              clear thinking has to survive real delivery.
+            </p>
+          </div>
+          <div className={styles.actions}>
+            <a
+              className={`${styles.btn} ${styles.btnAcid}`}
+              href="mailto:IsaacVazquez@berkeley.edu"
+            >
+              Send email
+              <MailIcon />
+            </a>
+            <Link className={`${styles.btn} ${styles.btnGhost}`} href="/resume">
+              View r&eacute;sum&eacute;
+              <DocIcon />
+            </Link>
+            <a
+              className={`${styles.btn} ${styles.btnGhost}`}
+              href="https://linkedin.com/in/isaac-vazquez"
+              target="_blank"
+              rel="noreferrer"
+            >
+              LinkedIn
+              <LinkedInIcon />
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,9 +4,8 @@ import Link from "next/link";
 import {
   BrandLinkedin,
   BrandGithub,
-  Mail,
-  ArrowRight,
 } from "@/components/ui/ServerIcons";
+import { ContactCta } from "@/components/ContactCta";
 
 const socialLinks = [
   {
@@ -37,42 +36,11 @@ export const Footer = ({ variant = "full" }: FooterProps) => {
       data-footer-variant={variant}
       className="relative z-20 border-t footer-home"
     >
+      {!isCompact ? <ContactCta /> : null}
+
       <div className={`page-shell ${isCompact ? "py-4 md:py-5" : "py-6 md:py-8"}`}>
-        {!isCompact ? (
-          <div className="section-panel p-8 md:p-10 footer-home-panel">
-            <div className="flex flex-col gap-8 lg:flex-row lg:items-end lg:justify-between">
-              <div className="space-y-4">
-                <h2 className="max-w-2xl text-3xl font-bold tracking-tight md:text-4xl footer-home-text-strong">
-                  Thanks for taking a look.
-                </h2>
-                <p className="max-w-2xl text-lg leading-relaxed footer-home-text">
-                  If a project stands out, I&apos;d be happy to share more about the
-                  work or my background.
-                </p>
-              </div>
-
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <Link
-                  href="/portfolio"
-                  className="home-button home-button-primary inline-flex items-center gap-2"
-                >
-                  View projects
-                  <ArrowRight className="h-4 w-4" />
-                </Link>
-                <Link
-                  href="/contact"
-                  className="home-button home-button-secondary inline-flex items-center gap-2"
-                >
-                  <Mail className="h-4 w-4" />
-                  Get in touch
-                </Link>
-              </div>
-            </div>
-          </div>
-        ) : null}
-
         <div
-          className={`flex flex-col gap-5 border-t pt-6 sm:flex-row sm:items-center sm:justify-between ${isCompact ? "" : "mt-8"}`}
+          className="flex flex-col gap-5 border-t pt-6 sm:flex-row sm:items-center sm:justify-between"
           style={{ borderTopColor: "var(--home-rule)" }}
         >
           <div className="space-y-1 text-sm footer-home-text">

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -30,9 +30,16 @@ describe("Footer", () => {
     const links = footer?.querySelectorAll("a");
 
     expect(footer?.getAttribute("data-footer-variant")).toBe("full");
-    expect(heading?.textContent).toBe("Thanks for taking a look.");
-    expect(Array.from(links ?? []).some((link) => link.getAttribute("href") === "/portfolio")).toBe(true);
-    expect(Array.from(links ?? []).some((link) => link.getAttribute("href") === "/contact")).toBe(true);
+    expect(heading?.getAttribute("id")).toBe("home-cta-heading");
+    expect(heading?.textContent).toBe(
+      "Building something that needs judgment and follow-through?",
+    );
+    expect(
+      Array.from(links ?? []).some(
+        (link) => link.getAttribute("href") === "mailto:IsaacVazquez@berkeley.edu",
+      ),
+    ).toBe(true);
+    expect(Array.from(links ?? []).some((link) => link.getAttribute("href") === "/resume")).toBe(true);
   });
 
   it("renders the compact variant without the large CTA block", () => {


### PR DESCRIPTION
## What

Put the home page's **updated** closing CTA — *"Building something that needs **judgment** and follow-through?"* with Email / Résumé / LinkedIn buttons — on **all pages**, replacing the older `Thanks for taking a look.` sign-off in the shared footer.

Per the clarifying question, the chosen approach was **"Replace footer CTA"**: the site already shares one closing CTA via `Footer.tsx`'s `full` variant, so swapping it there propagates the updated CTA to every full-footer page with no stacked CTAs.

## How

- **New `ContactCta` component** (`src/components/ContactCta.tsx` + `ContactCta.module.css`) — a faithful copy of the home page's dark inverse CTA panel with the acid-green diagonal. It uses the **global `--home-*` editorial tokens** (not the home page module's scoped `--h-*` namespace) so it renders correctly anywhere it's mounted, including inside the footer, in dark mode, and under `prefers-reduced-motion`. Keeps the `home-cta-heading` id and 44px touch targets.
- **`Footer.tsx`** renders `<ContactCta />` full-bleed above the footer meta row in the `full` variant. The `compact` footer (`/` and `/contact`, which already have their own closing CTA) is unchanged, so there are still no stacked CTAs.
- **Tests:** updated the `Footer` unit test and the `footer-cta` e2e spec to assert the new heading on full-footer pages and its absence in the compact footer.
- **Docs:** refreshed the footer references in `PAGES.md` and `docs/dashboard-spatial-system.md`, and resolved a stale merge-conflict marker in `PAGES.md` (both `/wine-cellar` and `/world-cup-2026` are valid self-shell routes per `ConditionalLayout.tsx`).

## Verification

- `npx tsc --noEmit` — no new type errors (one pre-existing, unrelated error in `fantasy-formula-1-state.ts`).
- `npx eslint` on changed files — clean.
- `Footer.test.tsx` — 3/3 pass.

## Note (pre-existing, out of scope)

The live home CTA renders *"Building something that needs judgment and follow-through?"*, but `content/sections/home-contact.md` and two e2e specs (`footer-cta.spec.ts`, `homepage.spec.ts`) still expect the older *"If you're building…I'd like to hear about it."* copy. That home-page mismatch predates this change and involves a content-vs-code decision, so it was left untouched.

https://claude.ai/code/session_017XKvVJmxteygG7dF3zesgP

---
_Generated by [Claude Code](https://claude.ai/code/session_017XKvVJmxteygG7dF3zesgP)_