### PR TITLE
Reformat /contact page: cut redundancy, drop "not a fit" section

### DIFF
--- a/src/app/contact/contact.module.css
+++ b/src/app/contact/contact.module.css
@@ -330,59 +330,7 @@
   color: var(--c-ink);
 }
 
-/* ============== Marquee band ============== */
-.c-band {
-  background: var(--c-paper-soft);
-  border-bottom: 1px solid var(--c-ink);
-  overflow: hidden;
-}
-.c-band-inner {
-  display: flex;
-  align-items: center;
-  padding: 14px 0;
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  font-weight: 500;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  white-space: nowrap;
-  overflow: hidden;
-}
-.c-band-inner .marquee {
-  display: inline-flex;
-  gap: 2.5rem;
-  animation: cscroll 80s linear infinite;
-  flex-shrink: 0;
-}
-@keyframes cscroll {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-50%);
-  }
-}
-@media (prefers-reduced-motion: reduce) {
-  .c-band-inner .marquee {
-    animation: none;
-  }
-}
-.c-band-inner .marquee span {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  color: var(--c-muted);
-}
-.c-band-inner .marquee span::before {
-  content: "◆";
-  color: var(--c-ink);
-  font-size: 6px;
-}
-.c-band-inner .marquee span.hot::before {
-  color: var(--c-haze);
-}
-
-/* ============== Two-column editorial: Good fit / Not a fit ============== */
+/* ============== "What I'm looking for" editorial grid ============== */
 .c-fit {
   border-bottom: 1px solid var(--c-ink);
   padding: clamp(2.5rem, 5vw, 4.5rem) 0;
@@ -441,196 +389,38 @@
     grid-template-columns: 1fr;
   }
 }
