### PR TITLE
docs: fix COMPONENTS drift and add four subsystem references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Operational context for agents working in this repo. Start here, then read `CLAUDE.md` for deeper implementation context.
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-16
 
 ---
 
@@ -397,6 +397,7 @@ Checked-in operational workflows:
 - `.github/workflows/update-golf.yml`
 - `.github/workflows/update-world-cup.yml`
 - `.github/workflows/update-bay-area-transit.yml`
+- `.github/workflows/update-earthquake.yml`
 - `netlify/functions/purge-cache.ts`
 
 Current behavior:
@@ -415,6 +416,7 @@ Current behavior:
 - `update-golf.yml` runs on manual dispatch and daily at `08:40 UTC`, then commits `src/data/golfSnapshot.ts` when it changes
 - `update-world-cup.yml` runs on manual dispatch and every six hours during June and July, then commits `src/data/worldCupSnapshot.ts` when it changes
 - `update-bay-area-transit.yml` runs on manual dispatch and every six hours year-round, then commits `src/data/bayAreaTransitSnapshot.ts` when it changes
+- `update-earthquake.yml` runs on manual dispatch and hourly (minute 20), then commits `src/data/earthquakeSnapshot.ts` when it changes
 - The tech startup tracker has no workflow by design — its dataset is editorially curated, so refreshes happen by editing the seed and running `npm run update:tech-startups` locally
 - A daily cron-job.org ping to the Netlify build hook triggers production deploys; `prebuild` refreshes Premier League and La Liga league-level snapshots with `tsx scripts/updateFootballSnapshots.ts --league-only`
 - `purge-cache.ts` is protected by `Authorization: Bearer <CRON_SECRET>` or `x-cron-secret` and calls Netlify Durable Cache purge; query-string secrets are intentionally rejected
@@ -444,5 +446,12 @@ For public fantasy updates, GitHub Actions is the source of truth.
 - `STYLING.md`
 - `WRITING_VOICE.md`
 - `docs/README.md`
+
+Subsystem references:
+
+- `SNAPSHOT_DRIVEN_DASHBOARDS.md` — shared snapshot-driven dashboard pattern
+- `PERSONAL_INTEREST_TOOLS.md` — browser-persisted localStorage tools
+- `RETIREMENT_PLANNER_ENGINE.md` — pure retirement projection engine
+- `docs/DATA_UPDATE_OPERATIONS.md` — command → artifact → schedule runbook
 
 Older plans, redesign notes, and summary docs are kept for history. Check `docs/README.md` before treating a markdown file as current.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Comprehensive repo context for agents and collaborators. `AGENTS.md` is the shorter start-here companion; this file holds the deeper implementation context.
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-16
 
 ---
 
@@ -503,6 +503,13 @@ Treat the following as current source of truth:
 - `WRITING_VOICE.md`
 - `docs/README.md`
 - `docs/ai-context/*`
+
+Subsystem references (current):
+
+- `SNAPSHOT_DRIVEN_DASHBOARDS.md` — the shared snapshot → builder → GitHub Action → accessors → API pattern used by 15+ data dashboards
+- `PERSONAL_INTEREST_TOOLS.md` — the browser-persisted localStorage tools (`/travel`, `/wine-cellar`, `/museum-log`, `/recipe-finder`, `/food-map`)
+- `RETIREMENT_PLANNER_ENGINE.md` — the pure projection/Monte Carlo engine in `src/lib/retirement/`
+- `docs/DATA_UPDATE_OPERATIONS.md` — consolidated command → artifact → schedule runbook for every data refresh
 
 Treat older plans, redesign specs, and reference templates as historical unless they explicitly say they are current. `SEO.md` (listed above) is the current SEO reference — older root-level SEO audit/summary docs are historical.
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -2,7 +2,14 @@
 
 Current component map for the live application.
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-16
+
+> The homepage, about, portfolio, contact, and writing-archive surfaces moved to
+> dedicated `*V3` composition roots in the 2026-05-31 refresh (commit `66063bb`).
+> The older single-purpose homepage components (`ModernHero`, `ThinkingPreview`,
+> `ContactSection`) and the `FeaturedWorkSection`/`ContactContent` names this doc
+> previously listed are no longer wired into any route — see *Legacy Or Unwired
+> Components*.
 
 ---
 
@@ -20,17 +27,20 @@ Current component map for the live application.
 | `RouteErrorBoundary` | `src/components/RouteErrorBoundary.tsx` | Shared editorial-styled error fallback re-exported by per-route `error.tsx` files |
 | `ContactCta` | `src/components/ContactCta.tsx` | Shared closing contact CTA used by the full footer |
 
-### Homepage and portfolio
+### Homepage, about, portfolio, contact, writing
+
+Each of these editorial surfaces renders a single dedicated `*V3` composition
+root (introduced in the 2026-05-31 refresh). The route page is a thin server
+shell that passes data in.
 
 | Component | File | Role |
 |----------|------|------|
-| `ModernHero` | `src/components/ModernHero.tsx` | Homepage hero |
-| `FeaturedWorkSection` | `src/components/FeaturedWorkSection.tsx` | Homepage featured projects |
-| `ThinkingPreview` | `src/components/ThinkingPreview.tsx` | Homepage product-thinking section |
-| `ContactSection` | `src/components/ContactSection.tsx` | Homepage closing contact section |
-| `About` | `src/components/About.tsx` | About page tabbed content |
-| `ContactContent` | `src/components/ContactContent.tsx` | Contact page content |
-| `ProjectDetailModal` | `src/components/ProjectDetailModal.tsx` | Legacy project modal used by non-primary flows |
+| `HomePageV3` | `src/components/home/HomePageV3.tsx` | Homepage composition root (hero, featured work, writing, contact). Props: `featuredProjects`, `recentPosts`, `heroIndex` |
+| `AboutV3` | `src/components/about/AboutV3.tsx` | `/about` content |
+| `PortfolioV3` | `src/components/portfolio/PortfolioV3.tsx` | `/portfolio` project grid and surfacing |
+| `ContactV3` | `src/components/contact/ContactV3.tsx` | `/contact` content |
+| `WritingArchiveV3` | `src/components/writing/WritingArchiveV3.tsx` | `/writing` archive index |
+| `ProjectDetailModal` | `src/components/ProjectDetailModal.tsx` | Legacy project modal, imported only by `ProjectsContent.tsx` (non-primary flow) |
 
 ### Writing and structured data
 
