### PR TITLE
Add tooltip explaining the fantasy "Avg" rank

### DIFF
--- a/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
@@ -4,7 +4,8 @@ import { useMemo, useState, type CSSProperties } from "react";
 import { Player, TeamRoster } from "@/types";
 import type { FantasySnapshot } from "@/lib/fantasy";
 import { useDebounce } from "@/hooks/useDebounce";
-import { FANTASY_CHIP_CLASS, formatRange, formatRankValue, getPositionTone } from "@/lib/fantasyUtils";
+import { FANTASY_AVG_RANK_TOOLTIP, FANTASY_CHIP_CLASS, formatRange, formatRankValue, getPositionTone } from "@/lib/fantasyUtils";
+import { MetricTooltip } from "@/components/investments/MetricTooltip";
 import { DraftTierColumns } from "./DraftTierColumns";
 
 interface DraftBoardProps {
@@ -312,7 +313,13 @@ export function DraftBoard({
                       </div>
                       <p className="mt-1 text-sm" style={{ color: "var(--home-ink-muted)" }}>
                         {player.team}
-                        {Number.isFinite(player.rankAverage) ? ` • Avg ${Number(player.rankAverage).toFixed(2)}` : ""}
+                        {Number.isFinite(player.rankAverage) ? (
+                          <span className="inline-flex items-center">
+                            {" • Avg "}
+                            {Number(player.rankAverage).toFixed(2)}
+                            <MetricTooltip term="Average rank" definition={FANTASY_AVG_RANK_TOOLTIP} />
+                          </span>
+                        ) : null}
                         {player.positionRank ? ` • ${player.position}${player.positionRank}` : ""}
                       </p>
                     </div>

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useEffect, useMemo, useState, useSyncExternalStore, type CSSProperties } from "react";
+import { Fragment, startTransition, useEffect, useMemo, useState, useSyncExternalStore, type CSSProperties, type ReactNode } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
@@ -15,6 +15,7 @@ import {
   getFantasyWeekLabel,
 } from "@/lib/fantasy";
 import {
+  FANTASY_AVG_RANK_TOOLTIP,
   FANTASY_CHIP_CLASS,
   formatOwnership,
   formatRange,
@@ -24,6 +25,7 @@ import {
   getSourceKindLabel,
 } from "@/lib/fantasyUtils";
 import { TierBreakdown } from "@/components/fantasy";
+import { MetricTooltip } from "@/components/investments/MetricTooltip";
 import { Player } from "@/types";
 import { buildFantasyHref, FantasySearchState, normalizeFantasyState } from "./fantasy-state";
 import { HomeStatsPanel, type HomeStatsCell } from "@/components/home/HomeStatsPanel";
@@ -84,8 +86,8 @@ function getPublishedBoardRank(player: Player, position: FantasyRoutePosition): 
   return formatRankValue(rankValue);
 }
 
-function getPlayerDescriptor(player: Player, position: FantasyRoutePosition): string {
-  const parts = [player.team];
+function getPlayerDescriptor(player: Player, position: FantasyRoutePosition): ReactNode {
+  const parts: ReactNode[] = [player.team];
   const isOverallView = position === "overall" || position === "flex";
 
   // Overall/flex boards lead with the player's position rank (e.g. "RB3");
@@ -95,10 +97,22 @@ function getPlayerDescriptor(player: Player, position: FantasyRoutePosition): st
   }
 
   if (Number.isFinite(player.rankAverage)) {
-    parts.push(`Avg ${Number(player.rankAverage).toFixed(2)}`);
+    parts.push(
+      <span className="inline-flex items-center">
+        Avg {Number(player.rankAverage).toFixed(2)}
+        <MetricTooltip term="Average rank" definition={FANTASY_AVG_RANK_TOOLTIP} />
+      </span>
+    );
   }
 
-  return parts.filter(Boolean).join(" • ");
+  // Render the parts inline, separated by bullets, so the "Avg" segment can
+  // carry its own explanatory tooltip instead of being flattened into a string.
+  return parts.filter(Boolean).map((part, index) => (
+    <Fragment key={index}>
+      {index > 0 ? " • " : ""}
+      {part}
+    </Fragment>
+  ));
 }
 
 type FantasyBoardDensity = "comfortable" | "compact";

--- a/src/lib/fantasyUtils.ts
+++ b/src/lib/fantasyUtils.ts
@@ -3,6 +3,16 @@ import type { CSSProperties } from "react";
 import type { FantasySnapshotSliceMetadata } from "@/lib/fantasy";
 import type { Player } from "@/types";
 
+/**
+ * Plain-language explanation of the "Avg" value shown next to each player.
+ * Shared by the rankings board and the draft tracker so both surfaces tell the
+ * same story. The number is FantasyPros' `rank_ave` — the mean of every
+ * expert's individual ranking, distinct from the consensus rank in the
+ * headline.
+ */
+export const FANTASY_AVG_RANK_TOOLTIP =
+  "The average of every expert's rank for this player. FantasyPros polls dozens of analysts, and this is the mean of their individual rankings. Lower is better, so 1.00 would mean every expert ranked the player first.";
+
 export function formatUpdatedAt(timestamp: string | null | undefined): string {
   if (!timestamp) {
     return "Unavailable";


### PR DESCRIPTION
## What

Each player row on the fantasy football board shows a descriptor like `BUF • QB1 • Avg 1.03`. That `Avg` value is FantasyPros' `rank_ave` (the mean of every expert's individual ranking, distinct from the consensus rank in the headline), but nothing on the page explained it. This adds a hover tooltip on the `Avg` value so the meaning is discoverable.

## Where

- **Rankings board** (`/fantasy-football`) — `getPlayerDescriptor` in `fantasy-football-client.tsx` now returns inline nodes so the `Avg` segment can carry a tooltip.
- **Draft tracker** (`/fantasy-football/draft-tracker`) — the inline descriptor in `DraftBoard.tsx` gets the same tooltip.

Both surfaces share a single definition string, `FANTASY_AVG_RANK_TOOLTIP` in `src/lib/fantasyUtils.ts`, so they stay in sync. The tooltip reuses the existing `MetricTooltip` component (the same `?`-badge pattern used across the investments dashboard).

## Copy

> The average of every expert's rank for this player. FantasyPros polls dozens of analysts, and this is the mean of their individual rankings. Lower is better, so 1.00 would mean every expert ranked the player first.

## Verification

- `npx tsc --noEmit` — clean
- `eslint` on the three changed files — clean
- `npx jest fantasy` — 17 suites / 62 tests pass

https://claude.ai/code/session_019vWW1YFCkc76i3UWjuP4wd

---
_Generated by [Claude Code](https://claude.ai/code/session_019vWW1YFCkc76i3UWjuP4wd)_