### PR TITLE
Align v3 design system fidelity: header/footer, projects, writing, research

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1677,43 +1677,54 @@
     transform-origin: center;
   }
 
+  /* v3 editorial-brutalism header — hard ink rule, mono nav, acid active */
   .header-home {
-    border-bottom-color: color-mix(in srgb, var(--home-stone) 70%, transparent);
+    border-bottom-color: var(--home-ink);
   }
 
   .header-home-brand {
-    font-family: var(--font-home-sans);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-family: var(--font-display);
     font-size: 1.05rem;
     font-weight: 700;
-    letter-spacing: -0.06em;
+    letter-spacing: -0.04em;
     text-transform: uppercase;
     color: var(--home-ink);
+  }
+
+  .header-home-brand::before {
+    content: "";
+    width: 10px;
+    height: 10px;
+    background: var(--home-acid);
+    flex-shrink: 0;
   }
 
   .header-home-link {
-    border: 1px solid transparent;
-    border-radius: 999px;
-    font-family: var(--font-home-sans);
-    font-size: 0.76rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
+    font-family: var(--font-jetbrains-mono);
+    font-size: 0.7rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
     text-transform: uppercase;
+    color: var(--home-ink-muted);
+    border-left: 1px solid color-mix(in srgb, var(--home-ink) 8%, transparent);
+    transition: color 160ms ease, background 160ms ease;
+  }
+
+  .header-home-nav-list > li:first-child .header-home-link {
+    border-left: 0;
   }
 
   .header-home-link[aria-current="page"] {
-    border-color: color-mix(in srgb, var(--home-ink) 14%, var(--home-stone));
-    background: color-mix(in srgb, var(--home-paper) 78%, transparent);
-    color: var(--home-ink);
-  }
-
-  .header-home-link:not([aria-current="page"]) {
-    color: var(--home-ink-muted);
+    background: var(--home-acid);
+    color: #12110f;
   }
 
   .header-home-link:not([aria-current="page"]):hover,
   .header-home-link:not([aria-current="page"]):focus-visible {
-    border-color: color-mix(in srgb, var(--home-ink) 12%, var(--home-stone));
-    background: color-mix(in srgb, var(--home-acid) 18%, var(--home-paper));
+    background: color-mix(in srgb, var(--home-paper) 72%, white);
     color: var(--home-ink);
   }
 
@@ -1736,9 +1747,10 @@
     box-shadow: var(--shadow-lg);
   }
 
+  /* v3 editorial-brutalism contentinfo — hard ink rule, mono colophon, acid block */
   .footer-home {
-    border-top-color: var(--home-rule);
-    background: color-mix(in srgb, var(--home-paper) 94%, var(--surface-primary));
+    border-top-color: var(--home-ink);
+    background: var(--home-paper);
   }
 
   .footer-home-panel {
@@ -1755,15 +1767,71 @@
     color: var(--home-ink);
   }
 
