### PR TITLE
content: bring the changelog current through June 10

### DIFF
--- a/content/changelog/2026-04-26-editorial-v3-redesign.mdx
+++ b/content/changelog/2026-04-26-editorial-v3-redesign.mdx
@@ -1,0 +1,18 @@
+---
+title: Editorial V3 — home, writing, and investments from the design handoff
+publishedAt: "2026-04-26"
+category: Design
+summary: Rolled out the V3 editorial design system across the homepage hero, the writing archive layout, and a rebuilt three-column investments dashboard.
+tags:
+  - design
+  - home
+  - investments
+---
+
+The biggest visual change in a while. The V3 editorial design handoff landed across three surfaces at once:
+
+- **Homepage hero** — a new editorial hero with proper rhythm and stretch baked into the spotlight board.
+- **Writing archive** — the [writing index](/writing) moved to the editorial archive layout from the handoff.
+- **Investments dashboard** — [investments](/investments) merged portfolio and research into one three-column shell, with a hero balance card, a dense key-metrics grid, and an asset header that drops the old bio in favor of the numbers you actually want.
+
+The goal was a single coherent system instead of a few pages that each looked slightly different. Everything since has been built to match it.

--- a/content/changelog/2026-04-29-dashboard-launch-wave.mdx
+++ b/content/changelog/2026-04-29-dashboard-launch-wave.mdx
@@ -1,0 +1,24 @@
+---
+title: Nine launches in one wave
+publishedAt: "2026-04-29"
+category: Launch
+summary: Four new sports and data dashboards plus five personal tools shipped over two days, from NBA and MLB Pulse to a wine cellar and a museum log.
+tags:
+  - dashboards
+  - launch
+---
+
+The snapshot-driven pattern that started with the Premier League dashboard turned out to scale, so I leaned into it. Over two days the dashboard family grew by a lot:
+
+- **[NBA](/nba)**, **[MLB](/mlb)**, and **[NFL](/nfl)** dashboards — same pattern, three leagues. Standings, fixtures, and stat leaders, refreshed by scheduled jobs from ESPN, the MLB Stats API, and NFLverse data.
+- **[GitHub Trending Pulse](/github-trending-pulse)** — what's moving on GitHub, built from the public search API.
+- **[Frontier Model Tracker](/frontier-models)** — an editorially curated view of the frontier AI model landscape.
+
+And a set of personal tools that have nothing to do with sports:
+
+- **[Food Map](/food-map)** — a curated map of my Austin restaurant list.
+- **[Wine Cellar](/wine-cellar)** — a wine reviewing app.
+- **[Museum Log](/museum-log)** — a Letterboxd-style tracker for museum visits.
+- **[Recipe Finder](/recipe-finder)** — ingredient-based recipe search.
+
+The common thread is that each one reads from a committed snapshot or curated dataset, so there are no live API calls at runtime and nothing to babysit.

--- a/content/changelog/2026-05-04-travel-planner.mdx
+++ b/content/changelog/2026-05-04-travel-planner.mdx
@@ -1,0 +1,13 @@
+---
+title: Travel planner
+publishedAt: "2026-05-04"
+category: Launch
+summary: A new /travel surface for planning trips with day-by-day itineraries and a per-trip journal. Everything stays in your browser.
+tags:
+  - travel
+  - launch
+---
+
+Launched the [travel planner](/travel) — trips, day-by-day itineraries, and a per-trip journal in one place.
+
+There is no backend and no account. State lives entirely in localStorage, the same approach the investments portfolio uses. I wanted a planning tool I would actually open the night before a trip, not another app asking me to sign up.

--- a/content/changelog/2026-05-31-about-portfolio-refresh.mdx
+++ b/content/changelog/2026-05-31-about-portfolio-refresh.mdx
@@ -1,0 +1,18 @@
+---
+title: About and portfolio refresh, plus quieter maintenance
+publishedAt: "2026-05-31"
+category: Update
+summary: Refreshed the about and portfolio surfaces, added shared stats panels to the homepage and writing archive, and hardened the sports data modules.
+tags:
+  - about
+  - portfolio
+---
+
+May was a slower month on purpose, but a few things still landed:
+
+- **About and portfolio refresh** — both surfaces got a content and layout pass to match where the site actually is now.
+- **`HomeStatsPanel`** — a shared stats panel component now feeds the homepage and the writing archive, so live numbers render the same way everywhere.
+- **Data hardening** — player ID validation and snapshot handling got tightened across the sports modules, and NBA player stats moved to a newer ESPN endpoint.
+- **Copy alignment** — UI text across the site was brought in line with the writing voice rules.
+
+The kind of month that doesn't demo well but makes the next month possible.

