### PR TITLE
fix(spacex): authenticate Launch Library API and add snapshot freshness gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,12 @@ FANTASYPROS_API_KEY=your-api-key-here
 # Premier League Data API
 FOOTBALL_DATA_API_TOKEN=your-football-data-api-token-here
 
+# SpaceX / Launch Library 2 (thespacedevs) — optional.
+# Anonymous requests are heavily rate limited (shared CI IPs get 429'd fast),
+# which silently freezes the snapshot. A free account token raises the limit.
+# Used only by `npm run update:spacex` / `update:spacex-images`; not needed at runtime.
+SPACEDEVS_API_TOKEN=your-spacedevs-api-token-here
+
 # Cron Job Secret (for scheduled updates)
 CRON_SECRET=your-cron-secret-here
 

--- a/.github/workflows/update-spacex.yml
+++ b/.github/workflows/update-spacex.yml
@@ -41,11 +41,13 @@ jobs:
         run: npm run update:spacex-images
         env:
           NODE_ENV: production
+          SPACEDEVS_API_TOKEN: ${{ secrets.SPACEDEVS_API_TOKEN }}
 
       - name: Refresh SpaceX data snapshot
         run: npm run update:spacex
         env:
           NODE_ENV: production
+          SPACEDEVS_API_TOKEN: ${{ secrets.SPACEDEVS_API_TOKEN }}
 
       - name: Verify SpaceX snapshot quality
         id: verify_quality
@@ -62,6 +64,11 @@ jobs:
           const MIN_DETAILS = 5;
           const MIN_MANIFEST_IMAGES = 5;
           const MIN_REFERENCE_LAUNCHES = 10;
+          // The data fetch falls back to the existing snapshot when the Launch
+          // Library API rate-limits us, which silently freezes the launch data.
+          // Fail loudly (and open an issue) once it goes stale so a sustained
+          // outage can't hide behind a green run.
+          const MAX_SNAPSHOT_AGE_DAYS = 4;
 
           function readJson(filePath) {
             if (!fs.existsSync(filePath)) {
@@ -99,14 +106,32 @@ jobs:
             }
           }
 
+          const generatedAtRaw = snapshot.generatedAt || (snapshot.summary && snapshot.summary.generatedAt) || null;
+          const generatedAtMs = generatedAtRaw ? Date.parse(generatedAtRaw) : NaN;
+          const ageDays = Number.isNaN(generatedAtMs)
+            ? null
+            : (Date.now() - generatedAtMs) / (1000 * 60 * 60 * 24);
+
           console.log('Upcoming launches:', upcoming);
           console.log('Past launches:', past);
           console.log('Launch details:', detailCount);
           console.log('Manifest images:', manifestEntries.length);
           console.log('Reference launches:', referenceLaunches);
+          console.log('Snapshot generatedAt:', generatedAtRaw || '(missing)');
+          console.log('Snapshot age (days):', ageDays === null ? '(unknown)' : ageDays.toFixed(2));
 
           if (!snapshot.summary) {
             console.error('::error::SpaceX snapshot summary is missing.');
+            process.exit(1);
+          }
+
+          if (ageDays === null) {
+            console.error('::error::SpaceX snapshot is missing a parseable generatedAt timestamp.');
+            process.exit(1);
+          }
+
+          if (ageDays > MAX_SNAPSHOT_AGE_DAYS) {
+            console.error('::error::SpaceX snapshot is ' + ageDays.toFixed(1) + ' days old (max ' + MAX_SNAPSHOT_AGE_DAYS + '). The Launch Library refresh is likely failing or rate limited.');
             process.exit(1);
           }
 
@@ -233,7 +258,8 @@ jobs:
               `**Trigger:** ${context.eventName}`,
               ``,
               `Check the run logs to diagnose. Common causes:`,
