### PR TITLE
fix(fantasy-formula-1): prevent null focus leaking into href query

### DIFF
--- a/src/app/fantasy-formula-1/fantasy-formula-1-state.ts
+++ b/src/app/fantasy-formula-1/fantasy-formula-1-state.ts
@@ -109,10 +109,10 @@ export function buildFantasyFormula1Href(
     params.set("sort", state.sort);
   }
 
-  if (state.focus === DEFAULT_FANTASY_FORMULA1_STATE.focus) {
-    params.delete("focus");
-  } else {
+  if (state.focus && state.focus !== DEFAULT_FANTASY_FORMULA1_STATE.focus) {
     params.set("focus", state.focus);
+  } else {
+    params.delete("focus");
   }
 
   const query = params.toString();

--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 import { StructuredData } from "@/components/StructuredData";
 import { constructMetadata, generateBreadcrumbStructuredData } from "@/lib/seo";
 import { TravelPlannerClient } from "./travel-planner-client";


### PR DESCRIPTION
## What was wrong

`npx tsc --noEmit` failed with a real type error:

```
src/app/fantasy-formula-1/fantasy-formula-1-state.ts(115,25): error TS2345:
  Argument of type 'string | null' is not assignable to parameter of type 'string'.
```

In `buildFantasyFormula1Href`, `state.focus` is typed `"drivers" | "constructors" | null`. The guard compared it against `DEFAULT_FANTASY_FORMULA1_STATE.focus` (a value, not the literal `null`), which does **not** narrow out `null`. So the `else` branch passed `string | null` into `URLSearchParams.set()`, which requires a `string`.

The production build didn't surface this because `next.config.mjs` sets `typescript.ignoreBuildErrors: true` — but it still breaks `tsc --noEmit` and, if the guard ever shifted, would serialize `focus=null` (the literal string) into the URL.

## The fix

- Guard on a **truthy, non-default** focus before `params.set(...)`; otherwise `params.delete(...)`. The truthy check narrows `null` out of the union, and `!== DEFAULT` keeps the existing "drop when default" semantics (and stays correct if the default ever becomes non-null). Behavior is unchanged for every valid input.
- Removed a dead `eslint-disable react-refresh/only-export-components` directive in `src/app/travel/page.tsx` that ESLint flagged as an unused directive.

## Verification

- `npx tsc --noEmit` → clean (exit 0)
- `npm run lint` → clean (0 errors, 0 warnings)
- `npx jest src/app/fantasy-formula-1/__tests__/` → 2 suites, 6 tests passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01RinWjMsYvhtszpUX3c7znq)_