### PR TITLE
Add explanatory tooltips across the fantasy football surfaces

### DIFF
--- a/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
@@ -187,6 +187,7 @@ export function DraftBoard({
             <span
               key={`need-${need}`}
               className={FANTASY_CHIP_CLASS}
+              title="Your roster still has an open starting spot at this position"
               style={{
                 borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
                 background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
@@ -286,7 +287,12 @@ export function DraftBoard({
                   >
                     <div>
                       <p className="home-kicker mb-1">Rank</p>
-                      <p className="text-2xl font-semibold">{formatRankValue(player.rankEcr ?? player.averageRank)}</p>
+                      <p
+                        className="text-2xl font-semibold"
+                        title="Published FantasyPros overall consensus rank"
+                      >
+                        {formatRankValue(player.rankEcr ?? player.averageRank)}
+                      </p>
                     </div>
 
                     <div className="min-w-0">
@@ -301,6 +307,7 @@ export function DraftBoard({
                         {fitsCurrentNeed && (
                           <span
                             className={FANTASY_CHIP_CLASS}
+                            title="Fills a starting spot your roster still needs"
                             style={{
                               borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
                               background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
@@ -319,12 +326,22 @@ export function DraftBoard({
 
                     <div>
                       <p className="home-kicker mb-1">Tier</p>
-                      <p className="text-sm font-semibold">{player.tier ? `Tier ${player.tier}` : "Not listed"}</p>
+                      <p
+                        className="text-sm font-semibold"
+                        title="FantasyPros consensus tier. Gaps between tiers mark the value drop-offs"
+                      >
+                        {player.tier ? `Tier ${player.tier}` : "Not listed"}
+                      </p>
                     </div>
 
                     <div>
                       <p className="home-kicker mb-1">Expert range</p>
-                      <p className="text-sm font-semibold">{formatRange(player)}</p>
+                      <p
+                        className="text-sm font-semibold"
+                        title="Best and worst rank across the experts in the consensus"
+                      >
+                        {formatRange(player)}
+                      </p>
                     </div>
 
                     <button

--- a/src/app/fantasy-football/draft-tracker/components/DraftTierColumns.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftTierColumns.tsx
@@ -165,6 +165,7 @@ export function DraftTierColumns({
                 {isNeed && (
                   <span
                     className={FANTASY_CHIP_CLASS}
+                    title="Your roster still has an open starting spot at this position"
                     style={{
                       borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
                       background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
@@ -174,7 +175,11 @@ export function DraftTierColumns({
                   </span>
                 )}
               </div>
-              <span className="text-xs font-semibold tabular-nums" style={{ color: "var(--home-ink-muted)" }}>
+              <span
+                className="text-xs font-semibold tabular-nums"
+                title="Undrafted players left at this position"
+                style={{ color: "var(--home-ink-muted)" }}
+              >
                 {column.available.length} left
               </span>
             </header>
@@ -182,6 +187,7 @@ export function DraftTierColumns({
             {isCliff && topGroup.tier !== "untiered" && (
               <p
                 className={`mt-3 self-start ${FANTASY_CHIP_CLASS}`}
+                title="The current tier is nearly empty. Expect a value drop once it clears"
                 style={{
                   borderColor: "color-mix(in srgb, var(--color-warning) 32%, var(--home-rule))",
                   background: "color-mix(in srgb, var(--color-warning) 12%, var(--home-paper))",

--- a/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
+++ b/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
@@ -63,39 +63,47 @@ export function DraftTrackerClient() {
   const draftStatsCells: HomeStatsCell[] = [
     {
       label: "Current pick",
+      tooltip: "Overall pick number on the clock right now.",
       value: draftState.currentPick.toLocaleString(),
       sub: `of ${totalPicks}`,
     },
     {
       label: "Round",
+      tooltip: "Current round out of the rounds configured for this room.",
       value: `${draftState.currentRound}`,
       sub: `of ${draftState.settings.rounds}`,
     },
     {
       label: "On the clock",
+      tooltip: "Team whose pick gets logged next.",
       value: currentTeamName,
       sub: isUserPick ? "Your pick" : undefined,
     },
     {
       label: "Picks made",
+      tooltip: "Picks logged in this room so far.",
       value: draftState.picks.length.toLocaleString(),
     },
     {
       label: "Total picks",
+      tooltip: "Teams times rounds from the room settings.",
       value: `${draftState.settings.totalTeams} × ${draftState.settings.rounds}`,
       sub: totalPicks.toLocaleString(),
     },
     {
       label: "Completion",
+      tooltip: "Share of the total picks already logged.",
       value: `${completionPercentage}%`,
       tone: completionPercentage > 0 ? "good" : "default",
     },
     {
       label: "Your team",
+      tooltip: "The roster this assistant tracks as yours.",
       value: userTeamName,
     },
     {
       label: "Best available",
+      tooltip: "Undrafted players left on the overall consensus board.",
       value: bestAvailableCount > 0 ? bestAvailableCount.toLocaleString() : "—",
       sub: "Players left on board",
     },

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -253,39 +253,47 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
   const fantasyStatsCells: HomeStatsCell[] = [
     {
       label: "Players visible",
+      tooltip: "Players on this board after the position, scoring, and search filters.",
       value: currentSliceUnavailable ? "—" : filteredPlayers.length.toLocaleString(),
       sub: currentSliceUnavailable ? "Board unavailable" : "After filters",
     },
     {
       label: "Active position",
+      tooltip: "The position board currently in view.",
       value: FANTASY_POSITION_LABELS[routeState.position],
       sub: "Switch via pills",
     },
     {
       label: "Scoring format",
+      tooltip: "Scoring rules behind the consensus ranks on this board.",
       value: selectedScoringLabel,
     },
     {
       label: "Tier count",
+      tooltip: "Highest tier number FantasyPros publishes for this board.",
       value: maxTier > 0 ? maxTier : "—",
       sub: maxTier > 0 ? "Highest tier in view" : "Not published",
     },
     {
       label: "Search hits",
+      tooltip: "Players matching the current search text.",
       value: trimmedQuery ? filteredPlayers.length.toLocaleString() : "—",
       sub: trimmedQuery ? `Query "${trimmedQuery}"` : "Type to filter",
     },
     {
       label: "Snapshot week",
+      tooltip: "Season and week the published snapshot covers.",
       value: snapshotWeekLabel,
     },
     {
       label: "Source updated",
+      tooltip: "When FantasyPros last refreshed the source consensus.",
       value: formatUpdatedAt(currentSourceUpdatedAt),
       sub: currentSourceKindLabel,
     },
     {
       label: "Built",
+      tooltip: "When this site last rebuilt its committed snapshot from the source.",
       value: formatUpdatedAt(metadata?.generatedAt),
       sub: "Snapshot generated",
     },
@@ -633,7 +641,10 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                       >
                         <div>
                           <p className={cellLabelClassName}>Rank</p>
-                          <p className={rankValueClassName}>
+                          <p
+                            className={rankValueClassName}
+                            title="Published FantasyPros consensus rank on this board"
+                          >
                             {getPublishedBoardRank(player, routeState.position)}
                           </p>
                         </div>
@@ -655,12 +666,22 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
 
                         <div>
                           <p className={cellLabelClassName}>Tier</p>
-                          <p className="text-sm font-semibold">{player.tier ? `Tier ${player.tier}` : "Not listed"}</p>
+                          <p
+                            className="text-sm font-semibold"
+                            title="FantasyPros consensus tier. Gaps between tiers mark the value drop-offs"
+                          >
+                            {player.tier ? `Tier ${player.tier}` : "Not listed"}
+                          </p>
                         </div>
 
                         <div>
                           <p className={cellLabelClassName}>Expert range</p>
-                          <p className="text-sm font-semibold tabular-nums">{formatRange(player)}</p>
+                          <p
+                            className="text-sm font-semibold tabular-nums"
+                            title="Best and worst rank across the experts in the consensus"
+                          >
+                            {formatRange(player)}
+                          </p>
                         </div>
 
                         <div>

--- a/src/components/fantasy/TierBreakdown.tsx
+++ b/src/components/fantasy/TierBreakdown.tsx
@@ -126,7 +126,11 @@ export function TierBreakdown({ players, position, getPublishedRank }: TierBreak
                 }
 
                 return (
-                  <p className="text-xs font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--home-ink-muted)" }}>
+                  <p
+                    className="text-xs font-semibold uppercase tracking-[0.12em]"
+                    title="Published consensus ranks covered by this tier"
+                    style={{ color: "var(--home-ink-muted)" }}
+                  >
                     Ranks {formatRankValue(rankedPlayers[0].rank)}–
                     {formatRankValue(rankedPlayers[rankedPlayers.length - 1].rank)}
                   </p>


### PR DESCRIPTION
## Summary

The fantasy football pages were the only dashboards without tooltips on their stats panels, and the jargon-heavy stat columns gave no hover explanation. This brings them up to the same standard the `/nfl` dashboard already uses.

- **Rankings page (`/fantasy-football`)**: every "Board at a glance" cell now has a `tooltip` (players visible, tier count, source updated, built, etc.), and the per-row Rank, Tier, and Expert range values explain on hover what the published consensus numbers mean. The existing Rostered tooltip is unchanged.
- **Draft assistant (`/fantasy-football/draft-tracker`)**: every "Draft at a glance" cell now has a tooltip, the best-available rows explain Rank/Tier/Expert range, and the Need and Priority chips say why they appear.
- **Tier columns view**: the tier-cliff chip, the per-position "N left" counter, and the Need chip now explain themselves.
- **Tiers view (`TierBreakdown`)**: the "Ranks X–Y" header explains it covers the published consensus ranks in that tier.

No behavior changes, copy only (native `title` attributes plus `HomeStatsCell.tooltip`).

## Testing

- `npx jest src/app/fantasy-football src/components/fantasy` — 18 tests, all passing
- `npx eslint` on the touched directories — clean
- `npx tsc --noEmit` — clean

https://claude.ai/code/session_019ayZnatNdUymtpGjzXt8xF

---
_Generated by [Claude Code](https://claude.ai/code/session_019ayZnatNdUymtpGjzXt8xF)_