-              `- Launch Library API outage, timeout, or rate limiting`,
+              `- Launch Library API outage, timeout, or rate limiting (set the SPACEDEVS_API_TOKEN secret to raise the limit)`,
+              `- Snapshot too stale: the data refresh kept old data past the freshness gate, so the launch board is no longer current`,
               `- Image download failure degraded the manifest or reference index`,
               `- Quality gate caught a degraded snapshot`,
               `- Git push rejected after 5 retries`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ npm run dev
 - `npm run update:tech-startups` processes a hand-maintained seed inside `scripts/buildTechStartupSnapshot.ts`; there is no live source to poll.
 - `npm run update:formula-1` reads historical OpenF1 endpoints and does not require an API key.
 - `npm run update:github-trending` reads the public GitHub Search API. GitHub Actions passes `GITHUB_TOKEN` for higher rate limits.
-- `npm run update:spacex` and `npm run update:spacex-images` read public Launch Library / SpaceDevs endpoints and do not require an API key.
+- `npm run update:spacex` and `npm run update:spacex-images` read public Launch Library / SpaceDevs endpoints. An API key is not strictly required, but the anonymous tier is heavily rate limited (shared CI IPs get 429'd fast, which silently freezes the snapshot) — set the optional `SPACEDEVS_API_TOKEN` to authenticate and raise the limit. The `update-spacex.yml` workflow now also fails loudly if the snapshot goes stale (older than 4 days).
 - `npm run update:frontier-models` rebuilds `src/data/frontierModelsSnapshot.ts` from `scripts/data/frontierModels.source.ts`.
 - If the investments fetch step fails on imports, install the Python dependency with `.venv/bin/pip install defeatbeta-api`.
 

--- a/scripts/buildSpaceXImageSnapshots.ts
+++ b/scripts/buildSpaceXImageSnapshots.ts
@@ -1,10 +1,26 @@
+import { config } from "dotenv";
 import crypto from "crypto";
 import { promises as fs } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 
+// Load SPACEDEVS_API_TOKEN from .env.local for local runs (read lazily at fetch
+// time). In CI the token is provided via the workflow env block instead.
+config({
+  path: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../.env.local"),
+});
+
 const LAUNCH_LIBRARY_API_BASE = "https://ll.thespacedevs.com/2.2.0";
 const SPACEX_AGENCY_ID = 121;
+
+// Optional Launch Library 2 API key. Anonymous requests (especially from shared
+// CI IPs) get throttled hard; authenticating with a token raises the limit.
+// thespacedevs uses DRF token auth: `Authorization: Token <key>`. Read lazily so
+// a dotenv-loaded value is picked up regardless of import order.
+function getLaunchLibraryAuthHeaders(): Record<string, string> {
+  const token = process.env.SPACEDEVS_API_TOKEN?.trim();
+  return token ? { Authorization: `Token ${token}` } : {};
+}
 const REQUEST_TIMEOUT_MS = 12000;
 const LIST_FETCH_LIMIT = 30;
 const ACTIVE_WINDOW_LIMIT = 24;
@@ -267,6 +283,7 @@ async function fetchLaunchLibraryJson<T>(
       signal: controller.signal,
       headers: {
         Accept: "application/json",
+        ...getLaunchLibraryAuthHeaders(),
       },
     });
 

--- a/scripts/buildSpaceXSnapshot.ts
+++ b/scripts/buildSpaceXSnapshot.ts
@@ -1,6 +1,13 @@
+import { config } from "dotenv";
 import { promises as fs } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+// Load SPACEDEVS_API_TOKEN (and any other secrets) from .env.local for local
+// runs. The token is read lazily at fetch time, so this only needs to run
+// before main() — not before the lib import.
+config({
+  path: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../.env.local"),
+});
 import { buildMissionControlSnapshot } from "../src/lib/spacexData";
 import type { MissionControlSnapshot } from "../src/types/spacex";
 

--- a/src/lib/spacexData.ts
+++ b/src/lib/spacexData.ts
@@ -387,6 +387,15 @@ function clearLaunchLibraryRateLimit() {
   launchLibraryConsecutive429s = 0;
 }
 
