### PR TITLE
style: enlarge primary nav link font to balance header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1704,7 +1704,7 @@
 
   .header-home-link {
     font-family: var(--font-jetbrains-mono);
-    font-size: 0.7rem;
+    font-size: 0.8rem;
     font-weight: 500;
     letter-spacing: 0.04em;
     text-transform: uppercase;


### PR DESCRIPTION
## What

Bumps the desktop primary navigation link font size from `0.7rem` to `0.8rem` in `.header-home-link` (`src/app/globals.css`).

## Why

The `ISAAC VAZQUEZ` brand wordmark (`1.05rem`) on the left of the header, paired with the small `0.7rem` nav links on the right, left a lot of empty space in the middle of the header. The larger link size lets the eight nav items occupy more of that gap, balancing the header visually.

## Notes

- Only a font-size change — padding, layout, and the mobile menu are untouched.
- Verified the larger links still fit: `.page-shell` is `max-w-6xl` with `lg:px-8`, giving ~960px of usable width at the 1024px `lg` breakpoint (where the horizontal nav appears), comfortably more than the brand + 8 links + theme toggle require at the new size, so there's no overflow/wrapping risk.

https://claude.ai/code/session_017psLvJjysVMeRaek35HYTu

---
_Generated by [Claude Code](https://claude.ai/code/session_017psLvJjysVMeRaek35HYTu)_