--- a/content/changelog/2026-06-08-fantasy-suite-upgrades.mdx
+++ b/content/changelog/2026-06-08-fantasy-suite-upgrades.mdx
@@ -1,0 +1,17 @@
+---
+title: Fantasy Formula 1 optimizer and a sharper draft board
+publishedAt: "2026-06-08"
+category: Feature
+summary: A new fantasy F1 lineup optimizer launched alongside a tier-grouped draft board view and a denser, more scannable rankings list.
+tags:
+  - fantasy
+  - formula-1
+---
+
+A run of fantasy upgrades across two sports:
+
+- **[Fantasy Formula 1 optimizer](/fantasy-formula-1)** — builds lineups from the same snapshot the F1 dashboard uses, with versioned browser-local storage for your saved teams.
+- **Tier-grouped draft board** — the [draft tracker](/fantasy-football/draft-tracker) gained a position-column board view grouped by tier, which is how I actually think during a draft.
+- **Denser rankings** — the [rankings page](/fantasy-football) picked up a list density toggle, a sticky board header, and compact rows.
+
+The football side also got a findability and data-robustness pass, with more honest framing on where the numbers come from.

--- a/content/changelog/2026-06-08-food-map-multi-city.mdx
+++ b/content/changelog/2026-06-08-food-map-multi-city.mdx
@@ -1,0 +1,16 @@
+---
+title: Food map goes multi-city
+publishedAt: "2026-06-08"
+category: Feature
+summary: The food map rebuilt on Leaflet as a multi-city, curator-driven surface, launching with Miami, Atlanta, Copenhagen, and San Sebastián alongside Austin.
+tags:
+  - food-map
+  - feature
+---
+
+The [food map](/food-map) started as a single Austin list. It's now a proper multi-city surface:
+
+- **Rebuilt on Leaflet** with a curator-driven data model, so each city is a maintained list rather than a dump of pins.
+- **Four new cities** — Miami, Atlanta, Copenhagen, and San Sebastián joined Austin.
+
+The bar for adding a spot stays the same as before. It has to be somewhere I'd actually send a friend.

