### PR TITLE
content: release full World Cup countdown, backdated with Spain (No. 1) today

### DIFF
--- a/content/blog/building-a-world-cup-dashboard.mdx
+++ b/content/blog/building-a-world-cup-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building a World Cup Dashboard for the First 48-Team Tournament"
 excerpt: "I built a 2026 World Cup hub because the expanded format scatters 104 matches across three countries. Here is what I chose to show, what I left out, and why it runs on a checked-in snapshot instead of a live feed."
-publishedAt: "2026-06-08"
+publishedAt: "2026-05-29"
 category: "Sports Analytics"
 tags: ["World Cup", "FIFA World Cup 2026", "Sports Analytics", "Next.js", "Sports Data", "Product Design", "Dashboard"]
 featured: false

--- a/content/blog/what-the-48-team-world-cup-changes.mdx
+++ b/content/blog/what-the-48-team-world-cup-changes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "What the 48-Team World Cup Actually Changes"
 excerpt: "Going from 32 teams to 48 is not just a bigger bracket. It changes the group-stage math, the rest a contender gets, and the kind of squad built to win across a summer spread over three countries."
-publishedAt: "2026-06-08"
+publishedAt: "2026-05-30"
 category: "Sports Analytics"
 tags: ["World Cup", "FIFA World Cup 2026", "Sports Analytics", "Soccer", "Tournament Format"]
 featured: false

--- a/content/blog/world-cup-2026-contenders-1-spain.mdx
+++ b/content/blog/world-cup-2026-contenders-1-spain.mdx
@@ -1,7 +1,7 @@
 ---
 title: "World Cup 2026 Countdown, No. 1: Spain Is the Most Complete Team at the Tournament"
 excerpt: "The reigning European champions top the Opta model, sit as co-favorites in the market, and got the friendliest path of any contender. Built around Yamal, Pedri and Rodri, Spain is my number one, and the only worry is the knockout nerve that history keeps raising."
-publishedAt: "2026-06-18"
+publishedAt: "2026-06-10"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "Spain", "Lamine Yamal", "Sports Analytics", "Betting"]
 featured: false

--- a/content/blog/world-cup-2026-contenders-10-belgium.mdx
+++ b/content/blog/world-cup-2026-contenders-10-belgium.mdx
@@ -1,7 +1,7 @@
 ---
 title: "World Cup 2026 Countdown, No. 10: Belgium's Golden Generation Gets One Last Shot"
 excerpt: "Belgium starts my top ten because of the one thing the higher-ceiling outsiders cannot offer, a soft group that all but guarantees knockout football, plus Courtois, De Bruyne and a last-dance story that is hard to bet against entirely."
-publishedAt: "2026-06-09"
+publishedAt: "2026-06-01"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "Belgium", "Soccer", "Sports Analytics", "Betting"]
 featured: false

--- a/content/blog/world-cup-2026-contenders-2-france.mdx
+++ b/content/blog/world-cup-2026-contenders-2-france.mdx
@@ -1,7 +1,7 @@
 ---
 title: "World Cup 2026 Countdown, No. 2: France Has the Best Squad and the Worst Draw"
 excerpt: "On talent alone, France might be my number one. The deepest pool in world football, Mbappé and the reigning Ballon d'Or winner, and Deschamps in his final tournament. Then the draw handed them the Group of Death, and that is the only reason they are second."
-publishedAt: "2026-06-17"
+publishedAt: "2026-06-09"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "France", "Kylian Mbappe", "Sports Analytics", "Betting"]
 featured: false

--- a/content/blog/world-cup-2026-contenders-3-england.mdx
+++ b/content/blog/world-cup-2026-contenders-3-england.mdx
@@ -1,7 +1,7 @@
 ---
 title: "World Cup 2026 Countdown, No. 3: England Did Everything Right Except Win"
 excerpt: "Eight qualifiers, eight wins, and a ruthless Tuchel squad that cut Foden, Palmer and Alexander-Arnold. England is a clean third on every board. The only thing standing between them and the trophy is a decade of evidence that they fall just short."
-publishedAt: "2026-06-16"
+publishedAt: "2026-06-08"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "England", "Soccer", "Sports Analytics", "Betting"]
 featured: false

--- a/content/blog/world-cup-2026-contenders-4-argentina.mdx
+++ b/content/blog/world-cup-2026-contenders-4-argentina.mdx
@@ -1,7 +1,7 @@
 ---
 title: "World Cup 2026 Countdown, No. 4: Argentina and the Last Act of Lionel Messi"
 excerpt: "The defending champions drew the softest group of any top seed and kept the spine of the Qatar winners together. The whole tournament bends around one question, whether a 38-year-old Messi has one more month of magic in his legs."
-publishedAt: "2026-06-15"
+publishedAt: "2026-06-07"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "Argentina", "Lionel Messi", "Sports Analytics", "Betting"]
 featured: false

--- a/content/blog/world-cup-2026-contenders-5-brazil.mdx
+++ b/content/blog/world-cup-2026-contenders-5-brazil.mdx
@@ -1,7 +1,7 @@
 ---
 title: "World Cup 2026 Countdown, No. 5: Brazil, Ancelotti, and a 24-Year Itch"
 excerpt: "Five stars on the shirt and not one of them added since 2002. Brazil hands the keys to Carlo Ancelotti, recalls Neymar at 34, and leaves Rodrygo at home entirely, a high-ceiling, high-variance bet on ending a drought that now matches the longest in the country's history."
