### PR TITLE
perf: dashboard loading states + lazy-loaded MBA dialogs

### DIFF
--- a/docs/website-improvement-suggestions.md
+++ b/docs/website-improvement-suggestions.md
@@ -1,0 +1,119 @@
+# Website Improvement Suggestions
+
+**Created:** 2026-06-09
+**Scope:** Repo-wide review of performance, accessibility, SEO, testing, code health, and tooling.
+
+This is a working reference, not a canonical spec. It captures a snapshot review of the
+site and tracks which items have been actioned. Re-check against code before relying on any
+single line — when docs and code disagree, code wins.
+
+---
+
+## What is already strong
+
+These areas were reviewed and found in good shape — listed so future reviews don't
+re-flag them as gaps:
+
+- **SEO.** ~93% of `page.tsx` routes export metadata; comprehensive JSON-LD via
+  `src/lib/seo.ts` (Person, Article, Project, Breadcrumb, Organization), auto-generated
+  sitemap/robots, and AI-optimized meta tags. The three routes without metadata are
+  auth/redirect pages that don't need it.
+- **Code health.** Zero `TODO`/`FIXME`/`HACK` markers in `src/`. No stray `console.log`
+  in components — logging is concentrated in `src/lib/logger.ts` and data scripts.
+  `removeConsole` is on for production builds (`next.config.mjs`).
+- **Dependencies.** Current stack — Next.js 16, React 19, TypeScript 6, Playwright,
+  Jest 30, MSW. No obviously stale packages.
+- **Fonts.** All web fonts use `display: swap`/`optional` with pinned weights and system
+  fallbacks (`src/app/layout.tsx`).
+- **Accessibility baseline.** Dedicated `/accessibility` statement, skip link, 147
+  `aria-label` usages, 49 `rel="noopener noreferrer"` external links, global
+  `prefers-reduced-motion` handling in `globals.css`.
+
+---
+
+## High impact
+
+### 1. Image loading attributes on raw `<img>` tags — _mostly already done_
+Most raw `<img>` tags render **external** sports/space assets (team crests, driver
+headshots, circuit maps, mission photos) from hosts not in `next.config.mjs`
+`remotePatterns`. Forcing `next/image` onto them would break rendering or require
+unbounded host config, so the right move is loading hints, not `next/image`.
+
+On review, the Formula 1, Fantasy F1, and SpaceX images **already** set
+`loading="lazy"` (and SpaceX adds `decoding="async"`/`fetchPriority`). The one gap was
+`src/components/football/CrestAvatar.tsx` — crests render many-per-page in standings and
+fixture lists with no lazy loading.
+
+- **Status: addressed.** `CrestAvatar` now sets `loading="lazy"` + `decoding="async"` and
+  explicit dimensions; `decoding="async"` added to the F1/Fantasy-F1 avatars for
+  consistency.
+
+### 2. Add `loading.tsx` to data-driven dashboard routes
+There were **zero** `loading.tsx` files across the app. Dashboard routes pair an
+`error.tsx` with no streaming fallback, so client-side navigation shows nothing until the
+server component resolves.
+
+- **Status: addressed.** Added a shared `src/components/RouteLoadingState.tsx` editorial
+  skeleton and a `loading.tsx` for each snapshot dashboard (NFL, NBA, MLB, Formula 1,
+  Fantasy F1, Premier League, La Liga, World Cup, SpaceX, News Pulse, Investments, Golf,
+  Polling Aggregator, GitHub Trending Pulse).
+
+### 3. Code-split the largest client components
+A few `"use client"` pages ship very large bundles:
+`mba-jobs-client.tsx` (~3,200 lines), `museum-log-client.tsx` (~1,775),
+`nfl-client.tsx` (~1,314). Heavy, interaction-only UI loads up front.
+
+- **Status: partially addressed.** In the MBA tracker, the two interaction-gated modals
+  (`EmailDigestDialog`, `ApplicationEditDialog`) were extracted to their own modules and
+  are now lazy-loaded via `next/dynamic`, gated on open state, so their JS only loads when
+  a user opens a dialog. Shared form types/helpers moved to `application-form.ts`.
+- **Follow-up:** apply the same interaction-gated `next/dynamic` pattern to the heaviest
+  panels in `museum-log-client.tsx` and `nfl-client.tsx`. These carry more shared state,
+  so they warrant their own focused PR with interactive verification.
+
+---
+
+## Medium impact
+
+### 4. Close the image alt-text gap
+Custom controls are well-labeled, but content images are sparse on `alt`. The
+`OptimizedImage` wrapper requires `alt` — routing more images through it (or auditing the
+raw tags) closes both the a11y and image-SEO gap.
+
+### 5. Component unit tests for primary surfaces
+Test infra is excellent (Jest + Playwright + CI coverage), but the most-visited
+components have no unit tests: `PortfolioV3.tsx`, `HomePageV3.tsx`, `AboutV3.tsx`,
+`ProjectsContent.tsx`. Lib/data logic is well-covered; the gap is interactive component
+behavior.
+
+### 6. Add a typecheck gate to CI
+CI runs lint, unit, and E2E, but no standalone `tsc --noEmit`, and `next.config.mjs` sets
+`typescript.ignoreBuildErrors: true`. With ESLint relaxing `no-explicit-any` and
+`exhaustive-deps` to warnings, a dedicated typecheck job would catch type regressions the
+build tolerates.
+
+---
+
+## Low effort / cleanup
+
+### 7. Accessibility page date drift
+`src/app/accessibility/page.tsx` says "Updated April 2026" in the kicker but "written in
+November 2025" in the body. Reconcile the two.
+
+### 8. Decide the fate of `ProjectsContent.tsx`
+~710 lines, referenced only by tests now that `PortfolioV3` is canonical for `/portfolio`.
+Either delete it (and its tests) or document why it is retained.
+
+### 9. Retirement planner CMA verification
+`CMA_VERIFIED = false` in `capitalMarketAssumptions.ts`. Disclaimers are honest and
+intact, but pinning the figures to a dated primary source would let the surface drop the
+"unverified" framing.
+
+---
+
+## Suggested sequencing
+
+1. **Done in this pass:** #1, #2, and the MBA slice of #3.
+2. **Next, low risk:** #7 and #8 (quick cleanups), then #6 (CI typecheck gate).
+3. **Then, focused PRs:** the museum-log/NFL slices of #3, #5 (component tests), #4
+   (image alt audit), #9 (CMA verification).