--- a/content/changelog/2026-06-08-retirement-planner.mdx
+++ b/content/changelog/2026-06-08-retirement-planner.mdx
@@ -1,0 +1,18 @@
+---
+title: Retirement planner inside the investments dashboard
+publishedAt: "2026-06-08"
+category: Feature
+summary: A full retirement projection engine joined the investments surface, with allocation-derived return assumptions, Monte Carlo confidence bands, and honest framing throughout.
+tags:
+  - investments
+  - retirement
+---
+
+The [investments dashboard](/investments#retirement) picked up a retirement planner, and I tried to build it the way I wish these tools worked:
+
+- **Returns derive from your allocation.** Expected return and volatility come from dated capital-market assumptions applied to your stock/bond mix, never a single hardcoded growth number.
+- **Monte Carlo with honest framing.** A seeded 1,000-trial simulation renders as confidence bands, and the verdict reads as "N of 100 scenarios" rather than a false-precision percentage.
+- **Two-phase projection** across accumulation and decumulation, with coarse account-aware taxes, RMDs, Social Security claim mechanics, and a choice of withdrawal strategies.
+- **Levers, not lectures.** A sensitivity panel shows which inputs actually move your outcome, computed off the critical path so the headline renders fast.
+
+It can pull your live portfolio value as the starting balance with one click. All of it is educational output, not advice, and the assumptions are disclosed and editable right on the page.

--- a/content/changelog/2026-06-08-world-cup-pulse.mdx
+++ b/content/changelog/2026-06-08-world-cup-pulse.mdx
@@ -1,0 +1,17 @@
+---
+title: World Cup Pulse and the contenders countdown
+publishedAt: "2026-06-08"
+category: Launch
+summary: A 2026 World Cup dashboard that works as a tournament hub before kickoff and becomes a live dashboard once play starts, plus a ten-part contenders series on the writing surface.
+tags:
+  - world-cup
+  - launch
+  - writing
+---
+
+With the tournament days away, two things shipped together:
+
+- **[World Cup Pulse](/world-cup-2026)** — a snapshot-driven dashboard for the 2026 World Cup. Before kickoff it works as a tournament hub with the format, venues, and dates; once play starts the groups, knockout bracket, schedule, and scorers fill in from ESPN data refreshed every six hours. The day after launch it also picked up the 2026-specific third-place qualification race and a kickoff countdown.
+- **The contenders countdown** — a ten-part series on the [writing surface](/writing) ranking the top contenders from Belgium at No. 10 to Spain at No. 1, built from a research dossier, plus companion pieces on building the dashboard and what the 48-team format changes.
+
+This is the surface I expect to use most myself over the next six weeks.

--- a/content/changelog/2026-06-09-polish-and-hardening.mdx
+++ b/content/changelog/2026-06-09-polish-and-hardening.mdx
@@ -1,0 +1,19 @@
+---
+title: Design tokens, performance, and a fix sweep
+publishedAt: "2026-06-09"
+category: Update
+summary: Off-system colors moved onto design tokens, dashboards gained loading states and lazy-loaded panels, and a long list of fixes landed across recently shipped surfaces.
+tags:
+  - design
+  - performance
+---
+
+With so many surfaces shipping in quick succession, this was the consolidation pass:
+
+- **Design tokens everywhere** — off-system colors and micro-typography moved onto the editorial tokens, card radius and shadows unified, and broken color-mix utilities fixed.
+- **Performance** — dashboards gained proper loading states, the MBA tracker's dialogs and team crests now lazy-load, and the snapshot refresh pipelines were hardened so golf and friends keep themselves current.
+- **Accessibility** — table headers across eight sports dashboards now announce column associations to screen readers, nested landmark elements on /writing and /travel are gone, keyboard access works on the transit and startup dashboards, and a stray sub-44px control got brought up to the touch-target standard.
+- **Fixes across the board** — the retirement planner now counts guaranteed income in its success metric, the World Cup dashboard classifies fixtures by date correctly, and the investments URL-sync loop on bare /investments visits is gone.
+- **Tests** — new unit coverage across March Madness, MLB, NBA, NFL, the museum log, polling, recipes, wine cellar, and Interchange IQ.
+
+Shipping fast only works if you stop and pay this bill regularly.

--- a/content/changelog/2026-06-09-pulse-dashboards.mdx
+++ b/content/changelog/2026-06-09-pulse-dashboards.mdx
@@ -1,0 +1,17 @@
+---
+title: Earthquake Pulse, Bay Area Transit Pulse, and a tech startup tracker
+publishedAt: "2026-06-09"
+category: Launch
+summary: Three new dashboards in one day — global seismic activity from USGS feeds, live BART departures and advisories, and a curated tracker of notable startups.
+tags:
+  - dashboards
+  - launch
+---
+
+Three more dashboards joined the family, each with a different data story:
+
+- **[Earthquake Pulse](/earthquake-pulse)** — global seismic activity from the public USGS feeds, refreshed hourly. Recent quakes, significant events, and a regional breakdown, all deep-linkable.
+- **[Bay Area Transit Pulse](/bay-area-transit)** — the first civic surface. BART lines, per-station departure boards, service advisories, and elevator outages, refreshed every six hours from BART's public API.
+- **[Tech Startup Tracker](/tech-startup-tracker)** — unlike the API-backed dashboards, this one is editorially curated. Figures are approximate, compiled from public reporting, and the page says so plainly with an as-of date, the same honest-disclosure approach the retirement planner uses.
+
+All three follow the snapshot pattern, so a failed refresh keeps the last good data instead of wiping the page.

--- a/content/changelog/2026-06-09-travel-upgrades.mdx
+++ b/content/changelog/2026-06-09-travel-upgrades.mdx
@@ -1,0 +1,17 @@
+---
+title: Travel planner gets time windows and sturdier storage
+publishedAt: "2026-06-09"
+category: Feature
+summary: Itinerary stops gained time windows with overlap detection, days picked up color-coding and progress, and a storage bug that could corrupt trips is fixed.
+tags:
+  - travel
+  - feature
+---
+
+The [travel planner](/travel) got its first real upgrade cycle since launch:
+
+- **Stop time windows** — itinerary stops can carry a time window, and the planner flags overlapping stops so you catch the double-booking before the trip does.
+- **Day polish** — category color-coding, an itinerary progress bar, and mood icons for journal entries.
+- **Sturdier storage** — fixed a bug where editing a trip could corrupt or delete stored trips. With everything living in localStorage, this was the one bug class I genuinely couldn't tolerate.
+
+Plan, then trust the plan.

--- a/content/changelog/2026-06-10-investments-research-column.mdx
+++ b/content/changelog/2026-06-10-investments-research-column.mdx
@@ -1,0 +1,17 @@
+---
+title: Investments research column gets real position data
+publishedAt: "2026-06-10"
+category: Feature
+summary: The research view now shows your actual position, a price chart with cost-basis and moving-average overlays, and cleaner news cards. Only real data, no fabricated figures.
+tags:
+  - investments
+  - feature
+---
+
+The research column on the [investments dashboard](/investments) filled out, with a hard rule that every number had to be real:
+
+- **Your position** — when you research a symbol you hold, a card shows shares, average cost, market value, total return, day P/L, and the allocation bar, all drawn from your local portfolio.
+- **Smarter price chart** — a cost-basis reference line from your actual lot, a 50-day moving average, up/down volume coloring, and toggle pills for each overlay.
+- **News cards** — monogram thumbnails and mono timestamps for a more editorial feel.
+
+A few smaller things rode along the same day. The Formula 1 dashboard swapped circuit map images for a cleaner marker tile, the header, footer, projects, and writing pages were trued up against the V3 design system, and the primary nav got a size bump to balance the header.

--- a/content/changelog/2026-06-10-writing-surge.mdx
+++ b/content/changelog/2026-06-10-writing-surge.mdx
@@ -1,0 +1,17 @@
+---
+title: A writing surge — horology, the AI rally, and the practice of building with agents
+publishedAt: "2026-06-10"
+category: Writing
+summary: A dozen new pieces landed on the writing surface, from a two-part horology history to a researched take on the AI mega-cap rally and a series on working with AI agents in production.
+tags:
+  - writing
+---
+
+The [writing surface](/writing) had its busiest stretch yet:
+
+- **Horology, twice** — a history of timekeeping and a companion piece on the companies and iconic models that shaped it. A personal interest that finally earned its word count.
+- **The AI mega-cap question** — a researched piece on whether the rally is a bubble, written to actually take a position rather than survey the takes.
+- **Building with AI, from practice** — pieces on context engineering replacing prompt engineering, evals as the new test suite, whether RAG is dead, prompt injection as a product problem, where the line is on vibe coding, what an AI agent actually costs in production, AI PM interviews in 2026, and a competitive-analysis workflow that holds up.
+- **June fantasy prep** — an early look at the 2026 fantasy football season, because it's never too early.
+
+The legacy posts also got their SEO descriptions rewritten in my own voice instead of search-bait phrasing.


### PR DESCRIPTION
## Summary

The changelog's last entry was April 20, but a lot has shipped since. This adds twelve entries to `content/changelog/` covering everything through today, reconstructed from git history:

- **2026-04-26** — Editorial V3 redesign (home hero, writing archive, three-column investments dashboard)
- **2026-04-29** — The launch wave: NBA, MLB, and NFL dashboards, GitHub Trending Pulse, Frontier Model Tracker, Food Map, Wine Cellar, Museum Log, Recipe Finder
- **2026-05-04** — Travel planner launch
- **2026-05-31** — About/portfolio refresh, HomeStatsPanel, sports data hardening
- **2026-06-08** — Retirement planner, Fantasy Formula 1 optimizer + draft board upgrades, World Cup Pulse + contenders series, multi-city food map
- **2026-06-09** — Earthquake Pulse, Bay Area Transit Pulse, Tech Startup Tracker; travel planner upgrades; design-token/perf/a11y/fix sweep
- **2026-06-10** — Writing surge (12 pieces) and the investments research column

## Verification

- All 19 entries (12 new + 7 existing) validated through the real gray-matter + remark pipeline: frontmatter parses, dates are valid, bodies render, internal links are well-formed, and the rendered sort order is correct
- `npx jest src/lib/__tests__/changelog.test.ts` passes
- Entry claims were cross-checked against the underlying commits (e.g., the a11y bullet matches what PR #163 actually changed)

Written to match the existing entry format and `WRITING_VOICE.md`.

https://claude.ai/code/session_01SSjgUf1cmYS1foji21bcEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSjgUf1cmYS1foji21bcEA)_