-.c-fit-col {
+.c-fit-item {
   border-right: 1px solid var(--c-ink);
   border-bottom: 1px solid var(--c-ink);
-  padding: clamp(1.5rem, 3vw, 2.5rem);
-  background: var(--c-paper);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-.c-fit-col.is-yes {
-  background: color-mix(in srgb, var(--c-acid) 18%, var(--c-paper));
-}
-.c-fit-col .colhead {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding-bottom: 14px;
-  border-bottom: 1px solid var(--c-rule-soft);
-  margin-bottom: 6px;
-}
-.c-fit-col .colhead .label {
-  font-family: var(--font-display);
-  font-size: 1.6rem;
-  font-weight: 500;
-  letter-spacing: -0.03em;
-  color: var(--c-ink);
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-}
-.c-fit-col .colhead .label em {
-  font-family: var(--font-serif);
-  font-style: italic;
-  font-weight: 400;
-}
-.c-fit-col .colhead .glyph {
-  width: 32px;
-  height: 32px;
-  border: 1px solid var(--c-ink);
-  display: grid;
-  place-items: center;
-  font-family: var(--font-display);
-  font-size: 1.2rem;
-  font-weight: 600;
-}
-.c-fit-col.is-yes .glyph {
-  background: var(--c-acid);
-}
-.c-fit-col.is-no .glyph {
-  background: var(--c-ink);
-  color: var(--c-paper);
-}
-.c-fit-col ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-.c-fit-col li {
-  padding: 14px 0;
-  border-bottom: 1px dashed var(--c-rule-soft);
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  background: color-mix(in srgb, var(--c-acid) 12%, var(--c-paper));
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 14px;
   align-items: start;
-  font-family: var(--font-display);
-  font-size: 1rem;
-  line-height: 1.45;
-  color: var(--c-ink-soft);
 }
-.c-fit-col li:last-child {
-  border-bottom: 0;
-}
-.c-fit-col li .li-num {
+.c-fit-item .li-num {
   font-family: var(--font-mono);
   font-size: 0.7rem;
   font-weight: 500;
   letter-spacing: 0.06em;
   color: var(--c-muted);
-  padding-top: 2px;
+  padding-top: 4px;
 }
-.c-fit-col li strong {
+.c-fit-item p {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.02rem;
+  line-height: 1.45;
+  color: var(--c-ink-soft);
+}
+.c-fit-item strong {
   font-family: var(--font-display);
   font-weight: 600;
   letter-spacing: -0.015em;
   color: var(--c-ink);
   display: block;
   margin-bottom: 4px;
-}
-
-/* ============== Side details (location · response · availability) ============== */
-.c-details {
-  background: var(--c-paper-soft);
-  border-bottom: 1px solid var(--c-ink);
-  padding: clamp(2rem, 4vw, 3.5rem) 0;
-}
-.c-details-head {
-  margin-bottom: clamp(1.5rem, 3vw, 2rem);
-}
-.c-details-head h2 {
-  font-family: var(--font-display);
-  font-size: clamp(1.6rem, 2.8vw, 2.2rem);
-  font-weight: 500;
-  letter-spacing: -0.035em;
-  margin: 0;
-  color: var(--c-ink);
-}
-.c-details-head h2 em {
-  font-family: var(--font-serif);
-  font-style: italic;
-  font-weight: 400;
-}
-.c-detail-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0;
-  border-top: 1px solid var(--c-ink);
-  border-left: 1px solid var(--c-ink);
-}
-@media (max-width: 880px) {
-  .c-detail-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-.c-detail {
-  border-right: 1px solid var(--c-ink);
-  border-bottom: 1px solid var(--c-ink);
-  padding: clamp(1.25rem, 2vw, 1.75rem);
-  background: var(--c-paper);
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-height: 10rem;
-  position: relative;
-}
-.c-detail::before {
-  content: "";
-  position: absolute;
-  top: 14px;
-  right: 14px;
-  width: 8px;
-  height: 8px;
-  background: var(--cell-dot, var(--c-acid));
-}
-.c-detail:nth-child(4n + 1) {
-  --cell-dot: var(--c-acid);
-}
-.c-detail:nth-child(4n + 2) {
-  --cell-dot: var(--c-haze);
-}
-.c-detail:nth-child(4n + 3) {
-  --cell-dot: var(--c-ink);
-}
-.c-detail:nth-child(4n + 4) {
-  --cell-dot: var(--c-acid);
-}
-.c-detail .lbl {
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
-  font-weight: 500;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--c-muted);
-}
-.c-detail .val {
-  font-family: var(--font-display);
-  font-size: 1.3rem;
-  font-weight: 500;
-  line-height: 1.1;
-  letter-spacing: -0.025em;
-  color: var(--c-ink);
-  margin: 0;
-  margin-top: auto;
-  font-variation-settings: "opsz" 36;
-}
-.c-detail .val em {
-  font-family: var(--font-serif);
-  font-style: italic;
-  font-weight: 400;
-  color: var(--c-haze);
-}
-.c-detail .sub {
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  color: var(--c-muted);
 }
 
 /* ============== Closing pull-quote / manifesto ============== */

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -7,7 +7,7 @@ export const metadata = constructMetadata({
   description:
     "Get in touch about product roles, analytics work, or fintech-focused projects.",
   canonicalUrl: "/contact",
-  dateModified: "2026-05-26",
+  dateModified: "2026-06-18",
 });
 
 export default function Contact() {

--- a/src/components/contact/ContactV3.tsx
+++ b/src/components/contact/ContactV3.tsx
@@ -8,6 +8,10 @@ import styles from "@/app/contact/contact.module.css";
  * with `mailto:` + external links. The global `StaticHeader` and `Footer`
  * (compact variant on /contact) handle chrome — this component only renders
  * the content sections.
+ *
+ * Each fact lives in exactly one place: status in the masthead pin, the
+ * quick facts in the stat strip, contact methods in the channel ribbon,
+ * and the explore-more links in the closing actions.
  */
 export function ContactV3() {
   return (
@@ -24,7 +28,7 @@ export function ContactV3() {
             <span>—</span>
             <span>Vol. 2026</span>
             <span className={styles["status-pin"]}>
-              Currently open · Available
+              Currently open · Product roles
             </span>
           </div>
           <h1 className={styles["c-wordmark"]}>
@@ -32,22 +36,22 @@ export function ContactV3() {
           </h1>
           <div className={styles["c-subline"]}>
             <p className={styles["c-tagline"]}>
-              Two ways in: a working email and a LinkedIn. No form, no funnel,
-              no <em>auto-responder</em>.
+              There are two ways in, a working email and a LinkedIn. No form, no
+              funnel, no <em>auto-responder</em>.
             </p>
             <div className={styles["c-side"]}>
               <div className={styles["c-stat-strip"]}>
                 <div>
-                  <span className={styles.lbl}>Reply within</span>
-                  <span className={styles.val}>2 days</span>
+                  <span className={styles.lbl}>Response</span>
+                  <span className={styles.val}>2 business days</span>
                 </div>
                 <div>
                   <span className={styles.lbl}>Best for</span>
                   <span className={styles.val}>Product · Analytics</span>
                 </div>
                 <div>
-                  <span className={styles.lbl}>Time zone</span>
-                  <span className={styles.val}>PT · Berkeley</span>
+                  <span className={styles.lbl}>Based in</span>
+                  <span className={styles.val}>Berkeley · PT</span>
                 </div>
               </div>
             </div>
@@ -88,7 +92,7 @@ export function ContactV3() {
               linkedin.com/<wbr />in/<em>isaac-vazquez</em>
             </p>
             <div className={styles.footline}>
-              <span>Best for intros · roles · referrals</span>
+              <span>Intros · roles · referrals</span>
               <span className={styles.arrow}>{"↗"}</span>
             </div>
           </a>
@@ -108,31 +112,7 @@ export function ContactV3() {
         </div>
       </div>
 
-      {/* Marquee band */}
-      <div className={styles["c-band"]} aria-hidden="true">
-        <div className={styles["c-band-inner"]}>
-          <div className={styles.marquee}>
-            <span className={styles.hot}>
-              Currently open · Available for product work
-            </span>
-            <span>Based in Berkeley, CA</span>
-            <span>Reply within 2 business days</span>
-            <span>Best for product · analytics · fintech</span>
-            <span>No form · no funnel · just email</span>
-            <span className={styles.hot}>UC Berkeley Haas MBA &apos;27</span>
-            <span className={styles.hot}>
-              Currently open · Available for product work
-            </span>
-            <span>Based in Berkeley, CA</span>
-            <span>Reply within 2 business days</span>
-            <span>Best for product · analytics · fintech</span>
-            <span>No form · no funnel · just email</span>
-            <span className={styles.hot}>UC Berkeley Haas MBA &apos;27</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Good fit / Not a fit */}
+      {/* What I'm looking for */}
       <section className={styles["c-fit"]} data-screen-label="02 Contact / Fit">
         <div className={styles.shell}>
           <div className={styles["c-fit-head"]}>
@@ -140,143 +120,41 @@ export function ContactV3() {
               <span className={styles.num}>02</span> Best conversations
             </span>
             <h2 className={styles["c-fit-title"]}>
-              What I&apos;m <em>looking for</em>, and what I&apos;m not.
+              What I&apos;m <em>looking for</em>.
             </h2>
           </div>
 
           <div className={styles["c-fit-grid"]}>
-            <div className={`${styles["c-fit-col"]} ${styles["is-yes"]}`}>
-              <div className={styles.colhead}>
-                <span className={styles.label}>
-                  Good <em>fit</em>.
-                </span>
-                <span className={styles.glyph} aria-hidden="true">
-                  +
-                </span>
-              </div>
-              <ul>
-                <li>
-                  <span className={styles["li-num"]}>01</span>
-                  <span>
-                    <strong>Product, analytics, or fintech work.</strong> The
-                    places where clear thinking actually changes the outcome —
-                    not just the roadmap.
-                  </span>
-                </li>
-                <li>
-                  <span className={styles["li-num"]}>02</span>
-                  <span>
-                    <strong>AI workflows and decision tools.</strong> Especially
-                    where the surface area has to survive contact with real
-                    users.
-                  </span>
-                </li>
-                <li>
-                  <span className={styles["li-num"]}>03</span>
-                  <span>
-                    <strong>Platform reliability + product judgment.</strong>{" "}
-                    Teams where the strategy and the delivery actually have to
-                    connect.
-                  </span>
-                </li>
-                <li>
-                  <span className={styles["li-num"]}>04</span>
-                  <span>
-                    <strong>Honest scope conversations.</strong>{" "}
-                    {"“"}Here is the rough budget and the actual problem
-                    {"”"} beats a polished RFP every time.
-                  </span>
-                </li>
-              </ul>
+            <div className={styles["c-fit-item"]}>
+              <span className={styles["li-num"]}>01</span>
+              <p>
+                <strong>Product, analytics, or fintech work.</strong> The places
+                where clear thinking actually changes the outcome, not just the
+                roadmap.
+              </p>
             </div>
-
-            <div className={`${styles["c-fit-col"]} ${styles["is-no"]}`}>
-              <div className={styles.colhead}>
-                <span className={styles.label}>
-                  Not a <em>fit</em>.
-                </span>
-                <span className={styles.glyph} aria-hidden="true">
-                  {"−"}
-                </span>
-              </div>
-              <ul>
-                <li>
-                  <span className={styles["li-num"]}>01</span>
-                  <span>
-                    <strong>Crypto or NFT projects.</strong> Outside what I can
-                    usefully help with right now.
-                  </span>
-                </li>
-                <li>
-                  <span className={styles["li-num"]}>02</span>
-                  <span>
-                    <strong>Logo-only or pure marketing site work.</strong>{" "}
-                    Other studios will serve you better than I will.
-                  </span>
-                </li>
-                <li>
-                  <span className={styles["li-num"]}>03</span>
-                  <span>
-                    <strong>
-                      {"“"}Build me a clone of X.{"”"}
-                    </strong>{" "}
-                    Happy to talk about the actual product instead —
-                    that&apos;s where the work is.
-                  </span>
-                </li>
-                <li>
-                  <span className={styles["li-num"]}>04</span>
-                  <span>
-                    <strong>Unpaid speculative work.</strong> Including{" "}
-                    {"“"}free pilot, paid if it goes well{"”"}{" "}
-                    framings.
-                  </span>
-                </li>
-              </ul>
+            <div className={styles["c-fit-item"]}>
+              <span className={styles["li-num"]}>02</span>
+              <p>
+                <strong>AI workflows and decision tools.</strong> Especially
+                where the surface area has to survive contact with real users.
+              </p>
             </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Side details */}
-      <section
-        className={styles["c-details"]}
-        data-screen-label="03 Contact / Details"
-      >
-        <div className={styles.shell}>
-          <div className={styles["c-details-head"]}>
-            <h2>
-              The <em>practical</em> details.
-            </h2>
-          </div>
-          <div className={styles["c-detail-grid"]}>
-            <div className={styles["c-detail"]}>
-              <span className={styles.lbl}>Location</span>
-              <span className={styles.val}>
-                Berkeley, <em>CA</em>
-              </span>
-              <span className={styles.sub}>Bay Area · PT</span>
+            <div className={styles["c-fit-item"]}>
+              <span className={styles["li-num"]}>03</span>
+              <p>
+                <strong>Platform reliability and product judgment.</strong>{" "}
+                Teams where the strategy and the delivery actually have to
+                connect.
+              </p>
             </div>
-            <div className={styles["c-detail"]}>
-              <span className={styles.lbl}>Status</span>
-              <span className={styles.val}>
-                Currently <em>open</em>
-              </span>
-              <span className={styles.sub}>For product roles · 2026</span>
-            </div>
-            <div className={styles["c-detail"]}>
-              <span className={styles.lbl}>Response</span>
-              <span className={styles.val}>
-                Within <em>2 days</em>
-              </span>
-              <span className={styles.sub}>Business days · PT</span>
-            </div>
-            <div className={styles["c-detail"]}>
-              <span className={styles.lbl}>Background</span>
-              <span className={styles.val}>
-                Haas <em>MBA</em> &apos;27
-              </span>
-              <span className={styles.sub}>Civic tech · SaaS · Investments</span>
+            <div className={styles["c-fit-item"]}>
+              <span className={styles["li-num"]}>04</span>
+              <p>
+                <strong>Honest scope conversations.</strong> {"“"}Here is the
+                rough budget and the actual problem{"”"} beats a polished RFP
+                every time.
+              </p>
             </div>
           </div>
         </div>
@@ -285,7 +163,7 @@ export function ContactV3() {
       {/* Closing pull-quote */}
       <section
         className={styles["c-quote"]}
-        data-screen-label="04 Contact / Quote"
+        data-screen-label="03 Contact / Quote"
       >
         <div className={styles.shell}>
           <div className={styles["c-quote-grid"]}>
@@ -296,59 +174,51 @@ export function ContactV3() {
                   I&apos;m looking for product work where the thinking{" "}
                   <em>and</em> the delivery both have to be good.
                 </strong>{" "}
-                Especially analytics, fintech, and workflow products — places
+                Especially analytics, fintech, and workflow products, the places
                 where clear strategy and reliable delivery are connected.
               </p>
               <div className={styles["c-quote-sig"]}>
-                Isaac Vazquez · Berkeley, CA
+                Isaac Vazquez · UC Berkeley Haas MBA &apos;27 · Berkeley, CA
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Quick action footer */}
+      {/* Explore more */}
       <section
         className={styles["c-actions"]}
-        data-screen-label="05 Contact / Actions"
+        data-screen-label="04 Contact / Explore"
       >
         <div className={styles.shell}>
           <div className={styles["c-actions-row"]}>
-            <a
-              className={styles["c-action"]}
-              href="mailto:IsaacVazquez@berkeley.edu"
-            >
-              <span className={styles.lbl}>Action · 01</span>
-              <span className={styles.head}>
-                Send <em>email</em>
-              </span>
-              <span className={styles.foot}>
-                <span>IsaacVazquez@berkeley.edu</span>
-                <span className={styles.arrow}>{"↗"}</span>
-              </span>
-            </a>
-            <a
-              className={styles["c-action"]}
-              href="https://www.linkedin.com/in/isaac-vazquez"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span className={styles.lbl}>Action · 02</span>
-              <span className={styles.head}>
-                Connect on <em>LinkedIn</em>
-              </span>
-              <span className={styles.foot}>
-                <span>in/isaac-vazquez</span>
-                <span className={styles.arrow}>{"↗"}</span>
-              </span>
-            </a>
             <Link className={styles["c-action"]} href="/portfolio">
-              <span className={styles.lbl}>Action · 03</span>
+              <span className={styles.lbl}>Explore · 01</span>
               <span className={styles.head}>
                 Browse the <em>work</em>
               </span>
               <span className={styles.foot}>
-                <span>22 projects · 21 live</span>
+                <span>Product · analytics · reliability</span>
+                <span className={styles.arrow}>{"↗"}</span>
+              </span>
+            </Link>
+            <Link className={styles["c-action"]} href="/resume">
+              <span className={styles.lbl}>Explore · 02</span>
+              <span className={styles.head}>
+                Read the <em>résumé</em>
+              </span>
+              <span className={styles.foot}>
+                <span>Background · experience</span>
+                <span className={styles.arrow}>{"↗"}</span>
+              </span>
+            </Link>
+            <Link className={styles["c-action"]} href="/about">
+              <span className={styles.lbl}>Explore · 03</span>
+              <span className={styles.head}>
+                More <em>about me</em>
+              </span>
+              <span className={styles.foot}>
+                <span>Who I am · how I work</span>
                 <span className={styles.arrow}>{"↗"}</span>
               </span>
             </Link>


### PR DESCRIPTION
## What

Reformats the `/contact` page to remove repeated information and tighten the structure.

## Why

The page said the same handful of facts in several places. Reply time, location, status, and "best for" appeared in the masthead stat strip **and** a scrolling marquee **and** a "practical details" grid, and email + LinkedIn were each listed twice (channel ribbon + bottom CTAs). It read as inconsistent and padded.

## Changes

- **Removed the "Not a fit" column** (per request). The section is retitled **"What I'm looking for"** and reflowed into a single bordered cell grid that matches the site's editorial pattern.
- **Deleted the marquee band** — it was pure repetition of the stat-strip facts.
- **Deleted the standalone "practical details" grid** — it duplicated the masthead facts. The unique MBA/background note now lives in the closing quote signature, so nothing is lost.
- **Replaced the duplicate email/LinkedIn CTAs** at the bottom with explore-more nav (Portfolio / Résumé / About), so contact methods appear once.
- **Relabeled the stat strip** to canonical facts (Response / Best for / Based in) and tidied copy to follow `WRITING_VOICE.md` (no colon-as-connector in the tagline, no em dash in the quote).
- **Removed the now-unused marquee / details / two-column CSS** from `contact.module.css`.
- Bumped `dateModified` on the page metadata.

Net result: each fact now appears exactly once. Email standardized to the canonical `IsaacVazquez@berkeley.edu` (matches `profile.ts` and the page schema). No interactivity or routing changed; the component remains a static server component.

Files: `src/components/contact/ContactV3.tsx`, `src/app/contact/contact.module.css`, `src/app/contact/page.tsx` (75 insertions, 415 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011BQ8HPGd7PgF7AfDgSNaoZ)_