--- a/src/app/fantasy-formula-1/fantasy-formula-1-client.tsx
+++ b/src/app/fantasy-formula-1/fantasy-formula-1-client.tsx
@@ -129,6 +129,7 @@ function AssetAvatar({ asset }: { asset: FantasyFormula1Asset }) {
         src={asset.headshotUrl}
         alt={asset.name}
         loading="lazy"
+        decoding="async"
         className="h-10 w-10 flex-shrink-0 rounded-full border border-[var(--home-rule)] bg-[var(--home-paper-alt)] object-cover object-top"
       />
     );

--- a/src/app/fantasy-formula-1/loading.tsx
+++ b/src/app/fantasy-formula-1/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function FantasyFormula1Loading() {
+  return <RouteLoadingState surfaceName="the Fantasy Formula 1 optimizer" />;
+}

--- a/src/app/formula-1/formula-1-client.tsx
+++ b/src/app/formula-1/formula-1-client.tsx
@@ -214,6 +214,7 @@ function CountryFlag({
       src={flagUrl}
       alt={`${countryName} flag`}
       loading="lazy"
+      decoding="async"
       className="h-4 w-7 flex-shrink-0 rounded-[3px] border border-[var(--home-rule)] object-cover"
     />
   );
@@ -250,6 +251,7 @@ function DriverHeadshot({
       src={url}
       alt={name}
       loading="lazy"
+      decoding="async"
       className="h-9 w-9 flex-shrink-0 rounded-full border bg-[var(--home-paper-alt)] object-cover object-top"
       style={{ borderColor: teamColor ?? "var(--home-rule)" }}
     />
@@ -541,6 +543,7 @@ function MeetingDetailPanel({
               src={meeting.circuitImage}
               alt={`${meeting.circuitShortName} circuit map`}
               loading="lazy"
+              decoding="async"
               className="hidden h-20 w-24 flex-shrink-0 rounded-2xl border border-[var(--home-rule)] bg-[var(--home-paper-alt)] object-contain p-2 sm:block"
             />
           ) : null}

--- a/src/app/formula-1/loading.tsx
+++ b/src/app/formula-1/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function Formula1Loading() {
+  return <RouteLoadingState surfaceName="the Formula 1 dashboard" />;
+}

--- a/src/app/github-trending-pulse/loading.tsx
+++ b/src/app/github-trending-pulse/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function GithubTrendingLoading() {
+  return <RouteLoadingState surfaceName="the GitHub trending dashboard" />;
+}

--- a/src/app/golf/loading.tsx
+++ b/src/app/golf/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function GolfLoading() {
+  return <RouteLoadingState surfaceName="the golf leaderboard" />;
+}

--- a/src/app/investments/loading.tsx
+++ b/src/app/investments/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function InvestmentsLoading() {
+  return <RouteLoadingState surfaceName="the investments tracker" />;
+}

--- a/src/app/la-liga/loading.tsx
+++ b/src/app/la-liga/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function LaLigaLoading() {
+  return <RouteLoadingState surfaceName="the La Liga dashboard" />;
+}

--- a/src/app/mba-internship-notifications/ApplicationEditDialog.tsx
+++ b/src/app/mba-internship-notifications/ApplicationEditDialog.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { X } from "lucide-react";
+import {
+  MBA_APPLICATION_PRIORITIES,
+  MBA_APPLICATION_PRIORITY_LABELS,
+  MBA_APPLICATION_STATUSES,
+  MBA_APPLICATION_STATUS_LABELS,
+} from "@/lib/mba-applications";
+import type {
+  MBAApplicationPriority,
+  MBAApplicationStatus,
+  MBATrackedApplication,
+} from "@/types/mba-jobs";
+import {
+  applicationInputClass,
+  applicationInputStyle,
+  getApplicationFormState,
+  type ApplicationFormState,
+} from "./application-form";
+
+/**
+ * Add/edit modal for a tracked MBA application. Code-split via `next/dynamic`
+ * and mounted only while open, so its form markup loads on first use.
+ */
+function FormField({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="block space-y-2">
+      <span className="home-meta mb-0">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+export default function ApplicationEditDialog({
+  isOpen,
+  application,
+  onClose,
+  onSave,
+}: {
+  isOpen: boolean;
+  application: MBATrackedApplication | null;
+  onClose: () => void;
+  onSave: (form: ApplicationFormState, application: MBATrackedApplication | null) => void;
+}) {
+  const [form, setForm] = useState<ApplicationFormState>(() =>
+    getApplicationFormState(application)
+  );
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Dialog form mirrors the selected application each time it opens.
+    setForm(getApplicationFormState(application));
+  }, [application, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const dialog = dialogRef.current;
+    dialog?.querySelector<HTMLElement>("input, select, textarea, button")?.focus();
+
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const canSave = form.companyName.trim() && form.title.trim();
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto p-4"
+      style={{ background: "rgba(0,0,0,0.45)" }}
+      role="presentation"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="application-dialog-title"
+        className="home-card max-h-[90vh] w-full max-w-2xl overflow-y-auto p-6 sm:p-7"
+        style={{ background: "var(--home-paper)" }}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="home-kicker mb-2">Application tracker</p>
+            <h2
+              id="application-dialog-title"
+              className="mb-0 text-xl font-semibold"
+              style={{ fontFamily: "var(--font-home-sans)", color: "var(--home-ink)" }}
+            >
+              {application ? "Edit application" : "Add application"}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full"
+            aria-label="Close application dialog"
+            style={{ color: "var(--home-ink-muted)" }}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+          <FormField label="Company">
+            <input
+              value={form.companyName}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, companyName: event.target.value }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+            />
+          </FormField>
+          <FormField label="Role">
+            <input
+              value={form.title}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, title: event.target.value }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+            />
+          </FormField>
+          <FormField label="Location">
+            <input
+              value={form.location}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, location: event.target.value }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+            />
+          </FormField>
+          <FormField label="Department">
+            <input
+              value={form.department}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, department: event.target.value }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+            />
+          </FormField>
+          <FormField label="Application URL">
+            <input
+              value={form.applyUrl}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, applyUrl: event.target.value }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+              inputMode="url"
+            />
+          </FormField>
+          <FormField label="Source URL">
+            <input
+              value={form.sourceUrl}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, sourceUrl: event.target.value }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+              inputMode="url"
+            />
+          </FormField>
+          <FormField label="Status">
+            <select
+              value={form.status}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  status: event.target.value as MBAApplicationStatus,
+                }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+            >
+              {MBA_APPLICATION_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {MBA_APPLICATION_STATUS_LABELS[status]}
+                </option>
+              ))}
+            </select>
+          </FormField>
+          <FormField label="Priority">
+            <select
+              value={form.priority}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  priority: event.target.value as MBAApplicationPriority,
+                }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+            >
+              {MBA_APPLICATION_PRIORITIES.map((priority) => (
+                <option key={priority} value={priority}>
+                  {MBA_APPLICATION_PRIORITY_LABELS[priority]}
+                </option>
+              ))}
+            </select>
+          </FormField>
+          <FormField label="Follow-up date">
+            <input
+              type="date"
+              value={form.followUpDate}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, followUpDate: event.target.value }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+            />
+          </FormField>
+          <FormField label="Deadline">
+            <input
+              type="date"
+              value={form.deadline}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, deadline: event.target.value }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+            />
+          </FormField>
+          <FormField label="Contact">
+            <input
+              value={form.contact}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, contact: event.target.value }))
+              }
+              className={applicationInputClass}
+              style={applicationInputStyle}
+            />
+          </FormField>
+          <div className="sm:col-span-2">
+            <FormField label="Notes">
+              <textarea
+                value={form.notes}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, notes: event.target.value }))
+                }
+                className={`${applicationInputClass} min-h-28 resize-y`}
+                style={applicationInputStyle}
+              />
+            </FormField>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-wrap justify-end gap-3">
+          <button type="button" onClick={onClose} className="home-button home-button-secondary">
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onSave(form, application)}
+            disabled={!canSave}
+            className="home-button home-button-primary disabled:opacity-50"
+          >
+            Save application
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/mba-internship-notifications/EmailDigestDialog.tsx
+++ b/src/app/mba-internship-notifications/EmailDigestDialog.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Email-digest modal for the MBA tracker. Code-split via `next/dynamic` and
+ * mounted only while open, so its focus-trap logic stays out of the initial bundle.
+ */
+export default function EmailDigestDialog({
+  isOpen,
+  onClose,
+  onSubmit,
+  sending,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (email: string) => void;
+  sending: boolean;
+}) {
+  const [email, setEmail] = useState("");
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<Element | null>(null);
+
+  // Trap focus within the dialog while open and restore it on close.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    triggerRef.current = document.activeElement;
+    const dialog: HTMLDivElement | null = dialogRef.current;
+    if (!dialog) return;
+    const dialogEl: HTMLDivElement = dialog;
+
+    const focusable = dialogEl.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    focusable[0]?.focus();
+
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape" && !sending) {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const items = dialogEl.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      if (triggerRef.current instanceof HTMLElement) {
+        triggerRef.current.focus();
+      }
+    };
+  }, [isOpen, onClose, sending]);
+
+  if (!isOpen) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: "rgba(0,0,0,0.45)" }}
+      role="presentation"
+      onClick={(event) => {
+        if (event.target === event.currentTarget && !sending) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="email-digest-title"
+        aria-describedby="email-digest-description"
+        className="home-card w-full max-w-sm p-6 sm:p-7"
+        style={{ background: "var(--home-paper)" }}
+      >
+        <h2
+          id="email-digest-title"
+          className="mb-3 text-lg font-semibold"
+          style={{ fontFamily: "var(--font-home-sans)", color: "var(--home-ink)" }}
+        >
+          Send email digest
+        </h2>
+        <p
+          id="email-digest-description"
+          className="mb-4 text-sm"
+          style={{ color: "var(--home-ink-muted)" }}
+        >
+          Enter your email to receive the current job list as a digest.
+        </p>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          className="mb-4 w-full rounded-xl border px-4 py-3 text-sm outline-none focus-visible:border-[var(--home-haze)] focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--home-haze)_35%,transparent)]"
+          style={{
+            background: "var(--home-paper-alt)",
+            borderColor: "var(--home-rule)",
+            color: "var(--home-ink)",
+          }}
+          disabled={sending}
+          autoComplete="email"
+          aria-label="Your email address"
+        />
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => onSubmit(email)}
+            disabled={sending || !email.includes("@")}
+            className="home-button home-button-primary flex-1 disabled:opacity-50"
+          >
+            {sending ? "Sending…" : "Send"}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={sending}
+            className="home-button home-button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/mba-internship-notifications/application-form.ts
+++ b/src/app/mba-internship-notifications/application-form.ts
@@ -1,0 +1,73 @@
+import type { CSSProperties } from "react";
+import type {
+  MBAApplicationPriority,
+  MBAApplicationStatus,
+  MBATrackedApplication,
+} from "@/types/mba-jobs";
+
+/**
+ * Shared application-form types, defaults, and input styling for the MBA tracker.
+ *
+ * Extracted from `mba-jobs-client.tsx` so the code-split `ApplicationEditDialog`
+ * and the main client (which seeds saves and reuses the input styling in the
+ * pipeline/cards) can both import them without duplicating the definitions.
+ */
+export interface ApplicationFormState {
+  companyName: string;
+  title: string;
+  location: string;
+  department: string;
+  applyUrl: string;
+  sourceUrl: string;
+  status: MBAApplicationStatus;
+  priority: MBAApplicationPriority;
+  contact: string;
+  followUpDate: string;
+  deadline: string;
+  notes: string;
+}
+
+export const EMPTY_APPLICATION_FORM: ApplicationFormState = {
+  companyName: "",
+  title: "",
+  location: "",
+  department: "",
+  applyUrl: "",
+  sourceUrl: "",
+  status: "saved",
+  priority: "medium",
+  contact: "",
+  followUpDate: "",
+  deadline: "",
+  notes: "",
+};
+
+export function getApplicationFormState(
+  application: MBATrackedApplication | null
+): ApplicationFormState {
+  if (!application) return EMPTY_APPLICATION_FORM;
+  return {
+    companyName: application.jobSnapshot.companyName,
+    title: application.jobSnapshot.title,
+    location: application.jobSnapshot.location,
+    department: application.jobSnapshot.department,
+    applyUrl: application.jobSnapshot.applyUrl,
+    sourceUrl: application.sourceUrl,
+    status: application.status,
+    priority: application.priority,
+    contact: application.contact,
+    followUpDate: application.followUpDate ?? "",
+    deadline: application.deadline ?? "",
+    notes: application.notes,
+  };
+}
+
+export const applicationInputClass =
+  "w-full min-h-[44px] rounded-[0.9rem] border px-3 py-2 text-sm outline-none transition-[border-color,box-shadow] duration-200 ease focus-visible:border-[var(--home-haze)] focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--home-haze)_35%,transparent)]";
+
+export const applicationInputStyle: CSSProperties = {
+  background: "var(--home-paper-alt)",
+  borderColor: "var(--home-rule)",
+  color: "var(--home-ink)",
+  fontFamily: "var(--font-home-sans)",
+};

--- a/src/app/mba-internship-notifications/mba-jobs-client.tsx
+++ b/src/app/mba-internship-notifications/mba-jobs-client.tsx
@@ -8,7 +8,6 @@ import {
   useRef,
   useState,
   type CSSProperties,
-  type ReactNode,
 } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -47,7 +46,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ChevronDown } from "lucide-react";
 import {
-  MBA_APPLICATION_PRIORITIES,
   MBA_APPLICATION_PRIORITY_LABELS,
   MBA_APPLICATION_STATUSES,
   MBA_APPLICATION_STATUS_LABELS,
@@ -90,6 +88,17 @@ import {
   SORT_OPTIONS,
   VIEW_LABELS,
 } from "./mba-jobs-state";
+import dynamic from "next/dynamic";
+import {
+  applicationInputClass,
+  applicationInputStyle,
+  type ApplicationFormState,
+} from "./application-form";
+
+// Interaction-gated dialogs are code-split so their chunks load only when a
+// user opens them — keeping them out of this large client page's initial bundle.
+const EmailDigestDialog = dynamic(() => import("./EmailDigestDialog"));
+const ApplicationEditDialog = dynamic(() => import("./ApplicationEditDialog"));
 
 // ---------------------------------------------------------------------------
 // Motion variants
@@ -1121,141 +1130,6 @@ function EmailDigestButton({
 }
 
 // ---------------------------------------------------------------------------
-// Email dialog (simple inline form)
-// ---------------------------------------------------------------------------
-
-function EmailDigestDialog({
-  isOpen,
-  onClose,
-  onSubmit,
-  sending,
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-  onSubmit: (email: string) => void;
-  sending: boolean;
-}) {
-  const [email, setEmail] = useState("");
-  const dialogRef = useRef<HTMLDivElement | null>(null);
-  const triggerRef = useRef<Element | null>(null);
-
-  // Trap focus within the dialog while open and restore it on close.
-  useEffect(() => {
-    if (!isOpen) return;
-
-    triggerRef.current = document.activeElement;
-    const dialog: HTMLDivElement | null = dialogRef.current;
-    if (!dialog) return;
-    const dialogEl: HTMLDivElement = dialog;
-
-    const focusable = dialogEl.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    );
-    focusable[0]?.focus();
-
-    function handleKey(event: KeyboardEvent) {
-      if (event.key === "Escape" && !sending) {
-        event.preventDefault();
-        onClose();
-        return;
-      }
-      if (event.key !== "Tab") return;
-      const items = dialogEl.querySelectorAll<HTMLElement>(
-        'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      if (items.length === 0) return;
-      const first = items[0];
-      const last = items[items.length - 1];
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    }
-
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      document.removeEventListener("keydown", handleKey);
-      if (triggerRef.current instanceof HTMLElement) {
-        triggerRef.current.focus();
-      }
-    };
-  }, [isOpen, onClose, sending]);
-
-  if (!isOpen) return null;
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      style={{ background: "rgba(0,0,0,0.45)" }}
-      role="presentation"
-      onClick={(event) => {
-        if (event.target === event.currentTarget && !sending) onClose();
-      }}
-    >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="email-digest-title"
-        aria-describedby="email-digest-description"
-        className="home-card w-full max-w-sm p-6 sm:p-7"
-        style={{ background: "var(--home-paper)" }}
-      >
-        <h2
-          id="email-digest-title"
-          className="mb-3 text-lg font-semibold"
-          style={{ fontFamily: "var(--font-home-sans)", color: "var(--home-ink)" }}
-        >
-          Send email digest
-        </h2>
-        <p
-          id="email-digest-description"
-          className="mb-4 text-sm"
-          style={{ color: "var(--home-ink-muted)" }}
-        >
-          Enter your email to receive the current job list as a digest.
-        </p>
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="you@example.com"
-          className="mb-4 w-full rounded-xl border px-4 py-3 text-sm outline-none focus-visible:border-[var(--home-haze)] focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--home-haze)_35%,transparent)]"
-          style={{
-            background: "var(--home-paper-alt)",
-            borderColor: "var(--home-rule)",
-            color: "var(--home-ink)",
-          }}
-          disabled={sending}
-          autoComplete="email"
-          aria-label="Your email address"
-        />
-        <div className="flex gap-3">
-          <button
-            type="button"
-            onClick={() => onSubmit(email)}
-            disabled={sending || !email.includes("@")}
-            className="home-button home-button-primary flex-1 disabled:opacity-50"
-          >
-            {sending ? "Sending…" : "Send"}
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={sending}
-            className="home-button home-button-secondary"
-          >
-            Cancel
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Company filter strip
 // ---------------------------------------------------------------------------
 
@@ -1460,327 +1334,6 @@ function CompanyFilterStrip({
           </div>
         </div>
       )}
-    </div>
-  );
-}
-
-interface ApplicationFormState {
-  companyName: string;
-  title: string;
-  location: string;
-  department: string;
-  applyUrl: string;
-  sourceUrl: string;
-  status: MBAApplicationStatus;
-  priority: MBAApplicationPriority;
-  contact: string;
-  followUpDate: string;
-  deadline: string;
-  notes: string;
-}
-
-const EMPTY_APPLICATION_FORM: ApplicationFormState = {
-  companyName: "",
-  title: "",
-  location: "",
-  department: "",
-  applyUrl: "",
-  sourceUrl: "",
-  status: "saved",
-  priority: "medium",
-  contact: "",
-  followUpDate: "",
-  deadline: "",
-  notes: "",
-};
-
-function getApplicationFormState(
-  application: MBATrackedApplication | null
-): ApplicationFormState {
-  if (!application) return EMPTY_APPLICATION_FORM;
-  return {
-    companyName: application.jobSnapshot.companyName,
-    title: application.jobSnapshot.title,
-    location: application.jobSnapshot.location,
-    department: application.jobSnapshot.department,
-    applyUrl: application.jobSnapshot.applyUrl,
-    sourceUrl: application.sourceUrl,
-    status: application.status,
-    priority: application.priority,
-    contact: application.contact,
-    followUpDate: application.followUpDate ?? "",
-    deadline: application.deadline ?? "",
-    notes: application.notes,
-  };
-}
-
-function FormField({
-  label,
-  children,
-}: {
-  label: string;
-  children: ReactNode;
-}) {
-  return (
-    <label className="block space-y-2">
-      <span className="home-meta mb-0">{label}</span>
-      {children}
-    </label>
-  );
-}
-
-const applicationInputClass =
-  "w-full min-h-[44px] rounded-[0.9rem] border px-3 py-2 text-sm outline-none transition-[border-color,box-shadow] duration-200 ease focus-visible:border-[var(--home-haze)] focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--home-haze)_35%,transparent)]";
-
-const applicationInputStyle: CSSProperties = {
-  background: "var(--home-paper-alt)",
-  borderColor: "var(--home-rule)",
-  color: "var(--home-ink)",
-  fontFamily: "var(--font-home-sans)",
-};
-
-function ApplicationEditDialog({
-  isOpen,
-  application,
-  onClose,
-  onSave,
-}: {
-  isOpen: boolean;
-  application: MBATrackedApplication | null;
-  onClose: () => void;
-  onSave: (form: ApplicationFormState, application: MBATrackedApplication | null) => void;
-}) {
-  const [form, setForm] = useState<ApplicationFormState>(() =>
-    getApplicationFormState(application)
-  );
-  const dialogRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- Dialog form mirrors the selected application each time it opens.
-    setForm(getApplicationFormState(application));
-  }, [application, isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const dialog = dialogRef.current;
-    dialog?.querySelector<HTMLElement>("input, select, textarea, button")?.focus();
-
-    function handleKey(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-      }
-    }
-
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [isOpen, onClose]);
-
-  if (!isOpen) return null;
-
-  const canSave = form.companyName.trim() && form.title.trim();
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto p-4"
-      style={{ background: "rgba(0,0,0,0.45)" }}
-      role="presentation"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-    >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="application-dialog-title"
-        className="home-card max-h-[90vh] w-full max-w-2xl overflow-y-auto p-6 sm:p-7"
-        style={{ background: "var(--home-paper)" }}
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <p className="home-kicker mb-2">Application tracker</p>
-            <h2
-              id="application-dialog-title"
-              className="mb-0 text-xl font-semibold"
-              style={{ fontFamily: "var(--font-home-sans)", color: "var(--home-ink)" }}
-            >
-              {application ? "Edit application" : "Add application"}
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full"
-            aria-label="Close application dialog"
-            style={{ color: "var(--home-ink-muted)" }}
-          >
-            <X className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
-
-        <div className="mt-6 grid gap-4 sm:grid-cols-2">
-          <FormField label="Company">
-            <input
-              value={form.companyName}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, companyName: event.target.value }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-            />
-          </FormField>
-          <FormField label="Role">
-            <input
-              value={form.title}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, title: event.target.value }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-            />
-          </FormField>
-          <FormField label="Location">
-            <input
-              value={form.location}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, location: event.target.value }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-            />
-          </FormField>
-          <FormField label="Department">
-            <input
-              value={form.department}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, department: event.target.value }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-            />
-          </FormField>
-          <FormField label="Application URL">
-            <input
-              value={form.applyUrl}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, applyUrl: event.target.value }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-              inputMode="url"
-            />
-          </FormField>
-          <FormField label="Source URL">
-            <input
-              value={form.sourceUrl}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, sourceUrl: event.target.value }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-              inputMode="url"
-            />
-          </FormField>
-          <FormField label="Status">
-            <select
-              value={form.status}
-              onChange={(event) =>
-                setForm((current) => ({
-                  ...current,
-                  status: event.target.value as MBAApplicationStatus,
-                }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-            >
-              {MBA_APPLICATION_STATUSES.map((status) => (
-                <option key={status} value={status}>
-                  {MBA_APPLICATION_STATUS_LABELS[status]}
-                </option>
-              ))}
-            </select>
-          </FormField>
-          <FormField label="Priority">
-            <select
-              value={form.priority}
-              onChange={(event) =>
-                setForm((current) => ({
-                  ...current,
-                  priority: event.target.value as MBAApplicationPriority,
-                }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-            >
-              {MBA_APPLICATION_PRIORITIES.map((priority) => (
-                <option key={priority} value={priority}>
-                  {MBA_APPLICATION_PRIORITY_LABELS[priority]}
-                </option>
-              ))}
-            </select>
-          </FormField>
-          <FormField label="Follow-up date">
-            <input
-              type="date"
-              value={form.followUpDate}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, followUpDate: event.target.value }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-            />
-          </FormField>
-          <FormField label="Deadline">
-            <input
-              type="date"
-              value={form.deadline}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, deadline: event.target.value }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-            />
-          </FormField>
-          <FormField label="Contact">
-            <input
-              value={form.contact}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, contact: event.target.value }))
-              }
-              className={applicationInputClass}
-              style={applicationInputStyle}
-            />
-          </FormField>
-          <div className="sm:col-span-2">
-            <FormField label="Notes">
-              <textarea
-                value={form.notes}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, notes: event.target.value }))
-                }
-                className={`${applicationInputClass} min-h-28 resize-y`}
-                style={applicationInputStyle}
-              />
-            </FormField>
-          </div>
-        </div>
-
-        <div className="mt-6 flex flex-wrap justify-end gap-3">
-          <button type="button" onClick={onClose} className="home-button home-button-secondary">
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={() => onSave(form, application)}
-            disabled={!canSave}
-            className="home-button home-button-primary disabled:opacity-50"
-          >
-            Save application
-          </button>
-        </div>
-      </div>
     </div>
   );
 }
