### PR TITLE
Fix investments dashboard data and formatting bugs

### DIFF
--- a/public/data/investments/AAPL/snapshot.json
+++ b/public/data/investments/AAPL/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 30.39,
       "roa": 7.88,
       "roic": 15.909999999999998,
-      "equityMultiplier": 386,
-      "assetTurnover": 30
+      "equityMultiplier": 3.86,
+      "assetTurnover": 0.3
     },
     "margins": [
       {

--- a/public/data/investments/ABBV/snapshot.json
+++ b/public/data/investments/ABBV/snapshot.json
@@ -48,8 +48,8 @@
       "roe": -13.8,
       "roa": 0.51,
       "roic": 9.13,
-      "equityMultiplier": -2706,
-      "assetTurnover": 47
+      "equityMultiplier": -27.06,
+      "assetTurnover": 0.47
     },
     "margins": [
       {

--- a/public/data/investments/ABNB/snapshot.json
+++ b/public/data/investments/ABNB/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 4.06,
       "roa": 1.51,
       "roic": 2.25,
-      "equityMultiplier": 269,
-      "assetTurnover": 12
+      "equityMultiplier": 2.69,
+      "assetTurnover": 0.12
     },
     "margins": [
       {

--- a/public/data/investments/ACN/snapshot.json
+++ b/public/data/investments/ACN/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 5.88,
       "roa": 2.77,
       "roic": 5.29,
-      "equityMultiplier": 212,
-      "assetTurnover": 27
+      "equityMultiplier": 2.12,
+      "assetTurnover": 0.27
     },
     "margins": [
       {

--- a/public/data/investments/ADBE/snapshot.json
+++ b/public/data/investments/ADBE/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 16.39,
       "roa": 6.38,
       "roic": 10.92,
-      "equityMultiplier": 257,
-      "assetTurnover": 22
+      "equityMultiplier": 2.57,
+      "assetTurnover": 0.22
     },
     "margins": [
       {

--- a/public/data/investments/ADI/snapshot.json
+++ b/public/data/investments/ADI/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 9.81,
       "roa": 6.909999999999999,
       "roic": 8.44,
-      "equityMultiplier": 142,
-      "assetTurnover": 8
+      "equityMultiplier": 1.42,
+      "assetTurnover": 0.08
     },
     "margins": [
       {

--- a/public/data/investments/AMAT/snapshot.json
+++ b/public/data/investments/AMAT/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 9.62,
       "roa": 5.48,
       "roic": 7.55,
-      "equityMultiplier": 176,
-      "assetTurnover": 19
+      "equityMultiplier": 1.76,
+      "assetTurnover": 0.19
     },
     "margins": [
       {

--- a/public/data/investments/AMD/snapshot.json
+++ b/public/data/investments/AMD/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 7.86,
       "roa": 6.4,
       "roic": 6.43,
-      "equityMultiplier": 123,
-      "assetTurnover": 13
+      "equityMultiplier": 1.23,
+      "assetTurnover": 0.13
     },
     "margins": [
       {

--- a/public/data/investments/AMGN/snapshot.json
+++ b/public/data/investments/AMGN/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 87.4,
       "roa": 8.52,
       "roic": 3.6799999999999997,
-      "equityMultiplier": 1026,
-      "assetTurnover": 9
+      "equityMultiplier": 10.26,
+      "assetTurnover": 0.09
     },
     "margins": [
       {

--- a/public/data/investments/AMT/snapshot.json
+++ b/public/data/investments/AMT/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 21.58,
       "roa": 1.29,
       "roic": 2.78,
-      "equityMultiplier": 1673,
-      "assetTurnover": 4
+      "equityMultiplier": 16.73,
+      "assetTurnover": 0.04
     },
     "margins": [
       {

--- a/public/data/investments/AMZN/snapshot.json
+++ b/public/data/investments/AMZN/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 7.090000000000001,
       "roa": 3.49,
       "roic": 5.949999999999999,
-      "equityMultiplier": 202.99999999999997,
-      "assetTurnover": 21
+      "equityMultiplier": 2.03,
+      "assetTurnover": 0.21
     },
     "margins": [
       {

--- a/public/data/investments/ANET/snapshot.json
+++ b/public/data/investments/ANET/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 7.91,
       "roa": 4.9799999999999995,
       "roic": 7.16,
-      "equityMultiplier": 159,
-      "assetTurnover": 13
+      "equityMultiplier": 1.59,
+      "assetTurnover": 0.13
     },
     "margins": [
       {

--- a/public/data/investments/APH/snapshot.json
+++ b/public/data/investments/APH/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 9.22,
       "roa": 3.7699999999999996,
       "roic": 5.25,
-      "equityMultiplier": 245.00000000000003,
-      "assetTurnover": 20
+      "equityMultiplier": 2.45,
+      "assetTurnover": 0.2
     },
     "margins": [
       {

--- a/public/data/investments/APO/snapshot.json
+++ b/public/data/investments/APO/snapshot.json
@@ -48,8 +48,8 @@
       "roe": -10.36,
       "roa": -0.48,
       "roic": 0.74,
-      "equityMultiplier": 2158,
-      "assetTurnover": 7.000000000000001
+      "equityMultiplier": 21.58,
+      "assetTurnover": 0.07
     },
     "margins": [
       {

--- a/public/data/investments/APP/snapshot.json
+++ b/public/data/investments/APP/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 53.6,
       "roa": 16.11,
       "roic": 21.61,
-      "equityMultiplier": 333,
-      "assetTurnover": 25
+      "equityMultiplier": 3.33,
+      "assetTurnover": 0.25
     },
     "margins": [
       {

--- a/public/data/investments/ASML/snapshot.json
+++ b/public/data/investments/ASML/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 13.63,
       "roa": 5.59,
       "roic": 19.63,
-      "equityMultiplier": 244,
-      "assetTurnover": 18
+      "equityMultiplier": 2.44,
+      "assetTurnover": 0.18
     },
     "margins": [
       {

--- a/public/data/investments/AVGO/snapshot.json
+++ b/public/data/investments/AVGO/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 9.120000000000001,
       "roa": 4.31,
       "roic": 5.54,
-      "equityMultiplier": 212,
-      "assetTurnover": 11
+      "equityMultiplier": 2.12,
+      "assetTurnover": 0.11
     },
     "margins": [
       {

--- a/public/data/investments/AXP/snapshot.json
+++ b/public/data/investments/AXP/snapshot.json
@@ -47,8 +47,8 @@
     "profitability": {
       "roe": 32.87,
       "roa": 3.64,
-      "equityMultiplier": 902.9999999999999,
-      "assetTurnover": 6
+      "equityMultiplier": 9.03,
+      "assetTurnover": 0.06
     },
     "margins": [
       {

--- a/public/data/investments/BA/snapshot.json
+++ b/public/data/investments/BA/snapshot.json
@@ -50,8 +50,8 @@
       "roe": -1.5699999999999998,
       "roa": -0.05,
       "roic": 0.6799999999999999,
-      "equityMultiplier": 3140,
-      "assetTurnover": 12
+      "equityMultiplier": 31.4,
+      "assetTurnover": 0.12
     },
     "margins": [
       {

--- a/public/data/investments/BAC/snapshot.json
+++ b/public/data/investments/BAC/snapshot.json
@@ -47,8 +47,8 @@
     "profitability": {
       "roe": 10.02,
       "roa": 0.88,
-      "equityMultiplier": 1139,
-      "assetTurnover": 3
+      "equityMultiplier": 11.39,
+      "assetTurnover": 0.03
     },
     "margins": [
       {

--- a/public/data/investments/BKNG/snapshot.json
+++ b/public/data/investments/BKNG/snapshot.json
@@ -50,8 +50,8 @@
       "roe": -27.689999999999998,
       "roa": 4.92,
       "roic": 12.8,
-      "equityMultiplier": -563,
-      "assetTurnover": 22
+      "equityMultiplier": -5.63,
+      "assetTurnover": 0.22
     },
     "margins": [
       {

--- a/public/data/investments/BLK/snapshot.json
+++ b/public/data/investments/BLK/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 11.110000000000001,
       "roa": 3.6799999999999997,
       "roic": 3.36,
-      "equityMultiplier": 302,
-      "assetTurnover": 4
+      "equityMultiplier": 3.02,
+      "assetTurnover": 0.04
     },
     "margins": [
       {

--- a/public/data/investments/BRK-B/snapshot.json
+++ b/public/data/investments/BRK-B/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 10.03,
       "roa": 5.86,
       "roic": 1.3,
-      "equityMultiplier": 171,
-      "assetTurnover": 7.000000000000001
+      "equityMultiplier": 1.71,
+      "assetTurnover": 0.07
     },
     "margins": [
       {

--- a/public/data/investments/BSX/snapshot.json
+++ b/public/data/investments/BSX/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 5.35,
       "roa": 3.05,
       "roic": 10.77,
-      "equityMultiplier": 175,
-      "assetTurnover": 47
+      "equityMultiplier": 1.75,
+      "assetTurnover": 0.47
     },
     "margins": [
       {

--- a/public/data/investments/BX/snapshot.json
+++ b/public/data/investments/BX/snapshot.json
@@ -47,8 +47,8 @@
     "profitability": {
       "roe": 7.630000000000001,
       "roa": 1.35,
-      "equityMultiplier": 565,
-      "assetTurnover": 26
+      "equityMultiplier": 5.65,
+      "assetTurnover": 0.26
     },
     "margins": [
       {

--- a/public/data/investments/CARR/snapshot.json
+++ b/public/data/investments/CARR/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 0.37,
       "roa": 0.13999999999999999,
       "roic": 0.36,
-      "equityMultiplier": 264,
-      "assetTurnover": 13
+      "equityMultiplier": 2.64,
+      "assetTurnover": 0.13
     },
     "margins": [
       {

--- a/public/data/investments/CAT/snapshot.json
+++ b/public/data/investments/CAT/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 11.44,
       "roa": 2.5,
       "roic": 3.7800000000000002,
-      "equityMultiplier": 458,
-      "assetTurnover": 20
+      "equityMultiplier": 4.58,
+      "assetTurnover": 0.2
     },
     "margins": [
       {

--- a/public/data/investments/CB/snapshot.json
+++ b/public/data/investments/CB/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 4.41,
       "roa": 1.18,
       "roic": 3.71,
-      "equityMultiplier": 374,
-      "assetTurnover": 6
+      "equityMultiplier": 3.74,
+      "assetTurnover": 0.06
     },
     "margins": [
       {

--- a/public/data/investments/CCI/snapshot.json
+++ b/public/data/investments/CCI/snapshot.json
@@ -50,8 +50,8 @@
       "roe": -18.8,
       "roa": 0.9299999999999999,
       "roic": 2.26,
-      "equityMultiplier": -2022,
-      "assetTurnover": 3
+      "equityMultiplier": -20.22,
+      "assetTurnover": 0.03
     },
     "margins": [
       {

--- a/public/data/investments/CDNS/snapshot.json
+++ b/public/data/investments/CDNS/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 5.58,
       "roa": 3.02,
       "roic": 4.12,
-      "equityMultiplier": 185,
-      "assetTurnover": 13
+      "equityMultiplier": 1.85,
+      "assetTurnover": 0.13
     },
     "margins": [
       {

--- a/public/data/investments/CI/snapshot.json
+++ b/public/data/investments/CI/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 14.99,
       "roa": 4.04,
       "roic": 5.89,
-      "equityMultiplier": 371,
-      "assetTurnover": 176
+      "equityMultiplier": 3.71,
+      "assetTurnover": 1.76
     },
     "margins": [
       {

--- a/public/data/investments/CMCSA/snapshot.json
+++ b/public/data/investments/CMCSA/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.2399999999999998,
       "roa": 0.79,
       "roic": 1.6099999999999999,
-      "equityMultiplier": 284,
-      "assetTurnover": 12
+      "equityMultiplier": 2.84,
+      "assetTurnover": 0.12
     },
     "margins": [
       {

--- a/public/data/investments/CME/snapshot.json
+++ b/public/data/investments/CME/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 15.340000000000002,
       "roa": 2.12,
       "roic": 14.11,
-      "equityMultiplier": 724,
-      "assetTurnover": 3
+      "equityMultiplier": 7.24,
+      "assetTurnover": 0.03
     },
     "margins": [
       {

--- a/public/data/investments/COP/snapshot.json
+++ b/public/data/investments/COP/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.22,
       "roa": 1.18,
       "roic": 1.8499999999999999,
-      "equityMultiplier": 188,
-      "assetTurnover": 11
+      "equityMultiplier": 1.88,
+      "assetTurnover": 0.11
     },
     "margins": [
       {

--- a/public/data/investments/COST/snapshot.json
+++ b/public/data/investments/COST/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 27.41,
       "roa": 10.27,
       "roic": 5.6000000000000005,
-      "equityMultiplier": 267,
-      "assetTurnover": 84
+      "equityMultiplier": 2.67,
+      "assetTurnover": 0.84
     },
     "margins": [
       {

--- a/public/data/investments/CRM/snapshot.json
+++ b/public/data/investments/CRM/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 4.51,
       "roa": 1.92,
       "roic": 3.18,
-      "equityMultiplier": 235,
-      "assetTurnover": 10
+      "equityMultiplier": 2.35,
+      "assetTurnover": 0.1
     },
     "margins": [
       {

--- a/public/data/investments/CRWD/snapshot.json
+++ b/public/data/investments/CRWD/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 0.61,
       "roa": 0.25,
       "roic": 0.51,
-      "equityMultiplier": 244,
-      "assetTurnover": 12
+      "equityMultiplier": 2.44,
+      "assetTurnover": 0.12
     },
     "margins": [
       {

--- a/public/data/investments/CVS/snapshot.json
+++ b/public/data/investments/CVS/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 3.84,
       "roa": 1.16,
       "roic": 3.51,
-      "equityMultiplier": 331,
-      "assetTurnover": 40
+      "equityMultiplier": 3.31,
+      "assetTurnover": 0.4
     },
     "margins": [
       {

--- a/public/data/investments/CVX/snapshot.json
+++ b/public/data/investments/CVX/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 1.47,
       "roa": 0.8500000000000001,
       "roic": 1.35,
-      "equityMultiplier": 173,
-      "assetTurnover": 14.000000000000002
+      "equityMultiplier": 1.73,
+      "assetTurnover": 0.14
     },
     "margins": [
       {

--- a/public/data/investments/DE/snapshot.json
+++ b/public/data/investments/DE/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.5100000000000002,
       "roa": 0.63,
       "roic": 1.34,
-      "equityMultiplier": 398,
-      "assetTurnover": 9
+      "equityMultiplier": 3.98,
+      "assetTurnover": 0.09
     },
     "margins": [
       {

--- a/public/data/investments/DIS/snapshot.json
+++ b/public/data/investments/DIS/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.1999999999999997,
       "roa": 1.2,
       "roic": 1.81,
-      "equityMultiplier": 183,
-      "assetTurnover": 13
+      "equityMultiplier": 1.83,
+      "assetTurnover": 0.13
     },
     "margins": [
       {

--- a/public/data/investments/DUK/snapshot.json
+++ b/public/data/investments/DUK/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.26,
       "roa": 0.6,
       "roic": 1.47,
-      "equityMultiplier": 377,
-      "assetTurnover": 4
+      "equityMultiplier": 3.77,
+      "assetTurnover": 0.04
     },
     "margins": [
       {

--- a/public/data/investments/ECL/snapshot.json
+++ b/public/data/investments/ECL/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 5.79,
       "roa": 2.32,
       "roic": 3.5700000000000003,
-      "equityMultiplier": 250,
-      "assetTurnover": 17
+      "equityMultiplier": 2.5,
+      "assetTurnover": 0.17
     },
     "margins": [
       {

--- a/public/data/investments/ELV/snapshot.json
+++ b/public/data/investments/ELV/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 11.95,
       "roa": 4.24,
       "roic": 2.9499999999999997,
-      "equityMultiplier": 282,
-      "assetTurnover": 41
+      "equityMultiplier": 2.82,
+      "assetTurnover": 0.41
     },
     "margins": [
       {

--- a/public/data/investments/EMR/snapshot.json
+++ b/public/data/investments/EMR/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.98,
       "roa": 1.44,
       "roic": 2.08,
-      "equityMultiplier": 206.99999999999997,
-      "assetTurnover": 10
+      "equityMultiplier": 2.07,
+      "assetTurnover": 0.1
     },
     "margins": [
       {

--- a/public/data/investments/EOG/snapshot.json
+++ b/public/data/investments/EOG/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.33,
       "roa": 1.35,
       "roic": 1.9900000000000002,
-      "equityMultiplier": 173,
-      "assetTurnover": 11
+      "equityMultiplier": 1.73,
+      "assetTurnover": 0.11
     },
     "margins": [
       {

--- a/public/data/investments/ETN/snapshot.json
+++ b/public/data/investments/ETN/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 5.92,
       "roa": 2.76,
       "roic": 4.08,
-      "equityMultiplier": 214,
-      "assetTurnover": 17
+      "equityMultiplier": 2.14,
+      "assetTurnover": 0.17
     },
     "margins": [
       {

--- a/public/data/investments/FDX/snapshot.json
+++ b/public/data/investments/FDX/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 3.42,
       "roa": 1.08,
       "roic": 2.44,
-      "equityMultiplier": 317,
-      "assetTurnover": 27
+      "equityMultiplier": 3.17,
+      "assetTurnover": 0.27
     },
     "margins": [
       {

--- a/public/data/investments/FTNT/snapshot.json
+++ b/public/data/investments/FTNT/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 51.300000000000004,
       "roa": 5.12,
       "roic": 25.779999999999998,
-      "equityMultiplier": 1002,
-      "assetTurnover": 19
+      "equityMultiplier": 10.02,
+      "assetTurnover": 0.19
     },
     "margins": [
       {

--- a/public/data/investments/GD/snapshot.json
+++ b/public/data/investments/GD/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 4.569999999999999,
       "roa": 1.9900000000000002,
       "roic": 3.9699999999999998,
-      "equityMultiplier": 229.99999999999997,
-      "assetTurnover": 25
+      "equityMultiplier": 2.3,
+      "assetTurnover": 0.25
     },
     "margins": [
       {

--- a/public/data/investments/GE/snapshot.json
+++ b/public/data/investments/GE/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 10.37,
       "roa": 1.47,
       "roic": 5.89,
-      "equityMultiplier": 705,
-      "assetTurnover": 10
+      "equityMultiplier": 7.05,
+      "assetTurnover": 0.1
     },
     "margins": [
       {

--- a/public/data/investments/GEHC/snapshot.json
+++ b/public/data/investments/GEHC/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 18.14,
       "roa": 5.16,
       "roic": 2.25,
-      "equityMultiplier": 352,
-      "assetTurnover": 56.99999999999999
+      "equityMultiplier": 3.52,
+      "assetTurnover": 0.57
     },
     "margins": [
       {

--- a/public/data/investments/GILD/snapshot.json
+++ b/public/data/investments/GILD/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 8.75,
       "roa": 3.51,
       "roic": 5.2,
-      "equityMultiplier": 249.00000000000003,
-      "assetTurnover": 52
+      "equityMultiplier": 2.49,
+      "assetTurnover": 0.52
     },
     "margins": [
       {

--- a/public/data/investments/GM/snapshot.json
+++ b/public/data/investments/GM/snapshot.json
@@ -50,8 +50,8 @@
       "roe": -5.220000000000001,
       "roa": -1.17,
       "roic": -1.6099999999999999,
-      "equityMultiplier": 446,
-      "assetTurnover": 16
+      "equityMultiplier": 4.46,
+      "assetTurnover": 0.16
     },
     "margins": [
       {

--- a/public/data/investments/GOOGL/snapshot.json
+++ b/public/data/investments/GOOGL/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 14.000000000000002,
       "roa": 9.629999999999999,
       "roic": 12.4,
-      "equityMultiplier": 145,
-      "assetTurnover": 17
+      "equityMultiplier": 1.45,
+      "assetTurnover": 0.17
     },
     "margins": [
       {

--- a/public/data/investments/GS/snapshot.json
+++ b/public/data/investments/GS/snapshot.json
@@ -47,8 +47,8 @@
     "profitability": {
       "roe": 13.819999999999999,
       "roa": 0.88,
-      "equityMultiplier": 1570,
-      "assetTurnover": 1
+      "equityMultiplier": 15.7,
+      "assetTurnover": 0.01
     },
     "margins": [
       {

--- a/public/data/investments/GWW/snapshot.json
+++ b/public/data/investments/GWW/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 12.36,
       "roa": 5.06,
       "roic": 8.110000000000001,
-      "equityMultiplier": 244,
-      "assetTurnover": 50
+      "equityMultiplier": 2.44,
+      "assetTurnover": 0.5
     },
     "margins": [
       {

--- a/public/data/investments/HCA/snapshot.json
+++ b/public/data/investments/HCA/snapshot.json
@@ -48,8 +48,8 @@
       "roe": -26.279999999999998,
       "roa": 2.65,
       "roic": 5.59,
-      "equityMultiplier": -992,
-      "assetTurnover": 125
+      "equityMultiplier": -9.92,
+      "assetTurnover": 1.25
     },
     "margins": [
       {

--- a/public/data/investments/HD/snapshot.json
+++ b/public/data/investments/HD/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 20.630000000000003,
       "roa": 2.4299999999999997,
       "roic": 4.44,
-      "equityMultiplier": 849,
-      "assetTurnover": 36
+      "equityMultiplier": 8.49,
+      "assetTurnover": 0.36
     },
     "margins": [
       {

--- a/public/data/investments/HON/snapshot.json
+++ b/public/data/investments/HON/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 5.970000000000001,
       "roa": 1.11,
       "roic": 2.26,
-      "equityMultiplier": 538,
-      "assetTurnover": 12
+      "equityMultiplier": 5.38,
+      "assetTurnover": 0.12
     },
     "margins": [
       {

--- a/public/data/investments/IBM/snapshot.json
+++ b/public/data/investments/IBM/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 3.71,
       "roa": 0.79,
       "roic": 1.69,
-      "equityMultiplier": 470,
-      "assetTurnover": 10
+      "equityMultiplier": 4.7,
+      "assetTurnover": 0.1
     },
     "margins": [
       {

--- a/public/data/investments/INTC/snapshot.json
+++ b/public/data/investments/INTC/snapshot.json
@@ -48,8 +48,8 @@
       "roe": -3.3000000000000003,
       "roa": -1.79,
       "roic": -0.27999999999999997,
-      "equityMultiplier": 184,
-      "assetTurnover": 26
+      "equityMultiplier": 1.84,
+      "assetTurnover": 0.26
     },
     "margins": [
       {

--- a/public/data/investments/INTU/snapshot.json
+++ b/public/data/investments/INTU/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 15.440000000000001,
       "roa": 8.32,
       "roic": 12.030000000000001,
-      "equityMultiplier": 186,
-      "assetTurnover": 23
+      "equityMultiplier": 1.86,
+      "assetTurnover": 0.23
     },
     "margins": [
       {

--- a/public/data/investments/ISRG/snapshot.json
+++ b/public/data/investments/ISRG/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 16.88,
       "roa": 14.69,
       "roic": 4.26,
-      "equityMultiplier": 114.99999999999999,
-      "assetTurnover": 14.000000000000002
+      "equityMultiplier": 1.15,
+      "assetTurnover": 0.14
     },
     "margins": [
       {

--- a/public/data/investments/ITW/snapshot.json
+++ b/public/data/investments/ITW/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 24.560000000000002,
       "roa": 4.89,
       "roic": 6.950000000000001,
-      "equityMultiplier": 501.99999999999994,
-      "assetTurnover": 25
+      "equityMultiplier": 5.02,
+      "assetTurnover": 0.25
     },
     "margins": [
       {

--- a/public/data/investments/JNJ/snapshot.json
+++ b/public/data/investments/JNJ/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 25.86,
       "roa": 10.52,
       "roic": 17.02,
-      "equityMultiplier": 246,
-      "assetTurnover": 12
+      "equityMultiplier": 2.46,
+      "assetTurnover": 0.12
     },
     "margins": [
       {

--- a/public/data/investments/JPM/snapshot.json
+++ b/public/data/investments/JPM/snapshot.json
@@ -47,8 +47,8 @@
     "profitability": {
       "roe": 15.83,
       "roa": 1.23,
-      "equityMultiplier": 1287,
-      "assetTurnover": 1
+      "equityMultiplier": 12.87,
+      "assetTurnover": 0.01
     },
     "margins": [
       {

--- a/public/data/investments/KKR/snapshot.json
+++ b/public/data/investments/KKR/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 1.1900000000000002,
       "roa": 0.09,
       "roic": 0.89,
-      "equityMultiplier": 1322,
-      "assetTurnover": 5
+      "equityMultiplier": 13.22,
+      "assetTurnover": 0.05
     },
     "margins": [
       {

--- a/public/data/investments/KLAC/snapshot.json
+++ b/public/data/investments/KLAC/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 21.26,
       "roa": 7.1499999999999995,
       "roic": 10.96,
-      "equityMultiplier": 297,
-      "assetTurnover": 78
+      "equityMultiplier": 2.97,
+      "assetTurnover": 0.78
     },
     "margins": [
       {

--- a/public/data/investments/KO/snapshot.json
+++ b/public/data/investments/KO/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 41.64,
       "roa": 13.11,
       "roic": 20.169999999999998,
-      "equityMultiplier": 318,
-      "assetTurnover": 12
+      "equityMultiplier": 3.18,
+      "assetTurnover": 0.12
     },
     "margins": [
       {

--- a/public/data/investments/LLY/snapshot.json
+++ b/public/data/investments/LLY/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 87.57000000000001,
       "roa": 22.07,
       "roic": 39.98,
-      "equityMultiplier": 397,
-      "assetTurnover": 17
+      "equityMultiplier": 3.97,
+      "assetTurnover": 0.17
     },
     "margins": [
       {

--- a/public/data/investments/LMT/snapshot.json
+++ b/public/data/investments/LMT/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 20.94,
       "roa": 2.5,
       "roic": 6.0600000000000005,
-      "equityMultiplier": 838.0000000000001,
-      "assetTurnover": 30
+      "equityMultiplier": 8.38,
+      "assetTurnover": 0.3
     },
     "margins": [
       {

--- a/public/data/investments/LOW/snapshot.json
+++ b/public/data/investments/LOW/snapshot.json
@@ -50,8 +50,8 @@
       "roe": -9.82,
       "roa": 1.8499999999999999,
       "roic": 4.45,
-      "equityMultiplier": -531,
-      "assetTurnover": 38
+      "equityMultiplier": -5.31,
+      "assetTurnover": 0.38
     },
     "margins": [
       {

--- a/public/data/investments/LRCX/snapshot.json
+++ b/public/data/investments/LRCX/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 17.61,
       "roa": 8.649999999999999,
       "roic": 48.11,
-      "equityMultiplier": 204,
-      "assetTurnover": 103
+      "equityMultiplier": 2.04,
+      "assetTurnover": 1.03
     },
     "margins": [
       {

--- a/public/data/investments/MA/snapshot.json
+++ b/public/data/investments/MA/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 53.71,
       "roa": 7.28,
       "roic": 15.25,
-      "equityMultiplier": 738,
-      "assetTurnover": 64
+      "equityMultiplier": 7.38,
+      "assetTurnover": 0.64
     },
     "margins": [
       {

--- a/public/data/investments/MCD/snapshot.json
+++ b/public/data/investments/MCD/snapshot.json
@@ -48,8 +48,8 @@
       "roe": -128.98000000000002,
       "roa": 3.32,
       "roic": 5.96,
-      "equityMultiplier": -3885,
-      "assetTurnover": 46
+      "equityMultiplier": -38.85,
+      "assetTurnover": 0.46
     },
     "margins": [
       {

--- a/public/data/investments/MCO/snapshot.json
+++ b/public/data/investments/MCO/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 70.8,
       "roa": 16.33,
       "roic": 25.11,
-      "equityMultiplier": 434,
-      "assetTurnover": 14.000000000000002
+      "equityMultiplier": 4.34,
+      "assetTurnover": 0.14
     },
     "margins": [
       {

--- a/public/data/investments/MDLZ/snapshot.json
+++ b/public/data/investments/MDLZ/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.56,
       "roa": 0.9299999999999999,
       "roic": 1.63,
-      "equityMultiplier": 275,
-      "assetTurnover": 15
+      "equityMultiplier": 2.75,
+      "assetTurnover": 0.15
     },
     "margins": [
       {

--- a/public/data/investments/MDT/snapshot.json
+++ b/public/data/investments/MDT/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 9.45,
       "roa": 5.050000000000001,
       "roic": 6.65,
-      "equityMultiplier": 187,
-      "assetTurnover": 39
+      "equityMultiplier": 1.87,
+      "assetTurnover": 0.39
     },
     "margins": [
       {

--- a/public/data/investments/META/snapshot.json
+++ b/public/data/investments/META/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 11.62,
       "roa": 7.03,
       "roic": 4.63,
-      "equityMultiplier": 165,
-      "assetTurnover": 15
+      "equityMultiplier": 1.65,
+      "assetTurnover": 0.15
     },
     "margins": [
       {

--- a/public/data/investments/MMC/snapshot.json
+++ b/public/data/investments/MMC/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 5.43,
       "roa": 1.4000000000000001,
       "roic": 2.94,
-      "equityMultiplier": 388,
-      "assetTurnover": 11
+      "equityMultiplier": 3.88,
+      "assetTurnover": 0.11
     },
     "margins": [
       {

--- a/public/data/investments/MMM/snapshot.json
+++ b/public/data/investments/MMM/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 16.400000000000002,
       "roa": 1.78,
       "roic": 4.95,
-      "equityMultiplier": 921.0000000000001,
-      "assetTurnover": 16
+      "equityMultiplier": 9.21,
+      "assetTurnover": 0.16
     },
     "margins": [
       {

--- a/public/data/investments/MO/snapshot.json
+++ b/public/data/investments/MO/snapshot.json
@@ -50,8 +50,8 @@
       "roe": -36.24,
       "roa": 3.18,
       "roic": 6.13,
-      "equityMultiplier": -1140,
-      "assetTurnover": 15
+      "equityMultiplier": -11.4,
+      "assetTurnover": 0.15
     },
     "margins": [
       {

--- a/public/data/investments/MRVL/snapshot.json
+++ b/public/data/investments/MRVL/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 2.79,
       "roa": 1.81,
       "roic": 15.329999999999998,
-      "equityMultiplier": 154,
-      "assetTurnover": 37
+      "equityMultiplier": 1.54,
+      "assetTurnover": 0.37
     },
     "margins": [
       {

--- a/public/data/investments/MS/snapshot.json
+++ b/public/data/investments/MS/snapshot.json
@@ -47,8 +47,8 @@
     "profitability": {
       "roe": 4.79,
       "roa": 0.36,
-      "equityMultiplier": 1331,
-      "assetTurnover": 5
+      "equityMultiplier": 13.31,
+      "assetTurnover": 0.05
     },
     "margins": [
       {

--- a/public/data/investments/MSFT/snapshot.json
+++ b/public/data/investments/MSFT/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 7.89,
       "roa": 4.67,
       "roic": 7.340000000000001,
-      "equityMultiplier": 169,
-      "assetTurnover": 12
+      "equityMultiplier": 1.69,
+      "assetTurnover": 0.12
     },
     "margins": [
       {

--- a/public/data/investments/MSI/snapshot.json
+++ b/public/data/investments/MSI/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 27.400000000000002,
       "roa": 3.4000000000000004,
       "roic": 6.39,
-      "equityMultiplier": 806,
-      "assetTurnover": 18
+      "equityMultiplier": 8.06,
+      "assetTurnover": 0.18
     },
     "margins": [
       {

--- a/public/data/investments/MU/snapshot.json
+++ b/public/data/investments/MU/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 36.74,
       "roa": 25.72,
       "roic": 18.89,
-      "equityMultiplier": 143,
-      "assetTurnover": 25
+      "equityMultiplier": 1.43,
+      "assetTurnover": 0.25
     },
     "margins": [
       {

--- a/public/data/investments/NEE/snapshot.json
+++ b/public/data/investments/NEE/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 3.9699999999999998,
       "roa": 1.01,
       "roic": 0.96,
-      "equityMultiplier": 393,
-      "assetTurnover": 3
+      "equityMultiplier": 3.93,
+      "assetTurnover": 0.03
     },
     "margins": [
       {

--- a/public/data/investments/NET/snapshot.json
+++ b/public/data/investments/NET/snapshot.json
@@ -49,8 +49,8 @@
       "roe": -1.54,
       "roa": -0.38,
       "roic": -0.24,
-      "equityMultiplier": 405,
-      "assetTurnover": 11
+      "equityMultiplier": 4.05,
+      "assetTurnover": 0.11
     },
     "margins": [
       {

--- a/public/data/investments/NFLX/snapshot.json
+++ b/public/data/investments/NFLX/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 18.3,
       "roa": 9.06,
       "roic": 12.740000000000002,
-      "equityMultiplier": 202,
-      "assetTurnover": 21
+      "equityMultiplier": 2.02,
+      "assetTurnover": 0.21
     },
     "margins": [
       {

--- a/public/data/investments/NKE/snapshot.json
+++ b/public/data/investments/NKE/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 3.6900000000000004,
       "roa": 1.39,
       "roic": 2,
-      "equityMultiplier": 265,
-      "assetTurnover": 30
+      "equityMultiplier": 2.65,
+      "assetTurnover": 0.3
     },
     "margins": [
       {

--- a/public/data/investments/NOC/snapshot.json
+++ b/public/data/investments/NOC/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 5.18,
       "roa": 1.73,
       "roic": 3.2,
-      "equityMultiplier": 299,
-      "assetTurnover": 20
+      "equityMultiplier": 2.99,
+      "assetTurnover": 0.2
     },
     "margins": [
       {

--- a/public/data/investments/NOW/snapshot.json
+++ b/public/data/investments/NOW/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 3.8,
       "roa": 1.8599999999999999,
       "roic": 3.4299999999999997,
-      "equityMultiplier": 204,
-      "assetTurnover": 15
+      "equityMultiplier": 2.04,
+      "assetTurnover": 0.15
     },
     "margins": [
       {

--- a/public/data/investments/NVDA/snapshot.json
+++ b/public/data/investments/NVDA/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 33.06,
       "roa": 25.019999999999996,
       "roic": 31.430000000000003,
-      "equityMultiplier": 132,
-      "assetTurnover": 35
+      "equityMultiplier": 1.32,
+      "assetTurnover": 0.35
     },
     "margins": [
       {

--- a/public/data/investments/NVO/snapshot.json
+++ b/public/data/investments/NVO/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 24.46,
       "roa": 8.81,
       "roic": 15.39,
-      "equityMultiplier": 278,
-      "assetTurnover": 59
+      "equityMultiplier": 2.78,
+      "assetTurnover": 0.59
     },
     "margins": [
       {

--- a/public/data/investments/NXPI/snapshot.json
+++ b/public/data/investments/NXPI/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 25.290000000000003,
       "roa": 9.89,
       "roic": 5.489999999999999,
-      "equityMultiplier": 256,
-      "assetTurnover": 12
+      "equityMultiplier": 2.56,
+      "assetTurnover": 0.12
     },
     "margins": [
       {

--- a/public/data/investments/ON/snapshot.json
+++ b/public/data/investments/ON/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 7.66,
       "roa": 4.68,
       "roic": -0.22999999999999998,
-      "equityMultiplier": 164,
-      "assetTurnover": 12
+      "equityMultiplier": 1.64,
+      "assetTurnover": 0.12
     },
     "margins": [
       {

--- a/public/data/investments/ORCL/snapshot.json
+++ b/public/data/investments/ORCL/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 10.81,
       "roa": 1.6400000000000001,
       "roic": 3.0700000000000003,
-      "equityMultiplier": 659,
-      "assetTurnover": 8
+      "equityMultiplier": 6.59,
+      "assetTurnover": 0.08
     },
     "margins": [
       {

--- a/public/data/investments/ORLY/snapshot.json
+++ b/public/data/investments/ORLY/snapshot.json
@@ -50,8 +50,8 @@
       "roe": -73.00999999999999,
       "roa": 3.6900000000000004,
       "roic": 12.78,
-      "equityMultiplier": -1979,
-      "assetTurnover": 27
+      "equityMultiplier": -19.79,
+      "assetTurnover": 0.27
     },
     "margins": [
       {

--- a/public/data/investments/PANW/snapshot.json
+++ b/public/data/investments/PANW/snapshot.json
@@ -51,8 +51,8 @@
       "roe": -0.96,
       "roa": -0.5,
       "roic": -0.49,
-      "equityMultiplier": 192,
-      "assetTurnover": 8
+      "equityMultiplier": 1.92,
+      "assetTurnover": 0.08
     },
     "margins": [
       {

--- a/public/data/investments/PEP/snapshot.json
+++ b/public/data/investments/PEP/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 41.8,
       "roa": 8.01,
       "roic": 3.6900000000000004,
-      "equityMultiplier": 522,
-      "assetTurnover": 18
+      "equityMultiplier": 5.22,
+      "assetTurnover": 0.18
     },
     "margins": [
       {

--- a/public/data/investments/PFE/snapshot.json
+++ b/public/data/investments/PFE/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 8.48,
       "roa": 3.5999999999999996,
       "roic": 5.92,
-      "equityMultiplier": 236,
-      "assetTurnover": 7.000000000000001
+      "equityMultiplier": 2.36,
+      "assetTurnover": 0.07
     },
     "margins": [
       {

--- a/public/data/investments/PG/snapshot.json
+++ b/public/data/investments/PG/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 30.349999999999998,
       "roa": 12.770000000000001,
       "roic": 19.18,
-      "equityMultiplier": 238,
-      "assetTurnover": 68
+      "equityMultiplier": 2.38,
+      "assetTurnover": 0.68
     },
     "margins": [
       {

--- a/public/data/investments/PH/snapshot.json
+++ b/public/data/investments/PH/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 6.02,
       "roa": 2.76,
       "roic": 3.83,
-      "equityMultiplier": 218.00000000000003,
-      "assetTurnover": 17
+      "equityMultiplier": 2.18,
+      "assetTurnover": 0.17
     },
     "margins": [
       {

--- a/public/data/investments/PLD/snapshot.json
+++ b/public/data/investments/PLD/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.64,
       "roa": 1.4200000000000002,
       "roic": 1.94,
-      "equityMultiplier": 186,
-      "assetTurnover": 2
+      "equityMultiplier": 1.86,
+      "assetTurnover": 0.02
     },
     "margins": [
       {

--- a/public/data/investments/PLTR/snapshot.json
+++ b/public/data/investments/PLTR/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 10.99,
       "roa": 9.120000000000001,
       "roic": 9.43,
-      "equityMultiplier": 121,
-      "assetTurnover": 17
+      "equityMultiplier": 1.21,
+      "assetTurnover": 0.17
     },
     "margins": [
       {

--- a/public/data/investments/PM/snapshot.json
+++ b/public/data/investments/PM/snapshot.json
@@ -50,8 +50,8 @@
       "roe": -25.230000000000004,
       "roa": 3.52,
       "roic": 7.84,
-      "equityMultiplier": -717,
-      "assetTurnover": 15
+      "equityMultiplier": -7.17,
+      "assetTurnover": 0.15
     },
     "margins": [
       {

--- a/public/data/investments/PNC/snapshot.json
+++ b/public/data/investments/PNC/snapshot.json
@@ -47,8 +47,8 @@
     "profitability": {
       "roe": 11.03,
       "roa": 1.16,
-      "equityMultiplier": 951,
-      "assetTurnover": 4
+      "equityMultiplier": 9.51,
+      "assetTurnover": 0.04
     },
     "margins": [
       {

--- a/public/data/investments/PSA/snapshot.json
+++ b/public/data/investments/PSA/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 4.92,
       "roa": 2.27,
       "roic": 3.02,
-      "equityMultiplier": 217,
-      "assetTurnover": 6
+      "equityMultiplier": 2.17,
+      "assetTurnover": 0.06
     },
     "margins": [
       {

--- a/public/data/investments/PYPL/snapshot.json
+++ b/public/data/investments/PYPL/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 7.1,
       "roa": 1.7999999999999998,
       "roic": 4.96,
-      "equityMultiplier": 394,
-      "assetTurnover": 11
+      "equityMultiplier": 3.94,
+      "assetTurnover": 0.11
     },
     "margins": [
       {

--- a/public/data/investments/QCOM/snapshot.json
+++ b/public/data/investments/QCOM/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 29.270000000000003,
       "roa": 13.38,
       "roic": 5.08,
-      "equityMultiplier": 219,
-      "assetTurnover": 81
+      "equityMultiplier": 2.19,
+      "assetTurnover": 0.81
     },
     "margins": [
       {

--- a/public/data/investments/RACE/snapshot.json
+++ b/public/data/investments/RACE/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 9.89,
       "roa": 3.9699999999999998,
       "roic": 5.88,
-      "equityMultiplier": 249.00000000000003,
-      "assetTurnover": 19
+      "equityMultiplier": 2.49,
+      "assetTurnover": 0.19
     },
     "margins": [
       {

--- a/public/data/investments/REGN/snapshot.json
+++ b/public/data/investments/REGN/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 2.32,
       "roa": 1.79,
       "roic": 2.18,
-      "equityMultiplier": 130,
-      "assetTurnover": 37
+      "equityMultiplier": 1.3,
+      "assetTurnover": 0.37
     },
     "margins": [
       {

--- a/public/data/investments/ROP/snapshot.json
+++ b/public/data/investments/ROP/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.15,
       "roa": 1.24,
       "roic": 1.71,
-      "equityMultiplier": 173,
-      "assetTurnover": 6
+      "equityMultiplier": 1.73,
+      "assetTurnover": 0.06
     },
     "margins": [
       {

--- a/public/data/investments/RTX/snapshot.json
+++ b/public/data/investments/RTX/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 3.1300000000000003,
       "roa": 1.21,
       "roic": 2.4299999999999997,
-      "equityMultiplier": 259,
-      "assetTurnover": 13
+      "equityMultiplier": 2.59,
+      "assetTurnover": 0.13
     },
     "margins": [
       {

--- a/public/data/investments/SAP/snapshot.json
+++ b/public/data/investments/SAP/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 4.32,
       "roa": 2.69,
       "roic": 4.53,
-      "equityMultiplier": 161,
-      "assetTurnover": 13
+      "equityMultiplier": 1.61,
+      "assetTurnover": 0.13
     },
     "margins": [
       {

--- a/public/data/investments/SBUX/snapshot.json
+++ b/public/data/investments/SBUX/snapshot.json
@@ -50,8 +50,8 @@
       "roe": -3.56,
       "roa": 0.91,
       "roic": 9.11,
-      "equityMultiplier": -391,
-      "assetTurnover": 31
+      "equityMultiplier": -3.91,
+      "assetTurnover": 0.31
     },
     "margins": [
       {

--- a/public/data/investments/SCHW/snapshot.json
+++ b/public/data/investments/SCHW/snapshot.json
@@ -47,8 +47,8 @@
     "profitability": {
       "roe": 18.279999999999998,
       "roa": 1.83,
-      "equityMultiplier": 999,
-      "assetTurnover": 1
+      "equityMultiplier": 9.99,
+      "assetTurnover": 0.01
     },
     "margins": [
       {

--- a/public/data/investments/SHOP/snapshot.json
+++ b/public/data/investments/SHOP/snapshot.json
@@ -51,8 +51,8 @@
       "roe": -4.47,
       "roa": -3.9600000000000004,
       "roic": 3.53,
-      "equityMultiplier": 112.99999999999999,
-      "assetTurnover": 22
+      "equityMultiplier": 1.13,
+      "assetTurnover": 0.22
     },
     "margins": [
       {

--- a/public/data/investments/SLB/snapshot.json
+++ b/public/data/investments/SLB/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 3.18,
       "roa": 1.5,
       "roic": 2.39,
-      "equityMultiplier": 212,
-      "assetTurnover": 18
+      "equityMultiplier": 2.12,
+      "assetTurnover": 0.18
     },
     "margins": [
       {

--- a/public/data/investments/SNPS/snapshot.json
+++ b/public/data/investments/SNPS/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 0.06,
       "roa": 0.04,
       "roic": 0.33,
-      "equityMultiplier": 150,
-      "assetTurnover": 5
+      "equityMultiplier": 1.5,
+      "assetTurnover": 0.05
     },
     "margins": [
       {

--- a/public/data/investments/SO/snapshot.json
+++ b/public/data/investments/SO/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 1.17,
       "roa": 0.27,
       "roic": 0.8,
-      "equityMultiplier": 433,
-      "assetTurnover": 5
+      "equityMultiplier": 4.33,
+      "assetTurnover": 0.05
     },
     "margins": [
       {

--- a/public/data/investments/SPGI/snapshot.json
+++ b/public/data/investments/SPGI/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 15.329999999999998,
       "roa": 7.829999999999999,
       "roic": 12.370000000000001,
-      "equityMultiplier": 196,
-      "assetTurnover": 7.000000000000001
+      "equityMultiplier": 1.96,
+      "assetTurnover": 0.07
     },
     "margins": [
       {

--- a/public/data/investments/SPOT/snapshot.json
+++ b/public/data/investments/SPOT/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 14.580000000000002,
       "roa": 7.9,
       "roic": 8.41,
-      "equityMultiplier": 185,
-      "assetTurnover": 30
+      "equityMultiplier": 1.85,
+      "assetTurnover": 0.3
     },
     "margins": [
       {

--- a/public/data/investments/STZ/snapshot.json
+++ b/public/data/investments/STZ/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.56,
       "roa": 0.9299999999999999,
       "roic": 1.51,
-      "equityMultiplier": 275,
-      "assetTurnover": 9
+      "equityMultiplier": 2.75,
+      "assetTurnover": 0.09
     },
     "margins": [
       {

--- a/public/data/investments/T/snapshot.json
+++ b/public/data/investments/T/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 3.39,
       "roa": 0.89,
       "roic": 2.36,
-      "equityMultiplier": 381,
-      "assetTurnover": 8
+      "equityMultiplier": 3.81,
+      "assetTurnover": 0.08
     },
     "margins": [
       {

--- a/public/data/investments/TDG/snapshot.json
+++ b/public/data/investments/TDG/snapshot.json
@@ -50,8 +50,8 @@
       "roe": -4.07,
       "roa": 1.6500000000000001,
       "roic": 3.9699999999999998,
-      "equityMultiplier": -247.00000000000003,
-      "assetTurnover": 10
+      "equityMultiplier": -2.47,
+      "assetTurnover": 0.1
     },
     "margins": [
       {

--- a/public/data/investments/TGT/snapshot.json
+++ b/public/data/investments/TGT/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 6.6000000000000005,
       "roa": 1.7500000000000002,
       "roic": 3.4799999999999995,
-      "equityMultiplier": 377,
-      "assetTurnover": 51
+      "equityMultiplier": 3.77,
+      "assetTurnover": 0.51
     },
     "margins": [
       {

--- a/public/data/investments/TJX/snapshot.json
+++ b/public/data/investments/TJX/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 18.14,
       "roa": 5,
       "roic": 14.099999999999998,
-      "equityMultiplier": 363,
-      "assetTurnover": 50
+      "equityMultiplier": 3.63,
+      "assetTurnover": 0.5
     },
     "margins": [
       {

--- a/public/data/investments/TMO/snapshot.json
+++ b/public/data/investments/TMO/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 13,
       "roa": 6.12,
       "roic": 2.07,
-      "equityMultiplier": 212,
-      "assetTurnover": 10
+      "equityMultiplier": 2.12,
+      "assetTurnover": 0.1
     },
     "margins": [
       {

--- a/public/data/investments/TMUS/snapshot.json
+++ b/public/data/investments/TMUS/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 3.51,
       "roa": 0.96,
       "roic": 2.01,
-      "equityMultiplier": 366,
-      "assetTurnover": 11
+      "equityMultiplier": 3.66,
+      "assetTurnover": 0.11
     },
     "margins": [
       {

--- a/public/data/investments/TSLA/snapshot.json
+++ b/public/data/investments/TSLA/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 0.5700000000000001,
       "roa": 0.33999999999999997,
       "roic": 0.6,
-      "equityMultiplier": 168,
-      "assetTurnover": 16
+      "equityMultiplier": 1.68,
+      "assetTurnover": 0.16
     },
     "margins": [
       {

--- a/public/data/investments/TSM/snapshot.json
+++ b/public/data/investments/TSM/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 10.18,
       "roa": 6.9,
       "roic": 8.6,
-      "equityMultiplier": 148,
-      "assetTurnover": 14.000000000000002
+      "equityMultiplier": 1.48,
+      "assetTurnover": 0.14
     },
     "margins": [
       {

--- a/public/data/investments/TXN/snapshot.json
+++ b/public/data/investments/TXN/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 9.35,
       "roa": 4.4799999999999995,
       "roic": 19.08,
-      "equityMultiplier": 209,
-      "assetTurnover": 53
+      "equityMultiplier": 2.09,
+      "assetTurnover": 0.53
     },
     "margins": [
       {

--- a/public/data/investments/UBER/snapshot.json
+++ b/public/data/investments/UBER/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 1.0699999999999998,
       "roa": 0.47000000000000003,
       "roic": 0.83,
-      "equityMultiplier": 227.99999999999997,
-      "assetTurnover": 23
+      "equityMultiplier": 2.28,
+      "assetTurnover": 0.23
     },
     "margins": [
       {

--- a/public/data/investments/UNH/snapshot.json
+++ b/public/data/investments/UNH/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 6.54,
       "roa": 2.02,
       "roic": 9.35,
-      "equityMultiplier": 324,
-      "assetTurnover": 144
+      "equityMultiplier": 3.24,
+      "assetTurnover": 1.44
     },
     "margins": [
       {

--- a/public/data/investments/UNP/snapshot.json
+++ b/public/data/investments/UNP/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 8.98,
       "roa": 2.44,
       "roic": 3.8600000000000003,
-      "equityMultiplier": 368,
-      "assetTurnover": 9
+      "equityMultiplier": 3.68,
+      "assetTurnover": 0.09
     },
     "margins": [
       {

--- a/public/data/investments/UPS/snapshot.json
+++ b/public/data/investments/UPS/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 11.18,
       "roa": 2.48,
       "roic": 4.95,
-      "equityMultiplier": 451,
-      "assetTurnover": 34
+      "equityMultiplier": 4.51,
+      "assetTurnover": 0.34
     },
     "margins": [
       {

--- a/public/data/investments/USB/snapshot.json
+++ b/public/data/investments/USB/snapshot.json
@@ -47,8 +47,8 @@
     "profitability": {
       "roe": 11.35,
       "roa": 1.0699999999999998,
-      "equityMultiplier": 1061,
-      "assetTurnover": 1
+      "equityMultiplier": 10.61,
+      "assetTurnover": 0.01
     },
     "margins": [
       {

--- a/public/data/investments/V/snapshot.json
+++ b/public/data/investments/V/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 16.05,
       "roa": 6.23,
       "roic": 38.379999999999995,
-      "equityMultiplier": 258,
-      "assetTurnover": 45
+      "equityMultiplier": 2.58,
+      "assetTurnover": 0.45
     },
     "margins": [
       {

--- a/public/data/investments/VRTX/snapshot.json
+++ b/public/data/investments/VRTX/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 22.82,
       "roa": 16.64,
       "roic": 20.549999999999997,
-      "equityMultiplier": 137,
-      "assetTurnover": 47
+      "equityMultiplier": 1.37,
+      "assetTurnover": 0.47
     },
     "margins": [
       {

--- a/public/data/investments/VZ/snapshot.json
+++ b/public/data/investments/VZ/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.2399999999999998,
       "roa": 0.59,
       "roic": 1.5,
-      "equityMultiplier": 380,
-      "assetTurnover": 9
+      "equityMultiplier": 3.8,
+      "assetTurnover": 0.09
     },
     "margins": [
       {

--- a/public/data/investments/WDAY/snapshot.json
+++ b/public/data/investments/WDAY/snapshot.json
@@ -51,8 +51,8 @@
       "roe": 3.06,
       "roa": 1.3,
       "roic": 2.35,
-      "equityMultiplier": 235,
-      "assetTurnover": 15
+      "equityMultiplier": 2.35,
+      "assetTurnover": 0.15
     },
     "margins": [
       {

--- a/public/data/investments/WELL/snapshot.json
+++ b/public/data/investments/WELL/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 0.24,
       "roa": 0.15,
       "roic": -1.82,
-      "equityMultiplier": 160,
-      "assetTurnover": 5
+      "equityMultiplier": 1.6,
+      "assetTurnover": 0.05
     },
     "margins": [
       {

--- a/public/data/investments/WFC/snapshot.json
+++ b/public/data/investments/WFC/snapshot.json
@@ -47,8 +47,8 @@
     "profitability": {
       "roe": 11.5,
       "roa": 0.95,
-      "equityMultiplier": 1211,
-      "assetTurnover": 1
+      "equityMultiplier": 12.11,
+      "assetTurnover": 0.01
     },
     "margins": [
       {

--- a/public/data/investments/WM/snapshot.json
+++ b/public/data/investments/WM/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 7.61,
       "roa": 1.6199999999999999,
       "roic": 2.78,
-      "equityMultiplier": 470,
-      "assetTurnover": 14.000000000000002
+      "equityMultiplier": 4.7,
+      "assetTurnover": 0.14
     },
     "margins": [
       {

--- a/public/data/investments/WMT/snapshot.json
+++ b/public/data/investments/WMT/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 4.33,
       "roa": 1.48,
       "roic": 3.45,
-      "equityMultiplier": 293,
-      "assetTurnover": 67
+      "equityMultiplier": 2.93,
+      "assetTurnover": 0.67
     },
     "margins": [
       {

--- a/public/data/investments/XOM/snapshot.json
+++ b/public/data/investments/XOM/snapshot.json
@@ -50,8 +50,8 @@
       "roe": 2.5,
       "roa": 1.44,
       "roic": 2.2399999999999998,
-      "equityMultiplier": 174,
-      "assetTurnover": 18
+      "equityMultiplier": 1.74,
+      "assetTurnover": 0.18
     },
     "margins": [
       {

--- a/public/data/investments/ZTS/snapshot.json
+++ b/public/data/investments/ZTS/snapshot.json
@@ -48,8 +48,8 @@
       "roe": 18.310000000000002,
       "roa": 3.93,
       "roic": 5.319999999999999,
-      "equityMultiplier": 466,
-      "assetTurnover": 62
+      "equityMultiplier": 4.66,
+      "assetTurnover": 0.62
     },
     "margins": [
       {

--- a/src/components/investments/ComparisonMetricTable.tsx
+++ b/src/components/investments/ComparisonMetricTable.tsx
@@ -8,7 +8,8 @@ export interface MetricRow {
   label: string;
   valueA: string | number | null | undefined;
   valueB: string | number | null | undefined;
-  higherIsBetter: boolean;
+  /** `null` for metrics with no meaningful "winner" (e.g. absolute prices). */
+  higherIsBetter: boolean | null;
 }
 
 interface Props {
@@ -26,8 +27,9 @@ function formatValue(v: string | number | null | undefined): string {
 function compareValues(
   a: string | number | null | undefined,
   b: string | number | null | undefined,
-  higherIsBetter: boolean
+  higherIsBetter: boolean | null
 ): "a" | "b" | "tie" | "none" {
+  if (higherIsBetter === null) return "none";
   const numA = typeof a === "number" ? a : parseFloat(String(a ?? ""));
   const numB = typeof b === "number" ? b : parseFloat(String(b ?? ""));
   if (isNaN(numA) || isNaN(numB)) return "none";

--- a/src/components/investments/ComparisonTab.tsx
+++ b/src/components/investments/ComparisonTab.tsx
@@ -312,8 +312,10 @@ export function ComparisonTab() {
   ];
 
   const dcfRows: MetricRow[] = [
-    { label: "DCF Fair Value",   valueA: fmt(dcfA?.fairValue, "currency"),  valueB: fmt(dcfB?.fairValue, "currency"),  higherIsBetter: true },
-    { label: "Current Price",    valueA: fmt(dcfA?.currentPrice, "currency"), valueB: fmt(dcfB?.currentPrice, "currency"), higherIsBetter: false },
+    // Absolute per-share prices aren't comparable across two different
+    // companies, so neither side gets a "better" flag.
+    { label: "DCF Fair Value",   valueA: fmt(dcfA?.fairValue, "currency"),  valueB: fmt(dcfB?.fairValue, "currency"),  higherIsBetter: null },
+    { label: "Current Price",    valueA: fmt(dcfA?.currentPrice, "currency"), valueB: fmt(dcfB?.currentPrice, "currency"), higherIsBetter: null },
     { label: "DCF Upside %",     valueA: fmt(dcfA?.upside, "percent"),      valueB: fmt(dcfB?.upside, "percent"),      higherIsBetter: true },
     { label: "WACC",             valueA: fmt(dcfA?.wacc, "percent"),        valueB: fmt(dcfB?.wacc, "percent"),        higherIsBetter: false },
     { label: "Beta (5Y)",        valueA: fmt(betaA?.beta5y),                valueB: fmt(betaB?.beta5y),                higherIsBetter: false },

--- a/src/components/investments/FinancialStatementsPanel.tsx
+++ b/src/components/investments/FinancialStatementsPanel.tsx
@@ -21,6 +21,7 @@ function formatNum(val: unknown): string {
   const n = typeof val === "number" ? val : Number(val);
   if (isNaN(n)) return String(val ?? "—");
   const abs = Math.abs(n);
+  if (abs >= 1e12) return `${(n / 1e12).toFixed(2)}T`;
   if (abs >= 1e9) return `${(n / 1e9).toFixed(2)}B`;
   if (abs >= 1e6) return `${(n / 1e6).toFixed(2)}M`;
   if (abs >= 1e3) return `${(n / 1e3).toFixed(1)}K`;

--- a/src/components/investments/IndustryPanel.tsx
+++ b/src/components/investments/IndustryPanel.tsx
@@ -3,6 +3,10 @@
 import React from "react";
 import { WarmCard } from "@/components/ui/WarmCard";
 import { useStockData } from "@/hooks/useStockData";
+import {
+  formatComparisonMetricValue,
+  isLowerBetterMetric,
+} from "@/lib/investmentFormatting";
 import type { IndustryData } from "@/types/investment";
 import { ErrorState } from "./ErrorState";
 
@@ -26,19 +30,22 @@ function extractRows(raw: unknown): Row[] {
   }));
 }
 
-function Indicator({ value, avg }: { value: number | undefined; avg: number | undefined }) {
+function Indicator({ metric, value, avg }: { metric: string; value: number | undefined; avg: number | undefined }) {
   if (value === undefined || avg === undefined || isNaN(value) || isNaN(avg)) return null;
   const pct = avg !== 0 ? ((value - avg) / Math.abs(avg)) * 100 : 0;
-  const above = pct > 0;
+  // Whether sitting above the industry average is favorable depends on the
+  // metric: a high P/E reads expensive, a high ROE or margin reads strong.
+  const favorable = isLowerBetterMetric(metric) ? pct < 0 : pct > 0;
+  const tone =
+    pct === 0
+      ? "bg-[var(--home-paper-alt)] text-[var(--home-ink-muted)]"
+      : favorable
+        ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
+        : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+  const sign = pct > 0 ? "+" : pct < 0 ? "−" : "";
   return (
-    <span
-      className={`ml-2 inline-flex items-center text-xs font-medium px-1.5 py-0.5 rounded ${
-        above
-          ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
-          : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
-      }`}
-    >
-      {above ? "+" : ""}{pct.toFixed(1)}% vs industry
+    <span className={`ml-2 inline-flex items-center text-xs font-medium px-1.5 py-0.5 rounded ${tone}`}>
+      {sign}{Math.abs(pct).toFixed(1)}% vs industry
     </span>
   );
 }
@@ -81,13 +88,13 @@ export function IndustryPanel({ symbol }: Props) {
                 <tr key={i} className="border-b border-[var(--home-rule)] last:border-0 hover:bg-[var(--home-paper-alt)] transition-colors">
                   <td className="py-2.5 text-[var(--home-ink-muted)]">{row.metric}</td>
                   <td className="py-2.5 text-right font-medium text-[var(--home-ink)]">
-                    {row.value !== undefined ? row.value.toFixed(2) : "—"}
+                    {formatComparisonMetricValue(row.metric, row.value)}
                   </td>
                   <td className="py-2.5 text-right text-[var(--home-ink-muted)]">
-                    {row.industryAvg !== undefined ? row.industryAvg.toFixed(2) : "—"}
+                    {formatComparisonMetricValue(row.metric, row.industryAvg)}
                   </td>
                   <td className="py-2.5 text-right">
-                    <Indicator value={row.value} avg={row.industryAvg} />
+                    <Indicator metric={row.metric} value={row.value} avg={row.industryAvg} />
                   </td>
                 </tr>
               ))}

--- a/src/components/investments/InvestmentsDashboard.tsx
+++ b/src/components/investments/InvestmentsDashboard.tsx
@@ -134,7 +134,7 @@ export function InvestmentsDashboard({
       },
       { id: "allocation", label: "Allocation", href: "#allocation", icon: IconChartArcs3 },
       { id: "stats", label: "Portfolio stats", href: "#portfolio-stats", icon: IconCircleHalf },
-      { id: "performance", label: "Performance", href: "#hero", icon: IconChartLine },
+      { id: "performance", label: "Performance", href: "#performance", icon: IconChartLine },
       { id: "research", label: "Research", href: "#research-section", icon: IconReportMoney },
       { id: "retirement", label: "Retirement", href: "#retirement", icon: IconPigMoney },
     ],

--- a/src/components/investments/PortfolioHeroCard.tsx
+++ b/src/components/investments/PortfolioHeroCard.tsx
@@ -251,7 +251,7 @@ export function PortfolioHeroCard({
 
   if (isLoading && snapshots.length === 0 && summary.totalValue === 0) {
     return (
-      <div className="invest-hero">
+      <div id="performance" className="invest-hero scroll-mt-28">
         <div className="invest-hero-left">
           <span className="invest-hero-eyebrow">
             <span className="invest-hero-livedot" aria-hidden="true" />
@@ -271,7 +271,7 @@ export function PortfolioHeroCard({
   const dayPositive = summary.dayChange >= 0;
 
   return (
-    <section className="invest-hero" aria-label="Portfolio total value">
+    <section id="performance" className="invest-hero scroll-mt-28" aria-label="Portfolio total value">
       <div className="invest-hero-left">
         <span className="invest-hero-eyebrow">
           <span className="invest-hero-livedot" aria-hidden="true" />

--- a/src/components/investments/PortfolioStatsGrid.tsx
+++ b/src/components/investments/PortfolioStatsGrid.tsx
@@ -238,7 +238,7 @@ export function PortfolioStatsGrid({ summary, holdings }: Props) {
         <a href="#holdings-list" className="invest-ghost">
           Per-position detail
         </a>
-        <a href="#hero" className="invest-ghost">
+        <a href="#performance" className="invest-ghost">
           Performance over time
         </a>
         <a href="#add-holding" className="invest-ghost">

--- a/src/components/investments/ProfitabilityPanel.tsx
+++ b/src/components/investments/ProfitabilityPanel.tsx
@@ -9,9 +9,9 @@ import { MetricTooltip } from "./MetricTooltip";
 
 interface Props { symbol: string }
 
-function fmt(n: number | undefined): string {
+function fmt(n: number | undefined, unit: "percent" | "ratio" = "percent"): string {
   if (n === undefined || n === null || isNaN(n)) return "—";
-  return `${n.toFixed(2)}%`;
+  return unit === "ratio" ? `${n.toFixed(2)}×` : `${n.toFixed(2)}%`;
 }
 
 function Bar({ value, max = 100 }: { value: number | undefined; max?: number }) {
@@ -31,7 +31,17 @@ function Bar({ value, max = 100 }: { value: number | undefined; max?: number }) 
   );
 }
 
-function MetricRow({ label, value, max }: { label: string; value: number | undefined; max?: number }) {
+function MetricRow({
+  label,
+  value,
+  max,
+  unit = "percent",
+}: {
+  label: string;
+  value: number | undefined;
+  max?: number;
+  unit?: "percent" | "ratio";
+}) {
   const positive = (value ?? 0) >= 0;
   return (
     <div className="flex items-center gap-3 py-2 border-b border-[var(--home-rule)] last:border-0">
@@ -45,7 +55,7 @@ function MetricRow({ label, value, max }: { label: string; value: number | undef
           positive ? "text-[var(--color-success)]" : "text-[var(--color-error)]"
         }`}
       >
-        {fmt(value)}
+        {fmt(value, unit)}
       </span>
     </div>
   );
@@ -77,8 +87,8 @@ export function ProfitabilityPanel({ symbol }: Props) {
               <MetricRow label="Return on Equity (ROE)" value={prof.roe} max={50} />
               <MetricRow label="Return on Assets (ROA)" value={prof.roa} max={30} />
               <MetricRow label="Return on Inv. Capital" value={prof.roic} max={40} />
-              <MetricRow label="Asset Turnover" value={prof.assetTurnover} max={3} />
-              <MetricRow label="Equity Multiplier" value={prof.equityMultiplier} max={10} />
+              <MetricRow label="Asset Turnover" value={prof.assetTurnover} max={2} unit="ratio" />
+              <MetricRow label="Equity Multiplier" value={prof.equityMultiplier} max={10} unit="ratio" />
             </div>
           )}
 

--- a/src/components/investments/ResearchAssetHeader.tsx
+++ b/src/components/investments/ResearchAssetHeader.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import {
-  IconBookmark,
   IconExternalLink,
   IconFileText,
   IconPlus,
@@ -329,11 +328,7 @@ export function ResearchAssetHeader({
         <div className="research-asset-meta">
           <div className="research-asset-titleline">
             <h1>{displayName}</h1>
-            <span className="research-ticker-pill">
-              {upper}
-              {info?.industry || info?.sector ? " · " : null}
-              {info?.industry || info?.sector || ""}
-            </span>
+            <span className="research-ticker-pill">{upper}</span>
             {isInPortfolio ? (
               <span className="research-badge-pill held">
                 Held
@@ -428,13 +423,6 @@ export function ResearchAssetHeader({
         >
           <IconFileText size={14} aria-hidden="true" />
           SEC filings
-        </a>
-        <a
-          href="#thesis-notes"
-          className="invest-ghost"
-        >
-          <IconBookmark size={14} aria-hidden="true" />
-          Research notes
         </a>
         <span className="invest-ghost research-asset-actions-clock" aria-hidden="true">
           <IconRefresh size={14} aria-hidden="true" />

--- a/src/components/investments/ResearchOverview.tsx
+++ b/src/components/investments/ResearchOverview.tsx
@@ -112,7 +112,7 @@ function buildSignals({
         dcf.upside >= 15
           ? `Model implies ${formatPercent(dcf.upside, true)} upside.`
           : dcf.upside <= -10
-            ? `Model implies ${formatPercent(dcf.upside, true)} downside.`
+            ? `Model implies ${formatPercent(Math.abs(dcf.upside))} downside.`
             : `Model sits near fair value at ${formatPercent(dcf.upside, true)}.`,
     });
   }

--- a/src/components/investments/ResearchSection.tsx
+++ b/src/components/investments/ResearchSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { ResearchAssetHeader } from "./ResearchAssetHeader";
 import { ResearchPosition } from "./ResearchPosition";
@@ -19,12 +19,10 @@ import {
 } from "./animations";
 import { useStockData } from "@/hooks/useStockData";
 import { useTablistKeyboard } from "@/hooks/useTablistKeyboard";
-import { getClientInvestmentsIndex } from "@/lib/investmentsClientData";
 import type {
   CompanyInfo,
   EnhancedHolding,
   InvestmentCapabilities,
-  InvestmentsIndex,
 } from "@/types/investment";
 import type { ResearchTab } from "@/app/investments/investments-state";
 
@@ -78,7 +76,6 @@ export function ResearchSection({
   portfolioSymbols = [],
   position = null,
 }: Props) {
-  const [, setDatasetLastUpdated] = useState<string | null>(null);
   const shouldReduceMotion = useReducedMotion();
   const {
     error: symbolError,
@@ -89,14 +86,6 @@ export function ResearchSection({
   } = useStockData<CompanyInfo>(symbol || null, "info");
 
   const v = shouldReduceMotion ? getReducedMotionVariants() : { fadeInVariants };
-
-  useEffect(() => {
-    getClientInvestmentsIndex()
-      .then((data: InvestmentsIndex) => {
-        if (data.lastUpdated) setDatasetLastUpdated(data.lastUpdated);
-      })
-      .catch(() => {});
-  }, []);
 
   const hasResearchContext = source !== null && !symbolError;
   const visibleTabs = useMemo(

--- a/src/components/investments/StockSearch.tsx
+++ b/src/components/investments/StockSearch.tsx
@@ -292,8 +292,8 @@ className="m-0 list-none p-0 box-border overflow-hidden rounded-2xl border borde
                   onMouseDown={() => selectEntry(entry)}
                   className={`flex min-h-[52px] w-full flex-col items-start justify-center px-3 py-2 text-left text-sm transition ${
                     indexPosition === activeIndex
-                      ? "bg-[var(--home-paper-alt)] text-[var(--home-ink)]"
-                      : "text-[var(--home-ink)] hover:bg-[var(--home-paper-alt)]"
+                      ? "bg-[color-mix(in_srgb,var(--home-haze)_14%,var(--home-paper-alt))] text-[var(--home-ink)]"
+                      : "text-[var(--home-ink)] hover:bg-[color-mix(in_srgb,var(--home-ink)_6%,var(--home-paper-alt))]"
                   }`}
                 >
                   <span className="font-semibold">{entry.symbol}</span>

--- a/src/components/investments/ValuationRatiosPanel.tsx
+++ b/src/components/investments/ValuationRatiosPanel.tsx
@@ -3,6 +3,10 @@
 import React from "react";
 import { WarmCard } from "@/components/ui/WarmCard";
 import { useStockData } from "@/hooks/useStockData";
+import {
+  formatComparisonMetricValue,
+  isLowerBetterMetric,
+} from "@/lib/investmentFormatting";
 import type { BetaData, DcfData, Fundamentals, IndustryData, WaccData } from "@/types/investment";
 import { ErrorState } from "./ErrorState";
 import { MetricTooltip } from "./MetricTooltip";
@@ -19,35 +23,37 @@ interface IndustryRow {
   [key: string]: unknown;
 }
 
-function fmt(n: number | undefined): string {
-  if (n === undefined || n === null || isNaN(n)) return "—";
-  return n.toFixed(2);
-}
-
 function CompareRow({ label, value, industryAvg }: { label: string; value: number | undefined; industryAvg: number | undefined }) {
   const hasComparison = value !== undefined && industryAvg !== undefined && !isNaN(value) && !isNaN(industryAvg);
-  const better = hasComparison ? value <= industryAvg : null; // lower P/E = better (rule of thumb)
+  const isAbove = hasComparison && value > industryAvg;
+  // Favorable side depends on the metric: below-average P/E reads cheap, but
+  // below-average ROE or margin is a weakness.
+  const favorable = hasComparison
+    ? isLowerBetterMetric(label)
+      ? !isAbove
+      : value >= industryAvg
+    : null;
   return (
     <div className="flex items-center gap-3 py-2.5 border-b border-[var(--home-rule)] last:border-0">
       <span className="text-sm text-[var(--home-ink-muted)] flex-1">{label}</span>
       <div className="flex items-center gap-4 shrink-0">
         <div className="text-right">
           <p className="text-xs text-[var(--home-ink-soft)]">Stock</p>
-          <p className="text-sm font-semibold text-[var(--home-ink)]">{fmt(value)}</p>
+          <p className="text-sm font-semibold text-[var(--home-ink)]">{formatComparisonMetricValue(label, value)}</p>
         </div>
         <div className="text-right">
           <p className="text-xs text-[var(--home-ink-soft)]">Industry</p>
-          <p className="text-sm text-[var(--home-ink-muted)]">{fmt(industryAvg)}</p>
+          <p className="text-sm text-[var(--home-ink-muted)]">{formatComparisonMetricValue(label, industryAvg)}</p>
         </div>
         {hasComparison && (
           <span
             className={`text-xs font-medium px-1.5 py-0.5 rounded ${
-              better
+              favorable
                 ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
                 : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
             }`}
           >
-            {better ? "Below" : "Above"}
+            {isAbove ? "Above" : "Below"}
           </span>
         )}
       </div>
@@ -168,6 +174,8 @@ export function ValuationRatiosPanel({
             value={
               fundamentals?.marketCap !== undefined
                 ? new Intl.NumberFormat("en-US", {
+                    style: "currency",
+                    currency: "USD",
                     notation: "compact",
                     maximumFractionDigits: 2,
                   }).format(fundamentals.marketCap)

--- a/src/components/investments/retirement/RetirementLevers.tsx
+++ b/src/components/investments/retirement/RetirementLevers.tsx
@@ -33,8 +33,8 @@ function LeverRow({ lever, threshold }: { lever: LeverEffect; threshold: number 
         </div>
         <span className="invest-retire-lever-delta" style={{ color: tone }}>
           <DeltaIcon delta={lever.delta} />
-          {pp > 0 ? "+" : ""}
-          {pp} pp
+          {pp > 0 ? "+" : pp < 0 ? "−" : ""}
+          {Math.abs(pp)} pp
         </span>
       </div>
       <p className="invest-retire-lever-desc">{lever.description}</p>

--- a/src/lib/__tests__/investmentSnapshot.test.ts
+++ b/src/lib/__tests__/investmentSnapshot.test.ts
@@ -110,6 +110,13 @@ describe("buildInvestmentSnapshot", () => {
       },
     });
     expect(snapshot.sections.fundamentals).toMatchObject({ ttmPe: 28.4 });
+    // Return metrics are scaled from fractions to percentage units; the equity
+    // multiplier and asset turnover are plain ratios and pass through as-is.
+    expect(snapshot.sections.profitability).toMatchObject({
+      roe: 33,
+      equityMultiplier: 2.7,
+      assetTurnover: 0.8,
+    });
     expect(prices[0]).toMatchObject({
       date: "2025-02-18",
       close: 148,

--- a/src/lib/investmentFormatting.ts
+++ b/src/lib/investmentFormatting.ts
@@ -33,6 +33,30 @@ export function formatPercent(n: number): string {
 }
 
 /**
+ * Whether a lower value is the favorable side for an industry-comparison
+ * metric. Valuation multiples (P/E, P/S, P/B, PEG) and discount/risk rates
+ * read "cheaper/safer is better"; profitability and growth metrics read
+ * "higher is better".
+ */
+export function isLowerBetterMetric(label: string): boolean {
+  return /p\/e|p\/s|p\/b|peg|wacc|beta/i.test(label);
+}
+
+/** Whether an industry-comparison metric is expressed in percentage units. */
+export function isPercentMetric(label: string): boolean {
+  return /margin|\broe\b|\broa\b|\broic\b|growth|yield|upside|wacc/i.test(label);
+}
+
+/**
+ * `37.18` for ratio metrics, `26.60%` for percentage metrics, `—` for missing
+ * values — keeps the industry-comparison tables honest about units.
+ */
+export function formatComparisonMetricValue(label: string, n: number | undefined): string {
+  if (n === undefined || n === null || !Number.isFinite(n)) return "—";
+  return isPercentMetric(label) ? `${n.toFixed(2)}%` : n.toFixed(2);
+}
+
+/**
  * Splits a balance into a whole-dollar part and a cents part so the hero card
  * can render them at different type sizes (e.g. `$12,345` + `.67`).
  */

--- a/src/lib/investmentTransforms.ts
+++ b/src/lib/investmentTransforms.ts
@@ -75,14 +75,17 @@ export function transformSection(section: string, raw: unknown): unknown {
     const roe = latest(d.roe, "roe");
     const roa = latest(d.roa, "roa");
     const roic = latest(d.roic, "roic");
+    // Equity multiplier and asset turnover are plain ratios (e.g. 3.9×, 0.8×),
+    // not fractions of one — unlike the return metrics, they must not be
+    // scaled to percentage units.
     const equityMultiplier = latest(d.equityMultiplier, "equity_multiplier");
     const assetTurnover = latest(d.assetTurnover, "asset_turnover");
     return {
       roe: roe !== undefined ? roe * 100 : undefined,
       roa: roa !== undefined ? roa * 100 : undefined,
       roic: roic !== undefined ? roic * 100 : undefined,
-      equityMultiplier: equityMultiplier !== undefined ? equityMultiplier * 100 : undefined,
-      assetTurnover: assetTurnover !== undefined ? assetTurnover * 100 : undefined,
+      equityMultiplier,
+      assetTurnover,
     };
   }
 


### PR DESCRIPTION
## Summary

Audit of `/investments` for things that don't work or render poorly. Every fix below was root-caused in the code (and verified against the committed snapshot data where relevant).

### Data bugs

- **Equity Multiplier showed "386.00%", Asset Turnover "30.00%"** — `transformSection("profitability")` multiplied these plain ratios by 100 as if they were fractional return metrics like ROE. The transform now passes them through unscaled, and the Profitability panel renders them as ratios (`3.86×`, `0.30×`) instead of percentages. All 150 committed `snapshot.json` files were regenerated: the 83 symbols with raw section files were rebuilt through `buildInvestmentSnapshot` (preserving each symbol's original `lastUpdated` so freshness badges stay honest), and the 67 snapshot-only symbols had the two fields divided back by 100 in place. The diff across `public/data/investments` touches exactly those two fields and nothing else.

### Backwards/misleading comparisons

- **Industry comparison colored "above average" red for every metric** — correct for P/E but backwards for ROE, ROA, and margins (where above-average is a strength). Both `IndustryPanel` and `ValuationRatiosPanel` now share direction-aware helpers in `investmentFormatting.ts`. The badge text still states the factual position (Above/Below); only the good/bad color flips per metric type.
- **Industry tables were unitless** — Net Margin rendered as bare `26.60` next to P/E `37.18`. Percent metrics now carry a `%` suffix in both panels.
- **Compare tab flagged a "winner" on DCF Fair Value / Current Price** — absolute per-share prices aren't comparable across two companies. `higherIsBetter` is now nullable and those rows opt out of the winner highlight.

### Broken navigation / interaction

- **Dead "Research notes" action** — linked to `#thesis-notes`, which doesn't exist anywhere in the app. Removed.
- **Sidebar "Performance" scrolled to the same place as "Overview"** (`#hero`) — the hero performance chart section now has its own `#performance` anchor, used by the nav item and the stats-grid footer link.
- **Stock search keyboard highlight was invisible** — the active suggestion used the same background as the dropdown itself (and hover did too). Both now use visible `color-mix` tints.

### Formatting polish

- Asset header repeated the industry inside the ticker pill and again as a tag pill — the pill now shows just the ticker.
- Standalone Market Cap metric dropped the `$` (showed `4.51T` instead of `$4.51T`).
- Financial statement tables had no trillions tier (a $4T balance-sheet line rendered as `4100.00B`).
- "Model implies −12.0% downside" double negative → "implies 12.0% downside".
- Two spots rendered negatives with ASCII hyphens instead of the repo's U+2212 minus convention (retirement levers, industry delta chip).
- Removed a dead state + effect in `ResearchSection` that fetched the investments index into never-read state on every mount.

## Verification

- Full Jest suite: 164 suites / 781 tests pass.
- `tsc --noEmit` and ESLint clean on changed files.
- Added test assertions pinning the corrected profitability transform (returns scale to %, ratios pass through).

## Notes for reviewer

- `StockResearch.tsx`, `PortfolioPerformanceChart.tsx`, `Sparkline.tsx`, and `InvestmentsFreshnessBanner.tsx` are dead components (only referenced by tests or type imports). Left untouched here to keep the diff focused — happy to remove them in a follow-up.
- 67 symbols (e.g. SBUX, DIS, CVX) have no raw section files in the repo (pre-dating the "keep raw files" change), so `npm run update:investments`'s build step would currently crash on them without a fresh Python fetch. Not addressed here, flagging for awareness.

https://claude.ai/code/session_01EpNCi8aYMhZ1mtH11Bj93Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpNCi8aYMhZ1mtH11Bj93Z)_