### PR TITLE
chore: expose frontend-design skill to Claude Code

### DIFF
--- a/.claude/skills/frontend-design
+++ b/.claude/skills/frontend-design
@@ -1,0 +1,1 @@
+../../.agents/skills/frontend-design


### PR DESCRIPTION
## What

Makes the `frontend-design` skill discoverable by Claude Code in this project.

## Why

The repo stores skills in `.agents/skills/` (the skills.sh / `npx skills` convention), and `frontend-design` already lives there. But Claude Code — including Claude Code on the web — discovers project skills from `.claude/skills/`, which didn't exist. So the skill was present in the repo but never surfaced to the agent.

## How

Adds a symlink:

```
.claude/skills/frontend-design -> ../../.agents/skills/frontend-design
```

This wires the skill into Claude Code's discovery path while keeping `.agents/skills/` as the single source of truth — so a future `npx skills update` won't create a stale duplicate. This mirrors how the skills.sh CLI itself sets up per-agent adapters.

No skill content was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW7RRu5rnD7smjEMLKkff1)_