@@ -2519,21 +2072,25 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
 
   return (
     <>
-      <EmailDigestDialog
-        isOpen={emailDialogOpen}
-        onClose={() => setEmailDialogOpen(false)}
-        onSubmit={handleEmailSend}
-        sending={emailSending}
-      />
-      <ApplicationEditDialog
-        isOpen={applicationDialogOpen}
-        application={editingApplication}
-        onClose={() => {
-          setApplicationDialogOpen(false);
-          setEditingApplication(null);
-        }}
-        onSave={handleSaveApplication}
-      />
+      {emailDialogOpen && (
+        <EmailDigestDialog
+          isOpen
+          onClose={() => setEmailDialogOpen(false)}
+          onSubmit={handleEmailSend}
+          sending={emailSending}
+        />
+      )}
+      {applicationDialogOpen && (
+        <ApplicationEditDialog
+          isOpen
+          application={editingApplication}
+          onClose={() => {
+            setApplicationDialogOpen(false);
+            setEditingApplication(null);
+          }}
+          onSave={handleSaveApplication}
+        />
+      )}
 
       <section className="home-page min-h-screen" aria-label="MBA role tracker">
         <div className="home-shell home-section space-y-8 sm:space-y-10">

--- a/src/app/mlb/loading.tsx
+++ b/src/app/mlb/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function MlbLoading() {
+  return <RouteLoadingState surfaceName="the MLB dashboard" />;
+}

--- a/src/app/nba/loading.tsx
+++ b/src/app/nba/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function NbaLoading() {
+  return <RouteLoadingState surfaceName="the NBA dashboard" />;
+}

--- a/src/app/news-pulse/loading.tsx
+++ b/src/app/news-pulse/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function NewsPulseLoading() {
+  return <RouteLoadingState surfaceName="the news pulse dashboard" />;
+}

--- a/src/app/nfl/loading.tsx
+++ b/src/app/nfl/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function NflLoading() {
+  return <RouteLoadingState surfaceName="the NFL dashboard" />;
+}

--- a/src/app/polling-aggregator/loading.tsx
+++ b/src/app/polling-aggregator/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function PollingAggregatorLoading() {
+  return <RouteLoadingState surfaceName="the polling aggregator" />;
+}

--- a/src/app/premier-league/loading.tsx
+++ b/src/app/premier-league/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function PremierLeagueLoading() {
+  return <RouteLoadingState surfaceName="the Premier League dashboard" />;
+}

--- a/src/app/spacex-mission-control/loading.tsx
+++ b/src/app/spacex-mission-control/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function SpacexLoading() {
+  return <RouteLoadingState surfaceName="SpaceX mission control" />;
+}

--- a/src/app/world-cup-2026/loading.tsx
+++ b/src/app/world-cup-2026/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoadingState } from "@/components/RouteLoadingState";
+
+export default function WorldCupLoading() {
+  return <RouteLoadingState surfaceName="the World Cup dashboard" />;
+}