+// Optional Launch Library 2 API key. The anonymous tier is throttled hard
+// (and shared CI IPs get 429'd almost immediately), so the refresh job should
+// run authenticated. thespacedevs uses DRF token auth: `Authorization: Token <key>`.
+// Read lazily so a dotenv-loaded value is picked up regardless of import order.
+function getLaunchLibraryAuthHeaders(): Record<string, string> {
+  const token = process.env.SPACEDEVS_API_TOKEN?.trim();
+  return token ? { Authorization: `Token ${token}` } : {};
+}
+
 async function fetchLaunchLibraryJson<T>(
   path: string,
   revalidateSeconds = 120
@@ -403,6 +412,7 @@ async function fetchLaunchLibraryJson<T>(
       signal: controller.signal,
       headers: {
         Accept: "application/json",
+        ...getLaunchLibraryAuthHeaders(),
       },
       next: {
         revalidate: revalidateSeconds,


### PR DESCRIPTION
## Why the SpaceX data is so behind

`/spacex-mission-control` launch data has been **frozen at 2026-04-29 (~49 days stale)** even though the refresh workflow runs twice daily and reports **success** every run.

Root cause — a silent fallback masking rate-limiting:

1. `scripts/buildSpaceXSnapshot.ts` fetches the **anonymous** Launch Library 2 API (`ll.thespacedevs.com`). The only header was `Accept` — no auth.
2. The anonymous tier throttles shared GitHub Actions IPs hard, so every scheduled run gets **HTTP 429**. Last night's log: `SpaceX snapshot refresh hit rate limiting. Keeping the existing snapshot.` (the data step ran in **1 second**).
3. On failure the script returns the **existing** snapshot instead of failing.
4. The workflow quality gate only checked **counts** (≥1 upcoming, ≥10 past…), never **recency**, so the stale snapshot passed.
5. `check_changes` saw no diff → commit **skipped** → run went **green** → no `spacex-refresh-failure` issue opened.

Net result: green checks, no alerts, data frozen for 7 weeks. Confirmed via run history (all recent runs `success`), the live job log, and `git log` on `spacexSnapshot.generated.json` (unchanged since the workflow was added).

## What this changes

- **Authenticate the API.** Send `Authorization: Token <key>` (thespacedevs DRF token auth) when `SPACEDEVS_API_TOKEN` is set. Read lazily so `.env.local` works locally and the CI env block works in Actions. Applied to both the data and image build paths.
- **Wire the secret** into the `update-spacex` workflow env for both refresh steps.
- **Fail loudly on staleness.** New freshness gate in the verify step fails (and opens the existing `spacex-refresh-failure` issue) when the snapshot's `generatedAt` is older than **4 days**. A sustained rate-limit/outage can no longer hide behind a green run.
- **Local parity + docs.** Load `.env.local` via `dotenv` in both build scripts; document the optional token in `.env.example`; correct the AGENTS.md note that claimed no key was needed.

## Validation

- `npx jest spacex` → **48 passed / 10 suites**
- `npx tsc --noEmit` → clean
- Workflow YAML parses; freshness gate simulated against the current snapshot correctly reports **49.5 days → would FAIL loudly** (exactly the staleness it was hiding)
- Build script runs end-to-end (dotenv loads, lazy token read works; fetch is network-restricted in this sandbox so the fallback correctly kept the snapshot)

## ⚠️ Action required to actually un-stick the data

Code alone fixes the *silent failure*; the data won't refresh until the API is authenticated. After merge:

1. Create a free account at **thespacedevs.com** (Launch Library 2) and copy the API token.
2. Add it as a GitHub Actions secret named **`SPACEDEVS_API_TOKEN`** (repo → Settings → Secrets and variables → Actions). Optionally add it to `.env.local` for local `npm run update:spacex`.
3. Re-run the **Refresh SpaceX Snapshots** workflow. With auth, the fetch should succeed and commit current launches.

Until the secret is added, the new freshness gate will (correctly) start **failing the workflow and opening an issue** so the staleness is visible instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzzKyJdmcwybJqdcvBZiWr)_