@@ -54,31 +64,23 @@ These are used across `/fantasy-football/*` routes.
 
 ### Investments
 
-The investments surface is split between a client shell and specialized panels.
+`InvestmentsDashboard` (`src/components/investments/InvestmentsDashboard.tsx`) is
+the main shell rendered by `src/app/investments/investments-client.tsx`. It
+composes the portfolio and research surfaces (all under
+`src/components/investments/`):
 
-Main components:
+- Portfolio: `PortfolioSummary`, `PortfolioHeroCard`, `PortfolioStatsGrid`, `HoldingsTable`, `AddStockForm`, `AllocationChart`, `PortfolioPerformanceChart`, `Sparkline`
+- Research: `StockResearch`, `StockSearch`, `ResearchOverview`, `ResearchSidebar`, `ResearchSection`, `ResearchAssetHeader`, `ResearchPosition`
+- Research panels: `PriceChartPanel`, `DCFPanel`, `FinancialStatementsPanel`, `GrowthPanel`, `ValuationRatiosPanel`, `ProfitabilityPanel`, `IndustryPanel`
+- Comparison: `ComparisonTab`, `ComparisonMetricTable`, `ComparisonRadarChart`
+- Freshness / chrome: `DataFreshnessIndicator`, `InvestmentsFreshnessBanner`, `MetricTooltip`, `ErrorState`
 
-- `StockResearch`
-- `PortfolioTracker`
-- `PortfolioSummary`
-- `StockCard`
-- `AddStockForm`
-- `AllocationChart`
-- `PortfolioPerformanceChart`
-- `ResearchOverview`
-- `ResearchSummaryStrip`
-- `ComparisonTab`
-- `PriceChartPanel`
-- `DCFPanel`
-- `FundamentalsPanel`
-- `FinancialStatementsPanel`
-- `GrowthPanel`
-- `ValuationRatiosPanel`
-- `ProfitabilityPanel`
-- `IndustryPanel`
-- `NewsPanel`
-
-Retirement planner components live in `src/components/investments/retirement/` (verdict headline, D3 confidence-band chart, levers panel, editable assumptions footer). They sit on the pure engine in `src/lib/retirement/` and `useRetirementPlan` browser-local state.
+Retirement planner components live in `src/components/investments/retirement/`
+(`RetirementPlanner` shell, `RetirementInputs`/`RetirementFields`,
+`RetirementVerdict`, `RetirementProjectionChart` D3 confidence-band chart,
+`RetirementLevers`, `RetirementAssumptions`, `RetirementDisclaimer`). They sit on
+the pure engine in `src/lib/retirement/` and `useRetirementPlan` browser-local
+state — see `RETIREMENT_PLANNER_ENGINE.md` for the engine reference.
 
 ### Football dashboards
 
@@ -98,6 +100,12 @@ Shared components for the `/premier-league`, `/la-liga`, `/mlb`, `/nba`, `/nfl`,
 | `EmptyPanel` | `src/components/football/EmptyPanel.tsx` | Empty-state placeholder panel |
 
 ### Standalone data tools
+
+Most of these are snapshot-driven dashboards that share one architecture
+(seed → builder → GitHub Action → accessors → API). See
+`SNAPSHOT_DRIVEN_DASHBOARDS.md` for the shared pattern, and
+`PERSONAL_INTEREST_TOOLS.md` for the browser-persisted tools (`/travel`,
+`/wine-cellar`, `/museum-log`, `/recipe-finder`, `/food-map`).
 
 | Area | Primary files | Role |
 |------|---------------|------|
@@ -148,21 +156,17 @@ Styling guidance for these lives in `STYLING.md`.
 
 ### Homepage
 
-The homepage uses:
-
-- `ModernHero`
-- `FeaturedWorkSection`
-- `ThinkingPreview`
-- `ContactSection`
-
-`WritingPreview.tsx` still exists in the repo but is not part of the current homepage.
+`src/app/page.tsx` renders `HomePageV3` (plus the `StructuredData` /
+`AIStructuredData` JSON-LD injectors). `HomePageV3` is a self-contained
+composition; the older `ModernHero` / `ThinkingPreview` / `ContactSection` files
+and `WritingPreview.tsx` still exist in the repo but are no longer wired into the
+homepage.
 
 ### `/investments`
 
-`src/app/investments/investments-client.tsx` is the top-level shell and lazy-loads:
-
-- `PortfolioTracker`
-- `StockResearch`
+`src/app/investments/investments-client.tsx` is the top-level shell; it renders
+`InvestmentsDashboard`, which composes the portfolio and research surfaces listed
+above.
 
 ### `/march-madness-2026`
 
@@ -188,8 +192,13 @@ These files still exist, but should not be described as the primary live path wi
 
 - `src/components/ProjectsContent.tsx`
 - `src/components/WritingPreview.tsx`
+- `src/components/ModernHero.tsx`
+- `src/components/ThinkingPreview.tsx`
+- `src/components/ContactSection.tsx`
+- `src/components/ProjectDetailModal.tsx` (imported only by `ProjectsContent.tsx`)
 
-They remain useful as historical or alternate implementation context.
+They remain useful as historical or alternate implementation context. The
+`*V3` composition roots replaced them on the live routes.
 
 ---
 

