### PR TITLE
fix(investments): stop infinite router.replace loop on clean /investments visits

### DIFF
--- a/src/app/investments/__tests__/investments-client.test.tsx
+++ b/src/app/investments/__tests__/investments-client.test.tsx
@@ -152,4 +152,27 @@ describe("InvestmentsClient", () => {
     );
     expect(container.querySelector('[data-testid="research-props"]')?.textContent).toBe(":overview");
   });
+
+  it("keeps a clean /investments visit clean without rewriting the URL", async () => {
+    currentSearchParams = new URLSearchParams();
+
+    await act(async () => {
+      root.render(<InvestmentsClient initialState={DEFAULT_INVESTMENTS_STATE} />);
+    });
+    await flushPromises();
+
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="research-props"]')?.textContent).toBe(":overview");
+  });
+
+  it("settles without replacing once the URL already matches the canonical href", async () => {
+    currentSearchParams = new URLSearchParams("section=overview");
+
+    await act(async () => {
+      root.render(<InvestmentsClient initialState={DEFAULT_INVESTMENTS_STATE} />);
+    });
+    await flushPromises();
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/investments/investments-client.tsx
+++ b/src/app/investments/investments-client.tsx
@@ -47,19 +47,27 @@ export function InvestmentsClient({
     };
   }, []);
 
-  // Keep URL in sync with normalized route state.
+  // Keep URL in sync with normalized route state. A clean visit with no
+  // managed params keeps its clean URL; once managed (or legacy `view`)
+  // params exist, rewrite only when the URL differs from the canonical href,
+  // so the replace settles instead of looping on absent-vs-empty params.
   useEffect(() => {
-    if (
-      searchParams.get("symbol") === routeState.symbol &&
-      searchParams.get("section") === routeState.section
-    ) {
+    if (!hasManagedParams && searchParams.get("view") === null) {
+      return;
+    }
+
+    const query = searchParams.toString();
+    const currentHref = query ? `/investments?${query}` : "/investments";
+    const canonicalHref = buildInvestmentsHref(routeState, searchParams);
+
+    if (canonicalHref === currentHref) {
       return;
     }
 
     startTransition(() => {
-      router.replace(buildInvestmentsHref(routeState, searchParams), { scroll: false });
+      router.replace(canonicalHref, { scroll: false });
     });
-  }, [routeState, router, searchParams]);
+  }, [hasManagedParams, routeState, router, searchParams]);
 
   function updateRouteState(nextState: Partial<InvestmentsSearchState>) {
     const href = buildInvestmentsHref(


### PR DESCRIPTION
## Summary

Fixes the e2e failure that has kept `test.yml` red on `main` (every run since at least May 26): `investments.spec.ts:258 › finds Visa by company name…`. The test was the canary for a real production bug — an **infinite `router.replace` loop on every clean visit to `/investments`**.

## Root cause

The URL-sync effect in `investments-client.tsx` guarded with:

```ts
if (
  searchParams.get("symbol") === routeState.symbol &&   // null === "" → never true
  searchParams.get("section") === routeState.section
) return;
```

On `/investments` with no query params, `searchParams.get("symbol")` is `null` while `routeState.symbol` is `""` — and `buildInvestmentsHref` intentionally never writes an empty `symbol` param, so the URL could never satisfy the guard. Every effect run called `router.replace`, every replace produced a new `searchParams` instance, and the effect re-fired forever. Instrumented in a real browser, the page issues `/investments?section=overview&_rsc=…` RSC fetches roughly **10×/second, indefinitely, for every visitor** — and that render churn is what kept the symbol-suggestions dropdown from ever appearing, failing the test. Deep-linked URLs (`?symbol=V&…`) satisfied the old guard, which is why only the clean-visit test failed.

## Fix

The sync effect now compares the canonical href (from `buildInvestmentsHref`) against the current URL, and skips clean visits entirely (no managed or legacy `view` params). Canonicalization of invalid/legacy params still happens, but settles after at most one replace instead of looping.

## Verification

- Reproduced the loop and the missing dropdown locally in headless Chromium before the fix; both gone after.
- `e2e/investments.spec.ts` (chromium): **8/8 pass**, including the previously failing Visa test.
- Investments unit suites: 14 pass, plus two new regression tests (clean visit never rewrites the URL; already-canonical URL settles without a replace).
- Full chromium e2e suite: 65 pass; the remaining local failures (`fantasy-football.spec.ts:79`, `product-surfaces.spec.ts:99`) fail identically on pristine `main` in this dev-mode environment and pass in CI's production-build runs.
- `tsc --noEmit` and ESLint clean.

https://claude.ai/code/session_01KBzbNV9fjMP4e9S5QbXttQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBzbNV9fjMP4e9S5QbXttQ)_