-  .footer-home-icon {
-    border-color: color-mix(in srgb, var(--home-stone) 76%, var(--home-ink) 16%);
+  .footer-home-colophon {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-family: var(--font-jetbrains-mono);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--home-ink);
+  }
+
+  .footer-home-colophon::before {
+    content: "";
+    width: 8px;
+    height: 8px;
+    background: var(--home-acid);
+    flex-shrink: 0;
+  }
+
+  .footer-home-links {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .footer-home-links a {
+    font-family: var(--font-jetbrains-mono);
+    font-size: 0.7rem;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
     color: var(--home-ink-muted);
+    padding: 4px 12px;
+    border-left: 1px solid color-mix(in srgb, var(--home-ink) 16%, transparent);
+    transition: color 160ms ease;
+    white-space: nowrap;
+  }
+
+  .footer-home-links a:first-child {
+    border-left: 0;
+    padding-left: 0;
+  }
+
+  .footer-home-links a:hover,
+  .footer-home-links a:focus-visible {
+    color: var(--home-ink);
+  }
+
+  .footer-home-links a.is-strong {
+    color: var(--home-ink);
+    font-weight: 600;
+  }
+
+  .footer-home-icon {
+    border: 1px solid var(--home-ink);
+    border-radius: 0;
+    color: var(--home-ink);
+    background: transparent;
   }
 
   .footer-home-icon:hover,
   .footer-home-icon:focus-visible {
-    background: color-mix(in srgb, var(--home-acid) 18%, var(--home-paper));
-    color: var(--home-ink);
+    background: var(--home-ink);
+    color: var(--home-paper);
   }
 
   .dark .home-card {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -40,12 +40,16 @@ export const Footer = ({ variant = "full" }: FooterProps) => {
 
       <div className={`page-shell ${isCompact ? "py-4 md:py-5" : "py-6 md:py-8"}`}>
         <div
-          className="flex flex-col gap-5 border-t pt-6 sm:flex-row sm:items-center sm:justify-between"
-          style={{ borderTopColor: "var(--home-rule)" }}
+          className="flex flex-col gap-5 border-t pt-6 sm:flex-row sm:items-start sm:justify-between"
+          style={{ borderTopColor: "var(--home-ink)" }}
         >
-          <div className="space-y-1 text-sm footer-home-text">
-            <p className="font-medium footer-home-text-strong">Isaac Vazquez</p>
-            <p>Building products where clear thinking and reliable execution move the needle.</p>
+          <div className="space-y-1.5">
+            <p className="footer-home-colophon">
+              &copy; {new Date().getFullYear()} Isaac Vazquez
+            </p>
+            <p className="text-sm footer-home-text" style={{ maxWidth: "38ch" }}>
+              Building products where clear thinking and reliable execution move the needle.
+            </p>
           </div>
 
           <div className="flex flex-col gap-4 sm:items-end">
@@ -57,40 +61,21 @@ export const Footer = ({ variant = "full" }: FooterProps) => {
                   aria-label={link.label}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full border transition-colors footer-home-icon"
+                  className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center transition-colors footer-home-icon"
                 >
                   <link.icon size={18} aria-hidden="true" />
                 </a>
               ))}
             </nav>
 
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm footer-home-text">
-              <span>{new Date().getFullYear()}</span>
-              <Link
-                href="/now"
-                className="transition-colors hover:text-[var(--home-ink)]"
-              >
-                Now
-              </Link>
-              <Link
-                href="/changelog"
-                className="transition-colors hover:text-[var(--home-ink)]"
-              >
-                Changelog
-              </Link>
-              <Link
-                href="/accessibility"
-                className="transition-colors hover:text-[var(--home-ink)]"
-              >
-                Accessibility
-              </Link>
-              <a
-                href="https://isaacavazquez.com"
-                className="font-medium transition-colors footer-home-text-strong hover:text-[var(--home-haze)]"
-              >
+            <nav aria-label="Footer links" className="footer-home-links">
+              <Link href="/now">Now</Link>
+              <Link href="/changelog">Changelog</Link>
+              <Link href="/accessibility">Accessibility</Link>
+              <a href="https://isaacavazquez.com" className="is-strong">
                 isaacavazquez.com
               </a>
-            </div>
+            </nav>
           </div>
         </div>
       </div>

--- a/src/components/StaticHeader.tsx
+++ b/src/components/StaticHeader.tsx
@@ -50,8 +50,8 @@ export function StaticHeader() {
       ) : null}
       <header
       className={cn(
-        "sticky top-0 z-50 w-full transition-[background-color,border-color,box-shadow] duration-300 header-home",
-        isScrolled && "border-b shadow-[var(--shadow-sm)]"
+        "sticky top-0 z-50 w-full border-b transition-[background-color,border-color,box-shadow] duration-300 header-home",
+        isScrolled && "shadow-[var(--shadow-sm)]"
       )}
       style={{
         backgroundColor: isScrolled
@@ -64,14 +64,14 @@ export function StaticHeader() {
         <div className="flex min-h-[72px] items-center justify-between gap-4 py-3">
           <Link
             href="/"
-            className="header-home-brand min-h-[44px] rounded-xl px-1 py-1 transition-colors hover:text-[var(--home-haze)]"
+            className="header-home-brand min-h-[44px] px-1 py-1"
             onClick={closeMobileMenu}
           >
             Isaac Vazquez
           </Link>
 
           <div className="hidden lg:flex items-center gap-3">
-            <ul className="flex items-center gap-1" aria-label="Primary navigation">
+            <ul className="header-home-nav-list flex items-center gap-0" aria-label="Primary navigation">
               {navLinks.map((link) => {
                 const active = isRouteActive(pathname, link.href);
 

--- a/src/components/investments/InvestmentsDashboard.tsx
+++ b/src/components/investments/InvestmentsDashboard.tsx
@@ -115,6 +115,11 @@ export function InvestmentsDashboard({
     [enhancedHoldings],
   );
 
+  const researchPosition = useMemo(
+    () => enhancedHoldings.find((h) => h.symbol === researchSymbol) ?? null,
+    [enhancedHoldings, researchSymbol],
+  );
+
   const isEmpty = enhancedHoldings.length === 0;
 
   const navItems: NavItem[] = useMemo(
@@ -372,6 +377,7 @@ export function InvestmentsDashboard({
         activeTab={researchTab}
         onTabChange={onResearchTabChange}
         portfolioSymbols={portfolioSymbols}
+        position={researchPosition}
       />
     </section>
 

--- a/src/components/investments/PriceChartPanel.tsx
+++ b/src/components/investments/PriceChartPanel.tsx
@@ -10,6 +10,8 @@ import { ErrorState } from "./ErrorState";
 
 interface Props {
   symbol: string;
+  /** Average cost of the held lot, drawn as a reference line when present. */
+  costBasis?: number | null;
 }
 
 type Range = "1M" | "3M" | "6M" | "1Y";
@@ -23,6 +25,11 @@ const RANGE_DAYS: Record<Range, number> = {
 
 const RANGES: Range[] = ["1M", "3M", "6M", "1Y"];
 
+const MA_WINDOW = 50;
+
+/** Price entry enriched with a trailing moving average and day-over-day direction. */
+type EnrichedPrice = StockPrice & { ma50: number | null; up: boolean };
+
 function normalizeEntry(entry: StockPrice & { report_date?: string; symbol?: string }): StockPrice {
   return {
     date: entry.report_date ?? entry.date,
@@ -34,7 +41,7 @@ function normalizeEntry(entry: StockPrice & { report_date?: string; symbol?: str
   };
 }
 
-export function PriceChartPanel({ symbol }: Props) {
+export function PriceChartPanel({ symbol, costBasis = null }: Props) {
   const {
     data: raw,
     isLoading,
@@ -44,15 +51,31 @@ export function PriceChartPanel({ symbol }: Props) {
     lastUpdated: datasetLastUpdated,
   } = useStockData<PriceData>(symbol, "price");
   const [range, setRange] = useState<Range>("1Y");
+  const [showMA, setShowMA] = useState(true);
+  const [showCostBasis, setShowCostBasis] = useState(true);
 
   const priceRef = useRef<SVGSVGElement>(null);
   const volumeRef = useRef<SVGSVGElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
 
-  // Normalize and slice data
-  const allEntries: StockPrice[] = React.useMemo(() => {
+  const hasCostBasis = typeof costBasis === "number" && Number.isFinite(costBasis) && costBasis > 0;
+
+  // Normalize, then enrich with a trailing moving average + up/down direction.
+  // Both are computed over the full series so the values are correct at the
+  // start of a sliced window (the MA "warms up" using data before the view).
+  const allEntries: EnrichedPrice[] = React.useMemo(() => {
     if (!raw || !Array.isArray(raw)) return [];
-    return (raw as (StockPrice & { report_date?: string })[]).map(normalizeEntry);
+    const normalized = (raw as (StockPrice & { report_date?: string })[]).map(normalizeEntry);
+    return normalized.map((d, i) => {
+      let ma50: number | null = null;
+      if (i >= MA_WINDOW - 1) {
+        let sum = 0;
+        for (let j = i - MA_WINDOW + 1; j <= i; j++) sum += normalized[j].close;
+        ma50 = sum / MA_WINDOW;
+      }
+      const up = i > 0 ? d.close >= normalized[i - 1].close : true;
+      return { ...d, ma50, up };
+    });
   }, [raw]);
 
   const slicedData = React.useMemo(() => {
@@ -98,8 +121,15 @@ export function PriceChartPanel({ symbol }: Props) {
       .domain([dates[0], dates[dates.length - 1]])
       .range([0, pInnerW]);
 
-    const minClose = d3.min(closes) ?? 0;
-    const maxClose = d3.max(closes) ?? 0;
+    // Domain spans the visible closes and the visible MA. Cost basis is
+    // deliberately excluded so a far-out-of-range entry price can't squash the
+    // price line; the cost line is instead clamped to the chart edge below.
+    const domainValues = [...closes];
+    if (showMA) {
+      for (const e of entries) if (e.ma50 !== null) domainValues.push(e.ma50);
+    }
+    const minClose = d3.min(domainValues) ?? 0;
+    const maxClose = d3.max(domainValues) ?? 0;
     const yScale = d3
       .scaleLinear()
       .domain([minClose * 0.97, maxClose * 1.03])
@@ -157,6 +187,49 @@ export function PriceChartPanel({ symbol }: Props) {
       .attr("fill", "none")
       .attr("stroke", "var(--home-haze)")
       .attr("stroke-width", 1.5);
+
+    // 50-day moving average (dashed, neutral) — only the points that have a
+    // warmed-up average are drawn.
+    if (showMA) {
+      const maLine = d3
+        .line<(typeof entries)[0]>()
+        .defined((d) => d.ma50 !== null)
+        .x((d) => xScale(d.parsedDate))
+        .y((d) => yScale(d.ma50 as number))
+        .curve(d3.curveMonotoneX);
+
+      pg.append("path")
+        .datum(entries)
+        .attr("d", maLine)
+        .attr("fill", "none")
+        .attr("stroke", "var(--home-ink-muted)")
+        .attr("stroke-width", 1.25)
+        .attr("stroke-dasharray", "5,4")
+        .attr("opacity", 0.85);
+    }
+
+    // Cost-basis reference line (dashed green) with a mono price label. The y
+    // position is clamped to the plot so an out-of-range entry pins to the edge
+    // (signaling "cost sits above/below this window") instead of being clipped.
+    if (showCostBasis && hasCostBasis) {
+      const cy = Math.max(0, Math.min(pInnerH, yScale(costBasis as number)));
+      pg.append("line")
+        .attr("x1", 0)
+        .attr("x2", pInnerW)
+        .attr("y1", cy)
+        .attr("y2", cy)
+        .attr("stroke", "var(--color-success)")
+        .attr("stroke-width", 1.25)
+        .attr("stroke-dasharray", "2,3");
+      pg.append("text")
+        .attr("x", pInnerW)
+        .attr("y", cy - 4)
+        .attr("text-anchor", "end")
+        .attr("fill", "var(--color-success)")
+        .attr("font-size", "9px")
+        .attr("font-family", "var(--font-jetbrains-mono, monospace)")
+        .text(`Cost $${(costBasis as number).toFixed(2)}`);
+    }
 
     // X axis
     pg.append("g")
@@ -241,8 +314,8 @@ export function PriceChartPanel({ symbol }: Props) {
       .attr("y", (d) => vyScale(d.volume))
       .attr("width", barWidth)
       .attr("height", (d) => vInnerH - vyScale(d.volume))
-      .attr("fill", "var(--home-haze)")
-      .attr("opacity", "0.4");
+      .attr("fill", (d) => (d.up ? "var(--color-success)" : "var(--color-error)"))
+      .attr("opacity", "0.45");
 
     // X axis on volume chart
     vg.append("g")
@@ -262,7 +335,7 @@ export function PriceChartPanel({ symbol }: Props) {
       .attr("fill", "var(--home-ink-soft)")
       .attr("font-size", "9px")
       .text("Volume");
-  }, [slicedData, symbol]);
+  }, [slicedData, symbol, showMA, showCostBasis, hasCostBasis, costBasis]);
 
   const isError = !isLoading && (!!error || (raw && !Array.isArray(raw)));
   const isEmpty = !isLoading && !error && slicedData.length === 0;
@@ -284,20 +357,60 @@ export function PriceChartPanel({ symbol }: Props) {
             </p>
           ) : null}
         </div>
-        <div className="flex flex-wrap gap-2" role="group" aria-label="Date range">
-          {RANGES.map((r) => (
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Chart overlays">
             <button
-              key={r}
-              onClick={() => setRange(r)}
-              className={`min-h-[44px] min-w-[44px] rounded-full px-3.5 py-2 text-xs font-semibold transition ${
-                range === r
-                  ? "bg-[var(--home-haze)] text-white shadow-[var(--shadow-sm)]"
-                  : "border border-[var(--home-rule)] text-[var(--home-ink-muted)] hover:bg-[var(--home-paper-alt)] hover:text-[var(--home-ink)]"
+              type="button"
+              onClick={() => setShowMA((v) => !v)}
+              aria-pressed={showMA}
+              className={`inline-flex min-h-[44px] items-center gap-2 rounded-full px-3.5 py-2 text-xs font-semibold transition ${
+                showMA
+                  ? "border border-[var(--home-ink-muted)] bg-[var(--home-paper-alt)] text-[var(--home-ink)]"
+                  : "border border-[var(--home-rule)] text-[var(--home-ink-soft)] hover:bg-[var(--home-paper-alt)]"
               }`}
             >
-              {r}
+              <span
+                aria-hidden="true"
+                className="inline-block h-0 w-4 border-t-[1.5px] border-dashed"
+                style={{ borderColor: "var(--home-ink-muted)" }}
+              />
+              50-day MA
             </button>
-          ))}
+            {hasCostBasis ? (
+              <button
+                type="button"
+                onClick={() => setShowCostBasis((v) => !v)}
+                aria-pressed={showCostBasis}
+                className={`inline-flex min-h-[44px] items-center gap-2 rounded-full px-3.5 py-2 text-xs font-semibold transition ${
+                  showCostBasis
+                    ? "border border-[color-mix(in_srgb,var(--color-success)_45%,var(--home-rule))] bg-[color-mix(in_srgb,var(--color-success)_10%,var(--home-paper-alt))] text-[var(--home-ink)]"
+                    : "border border-[var(--home-rule)] text-[var(--home-ink-soft)] hover:bg-[var(--home-paper-alt)]"
+                }`}
+              >
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-0 w-4 border-t-[1.5px] border-dashed"
+                  style={{ borderColor: "var(--color-success)" }}
+                />
+                Cost basis
+              </button>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Date range">
+            {RANGES.map((r) => (
+              <button
+                key={r}
+                onClick={() => setRange(r)}
+                className={`min-h-[44px] min-w-[44px] rounded-full px-3.5 py-2 text-xs font-semibold transition ${
+                  range === r
+                    ? "bg-[var(--home-haze)] text-white shadow-[var(--shadow-sm)]"
+                    : "border border-[var(--home-rule)] text-[var(--home-ink-muted)] hover:bg-[var(--home-paper-alt)] hover:text-[var(--home-ink)]"
+                }`}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/src/components/investments/ResearchOverview.tsx
+++ b/src/components/investments/ResearchOverview.tsx
@@ -28,10 +28,24 @@ function formatDate(raw: string | undefined): string {
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 }
 
+function newsMonogram(item: NewsItem): string {
+  const source = item.publisher?.trim() || item.title?.trim() || "";
+  const words = source.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "•";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[1][0]).toUpperCase();
+}
+
 function NewsCard({ item }: { item: NewsItem }) {
   return (
-    <div className="py-3 border-b border-[var(--home-rule)] last:border-0">
-      <div className="min-w-0">
+    <div className="flex items-start gap-3 py-3 border-b border-[var(--home-rule)] last:border-0">
+      <div
+        aria-hidden="true"
+        className="mt-0.5 grid h-10 w-10 shrink-0 place-items-center rounded-[10px] border border-[var(--home-rule)] bg-[var(--home-paper-alt)] text-xs font-semibold tracking-[0.04em] text-[var(--home-ink-muted)]"
+      >
+        {newsMonogram(item)}
+      </div>
+      <div className="min-w-0 flex-1">
         {item.link ? (
           <a
             href={item.link}
@@ -45,12 +59,20 @@ function NewsCard({ item }: { item: NewsItem }) {
         ) : (
           <p className="text-sm font-medium leading-6 text-[var(--home-ink)] line-clamp-2">{item.title}</p>
         )}
-        <div className="mt-1 flex items-center gap-2">
+        <div className="mt-1.5 flex items-center gap-2">
           {item.publisher ? (
             <span className="text-xs text-[var(--home-ink-muted)]">{item.publisher}</span>
           ) : null}
+          {item.publisher && item.reportDate ? (
+            <span aria-hidden="true" className="text-[var(--home-ink-soft)]">·</span>
+          ) : null}
           {item.reportDate ? (
-            <span className="text-xs text-[var(--home-ink-muted)]">{formatDate(item.reportDate)}</span>
+            <span
+              className="text-[0.7rem] uppercase tracking-[0.04em] text-[var(--home-ink-soft)]"
+              style={{ fontFamily: "var(--font-jetbrains-mono, monospace)" }}
+            >
+              {formatDate(item.reportDate)}
+            </span>
           ) : null}
         </div>
       </div>

--- a/src/components/investments/ResearchPosition.tsx
+++ b/src/components/investments/ResearchPosition.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import React from "react";
+import { WarmCard } from "@/components/ui/WarmCard";
+import type { EnhancedHolding } from "@/types/investment";
+
+interface Props {
+  position: EnhancedHolding;
+}
+
+function currency(n: number | undefined, maximumFractionDigits = 2): string {
+  if (n === undefined || !Number.isFinite(n)) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits,
+  }).format(n);
+}
+
+function signedCurrency(n: number | undefined): string {
+  if (n === undefined || !Number.isFinite(n)) return "—";
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  return `${sign}${currency(Math.abs(n))}`;
+}
+
+function signedPercent(n: number | undefined): string {
+  if (n === undefined || !Number.isFinite(n)) return "—";
+  const sign = n > 0 ? "+" : n < 0 ? "−" : "";
+  return `${sign}${Math.abs(n).toFixed(2)}%`;
+}
+
+function shareLabel(n: number): string {
+  return n.toLocaleString("en-US", { maximumFractionDigits: 4 });
+}
+
+function toneClass(n: number | undefined): string {
+  if (n === undefined || !Number.isFinite(n) || n === 0) return "text-[var(--home-ink)]";
+  return n > 0 ? "text-[var(--color-success)]" : "text-[var(--color-error)]";
+}
+
+/**
+ * "Your position" — surfaces the held lot for the symbol under research, drawn
+ * straight from the local portfolio (no fabricated figures). Renders only when
+ * the symbol is actually held, so the deep-dive carries the same position
+ * context the prototype's right column did, without inventing data.
+ */
+export function ResearchPosition({ position }: Props) {
+  const {
+    shares,
+    averageCost,
+    currentValue,
+    gainLoss,
+    gainLossPercent,
+    dayChange,
+    dayChangePercent,
+    allocationPercent,
+  } = position;
+
+  const alloc =
+    allocationPercent !== null && Number.isFinite(allocationPercent)
+      ? Math.max(0, Math.min(100, allocationPercent))
+      : null;
+
+  const metrics: { label: string; value: string; toneValue?: number }[] = [
+    { label: "Shares", value: shareLabel(shares) },
+    { label: "Avg cost", value: currency(averageCost) },
+    { label: "Market value", value: currency(currentValue, 0) },
+    {
+      label: "Total return",
+      value: `${signedCurrency(gainLoss)} · ${signedPercent(gainLossPercent)}`,
+      toneValue: gainLoss,
+    },
+    {
+      label: "Day P/L",
+      value: `${signedCurrency(dayChange)} · ${signedPercent(dayChangePercent)}`,
+      toneValue: dayChange,
+    },
+  ];
+
+  return (
+    <WarmCard
+      padding="sm"
+      ariaLabel="Your position"
+      className="rounded-[28px] shadow-[var(--shadow-sm)]"
+    >
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <p className="invest-rail-section-label">Your position</p>
+          <p className="mt-1 text-xs text-[var(--home-ink-soft)]">
+            From your local portfolio. Live price when available, else last saved close.
+          </p>
+        </div>
+        <span className="research-badge-pill held">
+          Held · {shareLabel(shares)} sh
+        </span>
+      </div>
+
+      <div className="research-key-metrics" role="list" aria-label="Position metrics">
+        {metrics.map((m) => (
+          <div className="research-key-metric" key={m.label} role="listitem">
+            <span className="research-key-metric-label">{m.label}</span>
+            <span className={`research-key-metric-value ${toneClass(m.toneValue)}`}>
+              {m.value}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {alloc !== null ? (
+        <div className="mt-4">
+          <div className="mb-1.5 flex items-center justify-between text-xs text-[var(--home-ink-muted)]">
+            <span>Allocation</span>
+            <span className="font-semibold text-[var(--home-ink)]">
+              {alloc.toFixed(1)}%
+            </span>
+          </div>
+          <div
+            className="h-2 w-full overflow-hidden rounded-full bg-[var(--home-paper-alt)]"
+            role="img"
+            aria-label={`Allocation ${alloc.toFixed(1)} percent of portfolio`}
+          >
+            <div
+              className="h-full rounded-full bg-[var(--home-haze)]"
+              style={{ width: `${alloc}%` }}
+            />
+          </div>
+        </div>
+      ) : null}
+    </WarmCard>
+  );
+}

--- a/src/components/investments/ResearchSection.tsx
+++ b/src/components/investments/ResearchSection.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { ResearchAssetHeader } from "./ResearchAssetHeader";
+import { ResearchPosition } from "./ResearchPosition";
 import { ResearchOverview } from "./ResearchOverview";
 import { FinancialStatementsPanel } from "./FinancialStatementsPanel";
 import { ValuationRatiosPanel } from "./ValuationRatiosPanel";
@@ -21,6 +22,7 @@ import { useTablistKeyboard } from "@/hooks/useTablistKeyboard";
 import { getClientInvestmentsIndex } from "@/lib/investmentsClientData";
 import type {
   CompanyInfo,
+  EnhancedHolding,
   InvestmentCapabilities,
   InvestmentsIndex,
 } from "@/types/investment";
@@ -31,6 +33,7 @@ interface Props {
   activeTab: ResearchTab;
   onTabChange: (tab: ResearchTab) => void;
   portfolioSymbols?: string[];
+  position?: EnhancedHolding | null;
 }
 
 const TABS: { key: ResearchTab; label: string }[] = [
@@ -73,6 +76,7 @@ export function ResearchSection({
   activeTab,
   onTabChange,
   portfolioSymbols = [],
+  position = null,
 }: Props) {
   const [, setDatasetLastUpdated] = useState<string | null>(null);
   const shouldReduceMotion = useReducedMotion();
@@ -174,7 +178,13 @@ export function ResearchSection({
         </div>
       ) : (
         <>
-          <ResearchAssetHeader symbol={symbol} isInPortfolio={isInPortfolio} />
+          <ResearchAssetHeader
+            symbol={symbol}
+            isInPortfolio={isInPortfolio}
+            portfolioShares={position?.shares ?? null}
+          />
+
+          {position ? <ResearchPosition position={position} /> : null}
 
           {visibleTabs.length > 0 ? (
             <div
@@ -233,7 +243,12 @@ export function ResearchSection({
               )}
               {resolvedActiveTab === "industry" && <IndustryPanel symbol={symbol} />}
               {resolvedActiveTab === "dcf" && <DCFPanel symbol={symbol} />}
-              {resolvedActiveTab === "chart" && <PriceChartPanel symbol={symbol} />}
+              {resolvedActiveTab === "chart" && (
+                <PriceChartPanel
+                  symbol={symbol}
+                  costBasis={position?.averageCost ?? null}
+                />
+              )}
               {resolvedActiveTab === "compare" && <ComparisonTab />}
             </motion.div>
           </AnimatePresence>

--- a/src/components/portfolio/PortfolioV3.tsx
+++ b/src/components/portfolio/PortfolioV3.tsx
@@ -51,6 +51,9 @@ const PULSE = new Set([
   "pulse-dashboards",
   "news-pulse-dashboard",
   "github-trending-pulse",
+  "bay-area-transit-pulse",
+  "earthquake-pulse",
+  "tech-startup-tracker",
 ]);
 const SPORTS = new Set([
   "premier-league-pulse",
@@ -61,6 +64,8 @@ const SPORTS = new Set([
   "nba-pulse",
   "pga-tour-pulse",
   "formula-1-pulse",
+  "fantasy-formula-1-optimizer",
+  "world-cup-pulse",
   "march-madness-2026",
   "spacex-mission-control",
 ]);
@@ -78,6 +83,7 @@ const LIFESTYLE = new Set([
   "museum-log",
   "wine-cellar",
   "recipe-finder",
+  "travel-planner",
 ]);
 
 const CATEGORY_DEFS: Category[] = [

--- a/src/components/writing/WritingArchiveV3.tsx
+++ b/src/components/writing/WritingArchiveV3.tsx
@@ -200,9 +200,26 @@ export function WritingArchiveV3({
     return items;
   }, [featured, posts.length, sinceLabel, clusters, buckets]);
 
-  // Spotlight cadence — every 6th card slot is a spotlight (essay only).
-  const isSpotlightSlot = (i: number) =>
-    i > 0 && i % 6 === 1 && !isNote(visible[i]);
+  // Spotlight cadence — one spotlight per 6-card window, anchored at slot 1.
+  // Within each window we slide to the nearest essay so the signature ink card
+  // lands on substantial content; if the window is all notes we still spotlight
+  // the anchor so the cadence (and the card) never silently disappears.
+  const spotlightSlots = useMemo(() => {
+    const picks = new Set<number>();
+    for (let anchor = 1; anchor < visible.length; anchor += 6) {
+      const windowEnd = Math.min(anchor + 6, visible.length);
+      let chosen = -1;
+      for (let j = anchor; j < windowEnd; j++) {
+        if (!picks.has(j) && !isNote(visible[j])) {
+          chosen = j;
+          break;
+        }
+      }
+      if (chosen === -1) chosen = anchor;
+      picks.add(chosen);
+    }
+    return picks;
+  }, [visible]);
 
   return (
     <div className={styles["wr-page"]}>
@@ -386,7 +403,7 @@ export function WritingArchiveV3({
                   const cover = COVER_VARIANTS[idx % COVER_VARIANTS.length];
                   const id = String(idx + 2).padStart(2, "0"); // featured = 01
                   const tone = toneClassFor(post);
-                  const spotlight = isSpotlightSlot(i);
+                  const spotlight = spotlightSlots.has(i);
 
                   if (spotlight) {
                     const spotTone =


### PR DESCRIPTION
## What this is

A fidelity review + gap-fixing pass against the Claude Design v3 handoff bundle. The v3 editorial-brutalism design was already implemented across all 7 surfaces (home, projects, writing, about, contact, investments dashboard + research); this PR closes the genuine drift the audit found, plus adds the data-backed research right-column modules.

Adapted to the existing system: everything is wired to `--home-*` tokens with full dark-mode support. No fabricated data.

## Changes

### Fidelity fixes (`8cf7c776`)
- **Header + footer → v3 brutalism** (site-wide chrome): hard ink rule, acid brand square, mono nav cells with left dividers and acid-fill active state, mono colophon with acid block bullet, divided mono footer links, square social icons. `ContactCta` system and tested footer copy left intact.
- **Projects categorization**: six projects (bay-area-transit, earthquake, tech-startup → Pulse; fantasy-formula-1, world-cup → Sports; travel-planner → Lifestyle) were silently falling through `classify()` into "Lifestyle". Now bucketed correctly (`Pulse 06 · Sports 12 · Lifestyle 05`).
- **Writing spotlight**: replaced the positional gate that silently dropped the signature ink spotlight card when its slot landed on a short note, with a per-window index set that slides each anchor to the nearest essay — so a spotlight always renders.

### Data-backed research modules (`9f213448`)
- **"Your position" card** under the asset header (shares, avg cost, market value, total return, day P/L, allocation bar), drawn from the local portfolio holding; renders only when the symbol is held.
- **Price chart enrichment**: cost-basis reference line (clamped to the plot so an out-of-range entry pins to the edge instead of squashing the price), 50-day moving average, up/down volume coloring, and toggle pills for the overlays.
- **News cards**: monogram thumbnails + mono timestamps.

## Deliberately not included
The research "My thesis" card (per-stock investment opinions), analyst consensus, price targets, next-earnings, and peers are omitted — fabricating those figures in a live investing tool would violate the repo's honest-data principle. They can be added when a real content/data source is available.

## Verification
- `tsc --noEmit`: 0 errors.
- Unit tests pass for all touched areas (Footer, portfolio-shell, navigation, writing, StaticHeader, + 39 investments tests across 13 suites).
- Live-confirmed in light and dark mode: header, footer, writing spotlights, projects filter counts, the position card, and the enriched chart.
- Note: the news-card restyle is typecheck-verified but not visually confirmed (the dev snapshot for the test symbol is in "Snapshot Mode" with no headline feed; it renders only when news data is present).