--- a/PERSONAL_INTEREST_TOOLS.md
+++ b/PERSONAL_INTEREST_TOOLS.md
@@ -1,0 +1,123 @@
+# Personal-Interest Tools
+
+The browser-persisted lifestyle surfaces: `/travel`, `/wine-cellar`,
+`/museum-log`, `/recipe-finder`, and `/food-map`. They have no server, no API,
+and no snapshot pipeline — state lives in the user's browser. This doc captures
+the shared pattern and the per-tool specifics so the next one is easy to add.
+
+**Last updated:** 2026-06-16
+
+---
+
+## Two sub-patterns
+
+These tools split into two shapes:
+
+1. **User-authored stores** — the user *creates* the data (trips, wine bottles,
+   museum visits). State is persisted to `localStorage` behind a versioned key
+   and surfaced through a hook. No server ever sees it. → `/travel`,
+   `/wine-cellar`, `/museum-log`.
+2. **Curated catalog + light client state** — the *content* is shipped as a
+   curated dataset; the browser only remembers small preferences. →
+   `/recipe-finder` (curated recipes, persisted pantry), `/food-map` (curated
+   places, in-memory + URL filters, nothing persisted).
+
+---
+
+## The user-authored store pattern
+
+Each store is three files plus a hook:
+
+| Piece | Example (`/travel`) | Role |
+|------|---------------------|------|
+| **Types** | `src/types/travel.ts` | Entity + summary shapes |
+| **Pure helpers + storage key** | `src/lib/travelPlanner.ts` | `*_STORAGE_KEY`, `load/parse/save`, `create*` factories, validators, derived summaries — all framework-free and unit-testable |
+| **Hook** | `src/hooks/useTravelPlanner.ts` | React binding that reads/writes the store and re-renders on change |
+
+Conventions that hold across the stores:
+
+- **Versioned keys** — `*_v1` suffix so a future shape change can migrate rather
+  than corrupt (e.g. `travel_planner_trips_v1`).
+- **Defensive parsing** — `load*`/`parse*` validate every field coming out of
+  `localStorage` (type guards like `isIsoDate`, `clampString` length caps,
+  array-shape checks) and fall back to an empty state on anything malformed.
+  Never trust persisted JSON.
+- **Ids** — `crypto.randomUUID()` when available, with a `Math.random` fallback,
+  prefixed per entity (`trip-…`, `wine-…`).
+- **SSR-safe** — every `window`/`localStorage` access is guarded
+  (`typeof window === "undefined"`), so the hook returns an empty snapshot during
+  server render and hydrates on the client.
+
+Two hook flavors are in use, both valid:
+
+- **`useSyncExternalStore` + cross-tab sync** (`useTravelPlanner`): a module-level
+  listener set plus a `storage` event handler keeps multiple tabs consistent and
+  gives React a stable external store. Prefer this for new stores.
+- **`useState` + `useEffect`** (`useMuseumLog`): simpler, single-tab; fine for
+  smaller surfaces.
+
+---
+
+## The tools
+
+### `/travel` — trip planner *(the blueprint; most complex)*
+
+- Files: `src/hooks/useTravelPlanner.ts`, `src/lib/travelPlanner.ts`,
+  `src/types/travel.ts`; client `src/app/travel/travel-planner-client.tsx`.
+- Key: `travel_planner_trips_v1`.
+- Model: trips → day-bucketed activities (categories: transit/lodging/food/
+  sight/activity/other) → per-trip journal entries (moods:
+  amazing/good/neutral/rough/tired). Derived `TripSummary` via
+  `calculateTripSummary`.
+- Cross-tab sync via `useSyncExternalStore`. Offers the richest validation
+  surface — copy it when building a new store.
+
+### `/wine-cellar` — tasting log
+
+- Files: `src/hooks/useWineCellar.ts`, `src/lib/wineCellar.ts`, `src/types/wine.ts`.
+- Key: `wine_cellar_entries_v1`.
+- Model: wine entries typed by `WineType` (red/white/rosé/sparkling/dessert/
+  fortified/orange), 0.5–5 star ratings (`MIN_RATING`/`MAX_RATING`/`RATING_STEP`),
+  with a derived `WineSummary` / per-type breakdown.
+
+### `/museum-log` — visit tracker
+
+- Files: `src/hooks/useMuseumLog.ts`, `src/types/museum.ts`; catalog
+  `src/data/museumSnapshot.ts`.
+- Key: `museum_log_user_state_v1`.
+- Model: a curated museum catalog (snapshot) + the user's `visited` / `watchlist`
+  / `liked` id lists persisted locally. Uses the `useState` + `useEffect` flavor.
+
+### `/recipe-finder` — curated catalog + pantry
+
+- Files: `src/lib/recipes.ts` (types, ingredient normalizer, match scoring),
+  catalog `src/data/recipesSnapshot.ts`; client
+  `src/app/recipe-finder/recipe-finder-client.tsx`.
+- Persisted: the user's pantry only, under `recipe-finder:pantry:v1`. The recipe
+  corpus is curated and read-only; the client scores recipes against the pantry
+  (staple pantry items don't count against a "missing ingredients" score).
+
+### `/food-map` — curated map *(no persistence)*
+
+- Files: `src/app/food-map/food-map-data.ts` (curated places),
+  `food-map-leaflet.tsx` + `leaflet.ts` (Leaflet map, lazy-loaded),
+  `food-map-state.ts` (deep-link/filter state), `food-map-client.tsx`.
+- Stores nothing in `localStorage`: search/filter state is in-memory and
+  reflected in the URL. The odd one out — included here because it's a
+  personal-interest surface, but it is a curated-data map, not a user store.
+
+---
+
+## Notes for contributors
+
+- The same localStorage discipline powers non-lifestyle surfaces too —
+  `useBudgetPlanner` (`budget_planner_months_v1`), `useInvestments`
+  (`portfolio_holdings`), `useRetirementPlan` (`retirement_plan`), and the fantasy
+  draft tracker — so improvements to the pattern can be shared.
+- **Testing:** because there's no server state, cover the pure
+  `src/lib/<tool>.ts` helpers (parse/validate/derive) with Jest; the hooks and
+  clients are thin. Malformed-JSON and version-bump cases are the high-value
+  tests.
+- **Privacy:** nothing here leaves the browser. Keep it that way — don't add an
+  API or analytics call that ships a user's trips/cellar/log off-device without a
+  deliberate decision.

--- a/RETIREMENT_PLANNER_ENGINE.md
+++ b/RETIREMENT_PLANNER_ENGINE.md
@@ -1,0 +1,160 @@
+# Retirement Planner Engine
+
+Technical reference for the retirement projection engine in
+`src/lib/retirement/`. The engine is **pure and framework-free** (no React, no
+DOM, no fetch) so it is unit-testable and could run server-side. The UI never
+does math — it calls `project()` and renders the result.
+
+**Last updated:** 2026-06-16
+
+Surfaced as the `#retirement` band inside the investments dashboard
+(`InvestmentsDashboard.tsx`), backed by browser-local state. Output is
+**educational only** — see *Compliance* below.
+
+---
+
+## Entry points
+
+`src/lib/retirement/index.ts`:
+
+```ts
+project(input: RetirementPlanInput, referenceYear?): RetirementResult
+projectCore(input: RetirementPlanInput, referenceYear?): RetirementCore  // = RetirementResult minus `levers`
+```
+
+- **`projectCore`** is the **fast path**: deterministic projection + headline
+  Monte Carlo + target number + verdict. The UI calls this synchronously so the
+  verdict gauge and chart paint immediately.
+- **`project`** = `projectCore` **plus** `computeLevers(...)`. The lever
+  sensitivity analysis is heavier (many extra simulations), so the UI computes it
+  **off the critical path** and fills the levers panel in after first paint.
+
+Both return real (today's-dollar) figures for display; the engine computes
+internally in **nominal** dollars and exposes real values alongside.
+
+### Output shape (`RetirementResult`)
+
+| Field | Meaning |
+|------|---------|
+| `expectedReturn`, `volatility` | Annualized nominal return + std dev **derived from the allocation** (not hardcoded) |
+| `targetNestEgg` | Real-dollar nest egg needed at retirement: `netSpend / safeWithdrawalRate` |
+| `safeWithdrawalRate` | SWR used for the target number (override or default) |
+| `deterministic` | Single expected-return path: year-by-year `path`, balance at retirement, ending balance, `depletionAge` |
+| `monteCarlo` | `successRate` (fraction funded through the horizon), per-year `bands` (p10–p90), balance triples, `medianDepletionAge` |
+| `levers` | The four what-if dials (see below) — only on `project()` |
+| `verdict` | `on-track` / `good` / `fair` / `at-risk`, tied to the user's own success threshold |
+| `assumptions` | Meta for disclosure: CMA source + as-of + `cmaVerified`, expected return/vol, inflation, threshold, RMD start age |
+
+---
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `index.ts` | `project` / `projectCore` orchestration; verdict + target-number math; re-exports |
+| `types.ts` | All input/output types. Inputs computed in nominal dollars, real exposed for display |
+| `capitalMarketAssumptions.ts` | Dated per-asset-class CMAs (return + std dev). `CMA_SOURCE`, `CMA_AS_OF`, `CMA_VERIFIED` |
+| `assumptions.ts` | `expandAllocation` (4 UI buckets → 6 CMA asset classes) and `computePortfolioAssumptions(allocation)` → blended `{ expectedReturn, volatility }` |
+| `projection.ts` | `simulatePath` / `runDeterministic`: two-phase (accumulation/decumulation) single-path projection in nominal dollars |
+| `monteCarlo.ts` | `runMonteCarlo`: N seeded lognormal return paths → success rate + percentile bands |
+| `random.ts` | `mulberry32` seeded PRNG + `makeNormalSampler` (Box–Muller) — deterministic for a fixed seed |
+| `tax.ts` | Account-aware withdrawals (`withdrawForYear`), effective tax by account type, RMD divisors + start age |
+| `socialSecurity.ts` | Claim-age benefit factor, COLA, `FULL_RETIREMENT_AGE`, real benefit at age |
+| `levers.ts` | The four sensitivity dials and their "how far to reach target" solving |
+| `defaults.ts` | `createDefaultPlan`, `DEFAULT_TAX_RATES`, `DEFAULT_SAFE_WITHDRAWAL_RATE` |
+| `format.ts` | `formatCurrency`, `formatCompactCurrency`, `formatPercent`, `formatScenarioCount` |
+
+---
+
+## How a projection runs
+
+1. **Allocation → assumptions.** `computePortfolioAssumptions(input.allocation)`
+   expands the four UI buckets (stocks/bonds/cash/other) into the six CMA asset
+   classes and blends their per-class return/volatility into a portfolio
+   `expectedReturn` + `volatility`. There is deliberately **no single "stocks do
+   10%" constant** — the number always traces to dated, citable CMAs.
+
+2. **Deterministic path.** `runDeterministic` walks one path from `currentAge` to
+   `horizonAge`:
+   `balance[t+1] = (balance[t] + contribution[t] − withdrawal[t]) · (1 + r[t])`.
+   Accumulation adds contributions + employer match; decumulation withdraws to
+   cover desired spend net of guaranteed income, applies account-aware taxes and
+   RMDs, layers in Social Security / pension / part-time income, pre-Medicare
+   healthcare (age < 65), and any lumpy expenses.
+
+3. **Monte Carlo.** `runMonteCarlo` draws `simulations` (default **1,000**)
+   lognormal return paths from `{ expectedReturn, volatility }` using the seeded
+   `mulberry32` PRNG, then reports the **success rate** (fraction of paths funded
+   through the horizon) and per-year **p10/p25/p50/p75/p90 bands**. Seeded, so a
+   given input always yields identical output (unit-testable, stable UI).
+
+4. **Withdrawal strategy** (decumulation), from `assumptions.withdrawalStrategy`:
+   - `fixed-real` — fixed real spend (4%-rule mental model). Default.
+   - `fixed-percent` — fixed % of the *current* balance (never depletes; income
+     swings with the market).
+   - `guardrails` — Guyton-Klinger inflation rule + capital-preservation /
+     prosperity guardrails.
+
+5. **Verdict + target.** `verdictFor(successRate, threshold)` ties the badge to
+   the user's own success threshold; `targetNestEgg = netSpend / SWR`.
+
+6. **Levers** (`project` only). Four dials, each reporting its marginal effect on
+   the success rate and — where it's a clean single dial — how far to push it to
+   reach the threshold: `save-more`, `retire-later`, `spend-less`, `more-stocks`.
+   Lever rows run at the headline simulation count (`LEVER_SIMS = 1000`) so their
+   absolute success figures agree with the gauge; only the threshold-solving
+   binary search uses a cheaper `TO_REACH_SIMS = 250`.
+
+---
+
+## State and UI
+
+- **State:** `src/hooks/useRetirementPlan.ts`, browser-local under localStorage
+  key `retirement_plan` (mirrors `useInvestments`). Offers the live portfolio
+  value as a one-click starting balance.
+- **UI:** `src/components/investments/retirement/` — `RetirementPlanner` (shell),
+  `RetirementInputs` / `RetirementFields` (progressive-disclosure inputs),
+  `RetirementVerdict` (headline gauge), `RetirementProjectionChart` (D3
+  confidence-band chart), `RetirementLevers`, `RetirementAssumptions` (editable
+  assumptions footer), `RetirementDisclaimer`.
+- **Headline vs. levers:** the verdict + chart use `projectCore` synchronously;
+  the levers panel runs `computeLevers` off the critical path and fills in after
+  paint.
+
+---
+
+## Capital market assumptions (unverified)
+
+`capitalMarketAssumptions.ts` ships **illustrative** long-term (10–15yr) nominal
+estimates shaped to align with published 2025 assumption sets (e.g. J.P. Morgan
+LTCMA, Research Affiliates, Vanguard VCMM). They are **not yet pinned to a
+primary source**:
+
+```ts
+export const CMA_AS_OF = "2026-06";
+export const CMA_VERIFIED = false;   // flip to true only after re-pinning
+```
+
+Before relying on the figures, re-pin them to a current dated primary source,
+update the numbers, **and** flip `CMA_VERIFIED` to `true` with the real source
+string + as-of date. The UI already surfaces the source, the as-of date, and the
+unverified state (spec §4.2, §9).
+
+---
+
+## Compliance (keep intact)
+
+Output is **educational only, not financial advice.** The disclaimer
+(`RetirementDisclaimer`), the honest "N of 100 scenarios" framing
+(`formatScenarioCount`), and the assumption disclosure (source + as-of +
+unverified state) are spec requirements (§9). Do not remove or soften them when
+editing the engine or its UI.
+
+---
+
+## Testing
+
+`src/lib/retirement/__tests__/retirement.test.ts` covers the pure engine. Because
+everything is seeded and framework-free, assertions are exact — add cases when
+changing projection math, tax/RMD logic, withdrawal strategies, or the lever
+solver. The engine should never need DOM or network mocks.

--- a/SNAPSHOT_DRIVEN_DASHBOARDS.md
+++ b/SNAPSHOT_DRIVEN_DASHBOARDS.md
@@ -1,0 +1,175 @@
+# Snapshot-Driven Dashboards
+
+How the site's data dashboards work. This is the single most-repeated
+architecture in the repo — 15+ public surfaces share it — so it gets one
+reference instead of being re-explained per route.
+
+**Last updated:** 2026-06-16
+
+The short version: **no dashboard calls an external API at request time.** A
+local script fetches data, transforms it, and writes a committed snapshot file. A
+GitHub Action re-runs that script on a schedule and commits the refreshed
+snapshot. The app reads the committed file. This keeps pages fast, keeps runtime
+free of third-party rate limits and outages, and makes every data change a
+reviewable diff.
+
+---
+
+## The five moving parts
+
+For a dashboard `x`:
+
+| Part | Path | Role |
+|------|------|------|
+| **Seed snapshot** | `src/data/<x>Snapshot.ts` | Committed `export const <x>Snapshot: <Type> = {…}`. Ships with a seed (empty or hand-authored) so the page works before the first refresh. |
+| **Builder** | `scripts/build<X>Snapshot.ts` (often via a `src/lib/<x>Data.ts` fetch/transform) | Fetches the upstream source, shapes it, writes the snapshot file. Run by `npm run update:<x>`. |
+| **GitHub Action** | `.github/workflows/update-<x>.yml` | Runs the builder on a schedule (+ manual dispatch) and commits the snapshot only when it changes. |
+| **Accessors** | `src/lib/<x>Snapshot.ts` | Pure read helpers the app and API routes call (`get<X>Summary()`, per-entity getters, id validation, empty-state factories). |
+| **API route(s)** | `src/app/api/<x>/summary/route.ts` (+ optional `[id]`) | Thin handlers that return accessor output. They read the committed snapshot, never the upstream source. |
+
+The route page (`src/app/<x>/page.tsx`) is a server shell — metadata + structured
+data — that hands the snapshot to a client component for deep-linkable `?view=` /
+`?team=` / `?station=` / `?player=` state.
+
+---
+
+## The fallback contract (important)
+
+A failed or empty refresh must **keep the previous snapshot**, never wipe it. The
+shared helper is `scripts/snapshotFallback.ts`:
+
+```ts
+export function readGeneratedSnapshot<T>(filePath: string, exportName: string): T | null
+```
+
+It reads the already-generated `export const <name> = {…};` literal back out of
+the `.ts` file and `JSON.parse`s it. It returns `null` for a missing file or a
+hand-authored seed that isn't in generated shape, so the caller can surface the
+original fetch error instead of masking it behind data that may not exist.
+
+Builders use it like this (from `scripts/buildGolfSnapshot.ts`):
+
+```ts
+try {
+  snapshot = await buildGolfSnapshotData();
+} catch (error) {
+  const existing = readGeneratedSnapshot<GolfSnapshot>(outPath, "golfSnapshot");
+  if (hasContents(existing)) {
+    console.warn("Golf refresh failed; keeping the existing snapshot.", error);
+    return;                       // keep last-good data
+  }
+  throw error;                    // no good data to fall back to → fail loudly
+}
+```
+
+Builders also **write atomically** (`writeFileAtomic`: write `.tmp`, then
+`renameSync`) so the snapshot is never observed half-written.
+
+---
+
+## Worked example: `/golf` (the simplest one)
+
+1. **Source:** ESPN's public golf leaderboard endpoint, no token.
+2. **Builder:** `scripts/buildGolfSnapshot.ts` calls `buildGolfSnapshotData()`
+   from `src/lib/golfData.ts`, JSON-stringifies the result into
+   `src/data/golfSnapshot.ts`, with the `readGeneratedSnapshot` fallback above.
+3. **Action:** `.github/workflows/update-golf.yml` runs daily at 08:40 UTC and
+   commits `src/data/golfSnapshot.ts` when it changes.
+4. **Accessors:** `src/lib/golfSnapshot.ts` exposes `getGolfSummary()`,
+   `getGolfPlayerSnapshot(id)`, `createEmptyGolfSummary()`, and id validation.
+5. **API:** `/api/golf/summary` and `/api/golf/players/[playerId]`.
+
+### Sub-resource pattern (id-keyed detail)
+
+Dashboards with a detail panel add an `[id]` accessor + route. Golf shows the id
+discipline that keeps handlers honest — **shape-check before membership** so the
+route can distinguish a malformed id (`400`) from a valid-shape unknown id
+(`404`):
+
+```ts
+const GOLF_PLAYER_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/i;
+isGolfPlayerIdShape(id)   // → 400 when false (bad input)
+isValidGolfPlayerId(id)   // shape AND id in golfSnapshot.playerSnapshots → else 404
+```
+
+The same idea keys other detail surfaces by a **lowercased identifier**: NBA/NFL/
+MLB/soccer `/teams/[teamId]` by team abbr, bay-area-transit `/stations/[stationId]`
+by BART abbr, world-cup `/teams/[teamId]` by team slug.
+
+---
+
+## All snapshot surfaces
+
+| Route(s) | Snapshot | Builder / `npm run` | Workflow | Upstream source | Cadence |
+|---|---|---|---|---|---|
+| `/premier-league` | `src/data/premierLeagueSnapshot.ts` | `buildPremierLeagueSnapshot.ts` · `update:premier-league` / `update:football` | `update-premier-league.yml` | football-data.org (token) | daily 06:15 UTC, Aug–May |
+| `/la-liga` | `src/data/laLigaSnapshot.ts` | `updateLaLigaSnapshot.ts` · `update:la-liga` / `update:football` | `update-la-liga.yml` | football-data.org (token) | daily 06:30 UTC, Aug–May |
+| `/nfl` | `src/data/nflSnapshot.ts` | `updateNflSnapshot.ts` · `update:nfl` | `update-nfl.yml` | NFLverse CSVs | Tue 10:35 UTC, Sep–Feb |
+| `/mlb` | `src/data/mlbSnapshot.ts` | `updateMlbSnapshot.ts` · `update:mlb` | `update-mlb.yml` | MLB Stats API | daily 10:05 UTC, Apr–Oct |
+| `/nba` | `src/data/nbaSnapshot.ts` | `updateNbaSnapshot.ts` · `update:nba` | `update-nba.yml` | ESPN NBA | daily 10:20 UTC, mid-Oct–Jun |
+| `/golf` | `src/data/golfSnapshot.ts` | `buildGolfSnapshot.ts` · `update:golf` | `update-golf.yml` | ESPN golf | daily 08:40 UTC |
+| `/formula-1`, `/fantasy-formula-1` | `src/data/formula1Snapshot.ts` | `buildFormula1Snapshot.ts` · `update:formula-1` | `update-formula-1.yml` | OpenF1 | daily 08:10 UTC |
+| `/world-cup-2026` | `src/data/worldCupSnapshot.ts` | `buildWorldCupSnapshot.ts` · `update:world-cup` | `update-world-cup.yml` | ESPN `soccer/fifa.world` | every 6h, Jun–Jul |
+| `/bay-area-transit` | `src/data/bayAreaTransitSnapshot.ts` | `buildBayAreaTransitSnapshot.ts` · `update:bay-area-transit` | `update-bay-area-transit.yml` | BART public API (demo key) | every 6h, year-round |
+| `/earthquake-pulse` | `src/data/earthquakeSnapshot.ts` | `buildEarthquakeSnapshot.ts` · `update:earthquake` | `update-earthquake.yml` | USGS GeoJSON feeds | hourly (min 20) |
+| `/github-trending-pulse` | `src/data/githubTrendingSnapshot.ts` | `buildGitHubTrendingSnapshot.ts` · `update:github-trending` | `update-github-trending.yml` | GitHub Search API | daily 07:45 UTC |
+| `/spacex-mission-control` | `src/data/spacexSnapshot.generated.json` (+ image manifest) | `buildSpaceXSnapshot.ts` · `update:spacex` | `update-spacex.yml` | Launch Library / SpaceDevs | daily 09:25 + 21:25 UTC |
+| `/tech-startup-tracker` | `src/data/techStartupSnapshot.ts` | `buildTechStartupSnapshot.ts` · `update:tech-startups` | none (curated) | hand-maintained seed | manual |
+| `/frontier-models` | `src/data/frontierModelsSnapshot.ts` | `buildFrontierModelsSnapshot.ts` · `update:frontier-models` | none (curated) | `scripts/data/frontierModels.source.ts` | manual |
+
+**Curated surfaces** (`tech-startup-tracker`, `frontier-models`) have no Action
+because there's no live source to poll — figures are approximate, tagged with an
+`asOf` date and a `verified: false` flag, and disclosed on-page. Refresh by
+editing the seed and re-running the builder.
+
+**Related but not this pattern:**
+- `/polling-aggregator` reads a committed `src/data/pollingSnapshot.ts` with **no
+  builder or Action** — a static curated snapshot.
+- `/news-pulse` is **API-backed at request time** (`/api/news-pulse` →
+  `src/lib/news-pulse-utils.ts`), not a build-time snapshot.
+
+For the operational view (command → artifact → schedule in one table) see
+`docs/DATA_UPDATE_OPERATIONS.md`.
+
+---
+
+## Per-route error boundaries
+
+Snapshot dashboards drop an `error.tsx` that re-exports the shared
+`RouteErrorBoundary` with a `surfaceName`, so a render failure shows an
+editorial, route-specific fallback instead of the global catch-all:
+
+```tsx
+// src/app/<x>/error.tsx
+"use client";
+import { RouteErrorBoundary } from "@/components/RouteErrorBoundary";
+export default function Error(props) {
+  return <RouteErrorBoundary {...props} surfaceName="Golf" />;
+}
+```
+
+---
+
+## Adding a new dashboard (checklist)
+
+1. **Types** — `src/types/<x>.ts` (snapshot + summary + detail shapes).
+2. **Seed** — `src/data/<x>Snapshot.ts` with an empty/seed `export const`.
+3. **Fetch/transform** — `src/lib/<x>Data.ts` (`build<X>SnapshotData()`).
+4. **Builder** — `scripts/build<X>Snapshot.ts`: call the fetcher, write
+   atomically, fall back via `readGeneratedSnapshot` on failure.
+5. **Script** — add `"update:<x>": "tsx scripts/build<X>Snapshot.ts"` to
+   `package.json`.
+6. **Accessors** — `src/lib/<x>Snapshot.ts` (`get<X>Summary()`, id validation,
+   empty-state factory).
+7. **API** — `src/app/api/<x>/summary/route.ts` (+ `[id]` if there's a detail
+   panel; return `400` for malformed ids, `404` for unknown).
+8. **Route** — `src/app/<x>/page.tsx` server shell + client component with
+   deep-linkable state; add `src/app/<x>/error.tsx`.
+9. **Action** — `.github/workflows/update-<x>.yml` on a sensible cron + manual
+   dispatch, committing the snapshot only when it changes.
+10. **Docs** — add a row to the table above and to
+    `docs/DATA_UPDATE_OPERATIONS.md`; register in `AGENTS.md` Automation Surfaces.
+
+Reuse the shared football components in `src/components/football/` (FixtureCard,
+LeaderList, StatCard, CrestAvatar, …) wherever the surface is a league/standings
+view — the soccer, NBA, NFL, MLB, and World Cup dashboards all do.

--- a/docs/DATA_UPDATE_OPERATIONS.md
+++ b/docs/DATA_UPDATE_OPERATIONS.md
@@ -1,0 +1,95 @@
+# Data Update Operations
+
+A single command → artifact → schedule lookup for every data refresh on the
+site. This is the operational index; it deliberately does **not** re-explain the
+architecture or the per-workflow prose:
+
+- Architecture (seed → builder → Action → accessors → API, the fallback
+  contract): `../SNAPSHOT_DRIVEN_DASHBOARDS.md`
+- Per-script and per-workflow detail: `AUTOMATION_SCRIPTS.md`, `CRON_SETUP.md`,
+  and the **Automation Surfaces** section of `../AGENTS.md`
+
+**Last updated:** 2026-06-16
+
+All `update:*` commands write a **committed** artifact (TS snapshot or JSON);
+nothing here runs at request time. A failed/empty fetch **keeps the previous
+snapshot** rather than wiping it. Workflows commit only when the artifact
+changes.
+
+---
+
+## Master table
+
+| Surface | `npm run` | Script(s) | Upstream source | Committed artifact | Workflow | Cadence |
+|---|---|---|---|---|---|---|
+| Fantasy football | `update:fantasy` | `buildFantasyPositionData.ts` → `buildFantasyAdpData.ts` → `buildFantasySnapshots.ts` | FantasyPros cheatsheets + FF Calculator ADP | `public/data/fantasy/{ppr,half_ppr,standard}.json`, `src/data/fantasy*.generated.ts` | `update-fantasy.yml` | Wed 17:00 UTC |
+| Investments | `update:investments` | `fetch_investments_data.py` (needs `.venv`) → `buildInvestmentsSnapshots.ts` | `defeatbeta-api` (Python) | `public/data/investments/index.json` + `{SYMBOL}/snapshot.json` | `update-investments.yml` | Mon + Thu 22:15 UTC |
+| Football (both) | `update:football` | `updateFootballSnapshots.ts` | football-data.org *(token)* | `src/data/premierLeagueSnapshot.ts` + `laLigaSnapshot.ts` | — *(full run is manual ~weekly)* | manual |
+| Premier League | `update:premier-league` | `buildPremierLeagueSnapshot.ts` | football-data.org *(token)* | `src/data/premierLeagueSnapshot.ts` | `update-premier-league.yml` | daily 06:15 UTC, Aug–May |
+| La Liga | `update:la-liga` | `updateLaLigaSnapshot.ts` | football-data.org *(token)* | `src/data/laLigaSnapshot.ts` | `update-la-liga.yml` | daily 06:30 UTC, Aug–May |
+| NFL | `update:nfl` | `updateNflSnapshot.ts` | NFLverse CSVs | `src/data/nflSnapshot.ts` | `update-nfl.yml` | Tue 10:35 UTC, Sep–Feb |
+| MLB | `update:mlb` | `updateMlbSnapshot.ts` | MLB Stats API | `src/data/mlbSnapshot.ts` | `update-mlb.yml` | daily 10:05 UTC, Apr–Oct |
+| NBA | `update:nba` | `updateNbaSnapshot.ts` | ESPN NBA | `src/data/nbaSnapshot.ts` | `update-nba.yml` | daily 10:20 UTC, mid-Oct–Jun |
+| Golf | `update:golf` | `buildGolfSnapshot.ts` | ESPN golf | `src/data/golfSnapshot.ts` | `update-golf.yml` | daily 08:40 UTC |
+| Formula 1 | `update:formula-1` | `buildFormula1Snapshot.ts` | OpenF1 | `src/data/formula1Snapshot.ts` | `update-formula-1.yml` | daily 08:10 UTC |
+| World Cup 2026 | `update:world-cup` | `buildWorldCupSnapshot.ts` | ESPN `soccer/fifa.world` | `src/data/worldCupSnapshot.ts` | `update-world-cup.yml` | every 6h, Jun–Jul |
+| Bay Area Transit | `update:bay-area-transit` | `buildBayAreaTransitSnapshot.ts` | BART public API *(demo key)* | `src/data/bayAreaTransitSnapshot.ts` | `update-bay-area-transit.yml` | every 6h, year-round |
+| Earthquake Pulse | `update:earthquake` | `buildEarthquakeSnapshot.ts` | USGS GeoJSON feeds | `src/data/earthquakeSnapshot.ts` | `update-earthquake.yml` | hourly (min 20) |
+| GitHub Trending | `update:github-trending` | `buildGitHubTrendingSnapshot.ts` | GitHub Search API *(`GITHUB_TOKEN` optional)* | `src/data/githubTrendingSnapshot.ts` | `update-github-trending.yml` | daily 07:45 UTC |
+| SpaceX data | `update:spacex` *(alias `update:spacex-data`)* | `buildSpaceXSnapshot.ts` | Launch Library / SpaceDevs | `src/data/spacexSnapshot.generated.json` | `update-spacex.yml` | daily 09:25 + 21:25 UTC |
+| SpaceX images | `update:spacex-images` | `buildSpaceXImageSnapshots.ts` | launch image assets | `src/data/spacexImageManifest.generated.json`, `public/data/spacex/*` | `update-spacex.yml` | daily 09:25 + 21:25 UTC |
+| Tech startups | `update:tech-startups` | `buildTechStartupSnapshot.ts` | curated seed *(in script)* | `src/data/techStartupSnapshot.ts` | none — curated | manual |
+| Frontier models | `update:frontier-models` | `buildFrontierModelsSnapshot.ts` | `scripts/data/frontierModels.source.ts` | `src/data/frontierModelsSnapshot.ts` | none — curated | manual |
+
+**No update path (not snapshot-built):**
+- `/polling-aggregator` — static committed `src/data/pollingSnapshot.ts`, edited by hand.
+- `/news-pulse` — API-backed at request time (`/api/news-pulse`), no committed snapshot.
+
+---
+
+## Tokens / prerequisites
+
+| Need | Used by |
+|------|---------|
+| `FOOTBALL_DATA_API_TOKEN` | `update:football`, `update:premier-league`, `update:la-liga` (only when rebuilding) |
+| `GITHUB_TOKEN` / `GH_TOKEN` (optional, higher rate limit) | `update:github-trending` |
+| Python `.venv` (`.venv/bin/python3`; `defeatbeta-api`) | `update:investments` |
+| *No token* | MLB, NBA, NFL, golf, Formula 1, World Cup, BART, USGS, SpaceX |
+
+---
+
+## Build-time refresh (Netlify)
+
+- `prebuild` runs `tsx scripts/updateFootballSnapshots.ts --league-only` on every
+  deploy — the fast standings/fixtures/scorers path for the two soccer leagues.
+- A daily cron-job.org ping to the Netlify build hook triggers a production
+  deploy, so the league-only football refresh and any newly committed snapshots
+  go live without manual steps.
+- **NFL is intentionally not in `prebuild`** — it refreshes only via
+  `update-nfl.yml` (or a manual run).
+- `update:football` (the ~16-min full refresh, incl. per-team fixtures + form) is
+  a **local weekly** task, not a build step.
+
+---
+
+## Recommended local refresh
+
+```bash
+npm run update:football   # ~16 min — run in background
+git add src/data/
+git commit -m "data: refresh football snapshots"
+git push
+```
+
+The same shape applies to any surface: run `npm run update:<x>`, then commit the
+changed artifact under `src/data/` or `public/data/`.
+
+---
+
+## Failure behavior
+
+Builders that fetch a live source fall back to the last-good snapshot on
+failure via `scripts/snapshotFallback.ts` (`readGeneratedSnapshot`) and write
+atomically. So a flaky upstream produces a no-op run, not a wiped dashboard. The
+investments builder is similar — symbols with no fresh raw sections keep their
+committed snapshot. See `../SNAPSHOT_DRIVEN_DASHBOARDS.md` for the contract.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Current map of tracked Markdown documentation.
 
-**Last updated:** 2026-06-08
+**Last updated:** 2026-06-16
 
 Tracked Markdown audit scope: `git ls-files '*.md'` returned 216 tracked files before the 2026-04-15 content coverage sync. That sync adds 16 new markdown files under `content/projects/` and `content/sections/`.
 
@@ -41,6 +41,12 @@ AI-oriented technical references:
 - `ai-context/SEO-AND-METADATA.md`
 - `ai-context/STYLING.md`
 
+Subsystem references (current):
+
+- `../SNAPSHOT_DRIVEN_DASHBOARDS.md` — shared snapshot-driven dashboard architecture
+- `../PERSONAL_INTEREST_TOOLS.md` — browser-persisted localStorage tools
+- `../RETIREMENT_PLANNER_ENGINE.md` — pure retirement projection engine (`src/lib/retirement/`)
+
 ---
 
 ## Supporting Operational Docs
@@ -53,6 +59,7 @@ Use these when the task is specifically about setup, deployment, data operations
 - `../TROUBLESHOOTING.md`
 - `AUTOMATION_SCRIPTS.md`
 - `CRON_SETUP.md`
+- `DATA_UPDATE_OPERATIONS.md` (consolidated command → artifact → schedule runbook)
 - `ENVIRONMENT_CONFIGURATION.md`
 - `FANTASY_PLATFORM_SETUP.md`
 - `SECURITY.md`


### PR DESCRIPTION
## What this does

An audit of the repo's markdown docs (full inventory + accuracy spot-checks against the code + gap analysis). Two outcomes, both acted on:

### 1. Fix the one doc with real drift — `COMPONENTS.md`
It predated the 2026-05-31 `*V3` surface refresh. Corrected (every name verified by grep against `src/`):
- Removed components that **no longer exist anywhere** in `src/`: `FeaturedWorkSection`, `ContactContent`, `PortfolioTracker`, `StockCard`, `ResearchSummaryStrip`, `FundamentalsPanel`, `NewsPanel`.
- Documented the live composition roots: `HomePageV3`, `AboutV3`, `PortfolioV3`, `ContactV3`, `WritingArchiveV3`, and the real `InvestmentsDashboard` component set.
- Moved the now-unwired `ModernHero` / `ThinkingPreview` / `ContactSection` (nothing imports them) to **Legacy Or Unwired Components**.

The other source-of-truth docs (PAGES.md 46/46 routes, API.md 31/31 routes, ARCHITECTURE.md, README.md, CLAUDE.md) were checked and are accurate — left untouched.

### 2. Add four docs for subsystems that had no dedicated home
- **`SNAPSHOT_DRIVEN_DASHBOARDS.md`** — the snapshot → builder → GitHub Action → accessors → API pattern shared by 15+ dashboards, the `readGeneratedSnapshot` fallback contract, a worked `/golf` example, the full surface table, and an add-a-new-dashboard checklist.
- **`PERSONAL_INTEREST_TOOLS.md`** — the browser-persisted localStorage tools (`/travel`, `/wine-cellar`, `/museum-log`, `/recipe-finder`, `/food-map`).
- **`RETIREMENT_PLANNER_ENGINE.md`** — the pure projection/Monte Carlo engine in `src/lib/retirement/`, including the unverified-CMA and educational-only compliance policy.
- **`docs/DATA_UPDATE_OPERATIONS.md`** — one consolidated command → artifact → schedule runbook (cross-links, doesn't duplicate, `AUTOMATION_SCRIPTS.md` / `CRON_SETUP.md`).

### 3. Register + a minor fix
- Added the four docs to the source-of-truth indexes in `CLAUDE.md`, `docs/README.md`, and `AGENTS.md`.
- Filled the missing `update-earthquake.yml` entry in the AGENTS.md automation list (spotted during the audit).

## Verification
- Every file path, script, workflow, and API route cited in the new docs was confirmed to exist on disk.
- `npm run lint` is clean (markdown-only change; `eslint src` is a no-op here).
- No stale component names remain in COMPONENTS.md outside the explicit "removed" note.

https://claude.ai/code/session_01P9UVqARi8pmN11F1y7ngVy

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9UVqARi8pmN11F1y7ngVy)_