### PR TITLE
fix(header): baseline-align brand wordmark with nav links

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1713,6 +1713,12 @@
     letter-spacing: -0.04em;
     text-transform: uppercase;
     color: var(--home-ink);
+    /* Baseline-align the display wordmark with the smaller mono nav links.
+       Both sides are center-aligned in equal-height (44px) boxes, but
+       Bricolage's shorter cap-height (~0.66) at 1.05rem leaves its baseline
+       ~0.94px below JetBrains Mono's (~0.73) at 0.8rem. Nudge the lockup up so
+       the letters share a baseline with the nav. Visual-only (no reflow). */
+    transform: translateY(-0.06rem);
   }
 
   .header-home-brand::before {


### PR DESCRIPTION
## What

Baseline-align the header brand wordmark (`Isaac Vazquez`) with the main-navigation links so the name sits on the same line as the nav.

## Why

The brand and nav are both `min-h-[44px] items-center`, so they were already vertically **centered to ~0.06px** — there was no box-model bug, and `line-height` provably drops out of the vertical math. I verified this by parsing the actual Google Font files:

| | Brand — Bricolage 700 @ 1.05rem | Nav — JetBrains Mono 500 @ 0.8rem |
|---|---|---|
| cap-height ratio | 0.66 | 0.73 |
| cap-center from box top | 22.00px | 21.94px |
| baseline from box top | **27.54px** | **26.61px** |

Because Bricolage has a shorter cap-height ratio, centering the larger display wordmark against the smaller mono nav left its **baseline ~0.94px lower** and its letters extending both above and below the nav letters — which reads as "not on the same line" even though the centers match.

## How

Nudge the wordmark lockup up by ~0.94px via `transform: translateY(-0.06rem)` so the letters share a baseline with the nav. It's a **visual-only** transform (no reflow) and the acid-dot ↔ text lockup stays intact. Single CSS rule in `.header-home-brand`.

## Notes

- Subtle by design (~1px); it removes the baseline mismatch without shrinking the logo.
- If the live header ever looks *more* than ~1px off, the likely culprit is a Bricolage `display: swap` font-load/fallback hiccup rather than the box model — worth confirming the computed `font-family` resolves to Bricolage Grotesque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YL1PHtgx9qcpaAYsb5Pxr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL1PHtgx9qcpaAYsb5Pxr9)_