--- a/src/components/RouteLoadingState.tsx
+++ b/src/components/RouteLoadingState.tsx
@@ -1,0 +1,69 @@
+interface RouteLoadingStateProps {
+  /** Surface label rendered in the heading ("the NFL dashboard", "investments", etc.). */
+  surfaceName?: string;
+  /** Number of skeleton cards to render in the grid. Defaults to 6. */
+  cardCount?: number;
+}
+
+/**
+ * Editorial-styled loading skeleton for snapshot-driven dashboard routes.
+ *
+ * Mirrors the shell used by {@link RouteErrorBoundary} so the loading and error
+ * states share a layout. Rendered by per-route `loading.tsx` files, it gives
+ * client-side navigation an instant fallback while the server component streams.
+ *
+ * Pure markup (no client JS); the `.skeleton` shimmer is disabled automatically
+ * for `prefers-reduced-motion` users via the global rule in `globals.css`.
+ */
+export function RouteLoadingState({
+  surfaceName,
+  cardCount = 6,
+}: RouteLoadingStateProps) {
+  return (
+    <section
+      className="home-page min-h-screen"
+      role="status"
+      aria-live="polite"
+      aria-label={surfaceName ? `Loading ${surfaceName}` : "Loading"}
+    >
+      <div className="home-shell home-section space-y-8" aria-hidden="true">
+        {/* Header band: kicker + title + lede */}
+        <div className="space-y-3">
+          <div className="skeleton h-3 w-28 rounded-full" />
+          <div className="skeleton h-9 w-2/3 max-w-md rounded-lg" />
+          <div className="skeleton h-4 w-full max-w-xl rounded-full" />
+        </div>
+
+        {/* Stat row */}
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="home-card space-y-3 p-5">
+              <div className="skeleton h-3 w-20 rounded-full" />
+              <div className="skeleton h-7 w-16 rounded-lg" />
+            </div>
+          ))}
+        </div>
+
+        {/* Content card grid */}
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: cardCount }, (_, i) => (
+            <div key={i} className="home-card space-y-4 p-6">
+              <div className="flex items-center gap-3">
+                <div className="skeleton h-10 w-10 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <div className="skeleton h-3 w-3/4 rounded-full" />
+                  <div className="skeleton h-2.5 w-1/2 rounded-full" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <div className="skeleton h-3 w-full rounded-full" />
+                <div className="skeleton h-3 w-5/6 rounded-full" />
+                <div className="skeleton h-3 w-2/3 rounded-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/football/CrestAvatar.tsx
+++ b/src/components/football/CrestAvatar.tsx
@@ -29,6 +29,8 @@ export function CrestAvatar({
       <img
         src={crest}
         alt={`${name} crest`}
+        loading="lazy"
+        decoding="async"
         className={cn(
           "rounded-full border border-[var(--home-rule)] bg-white object-contain p-1",
           dimensionClass


### PR DESCRIPTION
## Summary

Acts on the **high-impact** items from a repo-wide review. The full prioritized
review is committed as a reference at `docs/website-improvement-suggestions.md`.

### 1. Loading states for data dashboards
There were **zero** `loading.tsx` files in the app, so client-side navigation to a
dashboard showed a blank page until the server component resolved.

- New shared `src/components/RouteLoadingState.tsx` — an editorial skeleton that
  mirrors the `RouteErrorBoundary` shell (pure markup, no client JS; shimmer is
  disabled for `prefers-reduced-motion` via the existing global rule).
- Added `loading.tsx` to 14 snapshot dashboards: NFL, NBA, MLB, Formula 1,
  Fantasy F1, Premier League, La Liga, World Cup, SpaceX, News Pulse, Investments,
  Golf, Polling Aggregator, GitHub Trending. Each passes a `surfaceName` matching
  its existing `error.tsx` label.

### 2. Code-split the largest client component
`mba-jobs-client.tsx` (~3,200 lines) shipped its interaction-only modals up front.

- Extracted `EmailDigestDialog` and `ApplicationEditDialog` into their own modules,
  lazy-loaded via `next/dynamic` and **mounted only while open**, so their chunks
  load on first interaction instead of on initial render.
- Shared form types/helpers/input styles moved to `application-form.ts` (also used
  by the main client's save handler and pipeline cards).
- Main client drops **~440 lines**.

### 3. Image loading hints
The raw `<img>` tags are external sports/space assets (hosts not in
`next.config` `remotePatterns`), so the right fix is loading hints, not `next/image`.
Most already had `loading="lazy"`; the gap was football crests.

- `CrestAvatar` (rendered many-per-page in standings/fixtures) now sets
  `loading="lazy"` + `decoding="async"`.
- Added `decoding="async"` to the already-lazy F1 / Fantasy-F1 avatars.

## Verification
- `tsc --noEmit`: no errors in any changed/new file. (One pre-existing error in
  `fantasy-formula-1-state.ts`, untouched here, remains — tolerated by
  `typescript.ignoreBuildErrors`.)
- `eslint`: clean (0 errors/warnings on changed files).
- Tests: MBA tracker (11) + football components (18) pass — 29 total.

## Notes / follow-ups (tracked in the reference doc)
- Apply the same `next/dynamic` pattern to the heavy panels in
  `museum-log-client.tsx` and `nfl-client.tsx` (more shared state — warrants its own
  PR with interactive verification).
- Medium/low items: image alt-text audit, component unit tests for primary surfaces,
  a CI `tsc` gate, accessibility-page date drift, `ProjectsContent.tsx` dead-code
  decision, retirement-planner CMA verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ntf1sFYpXRXZWJLdmYQSu)_