### PR TITLE
style: clean up fantasy football layout and chip alignment

### DIFF
--- a/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState, type CSSProperties } from "react";
 import { Player, TeamRoster } from "@/types";
 import type { FantasySnapshot } from "@/lib/fantasy";
 import { useDebounce } from "@/hooks/useDebounce";
-import { formatRange, formatRankValue, getPositionTone } from "@/lib/fantasyUtils";
+import { FANTASY_CHIP_CLASS, formatRange, formatRankValue, getPositionTone } from "@/lib/fantasyUtils";
 import { DraftTierColumns } from "./DraftTierColumns";
 
 interface DraftBoardProps {
@@ -186,7 +186,7 @@ export function DraftBoard({
           {rosterNeeds.slice(0, 3).map((need) => (
             <span
               key={`need-${need}`}
-              className="inline-flex min-h-[36px] items-center rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em]"
+              className={FANTASY_CHIP_CLASS}
               style={{
                 borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
                 background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
@@ -278,7 +278,7 @@ export function DraftBoard({
                 return (
                   <div
                     key={player.id}
-                    className="grid gap-4 rounded-[1.5rem] border px-4 py-4 sm:grid-cols-[72px_minmax(0,1.45fr)_110px_140px_auto] sm:items-center"
+                    className="grid gap-4 rounded-[1.5rem] border px-4 py-3 sm:grid-cols-[72px_minmax(0,1.45fr)_110px_140px_auto] sm:items-center"
                     style={{
                       borderColor: "var(--home-rule)",
                       background: "color-mix(in srgb, var(--home-paper-alt) 42%, var(--home-elev-mix))",
@@ -293,14 +293,14 @@ export function DraftBoard({
                       <div className="flex flex-wrap items-center gap-2">
                         <p className="truncate text-base font-semibold">{player.name}</p>
                         <span
-                          className="inline-flex min-h-[32px] items-center rounded-full border px-2.5 py-1 text-2xs font-semibold uppercase tracking-[0.12em]"
+                          className={FANTASY_CHIP_CLASS}
                           style={getPositionTone(player.position)}
                         >
                           {player.position}
                         </span>
                         {fitsCurrentNeed && (
                           <span
-                            className="inline-flex min-h-[32px] items-center rounded-full border px-2.5 py-1 text-2xs font-semibold uppercase tracking-[0.12em]"
+                            className={FANTASY_CHIP_CLASS}
                             style={{
                               borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
                               background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",

--- a/src/app/fantasy-football/draft-tracker/components/DraftTierColumns.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftTierColumns.tsx
@@ -7,7 +7,7 @@ import {
   type FantasyRoutePosition,
   type FantasySnapshot,
 } from "@/lib/fantasy";
-import { formatRankValue, getPositionTone } from "@/lib/fantasyUtils";
+import { FANTASY_CHIP_CLASS, formatRankValue, getPositionTone } from "@/lib/fantasyUtils";
 import type { Player } from "@/types";
 
 interface DraftTierColumnsProps {
@@ -157,14 +157,14 @@ export function DraftTierColumns({
             >
               <div className="flex items-center gap-2">
                 <span
-                  className="inline-flex min-h-[28px] items-center rounded-full border px-2.5 py-1 text-2xs font-semibold uppercase tracking-[0.12em]"
+                  className={FANTASY_CHIP_CLASS}
                   style={getPositionTone(column.label)}
                 >
                   {column.label}
                 </span>
                 {isNeed && (
                   <span
-                    className="inline-flex min-h-[28px] items-center rounded-full border px-2.5 py-1 text-2xs font-semibold uppercase tracking-[0.12em]"
+                    className={FANTASY_CHIP_CLASS}
                     style={{
                       borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
                       background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
@@ -181,7 +181,7 @@ export function DraftTierColumns({
 
             {isCliff && topGroup.tier !== "untiered" && (
               <p
-                className="mt-3 inline-flex items-center self-start rounded-full border px-2.5 py-1 text-2xs font-semibold uppercase tracking-[0.12em]"
+                className={`mt-3 self-start ${FANTASY_CHIP_CLASS}`}
                 style={{
                   borderColor: "color-mix(in srgb, var(--color-warning) 32%, var(--home-rule))",
                   background: "color-mix(in srgb, var(--color-warning) 12%, var(--home-paper))",

--- a/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
+++ b/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
@@ -109,8 +109,8 @@ export function DraftTrackerClient() {
   }
 
   return (
-    <section className="home-page min-h-screen">
-      <div className="home-shell home-section space-y-5 sm:space-y-6">
+    <section className="home-page home-dash min-h-screen">
+      <div className="home-shell home-shell-wide home-section space-y-4 sm:space-y-5">
         <Breadcrumbs customItems={DRAFT_TRACKER_BREADCRUMBS} className="pt-2" />
         <div className="space-y-4">
           <div className="space-y-3">
@@ -139,7 +139,7 @@ export function DraftTrackerClient() {
 
           <div className="flex flex-wrap gap-2 text-sm">
             <span
-              className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 font-medium"
+              className="inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium"
               style={{
                 borderColor: "var(--home-rule)",
                 background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
@@ -148,7 +148,7 @@ export function DraftTrackerClient() {
               {metadata ? `${metadata.season} ${getFantasyWeekLabel(metadata.week)}` : "Loading snapshot"}
             </span>
             <span
-              className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 font-medium"
+              className="inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium"
               style={{
                 borderColor: "var(--home-rule)",
                 background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
@@ -157,7 +157,7 @@ export function DraftTrackerClient() {
               Source updated {formatUpdatedAt(overallSliceMetadata?.updatedAt ?? metadata?.upstreamUpdatedAt)}
             </span>
             <span
-              className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 font-medium"
+              className="inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium"
               style={{
                 borderColor: "var(--home-rule)",
                 background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
@@ -166,7 +166,7 @@ export function DraftTrackerClient() {
               Built {formatUpdatedAt(metadata?.generatedAt)}
             </span>
             <span
-              className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 font-medium"
+              className="inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium"
               style={{
                 borderColor: "var(--home-rule)",
                 background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
@@ -205,7 +205,7 @@ export function DraftTrackerClient() {
           </article>
         )}
 
-        <div className="grid gap-5 lg:grid-cols-[minmax(0,1.18fr)_minmax(18rem,22rem)]">
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1.18fr)_minmax(18rem,22rem)] min-[1440px]:grid-cols-[minmax(0,1.2fr)_minmax(20rem,26rem)]">
           <div className="grid gap-5">
             <article className="home-card p-5 sm:p-6">
               <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]">

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -15,6 +15,7 @@ import {
   getFantasyWeekLabel,
 } from "@/lib/fantasy";
 import {
+  FANTASY_CHIP_CLASS,
   formatOwnership,
   formatRange,
   formatRankValue,
@@ -296,20 +297,20 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
   // since the cells stack into a single column.
   const rowClassName = isCompact
     ? "grid gap-x-4 gap-y-1 rounded-[1.25rem] border px-4 py-2.5 md:grid-cols-[56px_minmax(0,1.6fr)_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1fr)] md:items-center"
-    : "grid gap-4 rounded-[1.5rem] border px-4 py-4 md:grid-cols-[64px_minmax(0,1.6fr)_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1fr)] md:items-center";
+    : "grid gap-4 rounded-[1.5rem] border px-4 py-3 md:grid-cols-[64px_minmax(0,1.6fr)_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1fr)] md:items-center";
   const rankValueClassName = isCompact
     ? "text-xl font-semibold tabular-nums"
     : "text-2xl font-semibold tabular-nums";
   const cellLabelClassName = isCompact ? "home-kicker mb-1 md:hidden" : "home-kicker mb-1";
-  const skeletonHeightClass = isCompact ? "h-[68px]" : "h-[104px]";
+  const skeletonHeightClass = isCompact ? "h-[76px]" : "h-[96px]";
 
   return (
     <section
-      className="home-page min-h-screen"
+      className="home-page home-dash min-h-screen"
       aria-label="Fantasy football rankings"
       data-testid="fantasy-football-shell"
     >
-      <div className="home-shell home-section space-y-5 sm:space-y-6">
+      <div className="home-shell home-shell-wide home-section space-y-4 sm:space-y-5">
         <motion.div
           className="space-y-4 pt-2"
           variants={variants}
@@ -367,7 +368,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
           </article>
         )}
 
-        <div className="grid gap-5 lg:grid-cols-[minmax(0,1.18fr)_minmax(18rem,22rem)]">
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1.18fr)_minmax(18rem,22rem)] min-[1440px]:grid-cols-[minmax(0,1.2fr)_minmax(20rem,26rem)]">
           <div className="grid gap-5">
             <article className="home-card p-5 sm:p-6">
               <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_18rem]">
@@ -641,7 +642,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                           <div className="flex flex-wrap items-center gap-2">
                             <p className="truncate text-base font-semibold">{player.name}</p>
                             <span
-                              className="inline-flex min-h-[32px] items-center rounded-full border px-2.5 py-1 text-2xs font-semibold uppercase tracking-[0.12em]"
+                              className={FANTASY_CHIP_CLASS}
                               style={getPositionTone(player.position)}
                             >
                               {player.position}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -792,6 +792,25 @@
     color: var(--home-ink);
   }
 
+  /*
+   * Data-dashboard opt-out: inside a dashboard surface, paragraphs and lists
+   * are UI labels, values, and rows — not prose — so the base typography
+   * margins (p margin-bottom, ul padding/margins) only add phantom space.
+   * Margin/padding utilities still win via the utilities layer.
+   */
+  .home-dash p {
+    margin-bottom: 0;
+    max-inline-size: none;
+  }
+  .home-dash ul,
+  .home-dash ol {
+    margin-bottom: 0;
+    padding-left: 0;
+  }
+  .home-dash li {
+    margin-bottom: 0;
+  }
+
   .home-shell,
   .home-shell-tight,
   .home-shell-narrow {
@@ -812,8 +831,10 @@
     max-width: 76rem;
   }
 
-  /* Investments dashboard density override: widen past .home-shell on xl+ screens. */
+  /* Wide data-dashboard override: widen past .home-shell on xl+ screens.
+     .home-shell-investments is the legacy alias; prefer .home-shell-wide. */
   @media (min-width: 1440px) {
+    .home-shell.home-shell-wide,
     .home-shell.home-shell-investments {
       max-width: 1680px;
     }

--- a/src/components/fantasy/TierBreakdown.tsx
+++ b/src/components/fantasy/TierBreakdown.tsx
@@ -146,7 +146,7 @@ export function TierBreakdown({ players, position, getPublishedRank }: TierBreak
                     }}
                   >
                     <span
-                      className="inline-flex min-w-[2rem] items-center justify-center rounded-full border px-2 py-0.5 text-2xs font-semibold"
+                      className="inline-flex min-w-[2rem] items-center justify-center rounded-full border px-2 py-0.5 text-2xs font-semibold tabular-nums"
                       style={getPositionTone(player.position)}
                       aria-hidden="true"
                     >

--- a/src/lib/fantasyUtils.ts
+++ b/src/lib/fantasyUtils.ts
@@ -77,6 +77,13 @@ export function formatOwnership(ownership: number | undefined): string {
   return `${ownership?.toFixed(1)}%`;
 }
 
+/**
+ * Natural-height label chip shared across fantasy surfaces (matches the /nfl
+ * badge recipe). Interactive pills keep min-h-[44px] separately for touch targets.
+ */
+export const FANTASY_CHIP_CLASS =
+  "inline-flex items-center rounded-full border px-2.5 py-1 text-2xs font-semibold uppercase tracking-[0.12em]";
+
 export function getPositionTone(position: string): CSSProperties {
   switch (position) {
     case "QB":


### PR DESCRIPTION
## Summary

Cleans up the `/fantasy-football` and `/fantasy-football/draft-tracker` formatting: less empty space, the page now stretches on wide screens, and the inline chips/badges are aligned consistently.

### Width
- New generic `.home-shell-wide` widens the shell to 1680px on ≥1440px screens (the investments-only override is folded into the same rule, no behavior change there). Applied to both fantasy pages, with the sidebar column widening at the same breakpoint.

### Empty space
- New `.home-dash` opt-out neutralizes the base prose typography margins (`p { margin-bottom: 1.25em }`, `ul/li` margins and the 1.5em list indent) inside dashboard surfaces, where paragraphs are labels/values rather than prose. Comfortable rankings rows drop from ~137px to ~95px of measured height, and the stray indent on the rankings list is gone. Margin utilities (`mb-*`) still win via the utilities layer, so existing kicker spacing is unaffected.
- Comfortable row padding tightened (`py-4` → `py-3`), loading skeleton heights re-matched to the measured row heights (96px comfortable / 76px compact), and the page rhythm tightened one step.

### Chip alignment
- All non-interactive badges (position, Priority, Need, tier-cliff) now share one natural-height recipe — `FANTASY_CHIP_CLASS` in `src/lib/fantasyUtils.ts`, identical to the `/nfl` badge — replacing the mixed `min-h-[28/32/36px]` variants that misaligned next to player names.
- Interactive pills/toggles keep their 44px+ touch targets.
- Draft-tracker hero meta chips restyled as tags instead of 44px button look-alikes; tier rank badges get `tabular-nums`.

## Testing
- `npm run lint` clean; full Jest suite passes (164 suites / 781 tests); production build succeeds.
- Visually verified via headless Chromium at 1280/1920px, light + dark: rankings list (both densities), tiers view, draft tracker setup, best-available board, and tier columns.
- Playwright e2e could not run in this environment (browser download blocked by the network allowlist) — worth a CI run.

https://claude.ai/code/session_017DcWFZUtBC68tse4fDKVMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017DcWFZUtBC68tse4fDKVMJ)_