-publishedAt: "2026-06-14"
+publishedAt: "2026-06-06"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "Brazil", "Soccer", "Sports Analytics", "Betting"]
 featured: false

--- a/content/blog/world-cup-2026-contenders-6-portugal.mdx
+++ b/content/blog/world-cup-2026-contenders-6-portugal.mdx
@@ -1,7 +1,7 @@
 ---
 title: "World Cup 2026 Countdown, No. 6: Portugal's Midfield Might Be the Best at the Tournament"
 excerpt: "Cristiano Ronaldo goes to a record sixth World Cup at 41 still chasing the one trophy that has eluded him, but the real reason Portugal is a contender is a midfield so deep that the models rate them this high despite the second-toughest group in the draw."
-publishedAt: "2026-06-13"
+publishedAt: "2026-06-05"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "Portugal", "Soccer", "Sports Analytics", "Betting"]
 featured: false

--- a/content/blog/world-cup-2026-contenders-7-germany.mdx
+++ b/content/blog/world-cup-2026-contenders-7-germany.mdx
@@ -1,7 +1,7 @@
 ---
 title: "World Cup 2026 Countdown, No. 7: Germany Got the Easiest Road in the Bracket"
 excerpt: "Two straight group-stage exits should make anyone cautious about a four-time champion. But Germany drew the softest path of any contender, and a young creative core in Musiala and Wirtz is exactly the kind of talent that turns an easy draw into a deep run."
-publishedAt: "2026-06-12"
+publishedAt: "2026-06-04"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "Germany", "Soccer", "Sports Analytics", "Betting"]
 featured: false

--- a/content/blog/world-cup-2026-contenders-8-netherlands.mdx
+++ b/content/blog/world-cup-2026-contenders-8-netherlands.mdx
@@ -1,7 +1,7 @@
 ---
 title: "World Cup 2026 Countdown, No. 8: The Netherlands and the Hole Where Xavi Simons Should Be"
 excerpt: "The Dutch have one of the deepest defenses at the tournament and a captain in Virgil van Dijk who drags teams through knockout ties. The problem is the ACL injury in April that took away the one player they could least afford to lose."
-publishedAt: "2026-06-11"
+publishedAt: "2026-06-03"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "Netherlands", "Soccer", "Sports Analytics", "Betting"]
 featured: false

--- a/content/blog/world-cup-2026-contenders-9-morocco.mdx
+++ b/content/blog/world-cup-2026-contenders-9-morocco.mdx
@@ -1,7 +1,7 @@
 ---
 title: "World Cup 2026 Countdown, No. 9: Morocco and the Weight of 2022"
 excerpt: "Morocco is the one outsider with genuine semifinal pedigree, the spine of the Qatar run still intact behind Hakimi and Brahim Díaz, but a manager who only took the job in March and Brazil in the group make this the hardest team in my ten to read."
-publishedAt: "2026-06-10"
+publishedAt: "2026-06-02"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "Morocco", "Soccer", "Sports Analytics", "Betting"]
 featured: false

--- a/content/blog/world-cup-2026-top-ten-contenders.mdx
+++ b/content/blog/world-cup-2026-top-ten-contenders.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ranking the 2026 World Cup Contenders: How I Built My Top Ten"
 excerpt: "Before a ball is kicked in the USA, Canada and Mexico, here is the method behind my countdown of the ten teams most likely to win it, why Spain and France sit clear of the field, and which dark horse I could not quite fit in."
-publishedAt: "2026-06-08"
+publishedAt: "2026-05-31"
 category: "Sports Analytics"
 tags: ["World Cup", "World Cup 2026", "Soccer", "Sports Analytics", "Power Rankings", "Betting"]
 featured: false


### PR DESCRIPTION
## Summary

The 2026 World Cup begins tomorrow, so this releases the entire World Cup countdown now instead of drip-publishing through 06-18. `/writing` hides future-dated posts (`isPublished` in `src/lib/blog.ts`), so previously only 5 of the 13 pieces were visible. All `publishedAt` dates have been pulled back so every post is live, preserving the one-per-day reveal order and ending with **No. 1 Spain today (2026-06-10)**.

## New schedule

| Article | Date |
|---|---|
| Building a World Cup Dashboard | 2026-05-29 |
| What the 48-Team World Cup Changes | 2026-05-30 |
| Ranking the Top Ten (method) | 2026-05-31 |
| No. 10 Belgium | 2026-06-01 |
| No. 9 Morocco | 2026-06-02 |
| No. 8 Netherlands | 2026-06-03 |
| No. 7 Germany | 2026-06-04 |
| No. 6 Portugal | 2026-06-05 |
| No. 5 Brazil | 2026-06-06 |
| No. 4 Argentina | 2026-06-07 |
| No. 3 England | 2026-06-08 |
| No. 2 France | 2026-06-09 |
| No. 1 Spain | 2026-06-10 (today) |

## Notes

- Only `publishedAt` frontmatter changed — no body edits. Article bodies were scanned for stale relative-date phrasing ("tomorrow", "this week", etc.) and none was found.

https://claude.ai/code/session_01Vh5CNLzSe3fE2RApxqDdK1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh5CNLzSe3fE2RApxqDdK1)_