### PR TITLE
Fantasy football & draft assistant overhaul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,1213 +107,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@ast-grep/napi": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi/-/napi-0.40.5.tgz",
-      "integrity": "sha512-hJA62OeBKUQT68DD2gDyhOqJxZxycqg8wLxbqjgqSzYttCMSDL9tiAQ9abgekBYNHudbJosm9sWOEbmCDfpX2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@ast-grep/napi-darwin-arm64": "0.40.5",
-        "@ast-grep/napi-darwin-x64": "0.40.5",
-        "@ast-grep/napi-linux-arm64-gnu": "0.40.5",
-        "@ast-grep/napi-linux-arm64-musl": "0.40.5",
-        "@ast-grep/napi-linux-x64-gnu": "0.40.5",
-        "@ast-grep/napi-linux-x64-musl": "0.40.5",
-        "@ast-grep/napi-win32-arm64-msvc": "0.40.5",
-        "@ast-grep/napi-win32-ia32-msvc": "0.40.5",
-        "@ast-grep/napi-win32-x64-msvc": "0.40.5"
-      }
-    },
-    "node_modules/@ast-grep/napi-darwin-arm64": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.40.5.tgz",
-      "integrity": "sha512-2F072fGN0WTq7KI3okuEnkGJVEHLbi56Bw1H6NAMf7j2mJJeQWsRyGOMcyNnUXZDeNdvoMH0OB2a5wwUegY/nQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ast-grep/napi-darwin-x64": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-x64/-/napi-darwin-x64-0.40.5.tgz",
-      "integrity": "sha512-dJMidHZhhxuLBYNi6/FKI812jQ7wcFPSKkVPwviez2D+KvYagapUMAV/4dJ7FCORfguVk8Y0jpPAlYmWRT5nvA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ast-grep/napi-linux-arm64-gnu": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-arm64-gnu/-/napi-linux-arm64-gnu-0.40.5.tgz",
-      "integrity": "sha512-nBRCbyoS87uqkaw4Oyfe5VO+SRm2B+0g0T8ME69Qry9ShMf41a2bTdpcQx9e8scZPogq+CTwDHo3THyBV71l9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ast-grep/napi-linux-arm64-musl": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.40.5.tgz",
-      "integrity": "sha512-/qKsmds5FMoaEj6FdNzepbmLMtlFuBLdrAn9GIWCqOIcVcYvM1Nka8+mncfeXB/MFZKOrzQsQdPTWqrrQzXLrA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ast-grep/napi-linux-x64-gnu": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.40.5.tgz",
-      "integrity": "sha512-DP4oDbq7f/1A2hRTFLhJfDFR6aI5mRWdEfKfHzRItmlKsR9WlcEl1qDJs/zX9R2EEtIDsSKRzuJNfJllY3/W8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ast-grep/napi-linux-x64-musl": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.40.5.tgz",
-      "integrity": "sha512-BRZUvVBPUNpWPo6Ns8chXVzxHPY+k9gpsubGTHy92Q26ecZULd/dTkWWdnvfhRqttsSQ9Pe/XQdi5+hDQ6RYcg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ast-grep/napi-win32-arm64-msvc": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.40.5.tgz",
-      "integrity": "sha512-y95zSEwc7vhxmcrcH0GnK4ZHEBQrmrszRBNQovzaciF9GUqEcCACNLoBesn4V47IaOp4fYgD2/EhGRTIBFb2Ug==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ast-grep/napi-win32-ia32-msvc": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-ia32-msvc/-/napi-win32-ia32-msvc-0.40.5.tgz",
-      "integrity": "sha512-K/u8De62iUnFCzVUs7FBdTZ2Jrgc5/DLHqjpup66KxZ7GIM9/HGME/O8aSoPkpcAeCD4TiTZ11C1i5p5H98hTg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ast-grep/napi-win32-x64-msvc": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-x64-msvc/-/napi-win32-x64-msvc-0.40.5.tgz",
-      "integrity": "sha512-dqm5zg/o4Nh4VOQPEpMS23ot8HVd22gG0eg01t4CFcZeuzyuSgBlOL3N7xLbz3iH2sVkk7keuBwAzOIpTqziNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/crc32c": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
-      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha1-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
-      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/checksums": {
-      "version": "3.1000.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.3.tgz",
-      "integrity": "sha512-vkPd3NMJf6Gw4QjBBdiUdu2uo4P0HfHrx5+1hqjDYZhZAF4HWkMHXoQtxHQmDi/LyysUgTU5uNhcZLCkpF9LKg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cloudfront": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.984.0.tgz",
-      "integrity": "sha512-couDuDLpJtoeWne/nYyJ+I+5ntBVdNgBVRTCoDaXuVV7OC3u/wz5Ps0+GogspEwMLEFoOJ8t691h3YXQtnpQTw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-node": "^3.972.5",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.984.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.984.0.tgz",
-      "integrity": "sha512-8/Oft9MWQtbG6p9f8eY5fsKC2CcO5YVDlwive8eUYS9mEbgnyQxm68OyH26WvsSTykQ9QkIbR+fOG56RsIBODw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-node": "^3.972.5",
-        "@aws-sdk/dynamodb-codec": "^3.972.7",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.3",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.984.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.984.0.tgz",
-      "integrity": "sha512-kqwNBIGNxGVhINwgN/UQfdsQkaMjbu9PFV2EhATWouV+RT60uMjK9JENgLDwbgJmEVbbnPsh9HaZ5KKwPSdiDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-node": "^3.972.5",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.984.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/eventstream-serde-browser": "^4.2.8",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.8",
-        "@smithy/eventstream-serde-node": "^4.2.8",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.984.0.tgz",
-      "integrity": "sha512-7ny2Slr93Y+QniuluvcfWwyDi32zWQfznynL56Tk0vVh7bWrvS/odm8WP2nInKicRVNipcJHY2YInur6Q/9V0A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-node": "^3.972.5",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.3",
-        "@aws-sdk/middleware-expect-continue": "^3.972.3",
-        "@aws-sdk/middleware-flexible-checksums": "^3.972.4",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-location-constraint": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.6",
-        "@aws-sdk/middleware-ssec": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/signature-v4-multi-region": "3.984.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.984.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/eventstream-serde-browser": "^4.2.8",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.8",
-        "@smithy/eventstream-serde-node": "^4.2.8",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-blob-browser": "^4.2.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/hash-stream-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/md5-js": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.984.0.tgz",
-      "integrity": "sha512-TDvHpOUWlpanc3xQ5Xw0y8L2hoojBFCCSmXQ/6rKqGOf1ScX3dMA+K9aF0Zp0iwjhSh4VvsHD42esl8XwQZDjA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-node": "^3.972.5",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-sdk-sqs": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.984.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/md5-js": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.974.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.19.tgz",
-      "integrity": "sha512-SMNfLCU/41xxfFaC5Slwy8V/f1FRhakvyeeMeDeIxqNF0DzhDlXsXnJDELJYke1EtnJbfzfilW7tvulGfxMY6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
-        "@aws-sdk/xml-builder": "^3.972.29",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.6",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.45.tgz",
-      "integrity": "sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.47",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.47.tgz",
-      "integrity": "sha512-1XdgHDIPbARHuzZXM7ouzIbSUZFU9dTi9k+ryMhiZU4QCam4dvwOyUEFjEHNxAZehCYUIOmsSUZ2un6BIgUkWg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.51.tgz",
-      "integrity": "sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/credential-provider-env": "^3.972.45",
-        "@aws-sdk/credential-provider-http": "^3.972.47",
-        "@aws-sdk/credential-provider-login": "^3.972.50",
-        "@aws-sdk/credential-provider-process": "^3.972.45",
-        "@aws-sdk/credential-provider-sso": "^3.972.50",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
-        "@aws-sdk/nested-clients": "^3.997.18",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.50.tgz",
-      "integrity": "sha512-NHHsKoMhw6UylSU0XDnDc87+IQW8tRBTIe6vnOX12GSIlBDtoce6bSzONleIglCyu8d3H9bmTSfk+sIN5yh3WA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.53.tgz",
-      "integrity": "sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.45",
-        "@aws-sdk/credential-provider-http": "^3.972.47",
-        "@aws-sdk/credential-provider-ini": "^3.972.51",
-        "@aws-sdk/credential-provider-process": "^3.972.45",
-        "@aws-sdk/credential-provider-sso": "^3.972.50",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.45.tgz",
-      "integrity": "sha512-QMJXjTGLmHE4Ie03T5H4hHOLfcvMc9DaODO6b5dgte3S8ECf5bBuHUJW4cQREcYZyRkOU8iymqtiBxqF4icxZg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.50.tgz",
-      "integrity": "sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
-        "@aws-sdk/token-providers": "3.1064.0",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.50.tgz",
-      "integrity": "sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.19.tgz",
-      "integrity": "sha512-V1OhlKIv3nYt4TTQaTawx7gDA2PnE7ABfFhr0Oz8kxD9EwNfsV5VSFXQC0iMJTBmUFtyUOXoVl7Hk6/IB8PAfw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.7.tgz",
-      "integrity": "sha512-LkwS3ZOUNL5kHzmz3dDx8lE3HOhZmf2VGjbJ/tMUZJYWWl3J0RJTZM7RFz1MLt06WDVvlShcAjY/RzhYlqLL7g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mnemonist": "0.38.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.22.tgz",
-      "integrity": "sha512-WdkE+PsVhwzexPV+yCISmww5R/hI2yWp7byWvnBfCvsP1sGSoC+54PG07XMh4UU76N3h4NEaK/qgHzF4KfnNGg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.49",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.18.tgz",
-      "integrity": "sha512-1vKJt/6MBB/MBMRM3qzCMdW70syJY8u2DH+dq7yCnPn7wVJmyeAzAa/sK1lIbbYh8BVLbM5FspsT4zbe885gOw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/endpoint-cache": "^3.972.7",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.18.tgz",
-      "integrity": "sha512-v+YJdAX5c0WszlEEK/8VxUpY2PwGbeQ0q9ClAosL3cG9YhjwY7C/coJAis6FCSEaWeQemCTqUho6wJdvPvJB1w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.49",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.28.tgz",
-      "integrity": "sha512-XkHArJreL8hnpKrBTlnwrIcynZT4kDiAF6BF/z7AVxV7VUvojrjL2RzeK8QLVNyfzkEJGIYBKoufOIOSSpd6nQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/checksums": "^3.1000.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.20.tgz",
-      "integrity": "sha512-RFnJEOl2+Qi2FHtFh5UjcHqvah8mp9PQFBw8Vgs2Vdwxk3Ns2UEfQ9IxIcT9u3OeSAnAour/jvngYb0oGPdHpw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.15.tgz",
-      "integrity": "sha512-Ia/3gTJjyQS3iJsZLuPlcKdjFsh4Ghq9VayPLFRQdRJaBhRhPVP9X75Y37PUWrTdnf6hvNKK0NwKwdu2U1rP2Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.49",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.19.tgz",
-      "integrity": "sha512-xczkIFCpE68Y+uec7U8DK90Pl/aHJQ3xC8wdskCLOTF9PRqtFImbWnrJvDubfEQ45Y2egdZAJf5zXnnCBBPCHw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.21.tgz",
-      "integrity": "sha512-UY+C0nWVrxw4hvxf0ZYES7em1rLfozoU48UlNo7aCGHlOpgocN56DcOeO/3erDPAp4S5sXnK9g7/sOPcYZmfkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.49",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.49.tgz",
-      "integrity": "sha512-9CQoJfMZMqGJVBqFO/C8Gwke6WM7CLskQBiAjGU5LyXsVtqhymAATfqFnIa87Dw23ssfgGzqBHpSSwSchldFXw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.33.tgz",
-      "integrity": "sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.30.tgz",
-      "integrity": "sha512-PVAj7VgWK/ZxCXnkgC4B7cdJyUN99Nsr7IEduHt4A1GieuB+ZnU5bSifHwapbr17wrFkmdxfSh+aA0Lj+Ads6w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.15.tgz",
-      "integrity": "sha512-dtaHPSkvl9WGOAsFLi+WCuBdj5o1t4F7UuJTGPKaC9k1Gd1ZFXPJE7wkskWRk8rq7b2DD9XV82a/rLZLusmWZA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.49",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.49",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.49.tgz",
-      "integrity": "sha512-SgnxMOOeUXJMLdBCWwT+lt+ABrbSSljXjMuBTSC7HDabi5uUaSvnPOMUw3llA+3bxwau5NqyBNtBFWe4F1Ae4g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.18.tgz",
-      "integrity": "sha512-xBWrodBvW5SHCZV11UZUJG0pSHkLCEREIBoNbff1C1sacOUCmxJnTCPE80sCGLCtqgXg98I2MQJe2z28tcZSsw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.33.tgz",
-      "integrity": "sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.23.tgz",
-      "integrity": "sha512-fY5CvQ2PytmQlIopqGaBGPET7imhZMVMZDXoN0BE+pL/2lQlQojiAfFv6gRfQkV8kGuVsOerpt333ju2irEHiQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.984.0.tgz",
-      "integrity": "sha512-TaWbfYCwnuOSvDSrgs7QgoaoXse49E7LzUkVOUhoezwB7bkmhp+iojADm7UepCEu4021SquD7NG1xA+WCvmldA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1064.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1064.0.tgz",
-      "integrity": "sha512-sjI+iA4JtgeckBgKwPQF7KzWillRoNDmtpiM0TRa0syiAKFHKUSf84kPXSO3+gA7aMMSxrcxzOM2oPSecaJvEA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
-        "@aws-sdk/types": "^3.973.12",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/types": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
-      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.984.0.tgz",
-      "integrity": "sha512-9ebjLA0hMKHeVvXEtTDCCOBtwjb0bOXiuUV06HNeVdgAjH6gj4x4Zwt4IBti83TiyTGOCl5YfZqGx4ehVsasbQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz",
-      "integrity": "sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.20.tgz",
-      "integrity": "sha512-3bXcdWOxYy/qjGxb2hxnXeNOkcHQyEfUTOnF5q4SqQDrx2YPJ0MuxaAM/Qyiwgz8Qn5QUh9H/l1W2QdX1VZX6w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.35.tgz",
-      "integrity": "sha512-uCKLDU+aotUcb6EthCql8GEIuAeWMQEOrnEhvKytspo8J8JuuPMUst/X+B38nQ67gJKy4NqENdWSLgr9WoQJbQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
-      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.3",
-        "fast-xml-parser": "5.7.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -1819,147 +612,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
-      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
-      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peerDependencies": {
-        "unenv": "2.0.0-rc.24",
-        "workerd": ">1.20260305.0 <2.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "workerd": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260603.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260603.1.tgz",
-      "integrity": "sha512-cEXDWu6V3ZrpmwWkM4OJE9AeXjdAgOY5rh8EHhcBVCuP5rxnzUbPzLtrVOHx0UUUAcCrFq0Xsa6mZKL1VUZsKQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260603.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260603.1.tgz",
-      "integrity": "sha512-uBPK4LaWJNbbCYwPnUAehlHbbVulhVZPZsdcAhBPfZhHb3QAuAEPAQepO/P67R3V6Cni4YGx1fLbL8A5wwoaNA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260603.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260603.1.tgz",
-      "integrity": "sha512-ht9l6/8Tk7Rp6kA4S9oFZ4X8u0VjnnFdmU/6B3fnABYKREYTKh2RdOqXqXxcp5eNJseireKnWik/hQOPK1CutQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260603.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260603.1.tgz",
-      "integrity": "sha512-LJZ6x00rAjSrobV4m0ZW0TpH5ilBbKcWBzlH+y+KOUsIE/CpTuhAzKV43TbSnFLRX5+jrWKiz2v0hO91lPXy6A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260603.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260603.1.tgz",
-      "integrity": "sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@corex/deepmerge": {
       "version": "4.0.43",
       "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
       "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -2084,95 +742,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
-      }
-    },
-    "node_modules/@dotenvx/dotenvx": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.31.0.tgz",
-      "integrity": "sha512-GeDxvtjiRuoyWVU9nQneId879zIyNdL05bS7RKiqMkfBSKpHMWHLoRyRqjYWLaXmX/llKO1hTlqHDmatkQAjPA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "commander": "^11.1.0",
-        "dotenv": "^16.4.5",
-        "eciesjs": "^0.4.10",
-        "execa": "^5.1.1",
-        "fdir": "^6.2.0",
-        "ignore": "^5.3.0",
-        "object-treeify": "1.1.33",
-        "picomatch": "^4.0.2",
-        "which": "^4.0.0"
-      },
-      "bin": {
-        "dotenvx": "src/cli/dotenvx.js",
-        "git-dotenvx": "src/cli/dotenvx.js"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/@dotenvx/dotenvx/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@dotenvx/dotenvx/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/@dotenvx/dotenvx/node_modules/isexe": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@dotenvx/dotenvx/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@ecies/ciphers": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.6.tgz",
-      "integrity": "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "bun": ">=1",
-        "deno": ">=2.7.10",
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@noble/ciphers": "^1.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2872,8 +1441,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -4008,17 +2577,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -4156,9 +2714,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4174,9 +2729,6 @@
       "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4194,9 +2746,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4212,9 +2761,6 @@
       "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4255,166 +2801,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@node-minify/core": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@node-minify/core/-/core-8.0.6.tgz",
-      "integrity": "sha512-/vxN46ieWDLU67CmgbArEvOb41zlYFOkOtr9QW9CnTrBLuTyGgkyNWC2y5+khvRw3Br58p2B5ZVSx/PxCTru6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@node-minify/utils": "8.0.6",
-        "glob": "9.3.5",
-        "mkdirp": "1.0.4"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@node-minify/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@node-minify/core/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@node-minify/core/node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@node-minify/core/node_modules/minimatch": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
-      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@node-minify/core/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@node-minify/terser": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@node-minify/terser/-/terser-8.0.6.tgz",
-      "integrity": "sha512-grQ1ipham743ch2c3++C8Isk6toJnxJSyDiwUI/IWUCh4CZFD6aYVw6UAY40IpCnjrq5aXGwiv5OZJn6Pr0hvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@node-minify/utils": "8.0.6",
-        "terser": "5.16.9"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@node-minify/utils": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@node-minify/utils/-/utils-8.0.6.tgz",
-      "integrity": "sha512-csY4qcR7jUwiZmkreNTJhcypQfts2aY2CK+a+rXgXUImZiZiySh0FvwHjRnlqWKvg+y6ae9lHFzDRjBTmqlTIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gzip-size": "6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4490,719 +2876,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@opennextjs/aws": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@opennextjs/aws/-/aws-4.0.2.tgz",
-      "integrity": "sha512-nXQPT8GZDV+NWMJV9mD/Ywxyo+tCZfFvrR6jpEOYNcxK/AqiEDlJzPybGOrHUDWAYdR1b6tmh+MoR3VbqIao3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ast-grep/napi": "^0.40.5",
-        "@aws-sdk/client-cloudfront": "3.984.0",
-        "@aws-sdk/client-dynamodb": "3.984.0",
-        "@aws-sdk/client-lambda": "3.984.0",
-        "@aws-sdk/client-s3": "3.984.0",
-        "@aws-sdk/client-sqs": "3.984.0",
-        "@node-minify/core": "^8.0.6",
-        "@node-minify/terser": "^8.0.6",
-        "@tsconfig/node18": "^1.0.3",
-        "aws4fetch": "^1.0.20",
-        "chalk": "^5.6.2",
-        "cookie": "^1.0.2",
-        "esbuild": "0.25.4",
-        "express": "^5.1.0",
-        "path-to-regexp": "^6.3.0",
-        "urlpattern-polyfill": "^10.1.0",
-        "yaml": "^2.8.1"
-      },
-      "bin": {
-        "open-next": "dist/index.js"
-      },
-      "peerDependencies": {
-        "next": ">=15.5.18 <16 || >=16.2.6"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
-      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/android-arm": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
-      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
-      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/android-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
-      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
-      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
-      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
-      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
-      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
-      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
-      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
-      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
-      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
-      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
-      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
-      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
-      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
-      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
-      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
-      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
-      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
-      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
-      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@opennextjs/aws/node_modules/esbuild": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
-      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.4",
-        "@esbuild/android-arm": "0.25.4",
-        "@esbuild/android-arm64": "0.25.4",
-        "@esbuild/android-x64": "0.25.4",
-        "@esbuild/darwin-arm64": "0.25.4",
-        "@esbuild/darwin-x64": "0.25.4",
-        "@esbuild/freebsd-arm64": "0.25.4",
-        "@esbuild/freebsd-x64": "0.25.4",
-        "@esbuild/linux-arm": "0.25.4",
-        "@esbuild/linux-arm64": "0.25.4",
-        "@esbuild/linux-ia32": "0.25.4",
-        "@esbuild/linux-loong64": "0.25.4",
-        "@esbuild/linux-mips64el": "0.25.4",
-        "@esbuild/linux-ppc64": "0.25.4",
-        "@esbuild/linux-riscv64": "0.25.4",
-        "@esbuild/linux-s390x": "0.25.4",
-        "@esbuild/linux-x64": "0.25.4",
-        "@esbuild/netbsd-arm64": "0.25.4",
-        "@esbuild/netbsd-x64": "0.25.4",
-        "@esbuild/openbsd-arm64": "0.25.4",
-        "@esbuild/openbsd-x64": "0.25.4",
-        "@esbuild/sunos-x64": "0.25.4",
-        "@esbuild/win32-arm64": "0.25.4",
-        "@esbuild/win32-ia32": "0.25.4",
-        "@esbuild/win32-x64": "0.25.4"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@opennextjs/cloudflare/-/cloudflare-1.19.11.tgz",
-      "integrity": "sha512-spZ7YsZZW9q/OJStaZlJhuklYKei5e2tNQ7PMi3DDSJ7x7167m7EYYHQZfVN5gwJBDkMR2jUDW88oHjnGz4YYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ast-grep/napi": "^0.40.5",
-        "@dotenvx/dotenvx": "1.31.0",
-        "@opennextjs/aws": "4.0.2",
-        "ci-info": "^4.2.0",
-        "cloudflare": "^4.4.1",
-        "comment-json": "^4.5.1",
-        "enquirer": "^2.4.1",
-        "glob": "^12.0.0",
-        "ts-tqdm": "^0.8.6",
-        "yargs": "^18.0.0"
-      },
-      "bin": {
-        "opennextjs-cloudflare": "dist/cli/index.js"
-      },
-      "peerDependencies": {
-        "next": ">=15.5.18 <16 || >=16.2.6",
-        "wrangler": "^4.86.0"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/glob": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-12.0.0.tgz",
-      "integrity": "sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/@opennextjs/cloudflare/node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -5256,48 +2929,6 @@
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@poppinss/colors": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
-      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^4.1.5"
-      }
-    },
-    "node_modules/@poppinss/dumper": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
-      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/colors": "^4.1.5",
-        "@sindresorhus/is": "^7.0.2",
-        "supports-color": "^10.0.0"
-      }
-    },
-    "node_modules/@poppinss/dumper/node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@poppinss/exception": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
-      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5902,19 +3533,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -5934,535 +3552,6 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
-    },
-    "node_modules/@smithy/config-resolver": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.5.6.tgz",
-      "integrity": "sha512-AXbvUX9aNY2qCLOMCikpl1Df5w2CNFEqbEb6XafG81FJbAbB8avIT7BOx1KDqiO86J/38qKQ3YuakfAfY3iBkQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/core": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
-      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
-      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.3.6.tgz",
-      "integrity": "sha512-BQao/dBhLCJqo953N1hadkcF3M/9G+i6qIgnMupfdpBQomwyhfV7Xfc5jjpCkm8HxfzaWAGrM/2nNnzronFqVQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.4.6.tgz",
-      "integrity": "sha512-OUoNRXJGZMM4ivoU7QIzOvCLbavD1YnadNEairrtYhTi+gmGhyn3c2wToL9CxEs4Cw2Ab/KeQM39T1K+/e9YdQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.3.6.tgz",
-      "integrity": "sha512-M6FeKRMi3oecpTy4EL5n1hLPWydw+xInFYQIzjbGYGBnFtW7IlJjnXrKr/Ev1GpMtmw44QCmrl8+ACEFPmRsIg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
-      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.3.6.tgz",
-      "integrity": "sha512-/8D8rOFs2VEwvHwsx68sb6nE7XfVr2wbJTbC1YuKBHPhHeMnOt7IHxr7CoT5wBWujdV4fjVoLPn1BXXP4Ijlow==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.3.6.tgz",
-      "integrity": "sha512-lIZyQ7gDxURrnfkjalM0lKmDnfZYuPzNBYlkza3czPTQNVYsg4e0o90Zx/RpxhamKKOGsQGCsopp0ULsJqltNQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-stream-node": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.3.6.tgz",
-      "integrity": "sha512-Ziap41FoxpKqmlO9IE68NeFwPKhUJD4PVNcCQ2tl6IUCPSj0KykIuAPnJNWIQbWXvApwCauhRNlAFdt9KRvDpw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.3.6.tgz",
-      "integrity": "sha512-jUH1Eth7Sgn4KPBX5OKYDRpNjzul7AzsIhxKXT1rHXPTSfY00/7Kb9RtNil5SDAlPPsxaUiesR/rql2wjackmw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/md5-js": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.3.6.tgz",
-      "integrity": "sha512-LYcuBrO9oiajdRFHyFx3FJAWNKrP89s0grI6mcfpwTAeX2ZJ/9Xyi7Imghh9LT6CIcAy6/k6/MpoUiPNjXr1/w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.3.6.tgz",
-      "integrity": "sha512-nfpYCrzSFAgfIXmIHFTjOGNeTV3DVF5E5rfi3ZuNfsOjKSpePBOJF3rjyXlWYND0anvxVoqioIwClWCNdKt4Og==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.5.6.tgz",
-      "integrity": "sha512-zdG5bJZOiM2PRgL2lwcgui6uwZ+s5y6Qsk/rk05Q69sZJT6oi1x+v8Kn++V/q9VY94EgOtEe5kivpu+eGau0wQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.6.6.tgz",
-      "integrity": "sha512-MWppaYUlc+W4cU2JZnYuMFeOxCWbKO4A57BWti6aCb7hRBK3+CL6llADGpX084hjImsqr3EvCGewArOj7G81eA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.3.6.tgz",
-      "integrity": "sha512-I3fPVYKKEog3a3qdqt1nttP1NBuQOAlNoQxEp6j5pMogSx0HHfid63difhcDgslV6p1XsTXG6D6ieTe13ycJtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.3.6.tgz",
-      "integrity": "sha512-QhNiWfg47Kl4SJHmuQvnlzCtlD1eX1J7d/vuuttIE17Ra2YUKp9Srv5lCwa3OvoYaSNWMKYn0PjGIsfCLMJsEA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.4.6.tgz",
-      "integrity": "sha512-M+gG6eQ0y073mSmNB+erRXJvwpsqsN72ol2w6vcd8FEKeG7pqYK0JvzfVqONkPj2ElBB2pg+cU13I850b//Wag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
-      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.4.6.tgz",
-      "integrity": "sha512-H6S7NyaaL+7qO8kIL7VQ7KyrGnKXdllGzJqvtp3hvDen25UOydKV51qGDVK0UciW125jV3CoLJQy/ihc0OEC6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/signature-v4": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
-      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.13.6.tgz",
-      "integrity": "sha512-tAf35/JW/DvMlACcazcoIOKOV0JBqyOvxjPTEME9W+m9wLcE0G1rwADc7Ntu38rY5C9OH8jZjpo4tbtjmIjEBQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/types": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
-      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/url-parser": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.3.6.tgz",
-      "integrity": "sha512-9MRJzwUrlswwHogOR7raDcykuzojZn74qGdQdbEQLVaixlvJuMiIT0g/CejKcmAIgrUVs8brBrnGtmYmBc0iuA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.4.6.tgz",
-      "integrity": "sha512-V6ApAGvCQnb7Wy1Sy60AQc+7UOEaNQxvAXBLdMi5Zzm66cmX0srvfAxDmg7BGuJ+9H9ez0PPWS/AeFgWxwGavA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.3.6.tgz",
-      "integrity": "sha512-+3vGcNHuvzuFLVWL9/wJgucOuQWufhuGhb3oxVDj9SWFGtwkOmtC2nFUwVC2IJoPe45uhs6TAb8bgE4IXDSPzA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.3.6.tgz",
-      "integrity": "sha512-T15zTQJ/xKYdS0/3CFckhz1QBbhxmhk/xjL6FKvHKgkJPN4E985If2FI9CcV2kh2v0sfiWMfXVEOKFbqgw4m4w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.4.6.tgz",
-      "integrity": "sha512-dRCZKu05AL7KQWrVuRJPotfjCRnvGkCjV56XNP067CRfyTtvgi/Ygu44qrBKb814Hsa52bWwDJ+Vt3pd04BjPA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.3.6.tgz",
-      "integrity": "sha512-tTR8tayMoa0WeRhtMH7j3WpHUtggBXjh7rBdf7j6POYI69R85gpWBW6B32kaJRnlQU8+0gOGAzJj50S7SU1Egw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "3.5.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.5.6.tgz",
-      "integrity": "sha512-kaB41eVUYC7ajVWUsZRqagxwRaa3VupjQ/Z2Z2v/Vffh/gJ/fFOS25s6mTyR2Lw1FrnBbRWo1iShR9BhekpPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.3.6.tgz",
-      "integrity": "sha512-TrAgOcL63TRi7G92arTzq0n+VDrmZifwP1I1T9y2xU3lJpybsHdm33S2d3xaFfG0c8zJNIF9yYRqLSe6rbhH/A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.4.6.tgz",
-      "integrity": "sha512-E/kFnvWQL6rIPr0Ucjk8oDgJSkKx2bv0nJkJ/cB3ywys7xCqeL1AXP9liHjgYONdQ+MKw/xT06IQK3vgbtu2Ww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.6.6.tgz",
-      "integrity": "sha512-g+hQ45sPnaIDU4CnaG8EufmeWwziQlcpIvPG6hVY7v65RcUgasM63J/WNfSsXEcZ1zFu9rS/r/qqfDxkIrQtDw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.6.tgz",
-      "integrity": "sha512-tAa4sePYB7mlJzdYbdBqdv37KwFKWixmM/r3ihcI0HFOVjf+a5oGvtcLXcGm4S1bY4DFsLAIOHgjubtp+oRufw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-waiter": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.4.6.tgz",
-      "integrity": "sha512-oTt3OP9NcJkrySCSCCdSbP6XLSMNgOmt/ulaiYtb0Ng6tfEWtXQ1mwfyqmLd+GapmDUjbU2mgkf7QIq9H4ij/g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@speed-highlight/core": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
-      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
-      "dev": true,
-      "license": "CC0-1.0"
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -6876,13 +3965,6 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
-    },
-    "node_modules/@tsconfig/node18": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-1.0.3.tgz",
-      "integrity": "sha512-RbwvSJQsuN9TB04AQbGULYfOGE/RnSFk/FLQ5b0NmDf5Kx2q/lABZbHQPKCO1vZ6Fiwkplu+yb9pGdLy1iGseQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -7392,17 +4474,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/react": {
@@ -7987,33 +5058,6 @@
         "win32"
       ]
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -8060,19 +5104,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -8088,16 +5119,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-escapes": {
@@ -8240,13 +5261,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-timsort": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
-      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
@@ -8384,13 +5398,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -8443,13 +5450,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws4fetch": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
-      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/axe-core": {
       "version": "4.11.2",
@@ -8602,67 +5602,11 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/blake3-wasm": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
-      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
-    },
-    "node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
@@ -8740,16 +5684,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -9069,39 +6003,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/cloudflare": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/cloudflare/-/cloudflare-4.5.0.tgz",
-      "integrity": "sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
-    },
-    "node_modules/cloudflare/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/cloudflare/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -9149,19 +6050,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -9181,50 +6069,12 @@
         "node": ">= 10"
       }
     },
-    "node_modules/comment-json": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.6.2.tgz",
-      "integrity": "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-timsort": "^1.0.3",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -9245,16 +6095,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -9930,26 +6770,6 @@
         "robust-predicates": "^3.0.2"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -10112,42 +6932,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eciesjs": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.18.tgz",
-      "integrity": "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ecies/ciphers": "^0.2.5",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0"
-      },
-      "engines": {
-        "bun": ">=1",
-        "deno": ">=2",
-        "node": ">=16"
-      }
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
       "license": "MIT"
     },
@@ -10178,16 +6966,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -10215,33 +6993,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/enquirer/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -10262,16 +7013,6 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/error-stack-parser-es": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
-      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-abstract": {
@@ -10503,13 +7244,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -10999,26 +7733,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -11076,60 +7790,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/extend": {
@@ -11207,45 +7867,6 @@
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -11308,28 +7929,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -11403,77 +8002,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -11513,16 +8041,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -11616,19 +8134,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -11876,22 +8381,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/gzip-size": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
-      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -12122,27 +8611,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -12179,16 +8647,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -12294,16 +8752,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -12635,13 +9083,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -14033,16 +10474,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -14714,29 +11145,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -15344,33 +11752,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -15389,37 +11770,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/miniflare": {
-      "version": "4.20260603.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260603.0.tgz",
-      "integrity": "sha512-+kMQYB82gC8MPOuojHur3icQsUeZUEJ+Sphuo5rVC3Ri9txBLAW/mH33b9OVrpmkogQeaaqPS4tPtugJZhk5Kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "0.34.5",
-        "undici": "7.24.8",
-        "workerd": "1.20260603.1",
-        "ws": "8.20.1",
-        "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/miniflare/node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/minimatch": {
@@ -15456,29 +11806,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mnemonist": {
-      "version": "0.38.3",
-      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
-      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "obliterator": "^1.6.1"
       }
     },
     "node_modules/motion-dom": {
@@ -15657,16 +11984,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/next": {
       "version": "16.2.7",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.7.tgz",
@@ -15815,27 +12132,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -15853,52 +12149,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -16005,16 +12255,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/object-treeify": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
-      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/object.assign": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
@@ -16105,13 +12345,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/obliterator": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/oidc-token-hash": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
@@ -16119,19 +12352,6 @@
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
-      }
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -16351,16 +12571,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -16369,22 +12579,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -16442,13 +12636,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -16755,20 +12942,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -16796,22 +12969,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -16832,49 +12989,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -17225,34 +13339,6 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -17393,53 +13479,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -17489,20 +13528,13 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -17545,8 +13577,8 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -18114,19 +14146,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -18260,43 +14279,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/terser": {
-      "version": "5.16.9",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
-      "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/terser/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -18422,16 +14404,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -18500,13 +14472,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-tqdm": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/ts-tqdm/-/ts-tqdm-0.8.6.tgz",
-      "integrity": "sha512-3X3M1PZcHtgQbnwizL+xU8CAgbYbeLHrrDwL9xxcZZrV5J+e7loJm1XrXozHjSkl44J0Zg0SgA8rXbh83kCkcQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -18604,39 +14569,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/type-is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^2.0.0",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -18790,16 +14722,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/unenv": {
-      "version": "2.0.0-rc.24",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
-      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pathe": "^2.0.3"
-      }
-    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -18885,16 +14807,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/unrs-resolver": {
@@ -18983,13 +14895,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/urlpattern-polyfill": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
-      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -19063,16 +14968,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -19122,16 +15017,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/web-vitals": {
@@ -19356,546 +15241,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/workerd": {
-      "version": "1.20260603.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260603.1.tgz",
-      "integrity": "sha512-NPcbhI1++CS+fnELyXtsIR52en+5kwr/OrKeiQeYXGy10HxmPdsQBv9N+DU7hJIOOmBHhOGAAsoGDjyiQ2YCaA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "workerd": "bin/workerd"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260603.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260603.1",
-        "@cloudflare/workerd-linux-64": "1.20260603.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260603.1",
-        "@cloudflare/workerd-windows-64": "1.20260603.1"
-      }
-    },
-    "node_modules/wrangler": {
-      "version": "4.98.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.98.0.tgz",
-      "integrity": "sha512-cXfFUuF4rMIvE0hiMnXjEAB27ERryaCgquBJdUoPIjFzYYE1rbRdMUkEdQ18qDPUtsPvhJdqxLntixT9OfSzQw==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.5.0",
-        "@cloudflare/unenv-preset": "2.16.1",
-        "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260603.0",
-        "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260603.1"
-      },
-      "bin": {
-        "wrangler": "bin/wrangler.js",
-        "wrangler2": "bin/wrangler.js"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.3"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260603.1"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -20034,22 +15379,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -20073,22 +15402,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -20178,31 +15491,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/youch": {
-      "version": "4.1.0-beta.10",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
-      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/colors": "^4.1.5",
-        "@poppinss/dumper": "^0.6.4",
-        "@speed-highlight/core": "^1.2.7",
-        "cookie": "^1.0.2",
-        "youch-core": "^0.3.3"
-      }
-    },
-    "node_modules/youch-core": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
-      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/exception": "^1.2.2",
-        "error-stack-parser-es": "^1.0.5"
       }
     },
     "node_modules/zod": {

--- a/scripts/updateFootballSnapshots.ts
+++ b/scripts/updateFootballSnapshots.ts
@@ -94,5 +94,19 @@ async function main() {
 
 main().catch((err) => {
   console.error("Football snapshot update failed:", err);
+  if (leagueOnly) {
+    // Deploy prebuild: a transient football-data.org error must not fail the
+    // whole build. Warn and exit 0 so the deploy proceeds with the committed
+    // snapshot — atomic writes (writeFileAtomic) mean a partial refresh never
+    // corrupts a file — mirroring the "failed fetch keeps the previous
+    // snapshot" pattern the other snapshot dashboards use. Manual full runs
+    // (npm run update:football, no --league-only) still exit 1 so failures
+    // surface locally.
+    const message =
+      "Football snapshot prebuild failed; continuing the build with the committed snapshot.";
+    console.warn(`::warning::${message}`);
+    console.error(`⚠️  ${message}`);
+    process.exit(0);
+  }
   process.exit(1);
 });

--- a/src/app/fantasy-football/__tests__/fantasy-football-client.test.tsx
+++ b/src/app/fantasy-football/__tests__/fantasy-football-client.test.tsx
@@ -21,12 +21,17 @@ jest.mock("framer-motion", () => ({
       children,
       initial: _initial,
       animate: _animate,
+      exit: _exit,
+      transition: _transition,
       ...props
     }: React.HTMLAttributes<HTMLDivElement> & {
       initial?: unknown;
       animate?: unknown;
+      exit?: unknown;
+      transition?: unknown;
     }) => <div {...props}>{children}</div>,
   },
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   useReducedMotion: () => true,
 }));
 

--- a/src/app/fantasy-football/draft-tracker/__tests__/draft-tracker-client.test.tsx
+++ b/src/app/fantasy-football/draft-tracker/__tests__/draft-tracker-client.test.tsx
@@ -5,6 +5,26 @@ import { DraftTrackerClient } from "../draft-tracker-client";
 const mockUseDraftState = jest.fn();
 const mockUseFantasySnapshot = jest.fn();
 
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      initial: _initial,
+      animate: _animate,
+      exit: _exit,
+      transition: _transition,
+      ...props
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      initial?: unknown;
+      animate?: unknown;
+      exit?: unknown;
+      transition?: unknown;
+    }) => <div {...props}>{children}</div>,
+  },
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  useReducedMotion: () => true,
+}));
+
 jest.mock("@/hooks/useFantasySnapshot", () => ({
   useFantasySnapshot: () => mockUseFantasySnapshot(),
 }));
@@ -46,6 +66,12 @@ describe("DraftTrackerClient", () => {
       updateSettings: jest.fn(),
       startDraft: jest.fn(),
       draftPlayer: jest.fn(),
+      undoLastPick: jest.fn(),
+      redoLastPick: jest.fn(),
+      undoToPick: jest.fn(),
+      setTeamName: jest.fn(),
+      getTeamName: (teamNumber: number) => `Team ${teamNumber}`,
+      canRedo: false,
       resetDraft: jest.fn(),
       exportDraftResults: jest.fn(),
       isUserPick: true,

--- a/src/app/fantasy-football/draft-tracker/components/DraftAnalyticsPanel.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftAnalyticsPanel.tsx
@@ -2,6 +2,7 @@
 
 import type { DraftAnalytics, DraftPick } from "@/types";
 import {
+  getEmergingRun,
   getLiveDraftSignals,
   getPickDelta,
 } from "@/lib/draftAnalytics";
@@ -14,6 +15,11 @@ interface DraftAnalyticsPanelProps {
   isDraftComplete: boolean;
   userTeamNumber: number;
   adpAvailable: boolean;
+  getTeamName?: (teamNumber: number) => string;
+}
+
+function defaultTeamName(teamNumber: number): string {
+  return `Team ${teamNumber}`;
 }
 
 const STEAL_CHIP_STYLE = {
@@ -41,7 +47,15 @@ function describeBaseline(adpAvailable: boolean): string {
     : "Deltas compare each pick's slot to the published consensus rank. The current snapshot has no ADP data.";
 }
 
-function PickValueRow({ pick, label }: { pick: DraftPick; label: "Steal" | "Reach" }) {
+function PickValueRow({
+  pick,
+  label,
+  teamName,
+}: {
+  pick: DraftPick;
+  label: "Steal" | "Reach";
+  teamName: string;
+}) {
   const delta = getPickDelta(pick) ?? 0;
 
   return (
@@ -59,7 +73,7 @@ function PickValueRow({ pick, label }: { pick: DraftPick; label: "Steal" | "Reac
         </span>
       </div>
       <p className="mt-1 text-xs" style={{ color: "var(--home-ink-muted)" }}>
-        Team {pick.teamNumber} • Pick {pick.pickNumber} • Round {pick.round}
+        {teamName} • Pick {pick.pickNumber} • Round {pick.round}
       </p>
     </div>
   );
@@ -77,15 +91,20 @@ export function DraftAnalyticsPanel({
   isDraftComplete,
   userTeamNumber,
   adpAvailable,
+  getTeamName = defaultTeamName,
 }: DraftAnalyticsPanelProps) {
   if (!isDraftComplete) {
     const { latestFlaggedPick, activeRun } = getLiveDraftSignals(picks, currentPick);
+    // Surface a forming run only when it isn't already the confirmed one, so the
+    // soft and hard signals never describe the same position twice.
+    const emergingRun = getEmergingRun(picks, currentPick);
+    const showEmerging = emergingRun && (!activeRun || activeRun.position !== emergingRun.position);
 
     return (
       <article className="home-card p-5 sm:p-6">
         <p className="home-kicker mb-1">Draft signals</p>
         <div className="mt-3 grid gap-3">
-          {latestFlaggedPick === null && activeRun === null ? (
+          {latestFlaggedPick === null && activeRun === null && !showEmerging ? (
             <p className="text-sm leading-6" style={{ color: "var(--home-ink-muted)" }}>
               Nothing unusual yet. Steals, reaches, and position runs show up here as picks come in.
             </p>
@@ -95,6 +114,7 @@ export function DraftAnalyticsPanel({
                 <PickValueRow
                   pick={latestFlaggedPick.pick}
                   label={latestFlaggedPick.kind === "steal" ? "Steal" : "Reach"}
+                  teamName={getTeamName(latestFlaggedPick.pick.teamNumber)}
                 />
               )}
               {activeRun && (
@@ -105,6 +125,20 @@ export function DraftAnalyticsPanel({
                   <p className="mt-1 text-xs" style={{ color: "var(--home-ink-muted)" }}>
                     {activeRun.playersSelected} {activeRun.position}s gone since pick{" "}
                     {activeRun.startPick}. If you want one, the shelf is emptying.
+                  </p>
+                </div>
+              )}
+              {showEmerging && emergingRun && (
+                <div
+                  className="rounded-[1.2rem] border px-4 py-3"
+                  style={{
+                    borderColor: "color-mix(in srgb, var(--home-acid) 36%, var(--home-rule))",
+                    background: "color-mix(in srgb, var(--home-acid) 10%, var(--home-paper))",
+                  }}
+                >
+                  <p className="text-sm font-semibold">{emergingRun.position}s starting to go</p>
+                  <p className="mt-1 text-xs" style={{ color: "var(--home-ink-muted)" }}>
+                    {emergingRun.count} off the board in the last few picks — a run may be forming.
                   </p>
                 </div>
               )}
@@ -140,7 +174,7 @@ export function DraftAnalyticsPanel({
         <div className="grid gap-3">
           <p className="home-kicker mb-0">Biggest steal</p>
           {biggestSteal ? (
-            <PickValueRow pick={biggestSteal} label="Steal" />
+            <PickValueRow pick={biggestSteal} label="Steal" teamName={getTeamName(biggestSteal.teamNumber)} />
           ) : (
             <p className="text-sm" style={{ color: "var(--home-ink-muted)" }}>
               No pick beat its baseline by enough to count.
@@ -149,7 +183,7 @@ export function DraftAnalyticsPanel({
 
           <p className="home-kicker mb-0 mt-2">Biggest reach</p>
           {biggestReach ? (
-            <PickValueRow pick={biggestReach} label="Reach" />
+            <PickValueRow pick={biggestReach} label="Reach" teamName={getTeamName(biggestReach.teamNumber)} />
           ) : (
             <p className="text-sm" style={{ color: "var(--home-ink-muted)" }}>
               Nobody jumped a player far enough ahead of his baseline to count.
@@ -192,7 +226,7 @@ export function DraftAnalyticsPanel({
               >
                 <div className="min-w-0">
                   <p className="text-sm font-semibold">
-                    Team {team.teamNumber}
+                    {getTeamName(team.teamNumber)}
                     {team.teamNumber === userTeamNumber ? " (you)" : ""}
                   </p>
                   {team.weaknesses.length > 0 && (

--- a/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
@@ -444,16 +444,18 @@ export function DraftBoard({
                             >
                               <Info size={15} aria-hidden="true" />
                             </button>
-                            <button
-                              type="button"
-                              onClick={() => onDraftPlayer(player)}
-                              disabled={isDraftComplete}
-                              className="inline-flex min-h-[44px] items-center justify-center rounded-full border px-4 text-sm font-semibold whitespace-nowrap transition-[background-color,border-color,color,box-shadow,opacity] duration-200 disabled:cursor-not-allowed disabled:opacity-60"
-                              style={{ borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }}
-                            >
-                              Log pick
-                            </button>
                           </div>
+                          {/* Log pick sits as a direct child of the row so its details
+                              (rank, tier, range) read as one labeled group. */}
+                          <button
+                            type="button"
+                            onClick={() => onDraftPlayer(player)}
+                            disabled={isDraftComplete}
+                            className="inline-flex min-h-[44px] items-center justify-center rounded-full border px-4 text-sm font-semibold whitespace-nowrap transition-[background-color,border-color,color,box-shadow,opacity] duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+                            style={{ borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }}
+                          >
+                            Log pick
+                          </button>
                         </div>
                       </div>
                     );

--- a/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx
@@ -1,12 +1,23 @@
 "use client";
 
-import { useMemo, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { GitCompareArrows, Info, Star } from "lucide-react";
 import { Player, TeamRoster } from "@/types";
 import type { FantasySnapshot } from "@/lib/fantasy";
 import { useDebounce } from "@/hooks/useDebounce";
+import { usePlayerQueue } from "@/hooks/usePlayerQueue";
+import { useCompareTray } from "@/hooks/useCompareTray";
 import { getReachStealThreshold, ROSTER_STARTER_TARGETS } from "@/lib/draftAnalytics";
-import { FANTASY_AVG_RANK_TOOLTIP, FANTASY_CHIP_CLASS, formatAdp, formatRange, formatRankValue, getPositionTone } from "@/lib/fantasyUtils";
+import {
+  FANTASY_AVG_RANK_TOOLTIP,
+  FANTASY_CHIP_CLASS,
+  formatAdp,
+  formatRange,
+  formatRankValue,
+  getPositionTone,
+} from "@/lib/fantasyUtils";
 import { MetricTooltip } from "@/components/investments/MetricTooltip";
+import { PositionFilterBar, type PositionFilterOption } from "@/components/fantasy";
 import { DraftTierColumns } from "./DraftTierColumns";
 
 interface DraftBoardProps {
@@ -14,9 +25,10 @@ interface DraftBoardProps {
   snapshot: FantasySnapshot | null;
   draftedPlayerIds: Set<string>;
   onDraftPlayer: (player: Player) => void;
+  onOpenDetail: (player: Player) => void;
   currentPick: number;
   currentRound: number;
-  currentTeamNumber: number;
+  currentTeamName: string;
   isUserPick: boolean;
   isDraftComplete: boolean;
   userTeam: TeamRoster | undefined;
@@ -25,15 +37,18 @@ interface DraftBoardProps {
 type BoardFilter = "ALL" | "QB" | "RB" | "WR" | "TE" | "K" | "DST" | "FLEX";
 type BoardView = "list" | "columns";
 
-const POSITION_LABELS: { value: BoardFilter; label: string }[] = [
+/** How many rows render before the "Load more" control on the board. */
+const BOARD_PAGE_SIZE = 25;
+
+const POSITION_OPTIONS: PositionFilterOption<BoardFilter>[] = [
   { value: "ALL", label: "All" },
-  { value: "QB", label: "QB" },
-  { value: "RB", label: "RB" },
-  { value: "WR", label: "WR" },
-  { value: "TE", label: "TE" },
+  { value: "QB", label: "QB", position: "QB" },
+  { value: "RB", label: "RB", position: "RB" },
+  { value: "WR", label: "WR", position: "WR" },
+  { value: "TE", label: "TE", position: "TE" },
   { value: "FLEX", label: "Flex" },
-  { value: "K", label: "K" },
-  { value: "DST", label: "DST" },
+  { value: "K", label: "K", position: "K" },
+  { value: "DST", label: "DST", position: "DST" },
 ];
 
 function getRosterNeedOrder(userTeam: TeamRoster | undefined): string[] {
@@ -65,30 +80,15 @@ function matchesFilter(player: Player, filter: BoardFilter): boolean {
   return player.position === filter;
 }
 
-function getFilterStyle(active: boolean): CSSProperties {
-  if (active) {
-    return {
-      borderColor: "var(--home-ink)",
-      background: "var(--home-ink)",
-      color: "var(--home-paper)",
-    };
-  }
-
-  return {
-    borderColor: "var(--home-rule)",
-    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-    color: "var(--home-ink)",
-  };
-}
-
 export function DraftBoard({
   players,
   snapshot,
   draftedPlayerIds,
   onDraftPlayer,
+  onOpenDetail,
   currentPick,
   currentRound,
-  currentTeamNumber,
+  currentTeamName,
   isUserPick,
   isDraftComplete,
   userTeam,
@@ -96,7 +96,11 @@ export function DraftBoard({
   const [boardView, setBoardView] = useState<BoardView>("list");
   const [selectedPosition, setSelectedPosition] = useState<BoardFilter>("ALL");
   const [searchQuery, setSearchQuery] = useState("");
+  const [visibleCount, setVisibleCount] = useState(BOARD_PAGE_SIZE);
   const debouncedSearch = useDebounce(searchQuery, 200);
+
+  const queue = usePlayerQueue();
+  const compare = useCompareTray();
 
   const availablePlayers = useMemo(
     () => players.filter((player) => !draftedPlayerIds.has(player.id)),
@@ -119,8 +123,22 @@ export function DraftBoard({
     });
   }, [availablePlayers, debouncedSearch, selectedPosition]);
 
-  const bestAvailable = filteredPlayers.slice(0, 30);
+  // Reset the window when the filter or search changes so a narrowed board
+  // doesn't open deep into a stale offset.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset on filter change
+    setVisibleCount(BOARD_PAGE_SIZE);
+  }, [selectedPosition, debouncedSearch]);
+
+  const bestAvailable = filteredPlayers.slice(0, visibleCount);
+  const hasMore = visibleCount < filteredPlayers.length;
   const rosterNeeds = getRosterNeedOrder(userTeam);
+
+  // Watchlist players still on the board — the "is my guy still here?" glance.
+  const queuedAvailable = useMemo(() => {
+    const byId = new Map(availablePlayers.map((player) => [player.id, player]));
+    return queue.queue.map((id) => byId.get(id)).filter((player): player is Player => Boolean(player));
+  }, [availablePlayers, queue.queue]);
 
   return (
     <div className="home-card scroll-mt-28 p-5 sm:p-6">
@@ -129,7 +147,7 @@ export function DraftBoard({
           <div className="min-w-0">
             <p className="home-kicker mb-1">Draft Board</p>
             <h2 className="text-2xl font-semibold">
-              Pick #{currentPick} on the clock: Team {currentTeamNumber}
+              Pick #{currentPick} on the clock: {currentTeamName}
             </h2>
           </div>
           <div className="flex flex-wrap items-center gap-2 xl:justify-end">
@@ -195,6 +213,38 @@ export function DraftBoard({
         </div>
       </div>
 
+      {/* Watchlist still on the board */}
+      {!isDraftComplete && queuedAvailable.length > 0 && (
+        <div
+          className="mt-4 rounded-[1.3rem] border px-4 py-3"
+          style={{
+            borderColor: "color-mix(in srgb, var(--home-acid) 40%, var(--home-rule))",
+            background: "color-mix(in srgb, var(--home-acid) 12%, var(--home-paper))",
+          }}
+        >
+          <div className="mb-2 flex items-center gap-1.5">
+            <Star size={14} fill="currentColor" style={{ color: "var(--home-acid)" }} aria-hidden="true" />
+            <p className="home-kicker mb-0">Your queue · still available ({queuedAvailable.length})</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {queuedAvailable.slice(0, 8).map((player) => (
+              <button
+                key={`queued-${player.id}`}
+                type="button"
+                onClick={() => onDraftPlayer(player)}
+                disabled={isDraftComplete}
+                title={`Log ${player.name}`}
+                className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+                style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)" }}
+              >
+                <span className="font-bold tabular-nums">{formatRankValue(player.rankEcr ?? player.averageRank)}</span>
+                <span className="max-w-[8rem] truncate">{player.name}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       {boardView === "columns" ? (
         <DraftTierColumns
           snapshot={snapshot}
@@ -224,23 +274,18 @@ export function DraftBoard({
               />
             </label>
 
-            <div className="flex flex-wrap gap-2" aria-label="Position filters">
-              {POSITION_LABELS.map((option) => {
-                const active = selectedPosition === option.value;
-                return (
-                  <button
-                    key={option.value}
-                    type="button"
-                    onClick={() => setSelectedPosition(option.value)}
-                    aria-pressed={active}
-                    className="min-h-[44px] rounded-full border px-4 py-2 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
-                    style={getFilterStyle(active)}
-                  >
-                    {option.label}
-                  </button>
-                );
-              })}
-            </div>
+            <PositionFilterBar
+              ariaLabel="Position filters"
+              options={POSITION_OPTIONS}
+              value={selectedPosition}
+              onChange={setSelectedPosition}
+            />
+
+            {!isDraftComplete && bestAvailable.length > 0 && (
+              <p aria-live="polite" className="text-sm" style={{ color: "var(--home-ink-muted)" }}>
+                {filteredPlayers.length} available · showing {bestAvailable.length}
+              </p>
+            )}
 
             <div className="grid gap-3">
               {isDraftComplete ? (
@@ -270,123 +315,160 @@ export function DraftBoard({
                   </p>
                 </div>
               ) : (
-                bestAvailable.map((player) => {
-                  const fitsCurrentNeed = rosterNeeds.includes(player.position);
-                  const isValueAtCurrentPick =
-                    Number.isFinite(player.adp) &&
-                    currentPick - (player.adp as number) >= getReachStealThreshold(currentRound);
+                <>
+                  {bestAvailable.map((player) => {
+                    const fitsCurrentNeed = rosterNeeds.includes(player.position);
+                    const isValueAtCurrentPick =
+                      Number.isFinite(player.adp) &&
+                      currentPick - (player.adp as number) >= getReachStealThreshold(currentRound);
+                    const isQueued = queue.isQueued(player.id);
+                    const inCompare = compare.inCompare(player.id);
 
-                  return (
-                    <div
-                      key={player.id}
-                      className="grid gap-4 rounded-[1.5rem] border px-4 py-4 md:grid-cols-[3.5rem_minmax(8rem,1fr)_4.5rem_6.5rem_5.5rem] md:items-center md:gap-x-3"
-                      style={{
-                        borderColor: fitsCurrentNeed
-                          ? "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))"
-                          : "var(--home-rule)",
-                        background: fitsCurrentNeed
-                          ? "color-mix(in srgb, var(--color-success) 7%, var(--home-paper))"
-                          : "color-mix(in srgb, var(--home-paper-alt) 42%, var(--home-elev-mix))",
-                      }}
-                    >
-                      <div className="flex min-w-0 items-start gap-3 md:contents">
-                        <div className="shrink-0">
-                          <p className="home-kicker mb-1">Rank</p>
-                          <p
-                            className="text-2xl font-semibold tabular-nums"
-                            title="Published FantasyPros overall consensus rank"
-                          >
-                            {formatRankValue(player.rankEcr ?? player.averageRank)}
-                          </p>
-                        </div>
-
-                        <div className="min-w-0 flex-1">
-                          <div className="flex min-w-0 flex-wrap items-center gap-2">
-                            <p className="min-w-0 truncate text-base font-semibold">{player.name}</p>
-                            <span className={FANTASY_CHIP_CLASS} style={getPositionTone(player.position)}>
-                              {player.position}
-                            </span>
-                            {fitsCurrentNeed && (
-                              <span
-                                className={FANTASY_CHIP_CLASS}
-                                title="Fills a starting spot your roster still needs"
-                                style={{
-                                  borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
-                                  background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
-                                }}
-                              >
-                                Priority
-                              </span>
-                            )}
-                            {isValueAtCurrentPick && (
-                              <span
-                                className={FANTASY_CHIP_CLASS}
-                                title={`Mock drafters usually take this player around pick ${formatAdp(player.adp)}, well before pick ${currentPick}`}
-                                style={{
-                                  borderColor: "color-mix(in srgb, var(--home-acid) 38%, var(--home-rule))",
-                                  background: "color-mix(in srgb, var(--home-acid) 18%, var(--home-paper))",
-                                }}
-                              >
-                                Value at #{currentPick}
-                              </span>
-                            )}
-                          </div>
-                          <p className="mt-1 text-sm" style={{ color: "var(--home-ink-muted)" }}>
-                            {player.team}
-                            {Number.isFinite(player.rankAverage) ? (
-                              <span className="inline-flex items-center">
-                                {" • Avg "}
-                                {Number(player.rankAverage).toFixed(2)}
-                                <MetricTooltip term="Average rank" definition={FANTASY_AVG_RANK_TOOLTIP} />
-                              </span>
-                            ) : null}
-                            {player.positionRank ? ` • ${player.position}${player.positionRank}` : ""}
-                            {Number.isFinite(player.adp) ? ` • ADP ${formatAdp(player.adp)}` : ""}
-                          </p>
-                        </div>
-                      </div>
-
+                    return (
                       <div
-                        className="grid grid-cols-2 gap-3 border-t pt-3 md:contents"
-                        style={{ borderColor: "var(--home-rule)" }}
-                      >
-                        <div className="min-w-0">
-                          <p className="home-kicker mb-1">Tier</p>
-                          <p
-                            className="truncate text-sm font-semibold"
-                            title="FantasyPros consensus tier. Gaps between tiers mark value drop-offs"
-                          >
-                            {player.tier ? `Tier ${player.tier}` : "Not listed"}
-                          </p>
-                        </div>
-
-                        <div className="min-w-0">
-                          <p className="home-kicker mb-1">Range</p>
-                          <p
-                            className="truncate text-sm font-semibold tabular-nums"
-                            title="Best and worst rank across the experts in the consensus"
-                          >
-                            {formatRange(player)}
-                          </p>
-                        </div>
-                      </div>
-
-                      <button
-                        type="button"
-                        onClick={() => onDraftPlayer(player)}
-                        disabled={isDraftComplete}
-                        className="inline-flex min-h-[44px] w-full items-center justify-center rounded-full border px-4 py-3 text-sm font-semibold whitespace-nowrap transition-[background-color,border-color,color,box-shadow,opacity] duration-200 disabled:cursor-not-allowed disabled:opacity-60 md:w-auto md:justify-self-end md:px-3"
+                        key={player.id}
+                        className="relative overflow-hidden rounded-[1.25rem] border"
                         style={{
-                          borderColor: "var(--home-ink)",
-                          background: "var(--home-ink)",
-                          color: "var(--home-paper)",
+                          borderColor: fitsCurrentNeed
+                            ? "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))"
+                            : "var(--home-rule)",
+                          background: fitsCurrentNeed
+                            ? "color-mix(in srgb, var(--color-success) 7%, var(--home-paper))"
+                            : "color-mix(in srgb, var(--home-paper-alt) 42%, var(--home-elev-mix))",
                         }}
                       >
-                        Log pick
-                      </button>
-                    </div>
-                  );
-                })
+                        {isQueued && (
+                          <span aria-hidden="true" className="absolute inset-y-0 left-0 w-1" style={{ background: "var(--home-acid)" }} />
+                        )}
+                        <div className="flex flex-col gap-3 px-4 py-3.5 md:flex-row md:items-center md:gap-4">
+                          <div className="flex min-w-0 flex-1 items-center gap-3">
+                            <span
+                              className="shrink-0 text-2xl font-semibold tabular-nums"
+                              title="Published FantasyPros overall consensus rank"
+                            >
+                              {formatRankValue(player.rankEcr ?? player.averageRank)}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => onOpenDetail(player)}
+                              className="min-w-0 flex-1 text-left"
+                              aria-label={`Open ${player.name} detail`}
+                            >
+                              <span className="flex min-w-0 flex-wrap items-center gap-2">
+                                <span className="min-w-0 truncate text-base font-semibold">{player.name}</span>
+                                <span className={FANTASY_CHIP_CLASS} style={getPositionTone(player.position)}>
+                                  {player.position}
+                                </span>
+                                {fitsCurrentNeed && (
+                                  <span
+                                    className={FANTASY_CHIP_CLASS}
+                                    title="Fills a starting spot your roster still needs"
+                                    style={{
+                                      borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
+                                      background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
+                                    }}
+                                  >
+                                    Priority
+                                  </span>
+                                )}
+                                {isValueAtCurrentPick && (
+                                  <span
+                                    className={FANTASY_CHIP_CLASS}
+                                    title={`Mock drafters usually take this player around pick ${formatAdp(player.adp)}, well before pick ${currentPick}`}
+                                    style={{
+                                      borderColor: "color-mix(in srgb, var(--home-acid) 38%, var(--home-rule))",
+                                      background: "color-mix(in srgb, var(--home-acid) 18%, var(--home-paper))",
+                                    }}
+                                  >
+                                    Value at #{currentPick}
+                                  </span>
+                                )}
+                              </span>
+                              <span className="mt-1 block text-sm" style={{ color: "var(--home-ink-muted)" }}>
+                                {player.team}
+                                {Number.isFinite(player.rankAverage) ? (
+                                  <span className="inline-flex items-center">
+                                    {" • Avg "}
+                                    {Number(player.rankAverage).toFixed(2)}
+                                    <MetricTooltip term="Average rank" definition={FANTASY_AVG_RANK_TOOLTIP} />
+                                  </span>
+                                ) : null}
+                                {player.positionRank ? ` • ${player.position}${player.positionRank}` : ""}
+                                {player.tier ? ` • Tier ${player.tier}` : ""}
+                                {Number.isFinite(player.adp) ? ` • ADP ${formatAdp(player.adp)}` : ""}
+                                {` • Range ${formatRange(player)}`}
+                              </span>
+                            </button>
+                          </div>
+
+                          <div className="flex items-center gap-1.5">
+                            <button
+                              type="button"
+                              onClick={() => queue.toggle(player.id)}
+                              aria-pressed={isQueued}
+                              aria-label={isQueued ? `Remove ${player.name} from queue` : `Add ${player.name} to queue`}
+                              className="inline-flex h-9 w-9 items-center justify-center rounded-full border"
+                              style={
+                                isQueued
+                                  ? {
+                                      borderColor: "color-mix(in srgb, var(--home-acid) 55%, var(--home-rule))",
+                                      background: "color-mix(in srgb, var(--home-acid) 28%, var(--home-paper))",
+                                      color: "var(--home-ink)",
+                                    }
+                                  : { borderColor: "var(--home-rule)", color: "var(--home-ink-muted)" }
+                              }
+                            >
+                              <Star size={15} fill={isQueued ? "currentColor" : "none"} aria-hidden="true" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => compare.toggle(player.id)}
+                              aria-pressed={inCompare}
+                              disabled={!inCompare && compare.isFull}
+                              aria-label={inCompare ? `Remove ${player.name} from compare` : `Add ${player.name} to compare`}
+                              className="hidden h-9 w-9 items-center justify-center rounded-full border disabled:cursor-not-allowed disabled:opacity-45 sm:inline-flex"
+                              style={
+                                inCompare
+                                  ? { borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }
+                                  : { borderColor: "var(--home-rule)", color: "var(--home-ink-muted)" }
+                              }
+                            >
+                              <GitCompareArrows size={15} aria-hidden="true" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => onOpenDetail(player)}
+                              aria-label={`Details for ${player.name}`}
+                              className="inline-flex h-9 w-9 items-center justify-center rounded-full border sm:hidden"
+                              style={{ borderColor: "var(--home-rule)", color: "var(--home-ink-muted)" }}
+                            >
+                              <Info size={15} aria-hidden="true" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => onDraftPlayer(player)}
+                              disabled={isDraftComplete}
+                              className="inline-flex min-h-[44px] items-center justify-center rounded-full border px-4 text-sm font-semibold whitespace-nowrap transition-[background-color,border-color,color,box-shadow,opacity] duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+                              style={{ borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }}
+                            >
+                              Log pick
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                  {hasMore && (
+                    <button
+                      type="button"
+                      onClick={() => setVisibleCount((count) => Math.min(count + BOARD_PAGE_SIZE, filteredPlayers.length))}
+                      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-full border px-5 text-sm font-semibold"
+                      style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)" }}
+                    >
+                      Load more ({filteredPlayers.length - bestAvailable.length} left)
+                    </button>
+                  )}
+                </>
               )}
             </div>
           </div>

--- a/src/app/fantasy-football/draft-tracker/components/DraftSetup.tsx
+++ b/src/app/fantasy-football/draft-tracker/components/DraftSetup.tsx
@@ -211,6 +211,56 @@ export function DraftSetup({ settings, onSaveSettings, onStartDraft }: DraftSetu
         </fieldset>
       </div>
 
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        <fieldset className="grid gap-2 text-sm">
+          <legend className="home-kicker mb-0">Per-pick timer</legend>
+          <div className="grid auto-rows-fr gap-2 sm:grid-cols-2">
+            {[
+              { value: 0, label: "Off", description: "No clock — log at your own pace." },
+              { value: 90, label: "On", description: "Advisory countdown each pick." },
+            ].map((option) => {
+              const active = (option.value > 0) === ((formState.timerSeconds ?? 0) > 0);
+              return (
+                <button
+                  key={option.label}
+                  type="button"
+                  onClick={() => updateField("timerSeconds", option.value === 0 ? 0 : formState.timerSeconds || 90)}
+                  className="min-h-[72px] rounded-[1.2rem] border px-4 py-3 text-left transition-[background-color,border-color,color,box-shadow] duration-200"
+                  style={getOptionStyle(active)}
+                >
+                  <span className="block text-sm font-semibold">{option.label}</span>
+                  <span
+                    className="mt-1 block text-xs"
+                    style={{ color: active ? "color-mix(in srgb, var(--home-paper) 78%, transparent)" : "var(--home-ink-muted)" }}
+                  >
+                    {option.description}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <label className="grid gap-2 text-sm" htmlFor="draft-timer-seconds">
+          <span className="home-kicker mb-0">Seconds per pick</span>
+          <select
+            id="draft-timer-seconds"
+            name="timerSeconds"
+            value={formState.timerSeconds || 90}
+            disabled={(formState.timerSeconds ?? 0) === 0}
+            onChange={(event) => updateField("timerSeconds", Number(event.target.value))}
+            className="min-h-[48px] w-full rounded-[1.2rem] border px-4 text-sm transition-[background-color,border-color,box-shadow] duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+            style={getFieldStyle()}
+          >
+            {[45, 60, 90, 120, 180].map((seconds) => (
+              <option key={seconds} value={seconds}>
+                {seconds} seconds
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
       <div
         className="mt-6 grid gap-3 rounded-[1.3rem] border px-4 py-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
         style={{

--- a/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
+++ b/src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx
@@ -2,19 +2,23 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { Download, RotateCcw, Undo2 } from "lucide-react";
+import { ChevronDown, Download, Redo2, RotateCcw, Timer, Undo2 } from "lucide-react";
 import { DraftAnalyticsPanel } from "./components/DraftAnalyticsPanel";
 import { DraftBoard } from "./components/DraftBoard";
 import { DraftSetup } from "./components/DraftSetup";
 import { useDraftState } from "./hooks/useDraftState";
+import { useDraftTimer } from "./hooks/useDraftTimer";
 import { useFantasySnapshot } from "@/hooks/useFantasySnapshot";
+import { usePlayerNotes } from "@/hooks/usePlayerNotes";
 import { computeDraftAnalytics } from "@/lib/draftAnalytics";
 import {
   FANTASY_SCORING_LABELS,
   getFantasyWeekLabel,
   scoringFormatToRouteScoring,
 } from "@/lib/fantasy";
-import { formatUpdatedAt } from "@/lib/fantasyUtils";
+import { formatRankValue, formatUpdatedAt } from "@/lib/fantasyUtils";
+import { CompareTray, PlayerDetailDrawer } from "@/components/fantasy";
+import type { Player } from "@/types";
 import { Breadcrumbs } from "@/components/navigation/Breadcrumbs";
 import { HomeStatsPanel, type HomeStatsCell } from "@/components/home/HomeStatsPanel";
 
@@ -23,6 +27,21 @@ const DRAFT_TRACKER_BREADCRUMBS = [
   { label: "Draft Assistant", href: "/fantasy-football/draft-tracker", isActive: true },
 ];
 
+const TILE_STYLE = {
+  borderColor: "var(--home-rule)",
+  background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
+} as const;
+
+const ACTION_STYLE = {
+  borderColor: "var(--home-rule)",
+  background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+  color: "var(--home-ink)",
+} as const;
+
+function publishedDraftRank(player: Player): string {
+  return formatRankValue(player.rankEcr ?? player.averageRank);
+}
+
 export function DraftTrackerClient() {
   const {
     draftState,
@@ -30,14 +49,20 @@ export function DraftTrackerClient() {
     startDraft,
     draftPlayer,
     undoLastPick,
+    redoLastPick,
+    undoToPick,
+    setTeamName,
+    getTeamName,
+    canRedo,
     resetDraft,
     exportDraftResults,
     isUserPick,
     isDraftComplete,
     currentTeamName,
-    currentTeamNumber,
     userTeam,
   } = useDraftState();
+
+  const notes = usePlayerNotes();
 
   const scoringKey = scoringFormatToRouteScoring(draftState.settings.scoringFormat);
   const { snapshot, metadata, isLoading, error } = useFantasySnapshot({
@@ -47,6 +72,11 @@ export function DraftTrackerClient() {
   const overallSliceMetadata = snapshot?.sliceMetadata?.overall ?? null;
   const rankingsUnavailable = Boolean(overallSliceMetadata && !overallSliceMetadata.available);
   const showSetup = draftState.picks.length === 0 && !draftState.isActive;
+
+  const [detailPlayer, setDetailPlayer] = useState<Player | null>(null);
+  const [showStats, setShowStats] = useState(false);
+  const [showTeamEditor, setShowTeamEditor] = useState(false);
+  const [exportToast, setExportToast] = useState<string | null>(null);
 
   const draftedPlayerIds = useMemo(
     () => new Set(draftState.picks.map((pick) => pick.player.id)),
@@ -61,6 +91,27 @@ export function DraftTrackerClient() {
   const adpAvailable = Boolean(snapshot?.adpSource);
   const totalPicks = draftState.settings.totalTeams * draftState.settings.rounds;
   const completionPercentage = Math.round((draftState.picks.length / totalPicks) * 100);
+
+  const playerLookup = useMemo(
+    () => new Map((snapshot?.overall ?? []).map((player) => [player.id, player])),
+    [snapshot]
+  );
+  const boardTierCount = useMemo(() => {
+    let max = 0;
+    for (const player of snapshot?.overall ?? []) {
+      if (player.tier && player.tier > max) max = player.tier;
+    }
+    return max;
+  }, [snapshot]);
+
+  const timerEnabled =
+    (draftState.settings.timerSeconds ?? 0) > 0 && !showSetup && !isDraftComplete && !rankingsUnavailable;
+  const timer = useDraftTimer({
+    currentPick: draftState.currentPick,
+    durationSeconds: draftState.settings.timerSeconds ?? 0,
+    enabled: timerEnabled,
+    isActive: draftState.isActive,
+  });
 
   const userTeamName = userTeam?.teamName ?? `Team ${draftState.settings.userTeam}`;
   const bestAvailableCount = (snapshot?.overall ?? []).filter(
@@ -116,10 +167,11 @@ export function DraftTrackerClient() {
     },
   ];
 
-  const [exportToast, setExportToast] = useState<string | null>(null);
-  function handleExport(format: "csv") {
-    exportDraftResults(format);
-    setExportToast(`Exported ${draftState.picks.length} picks as ${format.toUpperCase()}.`);
+  function handleExport(format: "csv" | "recap-csv" | "json") {
+    exportDraftResults(format, { notes: notes.notes });
+    const label =
+      format === "recap-csv" ? "team recap CSV" : format === "json" ? "JSON" : "picks CSV";
+    setExportToast(`Exported ${label}.`);
     window.setTimeout(() => setExportToast(null), 3500);
   }
 
@@ -133,75 +185,86 @@ export function DraftTrackerClient() {
             <h1
               style={{
                 fontFamily: "var(--font-home-sans)",
-                fontSize: "clamp(2.55rem, 6vw, 4.75rem)",
+                fontSize: "clamp(2rem, 4.4vw, 3.2rem)",
                 fontWeight: 600,
                 letterSpacing: "-0.04em",
-                lineHeight: 0.95,
-                maxWidth: "15ch",
+                lineHeight: 0.98,
+                maxWidth: "18ch",
               }}
             >
               Manual draft tracking that actually stays usable.
             </h1>
-            <p
-              className="max-w-[68ch] text-sm leading-7 sm:text-[1rem]"
-              style={{ color: "var(--home-ink-muted)" }}
-            >
-              Log every pick, keep the board on the same published snapshot as the public rankings,
-              and watch for steals, reaches, and position runs against attributed mock-draft ADP
-              while the room is still on the clock.
+            <p className="max-w-[60ch] text-sm leading-7" style={{ color: "var(--home-ink-muted)" }}>
+              Log every pick on the same published snapshot as the rankings, with your shared
+              watchlist, an advisory pick clock, multi-step undo, and steal/reach/run signals against
+              attributed mock-draft ADP.
             </p>
           </div>
 
-          <div className="flex flex-wrap gap-2 text-sm">
-            <span
-              className="inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium"
-              style={{
-                borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-              }}
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            {[
+              metadata ? `${metadata.season} ${getFantasyWeekLabel(metadata.week)}` : "Loading snapshot",
+              `Source updated ${formatUpdatedAt(overallSliceMetadata?.updatedAt ?? metadata?.upstreamUpdatedAt)}`,
+              `Built ${formatUpdatedAt(metadata?.generatedAt)}`,
+              `${FANTASY_SCORING_LABELS[scoringKey]} scoring`,
+            ].map((label) => (
+              <span
+                key={label}
+                className="inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium"
+                style={{
+                  borderColor: "var(--home-rule)",
+                  background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+                }}
+              >
+                {label}
+              </span>
+            ))}
+            {timerEnabled && (
+              <span
+                className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-semibold tabular-nums"
+                style={{
+                  borderColor: timer.isExpired
+                    ? "color-mix(in srgb, var(--color-warning) 40%, var(--home-rule))"
+                    : "var(--home-rule)",
+                  background: timer.isExpired
+                    ? "color-mix(in srgb, var(--color-warning) 16%, var(--home-paper))"
+                    : "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+                }}
+                aria-live="off"
+              >
+                <Timer className="h-4 w-4" aria-hidden="true" />
+                {timer.isExpired ? "Time's up" : `${timer.secondsLeft}s on the clock`}
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={() => setShowStats((open) => !open)}
+              aria-expanded={showStats}
+              aria-controls="draft-tracker-stats"
+              className="inline-flex min-h-[40px] items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-semibold"
+              style={ACTION_STYLE}
             >
-              {metadata ? `${metadata.season} ${getFantasyWeekLabel(metadata.week)}` : "Loading snapshot"}
-            </span>
-            <span
-              className="inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium"
-              style={{
-                borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-              }}
-            >
-              Source updated {formatUpdatedAt(overallSliceMetadata?.updatedAt ?? metadata?.upstreamUpdatedAt)}
-            </span>
-            <span
-              className="inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium"
-              style={{
-                borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-              }}
-            >
-              Built {formatUpdatedAt(metadata?.generatedAt)}
-            </span>
-            <span
-              className="inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium"
-              style={{
-                borderColor: "var(--home-rule)",
-                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-              }}
-            >
-              {FANTASY_SCORING_LABELS[scoringKey]} scoring
-            </span>
+              Draft at a glance
+              <ChevronDown
+                className="h-4 w-4 transition-transform"
+                style={{ transform: showStats ? "rotate(180deg)" : "none" }}
+              />
+            </button>
           </div>
         </div>
 
-        <HomeStatsPanel
-          id="draft-tracker-stats"
-          title="Draft at a glance"
-          meta={isDraftComplete ? "Draft complete" : `Pick ${draftState.currentPick} of ${totalPicks}`}
-          cells={draftStatsCells}
-          pills={[
-            { label: "Resume rankings", href: "/fantasy-football" },
-            { label: "Draft assistant", href: "/fantasy-football/draft-tracker" },
-          ]}
-        />
+        {showStats && (
+          <HomeStatsPanel
+            id="draft-tracker-stats"
+            title="Draft at a glance"
+            meta={isDraftComplete ? "Draft complete" : `Pick ${draftState.currentPick} of ${totalPicks}`}
+            cells={draftStatsCells}
+            pills={[
+              { label: "Resume rankings", href: "/fantasy-football" },
+              { label: "Draft assistant", href: "/fantasy-football/draft-tracker" },
+            ]}
+          />
+        )}
 
         {error && (
           <article className="home-card p-5 sm:p-6" style={{ borderColor: "var(--color-error)" }}>
@@ -222,35 +285,6 @@ export function DraftTrackerClient() {
 
         <div className="grid gap-5 lg:grid-cols-[minmax(0,1.18fr)_minmax(18rem,22rem)] min-[1440px]:grid-cols-[minmax(0,1.2fr)_minmax(20rem,26rem)]">
           <div className="grid gap-5">
-            <article className="home-card p-5 sm:p-6">
-              <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]">
-                <div>
-                  <p className="home-kicker mb-1">Room status</p>
-                  <h2 className="text-2xl font-semibold">
-                    {isDraftComplete ? "Draft complete" : currentTeamName}
-                  </h2>
-                  <p className="mt-2 text-sm leading-7" style={{ color: "var(--home-ink-muted)" }}>
-                    The assistant reads the same snapshot as the public rankings board. Best available,
-                    search, and roster pressure all stay on one consistent data source.
-                  </p>
-                </div>
-
-                <div
-                  className="rounded-[1.5rem] border px-4 py-4"
-                  style={{
-                    borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 52%, var(--home-elev-mix))",
-                  }}
-                >
-                  <p className="home-kicker mb-1">Snapshot</p>
-                  <p className="text-base font-semibold">Overall consensus board</p>
-                  <p className="mt-2 text-sm leading-6" style={{ color: "var(--home-ink-muted)" }}>
-                    Local persistence is enabled. Room state survives reloads until you reset the draft.
-                  </p>
-                </div>
-              </div>
-            </article>
-
             {rankingsUnavailable ? (
               <div className="home-card p-6 sm:p-8 text-center">
                 <p className="text-xl font-semibold">Draft assistant unavailable for this scoring format</p>
@@ -275,6 +309,7 @@ export function DraftTrackerClient() {
                     isDraftComplete
                     userTeamNumber={draftState.settings.userTeam}
                     adpAvailable={adpAvailable}
+                    getTeamName={getTeamName}
                   />
                 )}
                 <DraftBoard
@@ -282,9 +317,10 @@ export function DraftTrackerClient() {
                   snapshot={snapshot}
                   draftedPlayerIds={draftedPlayerIds}
                   onDraftPlayer={draftPlayer}
+                  onOpenDetail={setDetailPlayer}
                   currentPick={draftState.currentPick}
                   currentRound={draftState.currentRound}
-                  currentTeamNumber={currentTeamNumber}
+                  currentTeamName={currentTeamName}
                   isUserPick={isUserPick}
                   isDraftComplete={isDraftComplete}
                   userTeam={userTeam}
@@ -302,6 +338,7 @@ export function DraftTrackerClient() {
                 isDraftComplete={false}
                 userTeamNumber={draftState.settings.userTeam}
                 adpAvailable={adpAvailable}
+                getTeamName={getTeamName}
               />
             )}
             <article className="home-card p-5 sm:p-6">
@@ -311,10 +348,7 @@ export function DraftTrackerClient() {
               </h3>
 
               <div className="mt-4">
-                <div
-                  className="flex items-center justify-between text-sm"
-                  style={{ color: "var(--home-ink-muted)" }}
-                >
+                <div className="flex items-center justify-between text-sm" style={{ color: "var(--home-ink-muted)" }}>
                   <span>Completion</span>
                   <span>{completionPercentage}%</span>
                 </div>
@@ -326,43 +360,24 @@ export function DraftTrackerClient() {
                     className="h-2 rounded-full"
                     style={{
                       width: `${completionPercentage}%`,
-                      background:
-                        "linear-gradient(90deg, var(--home-haze) 0%, var(--home-acid) 100%)",
+                      background: "linear-gradient(90deg, var(--home-haze) 0%, var(--home-acid) 100%)",
                     }}
                   />
                 </div>
               </div>
 
               <div className="mt-5 grid gap-3">
-                <div
-                  className="rounded-[1.2rem] border px-4 py-3"
-                  style={{
-                    borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
-                  }}
-                >
+                <div className="rounded-[1.2rem] border px-4 py-3" style={TILE_STYLE}>
                   <p className="home-kicker mb-1">On clock</p>
                   <p className="text-sm font-semibold">{currentTeamName}</p>
                 </div>
-                <div
-                  className="rounded-[1.2rem] border px-4 py-3"
-                  style={{
-                    borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
-                  }}
-                >
+                <div className="rounded-[1.2rem] border px-4 py-3" style={TILE_STYLE}>
                   <p className="home-kicker mb-1">Current pick</p>
                   <p className="text-sm font-semibold">
                     {draftState.currentPick} / {totalPicks}
                   </p>
                 </div>
-                <div
-                  className="rounded-[1.2rem] border px-4 py-3"
-                  style={{
-                    borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
-                  }}
-                >
+                <div className="rounded-[1.2rem] border px-4 py-3" style={TILE_STYLE}>
                   <p className="home-kicker mb-1">Round</p>
                   <p className="text-sm font-semibold">
                     {draftState.currentRound} / {draftState.settings.rounds}
@@ -380,19 +395,18 @@ export function DraftTrackerClient() {
                   </p>
                 ) : (
                   userTeam?.picks.map((pick) => (
-                    <div
+                    <button
                       key={pick.pickNumber}
-                      className="rounded-[1.2rem] border px-4 py-3"
-                      style={{
-                        borderColor: "var(--home-rule)",
-                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
-                      }}
+                      type="button"
+                      onClick={() => setDetailPlayer(pick.player)}
+                      className="rounded-[1.2rem] border px-4 py-3 text-left"
+                      style={TILE_STYLE}
                     >
                       <p className="text-sm font-semibold">{pick.player.name}</p>
                       <p className="mt-1 text-xs" style={{ color: "var(--home-ink-muted)" }}>
                         Pick {pick.pickNumber} • {pick.player.position} • {pick.player.team}
                       </p>
-                    </div>
+                    </button>
                   ))
                 )}
               </div>
@@ -402,7 +416,7 @@ export function DraftTrackerClient() {
               <div className="flex items-center justify-between gap-2">
                 <p className="home-kicker mb-0">Recent picks</p>
                 <span className="text-xs" style={{ color: "var(--home-ink-muted)" }}>
-                  Newest first
+                  Tap to undo here
                 </span>
               </div>
               <div className="mt-4 grid gap-3">
@@ -414,68 +428,121 @@ export function DraftTrackerClient() {
                   recentPicks.map((pick) => (
                     <div
                       key={`recent-${pick.pickNumber}`}
-                      className="rounded-[1.2rem] border px-4 py-3"
-                      style={{
-                        borderColor: "var(--home-rule)",
-                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
-                      }}
+                      className="flex items-center gap-2 rounded-[1.2rem] border px-4 py-3"
+                      style={TILE_STYLE}
                     >
-                      <p className="text-sm font-semibold">{pick.player.name}</p>
-                      <p className="mt-1 text-xs" style={{ color: "var(--home-ink-muted)" }}>
-                        Team {pick.teamNumber} • Pick {pick.pickNumber} • {pick.player.position}
-                      </p>
+                      <button
+                        type="button"
+                        onClick={() => setDetailPlayer(pick.player)}
+                        className="min-w-0 flex-1 text-left"
+                      >
+                        <p className="truncate text-sm font-semibold">{pick.player.name}</p>
+                        <p className="mt-1 text-xs" style={{ color: "var(--home-ink-muted)" }}>
+                          {getTeamName(pick.teamNumber)} • Pick {pick.pickNumber} • {pick.player.position}
+                        </p>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => undoToPick(pick.pickNumber)}
+                        aria-label={`Undo back to pick ${pick.pickNumber}`}
+                        title={`Undo back to pick ${pick.pickNumber}`}
+                        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border"
+                        style={{ borderColor: "var(--home-rule)", color: "var(--home-ink-muted)" }}
+                      >
+                        <Undo2 size={14} aria-hidden="true" />
+                      </button>
                     </div>
                   ))
                 )}
               </div>
             </article>
 
+            {/* Team naming */}
+            <article className="home-card p-5 sm:p-6">
+              <button
+                type="button"
+                onClick={() => setShowTeamEditor((open) => !open)}
+                aria-expanded={showTeamEditor}
+                className="flex w-full items-center justify-between gap-2"
+              >
+                <span className="home-kicker mb-0">Name the teams</span>
+                <ChevronDown
+                  className="h-4 w-4 transition-transform"
+                  style={{ transform: showTeamEditor ? "rotate(180deg)" : "none" }}
+                />
+              </button>
+              {showTeamEditor && (
+                <div className="mt-4 grid gap-2">
+                  {draftState.teams.map((team) => (
+                    <label key={team.teamNumber} className="grid gap-1 text-xs">
+                      <span style={{ color: "var(--home-ink-muted)" }}>
+                        Slot {team.teamNumber}
+                        {team.teamNumber === draftState.settings.userTeam ? " (you)" : ""}
+                      </span>
+                      <input
+                        value={team.teamName ?? ""}
+                        onChange={(event) => setTeamName(team.teamNumber, event.target.value)}
+                        maxLength={40}
+                        placeholder={`Team ${team.teamNumber}`}
+                        className="min-h-[40px] rounded-[0.9rem] border px-3 text-sm"
+                        style={ACTION_STYLE}
+                      />
+                    </label>
+                  ))}
+                </div>
+              )}
+            </article>
+
             <article className="home-card p-5 sm:p-6">
               <p className="home-kicker mb-1">Actions</p>
               <div className="mt-4 grid gap-3">
+                <div className="grid grid-cols-2 gap-3">
+                  <button
+                    type="button"
+                    onClick={undoLastPick}
+                    disabled={draftState.picks.length === 0}
+                    aria-label={draftState.picks.length === 0 ? "Undo last pick (no picks yet)" : "Undo last pick"}
+                    className="flex min-h-[48px] items-center justify-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow,opacity] duration-200 disabled:cursor-not-allowed disabled:opacity-50"
+                    style={ACTION_STYLE}
+                  >
+                    <Undo2 className="h-4 w-4" />
+                    Undo
+                  </button>
+                  <button
+                    type="button"
+                    onClick={redoLastPick}
+                    disabled={!canRedo}
+                    aria-label={canRedo ? "Redo the last undone pick" : "Redo (nothing to redo)"}
+                    className="flex min-h-[48px] items-center justify-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow,opacity] duration-200 disabled:cursor-not-allowed disabled:opacity-50"
+                    style={ACTION_STYLE}
+                  >
+                    <Redo2 className="h-4 w-4" />
+                    Redo
+                  </button>
+                </div>
+                <div className="grid grid-cols-3 gap-2">
+                  {([
+                    { format: "csv", label: "Picks CSV" },
+                    { format: "recap-csv", label: "Recap CSV" },
+                    { format: "json", label: "JSON" },
+                  ] as const).map((option) => (
+                    <button
+                      key={option.format}
+                      type="button"
+                      onClick={() => handleExport(option.format)}
+                      className="flex min-h-[48px] items-center justify-center gap-1.5 rounded-full border px-2 py-3 text-xs font-semibold"
+                      style={ACTION_STYLE}
+                    >
+                      <Download className="h-3.5 w-3.5" />
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
                 <button
                   type="button"
-                  onClick={undoLastPick}
-                  disabled={draftState.picks.length === 0}
-                  aria-label={
-                    draftState.picks.length === 0
-                      ? "Undo last pick (no picks yet)"
-                      : "Undo last pick"
-                  }
-                  className="flex min-h-[48px] items-center justify-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow,opacity] duration-200 disabled:cursor-not-allowed disabled:opacity-50"
-                  style={{
-                    borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-                    color: "var(--home-ink)",
-                  }}
-                >
-                  <Undo2 className="h-4 w-4" />
-                  Undo last pick
-                </button>
-                <button
-                  type="button"
-                  onClick={() => handleExport("csv")}
+                  onClick={() => resetDraft()}
                   className="flex min-h-[48px] items-center justify-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
-                  style={{
-                    borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-                    color: "var(--home-ink)",
-                  }}
-                >
-                  <Download className="h-4 w-4" />
-                  Export CSV
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    resetDraft();
-                  }}
-                  className="flex min-h-[48px] items-center justify-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
-                  style={{
-                    borderColor: "var(--home-ink)",
-                    background: "var(--home-ink)",
-                    color: "var(--home-paper)",
-                  }}
+                  style={{ borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }}
                 >
                   <RotateCcw className="h-4 w-4" />
                   Reset draft
@@ -483,11 +550,7 @@ export function DraftTrackerClient() {
                 <Link
                   href="/fantasy-football"
                   className="flex min-h-[48px] items-center justify-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
-                  style={{
-                    borderColor: "var(--home-rule)",
-                    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-                    color: "var(--home-ink)",
-                  }}
+                  style={ACTION_STYLE}
                 >
                   Back to rankings board
                 </Link>
@@ -513,17 +576,21 @@ export function DraftTrackerClient() {
           {exportToast ? (
             <div
               className="rounded-full border px-4 py-2 text-sm font-semibold shadow-[var(--shadow-md)]"
-              style={{
-                borderColor: "var(--home-rule)",
-                background: "var(--home-ink)",
-                color: "var(--home-paper)",
-              }}
+              style={{ borderColor: "var(--home-rule)", background: "var(--home-ink)", color: "var(--home-paper)" }}
             >
               {exportToast}
             </div>
           ) : null}
         </div>
       </div>
+
+      <PlayerDetailDrawer
+        player={detailPlayer}
+        publishedRank={detailPlayer ? publishedDraftRank(detailPlayer) : undefined}
+        boardTierCount={boardTierCount > 0 ? boardTierCount : undefined}
+        onClose={() => setDetailPlayer(null)}
+      />
+      <CompareTray resolvePlayer={(id) => playerLookup.get(id)} publishedRank={publishedDraftRank} />
     </section>
   );
 }

--- a/src/app/fantasy-football/draft-tracker/hooks/useDraftState.test.tsx
+++ b/src/app/fantasy-football/draft-tracker/hooks/useDraftState.test.tsx
@@ -107,6 +107,84 @@ describe("useDraftState", () => {
     }
   });
 
+  it("redoes the most recently undone pick", () => {
+    const { result } = renderHook(() => useDraftState());
+
+    act(() => {
+      result.current.draftPlayer(SAMPLE_PLAYER);
+    });
+    act(() => {
+      result.current.undoLastPick();
+    });
+
+    expect(result.current.draftState.picks).toHaveLength(0);
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.redoLastPick();
+    });
+
+    expect(result.current.draftState.picks).toHaveLength(1);
+    expect(result.current.draftState.picks[0].player.name).toBe("Bijan Robinson");
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("clears the redo stack when a fresh pick branches the timeline", () => {
+    const { result } = renderHook(() => useDraftState());
+
+    act(() => {
+      result.current.draftPlayer(SAMPLE_PLAYER);
+    });
+    act(() => {
+      result.current.undoLastPick();
+    });
+    act(() => {
+      result.current.draftPlayer({ ...SAMPLE_PLAYER, id: "other", name: "Other Player" });
+    });
+
+    expect(result.current.canRedo).toBe(false);
+    expect(result.current.draftState.undoHistory).toHaveLength(0);
+  });
+
+  it("undoes back to a target pick in one step", () => {
+    const { result } = renderHook(() => useDraftState());
+
+    act(() => {
+      result.current.draftPlayer({ ...SAMPLE_PLAYER, id: "a", name: "A" });
+    });
+    act(() => {
+      result.current.draftPlayer({ ...SAMPLE_PLAYER, id: "b", name: "B" });
+    });
+    act(() => {
+      result.current.draftPlayer({ ...SAMPLE_PLAYER, id: "c", name: "C" });
+    });
+
+    expect(result.current.draftState.picks).toHaveLength(3);
+
+    act(() => {
+      result.current.undoToPick(2);
+    });
+
+    expect(result.current.draftState.picks).toHaveLength(1);
+    expect(result.current.draftState.currentPick).toBe(2);
+    // Next redo restores the lowest removed pick first.
+    act(() => {
+      result.current.redoLastPick();
+    });
+    expect(result.current.draftState.picks[1].player.name).toBe("B");
+  });
+
+  it("renames a team and resolves it through getTeamName", () => {
+    const { result } = renderHook(() => useDraftState());
+
+    act(() => {
+      result.current.setTeamName(2, "The Commish");
+    });
+
+    expect(result.current.getTeamName(2)).toBe("The Commish");
+    expect(result.current.getTeamName(3)).toBe("Team 3");
+  });
+
   it("persists the draft to localStorage", async () => {
     const { result, unmount } = renderHook(() => useDraftState());
 

--- a/src/app/fantasy-football/draft-tracker/hooks/useDraftState.ts
+++ b/src/app/fantasy-football/draft-tracker/hooks/useDraftState.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { DraftState, DraftSettings, DraftPick, Player, TeamRoster, ScoringFormat } from '@/types';
+import { classifyPickValue, computeDraftAnalytics, getPickDelta } from '@/lib/draftAnalytics';
 
 export const DRAFT_STORAGE_VERSION = 2;
 const LEGACY_FANTASY_DRAFT_STORAGE_KEY = 'fantasy-draft-tracker';
@@ -66,6 +67,24 @@ export const initializeTeams = (totalTeams: number): TeamRoster[] => {
     totalValue: 0,
     projectedPoints: 0,
   }));
+};
+
+// Rebuild every team roster from a flat list of kept picks. Used by multi-level
+// undo so position counts and value totals stay exactly consistent with the
+// remaining picks instead of being decremented one at a time.
+const rebuildTeams = (totalTeams: number, picks: DraftPick[]): TeamRoster[] => {
+  const teams = initializeTeams(totalTeams);
+  for (const pick of picks) {
+    const team = teams[pick.teamNumber - 1];
+    if (!team) continue;
+    team.picks.push(pick);
+    if (pick.player.position !== 'FLEX' && pick.player.position !== 'OVERALL') {
+      team.positionCounts[pick.player.position as keyof typeof team.positionCounts]++;
+    }
+    team.totalValue += pick.player.auctionValue || 0;
+    team.projectedPoints += pick.player.projectedPoints || 0;
+  }
+  return teams;
 };
 
 // Calculate draft order for snake draft
@@ -261,6 +280,9 @@ export const useDraftState = () => {
         isActive: !isComplete,
         endTime: isComplete ? new Date() : prev.endTime,
         startTime: prev.picks.length === 0 ? new Date() : prev.startTime,
+        // A fresh manual pick branches the timeline, so any redo stack from a
+        // prior undo no longer applies.
+        undoHistory: [],
       };
     });
   }, []);
@@ -307,6 +329,94 @@ export const useDraftState = () => {
     });
   }, []);
 
+  // Redo the most recently undone pick, replaying it at the current slot.
+  const redoLastPick = useCallback(() => {
+    setDraftState(prev => {
+      if (prev.undoHistory.length === 0) return prev;
+      const totalPicks = prev.settings.totalTeams * prev.settings.rounds;
+      if (prev.currentPick > totalPicks) return prev;
+
+      const player = prev.undoHistory[prev.undoHistory.length - 1].player;
+      const currentTeam = calculateDraftOrder(prev.currentPick, prev.settings.totalTeams, prev.settings.draftType);
+      const currentRound = calculateCurrentRound(prev.currentPick, prev.settings.totalTeams);
+
+      const pick: DraftPick = {
+        pickNumber: prev.currentPick,
+        round: currentRound,
+        teamNumber: currentTeam,
+        player,
+        timestamp: new Date(),
+        pickTimeSeconds: 0,
+        isKeeper: false,
+      };
+
+      const updatedTeams = prev.teams.map(team => {
+        if (team.teamNumber === currentTeam) {
+          const newPositionCounts = { ...team.positionCounts };
+          if (player.position !== 'FLEX' && player.position !== 'OVERALL') {
+            newPositionCounts[player.position as keyof typeof newPositionCounts]++;
+          }
+          return {
+            ...team,
+            picks: [...team.picks, pick],
+            positionCounts: newPositionCounts,
+            totalValue: team.totalValue + (player.auctionValue || 0),
+            projectedPoints: team.projectedPoints + (player.projectedPoints || 0),
+          };
+        }
+        return team;
+      });
+
+      const isComplete = prev.currentPick >= totalPicks;
+      return {
+        ...prev,
+        picks: [...prev.picks, pick],
+        currentPick: prev.currentPick + 1,
+        currentRound: calculateCurrentRound(prev.currentPick + 1, prev.settings.totalTeams),
+        teams: updatedTeams,
+        isActive: !isComplete,
+        endTime: isComplete ? new Date() : prev.endTime,
+        undoHistory: prev.undoHistory.slice(0, -1),
+      };
+    });
+  }, []);
+
+  // Undo every pick back to (and including) a target pick number, rebuilding the
+  // affected rosters in one pass. Undone picks land on the redo stack newest-out.
+  const undoToPick = useCallback((targetPickNumber: number) => {
+    setDraftState(prev => {
+      const removed = prev.picks.filter(pick => pick.pickNumber >= targetPickNumber);
+      if (removed.length === 0) return prev;
+
+      const keptPicks = prev.picks.filter(pick => pick.pickNumber < targetPickNumber);
+      const newCurrentPick = keptPicks.length + 1;
+
+      return {
+        ...prev,
+        picks: keptPicks,
+        teams: rebuildTeams(prev.settings.totalTeams, keptPicks),
+        currentPick: newCurrentPick,
+        currentRound: calculateCurrentRound(newCurrentPick, prev.settings.totalTeams),
+        undoHistory: [
+          ...prev.undoHistory,
+          ...[...removed].sort((left, right) => right.pickNumber - left.pickNumber),
+        ],
+        isActive: true,
+        endTime: undefined,
+      };
+    });
+  }, []);
+
+  // Rename a team in the room (league-mate personalization).
+  const setTeamName = useCallback((teamNumber: number, name: string) => {
+    setDraftState(prev => ({
+      ...prev,
+      teams: prev.teams.map(team =>
+        team.teamNumber === teamNumber ? { ...team, teamName: name.slice(0, 40) } : team
+      ),
+    }));
+  }, []);
+
   // Reset draft
   const resetDraft = useCallback(() => {
     const settings = draftState.settings;
@@ -322,58 +432,124 @@ export const useDraftState = () => {
     });
   }, [draftState.settings]);
 
-  // Export draft results
-  const exportDraftResults = useCallback((format: 'csv' | 'json') => {
-    const exportData = {
-      settings: draftState.settings,
-      picks: draftState.picks,
-      teams: draftState.teams,
-      draftId: draftState.draftId,
-      exportDate: new Date().toISOString(),
-    };
+  // Resolve a team's display name, falling back to "Team N".
+  const resolveTeamName = useCallback(
+    (teamNumber: number) => {
+      const team = draftState.teams.find((entry) => entry.teamNumber === teamNumber);
+      return team?.teamName?.trim() || `Team ${teamNumber}`;
+    },
+    [draftState.teams]
+  );
 
-    if (format === 'csv') {
-      const csvHeaders = ['Pick', 'Round', 'Team', 'Player', 'Position', 'NFL Team', 'Consensus Rank', 'Tier', 'Expert Range', 'ADP'];
-      const csvRows = draftState.picks.map(pick => [
-        pick.pickNumber,
-        pick.round,
-        `Team ${pick.teamNumber}`,
-        pick.player.name,
-        pick.player.position,
-        pick.player.team,
-        pick.player.rankEcr || pick.player.averageRank,
-        pick.player.tier ? `Tier ${pick.player.tier}` : '',
-        pick.player.minRank !== undefined && pick.player.maxRank !== undefined
-          ? `${pick.player.minRank}-${pick.player.maxRank}`
-          : '',
-        typeof pick.player.adp === 'number' && Number.isFinite(pick.player.adp)
-          ? pick.player.adp.toFixed(1)
-          : '',
-      ]);
+  function downloadBlob(parts: BlobPart[], type: string, filename: string) {
+    const blob = new Blob(parts, { type });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
 
-      // CRLF row endings per RFC 4180, and a UTF-8 BOM so Excel on Windows
-      // doesn't garble accented player names.
-      const csvContent = [csvHeaders, ...csvRows]
-        .map(row => row.map(escapeCsvValue).join(','))
-        .join('\r\n');
+  function toCsv(rows: (string | number)[][]): string {
+    // CRLF row endings per RFC 4180.
+    return rows.map((row) => row.map(escapeCsvValue).join(',')).join('\r\n');
+  }
 
-      const blob = new Blob(['\uFEFF', csvContent], { type: 'text/csv;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `draft-results-${draftState.draftId}.csv`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } else {
-      const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `draft-results-${draftState.draftId}.json`;
-      a.click();
-      URL.revokeObjectURL(url);
-    }
-  }, [draftState]);
+  // Export draft results. CSV is the per-pick log (now with value deltas,
+  // steal/reach flags, team names, and your private notes); recap-csv is one row
+  // per team with grades; json is the full structured blob including analytics.
+  const exportDraftResults = useCallback(
+    (format: 'csv' | 'json' | 'recap-csv', options: { notes?: Record<string, string> } = {}) => {
+      const notes = options.notes ?? {};
+
+      if (format === 'csv') {
+        const headers = [
+          'Pick', 'Round', 'Team', 'Player', 'Position', 'NFL Team', 'Consensus Rank',
+          'Tier', 'Expert Range', 'ADP', 'Value Delta', 'Signal', 'Note',
+        ];
+        const rows: (string | number)[][] = draftState.picks.map((pick) => {
+          const delta = getPickDelta(pick);
+          const signal = classifyPickValue(pick);
+          return [
+            pick.pickNumber,
+            pick.round,
+            resolveTeamName(pick.teamNumber),
+            pick.player.name,
+            pick.player.position,
+            pick.player.team,
+            pick.player.rankEcr || pick.player.averageRank,
+            pick.player.tier ? `Tier ${pick.player.tier}` : '',
+            pick.player.minRank !== undefined && pick.player.maxRank !== undefined
+              ? `${pick.player.minRank}-${pick.player.maxRank}`
+              : '',
+            typeof pick.player.adp === 'number' && Number.isFinite(pick.player.adp)
+              ? pick.player.adp.toFixed(1)
+              : '',
+            delta === null ? '' : delta,
+            signal ?? '',
+            notes[pick.player.id] ?? '',
+          ];
+        });
+
+        // UTF-8 BOM so Excel on Windows doesn't garble accented player names.
+        downloadBlob(
+          ['\uFEFF', toCsv([headers, ...rows])],
+          'text/csv;charset=utf-8',
+          `draft-results-${draftState.draftId}.csv`
+        );
+        return;
+      }
+
+      if (format === 'recap-csv') {
+        const analytics = computeDraftAnalytics(draftState.picks, draftState.teams);
+        const headers = [
+          'Team', 'Grade', 'Net Value', 'Strengths', 'Weaknesses', 'QB', 'RB', 'WR', 'TE', 'K', 'DST',
+        ];
+        const rows: (string | number)[][] = [...analytics.teamStrengths]
+          .sort((left, right) => (right.valueTotal ?? 0) - (left.valueTotal ?? 0))
+          .map((team) => {
+            const counts =
+              draftState.teams.find((entry) => entry.teamNumber === team.teamNumber)?.positionCounts;
+            return [
+              resolveTeamName(team.teamNumber),
+              team.overallGrade,
+              team.valueTotal ?? 0,
+              team.strengths.join(' '),
+              team.weaknesses.join(' '),
+              counts?.QB ?? 0,
+              counts?.RB ?? 0,
+              counts?.WR ?? 0,
+              counts?.TE ?? 0,
+              counts?.K ?? 0,
+              counts?.DST ?? 0,
+            ];
+          });
+
+        downloadBlob(
+          ['\uFEFF', toCsv([headers, ...rows])],
+          'text/csv;charset=utf-8',
+          `draft-recap-${draftState.draftId}.csv`
+        );
+        return;
+      }
+
+      const exportData = {
+        settings: draftState.settings,
+        picks: draftState.picks,
+        teams: draftState.teams,
+        analytics: computeDraftAnalytics(draftState.picks, draftState.teams),
+        draftId: draftState.draftId,
+        exportDate: new Date().toISOString(),
+      };
+      downloadBlob(
+        [JSON.stringify(exportData, null, 2)],
+        'application/json',
+        `draft-results-${draftState.draftId}.json`
+      );
+    },
+    [draftState, resolveTeamName]
+  );
 
   // Computed values
   const isDraftComplete = useMemo(() => {
@@ -399,12 +575,19 @@ export const useDraftState = () => {
     return draftState.teams.find(team => team.teamNumber === draftState.settings.userTeam);
   }, [draftState.teams, draftState.settings.userTeam]);
 
+  const canRedo = draftState.undoHistory.length > 0 && !isDraftComplete;
+
   return {
     draftState,
     updateSettings,
     startDraft,
     draftPlayer,
     undoLastPick,
+    redoLastPick,
+    undoToPick,
+    setTeamName,
+    getTeamName: resolveTeamName,
+    canRedo,
     resetDraft,
     exportDraftResults,
     isUserPick,

--- a/src/app/fantasy-football/draft-tracker/hooks/useDraftTimer.ts
+++ b/src/app/fantasy-football/draft-tracker/hooks/useDraftTimer.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface UseDraftTimerOptions {
+  /** Resets the countdown whenever this changes — i.e. each new pick. */
+  currentPick: number;
+  durationSeconds: number;
+  enabled: boolean;
+  isActive: boolean;
+}
+
+/**
+ * An advisory per-pick countdown for the draft assistant. It resets on every
+ * pick, ticks down once a second, and pauses while the tab is hidden so a
+ * backgrounded draft doesn't burn the clock. It never auto-picks — this is a
+ * manual tracker; the timer is just a nudge.
+ */
+export function useDraftTimer({ currentPick, durationSeconds, enabled, isActive }: UseDraftTimerOptions) {
+  const [secondsLeft, setSecondsLeft] = useState(durationSeconds);
+
+  // Reset on each new pick (or when the duration / enabled state changes).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset the countdown when the pick changes
+    setSecondsLeft(durationSeconds);
+  }, [currentPick, durationSeconds, enabled, isActive]);
+
+  useEffect(() => {
+    if (!enabled || !isActive || typeof window === "undefined") return;
+
+    const id = window.setInterval(() => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      setSecondsLeft((seconds) => Math.max(0, seconds - 1));
+    }, 1000);
+
+    return () => window.clearInterval(id);
+  }, [enabled, isActive, currentPick, durationSeconds]);
+
+  return {
+    secondsLeft,
+    isExpired: enabled && isActive && secondsLeft <= 0,
+    isRunning: enabled && isActive,
+  };
+}

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -638,12 +638,35 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                 onChange={(position) => updateRouteState({ position })}
               />
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <SegmentedToggle
-                  ariaLabel="Scoring format"
-                  options={SCORING_OPTIONS.map((option) => ({ value: option.key, label: option.label }))}
-                  value={routeState.scoring}
-                  onChange={(scoring) => updateRouteState({ scoring })}
-                />
+                {/* Scoring is a toggle-button group (aria-pressed), distinct from
+                    the position radiogroup, so each format reads as an independent
+                    on/off rather than a single-select. */}
+                <div role="group" aria-label="Scoring format" className="flex flex-wrap gap-2">
+                  {SCORING_OPTIONS.map((option) => {
+                    const active = routeState.scoring === option.key;
+                    return (
+                      <button
+                        key={option.key}
+                        type="button"
+                        aria-pressed={active}
+                        disabled={currentSliceUnavailable}
+                        onClick={() => updateRouteState({ scoring: option.key })}
+                        className="inline-flex min-h-[44px] items-center rounded-full border px-4 text-sm font-semibold transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+                        style={
+                          active
+                            ? { borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }
+                            : {
+                                borderColor: "var(--home-rule)",
+                                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+                                color: "var(--home-ink)",
+                              }
+                        }
+                      >
+                        {option.label}
+                      </button>
+                    );
+                  })}
+                </div>
                 <div className="relative sm:max-w-[18rem] sm:flex-1">
                   <label htmlFor="fantasy-search" className="sr-only">
                     Search the current rankings board

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -1,11 +1,24 @@
 "use client";
 
-import { Fragment, startTransition, useEffect, useMemo, useState, useSyncExternalStore, type CSSProperties, type ReactNode } from "react";
+import {
+  Fragment,
+  startTransition,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
-import { ArrowUpRight, Search, Shield, Users } from "lucide-react";
+import { ArrowUpRight, ChevronDown, Search, Shield, Star, X } from "lucide-react";
 import { useFantasySnapshot } from "@/hooks/useFantasySnapshot";
+import { usePlayerQueue } from "@/hooks/usePlayerQueue";
+import { usePlayerNotes } from "@/hooks/usePlayerNotes";
+import { useCompareTray } from "@/hooks/useCompareTray";
 import {
   FANTASY_POSITION_LABELS,
   FANTASY_SCORING_LABELS,
@@ -15,23 +28,28 @@ import {
   getFantasyWeekLabel,
 } from "@/lib/fantasy";
 import {
-  FANTASY_ADP_TOOLTIP,
   FANTASY_AVG_RANK_TOOLTIP,
   FANTASY_CHIP_CLASS,
-  formatAdp,
-  formatOwnership,
-  formatRange,
-  formatRankValue,
   formatUpdatedAt,
+  formatRankValue,
   getFantasyAdpFreshness,
   getPositionTone,
   getSnapshotStaleness,
   getSnapshotStalenessLabel,
   getSourceKindLabel,
-  getValueVsAdp,
+  getTierGap,
+  withTierBreaks,
   type FantasySnapshotStaleness,
 } from "@/lib/fantasyUtils";
-import { TierBreakdown } from "@/components/fantasy";
+import {
+  CompareTray,
+  PlayerDetailDrawer,
+  PositionFilterBar,
+  RankingsListRow,
+  TierBreakdown,
+  TierBreakSeparator,
+  type PositionFilterOption,
+} from "@/components/fantasy";
 import { MetricTooltip } from "@/components/investments/MetricTooltip";
 import { Player } from "@/types";
 import { buildFantasyHref, FantasySearchState, normalizeFantasyState } from "./fantasy-state";
@@ -43,6 +61,9 @@ const SCORING_OPTIONS: { key: FantasyRouteScoring; label: string }[] = [
   { key: "half_ppr", label: "Half PPR" },
   { key: "standard", label: "Standard" },
 ];
+
+/** How many list rows render before the "Load more" sentinel kicks in. */
+const RANKINGS_PAGE_SIZE = 60;
 
 const fadeIn = {
   hidden: { opacity: 0, y: 12 },
@@ -88,32 +109,6 @@ function FreshnessChip({ date }: { date: string | null | undefined }) {
 
 interface FantasyFootballClientProps {
   initialState: FantasySearchState;
-}
-
-function getPillStyle(active: boolean, unavailable = false): CSSProperties {
-  if (active) {
-    return {
-      borderColor: unavailable ? "var(--color-warning)" : "var(--home-ink)",
-      background: unavailable
-        ? "color-mix(in srgb, var(--color-warning) 12%, var(--home-paper))"
-        : "var(--home-ink)",
-      color: unavailable ? "var(--home-ink)" : "var(--home-paper)",
-    };
-  }
-
-  if (unavailable) {
-    return {
-      borderColor: "color-mix(in srgb, var(--color-warning) 28%, var(--home-rule))",
-      background: "color-mix(in srgb, var(--color-warning) 7%, var(--home-paper))",
-      color: "var(--home-ink-muted)",
-    };
-  }
-
-  return {
-    borderColor: "var(--home-rule)",
-    background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-    color: "var(--home-ink)",
-  };
 }
 
 function getPublishedBoardRank(player: Player, position: FantasyRoutePosition): string {
@@ -207,12 +202,66 @@ function persistDensity(next: FantasyBoardDensity) {
   densityListeners.forEach((listener) => listener());
 }
 
+/** A compact segmented control used for the scoring format and view toggles. */
+function SegmentedToggle<T extends string>({
+  ariaLabel,
+  options,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  ariaLabel: string;
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (value: T) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="flex rounded-full border p-1 text-sm font-semibold"
+      style={{
+        borderColor: "var(--home-rule)",
+        background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+      }}
+    >
+      {options.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            disabled={disabled}
+            onClick={() => onChange(option.value)}
+            className="inline-flex min-h-[44px] items-center rounded-full px-3.5 py-1.5 text-sm transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+            style={active ? { background: "var(--home-ink)", color: "var(--home-paper)" } : { color: "var(--home-ink-muted)" }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function FantasyFootballClient({ initialState }: FantasyFootballClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const shouldReduceMotion = useReducedMotion();
   const variants = shouldReduceMotion ? noMotion : fadeIn;
   const [searchQuery, setSearchQuery] = useState("");
+  const [detailPlayer, setDetailPlayer] = useState<Player | null>(null);
+  const [showStats, setShowStats] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(RANKINGS_PAGE_SIZE);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const queue = usePlayerQueue();
+  const notes = usePlayerNotes();
+  const compare = useCompareTray();
+
   const density = useSyncExternalStore(
     subscribeDensityChange,
     getDensitySnapshot,
@@ -258,6 +307,16 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
     position: routeState.position,
     scoring: routeState.scoring,
   });
+  // A scoring-wide lookup powers the queue card, compare tray, and detail drawer
+  // when a pinned player belongs to a different board than the one in view.
+  const { players: allBoardPlayers } = useFantasySnapshot({ scoring: routeState.scoring, all: true });
+
+  const playerLookup = useMemo(() => {
+    const map = new Map<string, Player>();
+    for (const player of allBoardPlayers) map.set(player.id, player);
+    for (const player of players) if (!map.has(player.id)) map.set(player.id, player);
+    return map;
+  }, [allBoardPlayers, players]);
 
   const currentSliceUnavailable = Boolean(sliceMetadata && !sliceMetadata.available);
   const adpSource = metadata?.adpSource ?? null;
@@ -280,22 +339,6 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
     return players.filter((player) => getFantasyPlayerSearchText(player).includes(query));
   }, [currentSliceUnavailable, players, searchQuery]);
 
-  const tierSummaries = useMemo(() => {
-    const tierCounts = new Map<number, number>();
-
-    for (const player of players) {
-      if (!player.tier) {
-        continue;
-      }
-
-      tierCounts.set(player.tier, (tierCounts.get(player.tier) ?? 0) + 1);
-    }
-
-    return Array.from(tierCounts.entries())
-      .sort((left, right) => left[0] - right[0])
-      .slice(0, 4);
-  }, [players]);
-
   const maxTier = useMemo(() => {
     let max = 0;
     for (const player of players) {
@@ -305,6 +348,41 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
     }
     return max;
   }, [players]);
+
+  // Reset the window whenever the board, scoring, view, or search changes so a
+  // narrowed list never starts deep into a stale offset.
+  useEffect(() => {
+    setVisibleCount(RANKINGS_PAGE_SIZE);
+  }, [routeState.position, routeState.scoring, routeState.view, searchQuery]);
+
+  const windowedPlayers =
+    routeState.view === "list" ? filteredPlayers.slice(0, visibleCount) : filteredPlayers;
+  const hasMore = routeState.view === "list" && visibleCount < filteredPlayers.length;
+
+  useEffect(() => {
+    if (!hasMore || typeof IntersectionObserver === "undefined") return;
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setVisibleCount((count) => Math.min(count + RANKINGS_PAGE_SIZE, filteredPlayers.length));
+        }
+      },
+      { rootMargin: "600px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasMore, filteredPlayers.length]);
+
+  const queuedPlayers = useMemo(
+    () =>
+      queue.queue
+        .map((id) => playerLookup.get(id))
+        .filter((player): player is Player => Boolean(player)),
+    [queue.queue, playerLookup]
+  );
 
   const trimmedQuery = searchQuery.trim();
   const snapshotWeekLabel = metadata
@@ -336,10 +414,10 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
       sub: maxTier > 0 ? "Highest tier in view" : "Not published",
     },
     {
-      label: "Search hits",
-      tooltip: "Players matching the current search text.",
-      value: trimmedQuery ? filteredPlayers.length.toLocaleString() : "—",
-      sub: trimmedQuery ? `Query "${trimmedQuery}"` : "Type to filter",
+      label: "Queued",
+      tooltip: "Players you have starred to your browser-local watchlist.",
+      value: queue.queue.length,
+      sub: "On your watchlist",
     },
     {
       label: "Snapshot week",
@@ -361,22 +439,71 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
   ];
 
   const isCompact = density === "compact";
-  // Compact trims vertical rhythm and, on desktop where the columns are
-  // self-evident, drops the per-cell kicker labels. Mobile keeps the labels
-  // since the cells stack into a single column. The ADP column only renders
-  // when the snapshot actually carries ADP data, so the grid widens with it.
-  const rowClassName = isCompact
-    ? adpAvailable
-      ? "grid gap-3 rounded-[1.25rem] border px-4 py-3 md:grid-cols-[3.5rem_minmax(8rem,1.6fr)_5rem_7rem_5.5rem_6rem] md:items-center md:gap-x-4"
-      : "grid gap-3 rounded-[1.25rem] border px-4 py-3 md:grid-cols-[3.5rem_minmax(8rem,1.6fr)_5rem_7rem_6rem] md:items-center md:gap-x-4"
-    : adpAvailable
-      ? "grid gap-4 rounded-[1.5rem] border px-4 py-4 md:grid-cols-[4rem_minmax(9rem,1.6fr)_5rem_7rem_5.5rem_6rem] md:items-center md:gap-x-5"
-      : "grid gap-4 rounded-[1.5rem] border px-4 py-4 md:grid-cols-[4rem_minmax(9rem,1.6fr)_5rem_7rem_6rem] md:items-center md:gap-x-5";
-  const rankValueClassName = isCompact
-    ? "text-xl font-semibold tabular-nums"
-    : "text-2xl font-semibold tabular-nums";
-  const cellLabelClassName = isCompact ? "home-kicker mb-1 md:hidden" : "home-kicker mb-1";
-  const skeletonHeightClass = isCompact ? "h-[76px]" : "h-[96px]";
+  const skeletonHeightClass = isCompact ? "h-[68px]" : "h-[84px]";
+
+  const positionOptions: PositionFilterOption<FantasyRoutePosition>[] = POSITION_OPTIONS.map((position) => {
+    const meta = sliceMetadataMap?.[position];
+    return {
+      value: position,
+      label: FANTASY_POSITION_LABELS[position],
+      position: position === "overall" || position === "flex" ? undefined : position.toUpperCase(),
+      available: meta ? meta.available : true,
+      unavailableLabel: meta?.reason,
+    };
+  });
+
+  // Build the list view rows with labeled tier separators wherever the published
+  // rank crosses a tier boundary. A running rank lets each break annotate the
+  // cliff to the prior tier.
+  function renderListRows(): ReactNode {
+    const tierRows = withTierBreaks(windowedPlayers);
+    const items: ReactNode[] = [];
+    let previousRank: number | null = null;
+
+    for (const { player, tier, startsTier } of tierRows) {
+      const publishedRank = getPublishedBoardRank(player, routeState.position);
+      const numericRank = Number.parseFloat(publishedRank);
+
+      if (startsTier && tier !== null) {
+        items.push(
+          <TierBreakSeparator
+            key={`tier-${tier}-${player.id}`}
+            tier={tier}
+            gap={
+              previousRank !== null && Number.isFinite(numericRank)
+                ? getTierGap(previousRank, numericRank)
+                : undefined
+            }
+          />
+        );
+      }
+
+      const inCompare = compare.inCompare(player.id);
+      items.push(
+        <RankingsListRow
+          key={player.id}
+          player={player}
+          publishedRank={publishedRank}
+          descriptor={getPlayerDescriptor(player, routeState.position)}
+          adpAvailable={adpAvailable}
+          compact={isCompact}
+          isQueued={queue.isQueued(player.id)}
+          hasNote={notes.hasNote(player.id)}
+          inCompare={inCompare}
+          compareDisabled={!inCompare && compare.isFull}
+          onOpenDetail={() => setDetailPlayer(player)}
+          onToggleQueue={() => queue.toggle(player.id)}
+          onToggleCompare={() => compare.toggle(player.id)}
+        />
+      );
+
+      if (Number.isFinite(numericRank)) {
+        previousRank = numericRank;
+      }
+    }
+
+    return items;
+  }
 
   return (
     <section
@@ -385,58 +512,60 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
       data-testid="fantasy-football-shell"
     >
       <div className="home-shell home-shell-wide home-section space-y-4 sm:space-y-5">
-        <motion.div
-          className="space-y-4 pt-2"
-          variants={variants}
-          initial="hidden"
-          animate="visible"
-        >
+        <motion.div className="space-y-4 pt-2" variants={variants} initial="hidden" animate="visible">
           <div className="space-y-3">
             <p className="home-kicker mb-0">Fantasy Football</p>
             <h1
               style={{
                 fontFamily: "var(--font-home-sans)",
-                fontSize: "clamp(2.7rem, 6vw, 4.9rem)",
+                fontSize: "clamp(2rem, 4.4vw, 3.3rem)",
                 fontWeight: 600,
                 letterSpacing: "-0.04em",
-                lineHeight: 0.95,
-                maxWidth: "15ch",
+                lineHeight: 0.98,
+                maxWidth: "18ch",
               }}
             >
               Rankings first. Draft utility second.
             </h1>
-            <p
-              className="max-w-[68ch] text-sm leading-7 sm:text-[1rem]"
-              style={{ color: "var(--home-ink-muted)" }}
-            >
-              The public board is snapshot-backed and sourced from FantasyPros consensus pages. The
-              page shows when the source last moved and when this repo rebuilt the snapshot, so
-              freshness is explicit instead of implied.
+            <p className="max-w-[60ch] text-sm leading-7" style={{ color: "var(--home-ink-muted)" }}>
+              A snapshot-backed FantasyPros consensus board with explicit freshness, a shared watchlist, and a
+              side-by-side compare — feeding the same data into the draft assistant.
             </p>
-            <div className="pt-1">
+            <div className="flex flex-wrap items-center gap-3 pt-1">
               <Link
                 href="/fantasy-football/draft-tracker"
                 className="inline-flex min-h-[48px] items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
-                style={{
-                  borderColor: "var(--home-ink)",
-                  background: "var(--home-ink)",
-                  color: "var(--home-paper)",
-                }}
+                style={{ borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }}
               >
                 Launch draft assistant
                 <ArrowUpRight className="h-4 w-4" />
               </Link>
+              <button
+                type="button"
+                onClick={() => setShowStats((open) => !open)}
+                aria-expanded={showStats}
+                aria-controls="fantasy-football-stats"
+                className="inline-flex min-h-[44px] items-center gap-1.5 rounded-full border px-4 text-sm font-semibold"
+                style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)", color: "var(--home-ink)" }}
+              >
+                Board at a glance
+                <ChevronDown
+                  className="h-4 w-4 transition-transform"
+                  style={{ transform: showStats ? "rotate(180deg)" : "none" }}
+                />
+              </button>
             </div>
           </div>
-
         </motion.div>
 
-        <HomeStatsPanel
-          id="fantasy-football-stats"
-          title="Board at a glance"
-          meta={`Updated ${formatUpdatedAt(currentSourceUpdatedAt)}`}
-          cells={fantasyStatsCells}
-        />
+        {showStats && (
+          <HomeStatsPanel
+            id="fantasy-football-stats"
+            title="Board at a glance"
+            meta={`Updated ${formatUpdatedAt(currentSourceUpdatedAt)}`}
+            cells={fantasyStatsCells}
+          />
+        )}
 
         {error && (
           <article className="home-card p-5 sm:p-6" style={{ borderColor: "var(--color-error)" }}>
@@ -447,386 +576,184 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
         )}
 
         <div className="grid gap-5 lg:grid-cols-[minmax(0,1.18fr)_minmax(18rem,22rem)] min-[1440px]:grid-cols-[minmax(0,1.2fr)_minmax(20rem,26rem)]">
-          <div className="grid gap-5">
-            <article className="home-card p-5 sm:p-6">
-              <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_18rem]">
-                <div className="space-y-4">
-                  <div>
-                    <p className="home-kicker mb-2" id="fantasy-position-label">
-                      Board
-                    </p>
-                    <div
-                      className="flex flex-wrap gap-2"
-                      role="radiogroup"
-                      aria-labelledby="fantasy-position-label"
-                    >
-                      {POSITION_OPTIONS.map((position) => {
-                        const active = routeState.position === position;
-                        const positionSliceMetadata = sliceMetadataMap?.[position];
-                        const unavailable = positionSliceMetadata ? !positionSliceMetadata.available : false;
-
-                        return (
-                          <button
-                            key={position}
-                            type="button"
-                            role="radio"
-                            aria-checked={active}
-                            disabled={unavailable}
-                            onClick={() => updateRouteState({ position })}
-                            title={unavailable ? positionSliceMetadata?.reason : undefined}
-                            className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200 disabled:cursor-not-allowed disabled:opacity-70"
-                            style={getPillStyle(active, unavailable)}
-                          >
-                            <span>{FANTASY_POSITION_LABELS[position]}</span>
-                            {unavailable && <span className="ml-2 text-2xs uppercase tracking-[0.12em]">NA</span>}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-
-                  <div>
-                    <p className="home-kicker mb-2">Scoring</p>
-                    <div className="flex flex-wrap gap-2">
-                      {SCORING_OPTIONS.map((option) => {
-                        const active = routeState.scoring === option.key;
-                        return (
-                          <button
-                            key={option.key}
-                            type="button"
-                            aria-pressed={active}
-                            onClick={() => updateRouteState({ scoring: option.key })}
-                            className="inline-flex min-h-[44px] items-center rounded-full border px-4 py-2 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
-                            style={getPillStyle(active)}
-                          >
-                            {option.label}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-
-                <div className="space-y-3">
-                  <label className="grid gap-2 text-sm" htmlFor="fantasy-search">
-                    <span className="home-kicker mb-0">Search</span>
-                    <span className="sr-only">Search the current rankings board</span>
-                    <div className="relative">
-                      <Search
-                        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2"
-                        style={{ color: "var(--home-ink-muted)" }}
-                      />
-                      <input
-                        id="fantasy-search"
-                        name="fantasy-search"
-                        value={searchQuery}
-                        onChange={(event) => setSearchQuery(event.target.value)}
-                        disabled={currentSliceUnavailable}
-                        autoComplete="off"
-                        placeholder={`Search ${FANTASY_POSITION_LABELS[routeState.position].toLowerCase()} board`}
-                        className="min-h-[48px] w-full rounded-[1.2rem] border px-11 pr-4 text-sm transition-[background-color,border-color,box-shadow] duration-200 placeholder:text-[var(--home-ink-muted)] disabled:cursor-not-allowed disabled:opacity-60"
-                        style={{
-                          borderColor: "var(--home-rule)",
-                          background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-                          color: "var(--home-ink)",
-                        }}
-                      />
-                    </div>
-                  </label>
-
-                  <div
-                    className="rounded-[1.5rem] border px-4 py-4"
-                    style={{
-                      borderColor: "var(--home-rule)",
-                      background: "color-mix(in srgb, var(--home-paper-alt) 62%, var(--home-elev-mix))",
-                    }}
-                  >
-                    <p className="home-kicker mb-1">Status</p>
-                    <p className="text-base font-semibold">{currentSourceKindLabel}</p>
-                    <p className="mt-2 text-sm leading-6" style={{ color: "var(--home-ink-muted)" }}>
-                      {isLoading
-                        ? "Loading the current board."
-                        : currentSliceUnavailable
-                          ? sliceMetadata?.reason ?? "This board is unavailable in the current snapshot."
-                          : `${filteredPlayers.length} players visible from the current snapshot.`}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </article>
-
-            <article
-              className="home-card scroll-mt-28 p-5 sm:p-6"
-              aria-labelledby="rankings-board-heading"
+          <article className="home-card scroll-mt-28 p-5 sm:p-6" aria-labelledby="rankings-board-heading">
+            <div
+              className="z-20 -mx-5 flex flex-col gap-3 border-b px-5 pb-4 pt-1 sm:sticky sm:top-20 sm:-mx-6 sm:flex-row sm:items-end sm:justify-between sm:px-6"
+              style={{
+                borderColor: "var(--home-rule)",
+                background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+              }}
             >
-              <div
-                className="z-20 -mx-5 flex flex-col gap-3 border-b px-5 pb-4 pt-1 sm:sticky sm:top-20 sm:-mx-6 sm:flex-row sm:items-end sm:justify-between sm:px-6"
-                style={{
-                  borderColor: "var(--home-rule)",
-                  background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-                }}
-              >
-                <div>
-                  <p className="home-kicker mb-1">Rankings Board</p>
-                  <h2 id="rankings-board-heading" className="text-2xl font-semibold">
-                    {FANTASY_POSITION_LABELS[routeState.position]} rankings
-                  </h2>
-                </div>
-                <div className="grid gap-2 sm:flex sm:flex-wrap sm:items-center sm:justify-end sm:gap-3">
-                  {routeState.view === "list" && (
-                    <div
-                      className="flex rounded-full border p-1 text-sm font-semibold"
-                      style={{
-                        borderColor: "var(--home-rule)",
-                        background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
-                      }}
-                      role="radiogroup"
-                      aria-label="List density"
-                    >
-                      {(["comfortable", "compact"] as const).map((option) => {
-                        const active = density === option;
-                        return (
-                          <button
-                            key={option}
-                            type="button"
-                            role="radio"
-                            aria-checked={active}
-                            onClick={() => persistDensity(option)}
-                            disabled={currentSliceUnavailable}
-                            className="inline-flex min-h-[44px] items-center rounded-full px-3.5 py-1.5 text-sm transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60"
-                            style={
-                              active
-                                ? { background: "var(--home-ink)", color: "var(--home-paper)" }
-                                : { color: "var(--home-ink-muted)" }
-                            }
-                          >
-                            {option === "comfortable" ? "Comfortable" : "Compact"}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  )}
-                  <div
-                    className="flex rounded-full border p-1 text-sm font-semibold"
+              <div>
+                <p className="home-kicker mb-1">Rankings Board</p>
+                <h2 id="rankings-board-heading" className="text-2xl font-semibold">
+                  {FANTASY_POSITION_LABELS[routeState.position]} rankings
+                </h2>
+              </div>
+              <div className="grid gap-2 sm:flex sm:flex-wrap sm:items-center sm:justify-end sm:gap-3">
+                {routeState.view === "list" && (
+                  <SegmentedToggle
+                    ariaLabel="List density"
+                    options={[
+                      { value: "comfortable", label: "Comfortable" },
+                      { value: "compact", label: "Compact" },
+                    ]}
+                    value={density}
+                    onChange={(value) => persistDensity(value)}
+                    disabled={currentSliceUnavailable}
+                  />
+                )}
+                <SegmentedToggle
+                  ariaLabel="Rankings view"
+                  options={[
+                    { value: "list", label: "List" },
+                    { value: "tiers", label: "Tiers" },
+                  ]}
+                  value={routeState.view}
+                  onChange={(value) => updateRouteState({ view: value })}
+                  disabled={currentSliceUnavailable}
+                />
+                <p
+                  aria-live="polite"
+                  className="text-sm sm:min-w-[9.5rem] sm:text-right"
+                  style={{ color: "var(--home-ink-muted)" }}
+                >
+                  {isLoading
+                    ? "Loading players..."
+                    : currentSliceUnavailable
+                      ? "Board unavailable"
+                      : routeState.view === "list" && hasMore
+                        ? `${windowedPlayers.length} of ${filteredPlayers.length} shown`
+                        : `${filteredPlayers.length} players shown`}
+                </p>
+              </div>
+            </div>
+
+            {/* Controls: position, scoring, search */}
+            <div className="mt-4 grid gap-3">
+              <PositionFilterBar
+                ariaLabel="Position board"
+                options={positionOptions}
+                value={routeState.position}
+                onChange={(position) => updateRouteState({ position })}
+              />
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <SegmentedToggle
+                  ariaLabel="Scoring format"
+                  options={SCORING_OPTIONS.map((option) => ({ value: option.key, label: option.label }))}
+                  value={routeState.scoring}
+                  onChange={(scoring) => updateRouteState({ scoring })}
+                />
+                <div className="relative sm:max-w-[18rem] sm:flex-1">
+                  <label htmlFor="fantasy-search" className="sr-only">
+                    Search the current rankings board
+                  </label>
+                  <Search
+                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2"
+                    style={{ color: "var(--home-ink-muted)" }}
+                  />
+                  <input
+                    id="fantasy-search"
+                    name="fantasy-search"
+                    value={searchQuery}
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                    disabled={currentSliceUnavailable}
+                    autoComplete="off"
+                    placeholder={`Search ${FANTASY_POSITION_LABELS[routeState.position].toLowerCase()} board`}
+                    className="min-h-[48px] w-full rounded-[1.2rem] border px-11 pr-10 text-sm transition-[background-color,border-color,box-shadow] duration-200 placeholder:text-[var(--home-ink-muted)] disabled:cursor-not-allowed disabled:opacity-60"
                     style={{
                       borderColor: "var(--home-rule)",
                       background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+                      color: "var(--home-ink)",
                     }}
-                    role="radiogroup"
-                    aria-label="Rankings view"
-                  >
-                    {(["list", "tiers"] as const).map((option) => {
-                      const active = routeState.view === option;
-                      return (
-                        <button
-                          key={option}
-                          type="button"
-                          role="radio"
-                          aria-checked={active}
-                          onClick={() => updateRouteState({ view: option })}
-                          disabled={currentSliceUnavailable}
-                          className="inline-flex min-h-[44px] items-center rounded-full px-3.5 py-1.5 text-sm transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60"
-                          style={
-                            active
-                              ? { background: "var(--home-ink)", color: "var(--home-paper)" }
-                              : { color: "var(--home-ink-muted)" }
-                          }
-                        >
-                          {option === "list" ? "List" : "Tiers"}
-                        </button>
-                      );
-                    })}
-                  </div>
-                  <p
-                    aria-live="polite"
-                    className="text-sm sm:min-w-[8.5rem] sm:text-right"
-                    style={{ color: "var(--home-ink-muted)" }}
-                  >
-                    {isLoading
-                      ? "Loading players..."
-                      : currentSliceUnavailable
-                        ? "Board unavailable"
-                        : `${filteredPlayers.length} players shown`}
-                  </p>
+                  />
+                  {searchQuery && (
+                    <button
+                      type="button"
+                      onClick={() => setSearchQuery("")}
+                      aria-label="Clear search"
+                      className="absolute right-2 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full border"
+                      style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)" }}
+                    >
+                      <X size={14} aria-hidden="true" />
+                    </button>
+                  )}
                 </div>
               </div>
+            </div>
 
-              <div className="mt-4">
-                {isLoading ? (
-                  <div className="grid gap-3">
-                    {Array.from({ length: 10 }).map((_, index) => (
-                      <div
-                        key={`loading-${index}`}
-                        className={`${skeletonHeightClass} animate-pulse rounded-[1.5rem] border`}
-                        style={{
-                          borderColor: "var(--home-rule)",
-                          background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
-                        }}
-                      />
-                    ))}
-                  </div>
-                ) : currentSliceUnavailable ? (
-                  <div
-                    className="rounded-[1.5rem] border px-5 py-12 text-center"
-                    style={{
-                      borderColor: "color-mix(in srgb, var(--color-warning) 32%, var(--home-rule))",
-                      background: "color-mix(in srgb, var(--color-warning) 10%, var(--home-paper))",
-                    }}
-                  >
-                    <p className="text-lg font-semibold">
-                      {selectedScoringLabel} {FANTASY_POSITION_LABELS[routeState.position]} rankings are unavailable.
-                    </p>
-                    <p className="mt-2 text-sm" style={{ color: "var(--home-ink-muted)" }}>
-                      {sliceMetadata?.reason ??
-                        "This scoring-position combination is not published in the current snapshot."}
-                    </p>
-                  </div>
-                ) : filteredPlayers.length === 0 ? (
-                  <div
-                    className="rounded-[1.5rem] border px-5 py-12 text-center"
-                    style={{
-                      borderColor: "var(--home-rule)",
-                      background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
-                    }}
-                  >
-                    <p className="text-lg font-semibold">No matching players</p>
-                    <p className="mt-2 text-sm" style={{ color: "var(--home-ink-muted)" }}>
-                      Clear the search or switch the board to see more names.
-                    </p>
-                  </div>
-                ) : routeState.view === "tiers" ? (
-                  <TierBreakdown
-                    players={filteredPlayers}
-                    position={routeState.position}
-                    getPublishedRank={(player) => getPublishedBoardRank(player, routeState.position)}
-                  />
-                ) : (
-                  <ul role="list" className="grid gap-3">
-                    {filteredPlayers.map((player) => (
-                      <li
-                        key={player.id}
-                        className={rowClassName}
-                        style={{
-                          borderColor: "var(--home-rule)",
-                          background: "color-mix(in srgb, var(--home-paper-alt) 42%, var(--home-elev-mix))",
-                        }}
-                        aria-label={`${player.name}, ${player.position}, rank ${getPublishedBoardRank(player, routeState.position)}`}
-                      >
-                        <div className="flex min-w-0 items-start gap-3 md:contents">
-                          <div className="shrink-0">
-                            <p className={cellLabelClassName}>Rank</p>
-                            <p
-                              className={rankValueClassName}
-                              title="Published FantasyPros consensus rank on this board"
-                            >
-                              {getPublishedBoardRank(player, routeState.position)}
-                            </p>
-                          </div>
-
-                          <div className="min-w-0 flex-1">
-                            <div className="flex min-w-0 flex-wrap items-center gap-2">
-                              <p className="min-w-0 truncate text-base font-semibold">{player.name}</p>
-                              <span
-                                className={FANTASY_CHIP_CLASS}
-                                style={getPositionTone(player.position)}
-                              >
-                                {player.position}
-                              </span>
-                            </div>
-                            <p className="mt-1 text-sm" style={{ color: "var(--home-ink-muted)" }}>
-                              {getPlayerDescriptor(player, routeState.position)}
-                            </p>
-                          </div>
-                        </div>
-
-                        <div
-                          className="grid grid-cols-2 gap-3 border-t pt-3 md:contents"
-                          style={{ borderColor: "var(--home-rule)" }}
-                        >
-                          <div className="min-w-0">
-                            <p className={cellLabelClassName}>Tier</p>
-                            <p
-                              className="truncate text-sm font-semibold"
-                              title="FantasyPros consensus tier. Gaps between tiers mark value drop-offs"
-                            >
-                              {player.tier ? `Tier ${player.tier}` : "Not listed"}
-                            </p>
-                          </div>
-
-                          <div className="min-w-0">
-                            <p className={cellLabelClassName}>Expert range</p>
-                            <p
-                              className="truncate text-sm font-semibold tabular-nums"
-                              title="Best and worst rank across the experts in the consensus"
-                            >
-                              {formatRange(player)}
-                            </p>
-                          </div>
-
-                          {adpAvailable && (
-                            <div className="min-w-0">
-                              <p className={cellLabelClassName}>ADP</p>
-                              <p className="text-sm font-semibold tabular-nums" title={FANTASY_ADP_TOOLTIP}>
-                                {formatAdp(player.adp)}
-                              </p>
-                              {(() => {
-                                const valueVsAdp = getValueVsAdp(player);
-                                if (!valueVsAdp?.signal) {
-                                  return null;
-                                }
-
-                                return (
-                                  <span
-                                    className={`${FANTASY_CHIP_CLASS} mt-1`}
-                                    title={
-                                      valueVsAdp.signal === "value"
-                                        ? "Drafters take this player well after where the experts rank him"
-                                        : "Drafters take this player well before where the experts rank him"
-                                    }
-                                    style={
-                                      valueVsAdp.signal === "value"
-                                        ? {
-                                            borderColor:
-                                              "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
-                                            background:
-                                              "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
-                                          }
-                                        : {
-                                            borderColor:
-                                              "color-mix(in srgb, var(--color-warning) 30%, var(--home-rule))",
-                                            background:
-                                              "color-mix(in srgb, var(--color-warning) 12%, var(--home-paper))",
-                                          }
-                                    }
-                                  >
-                                    {valueVsAdp.signal === "value" ? "Value" : "Reach"}{" "}
-                                    {valueVsAdp.delta > 0 ? `+${valueVsAdp.delta}` : valueVsAdp.delta}
-                                  </span>
-                                );
-                              })()}
-                            </div>
-                          )}
-
-                          <div className="min-w-0">
-                            <p className={cellLabelClassName}>Rostered</p>
-                            <p
-                              className="text-sm font-semibold"
-                              title="Share of leagues where this player is on a roster"
-                            >
-                              {formatOwnership(player.ownership)}
-                            </p>
-                            <p className="mt-1 text-xs" style={{ color: "var(--home-ink-muted)" }}>
-                              {player.byeWeek ? `Bye ${player.byeWeek}` : "Bye not listed"}
-                            </p>
-                          </div>
-                        </div>
-                      </li>
-                    ))}
+            <div className="mt-4">
+              {isLoading ? (
+                <div className="grid gap-3">
+                  {Array.from({ length: 10 }).map((_, index) => (
+                    <div
+                      key={`loading-${index}`}
+                      className={`${skeletonHeightClass} animate-pulse rounded-[1.25rem] border`}
+                      style={{
+                        borderColor: "var(--home-rule)",
+                        background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
+                      }}
+                    />
+                  ))}
+                </div>
+              ) : currentSliceUnavailable ? (
+                <div
+                  className="rounded-[1.5rem] border px-5 py-12 text-center"
+                  style={{
+                    borderColor: "color-mix(in srgb, var(--color-warning) 32%, var(--home-rule))",
+                    background: "color-mix(in srgb, var(--color-warning) 10%, var(--home-paper))",
+                  }}
+                >
+                  <p className="text-lg font-semibold">
+                    {selectedScoringLabel} {FANTASY_POSITION_LABELS[routeState.position]} rankings are unavailable.
+                  </p>
+                  <p className="mt-2 text-sm" style={{ color: "var(--home-ink-muted)" }}>
+                    {sliceMetadata?.reason ??
+                      "This scoring-position combination is not published in the current snapshot."}
+                  </p>
+                </div>
+              ) : filteredPlayers.length === 0 ? (
+                <div
+                  className="rounded-[1.5rem] border px-5 py-12 text-center"
+                  style={{
+                    borderColor: "var(--home-rule)",
+                    background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
+                  }}
+                >
+                  <p className="text-lg font-semibold">No matching players</p>
+                  <p className="mt-2 text-sm" style={{ color: "var(--home-ink-muted)" }}>
+                    Clear the search or switch the board to see more names.
+                  </p>
+                </div>
+              ) : routeState.view === "tiers" ? (
+                <TierBreakdown
+                  players={filteredPlayers}
+                  position={routeState.position}
+                  getPublishedRank={(player) => getPublishedBoardRank(player, routeState.position)}
+                />
+              ) : (
+                <>
+                  <ul role="list" className="grid gap-2.5">
+                    {renderListRows()}
                   </ul>
-                )}
-              </div>
-            </article>
-          </div>
+                  {hasMore && (
+                    <div ref={sentinelRef} className="mt-4 flex justify-center">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setVisibleCount((count) => Math.min(count + RANKINGS_PAGE_SIZE, filteredPlayers.length))
+                        }
+                        className="inline-flex min-h-[44px] items-center gap-2 rounded-full border px-5 text-sm font-semibold"
+                        style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)" }}
+                      >
+                        Load more ({filteredPlayers.length - windowedPlayers.length} left)
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </article>
 
           <aside className="grid gap-5 lg:sticky lg:top-24 lg:self-start">
             <article className="home-card p-5 sm:p-6">
@@ -895,46 +822,73 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                   </div>
                 )}
               </div>
-              <p className="mt-4 text-sm leading-7" style={{ color: "var(--home-ink-muted)" }}>
-                {adpAvailable
-                  ? "Consensus ranks, tiers, ranges, and ownership come from FantasyPros. ADP is layered on from the mock-draft source named above, with its own as-of date, and players without a clean match simply show no ADP."
-                  : "The board only publishes fields the source actually exposes: consensus rank, tier, range, ownership, and freshness."}
-              </p>
             </article>
 
+            {/* Watchlist — shared with the draft assistant via the browser. */}
             <article className="home-card p-5 sm:p-6">
-              <div className="flex items-center gap-3">
-                <Users className="h-5 w-5" style={{ color: "var(--home-moss)" }} />
-                <div>
-                  <p className="home-kicker mb-0">Tier Snapshot</p>
-                  <p className="text-sm font-semibold">Where the breaks sit right now</p>
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <Star className="h-5 w-5" style={{ color: "var(--home-acid)" }} fill="currentColor" />
+                  <div>
+                    <p className="home-kicker mb-0">My Queue</p>
+                    <p className="text-sm font-semibold">{queue.queue.length} starred</p>
+                  </div>
                 </div>
+                {queue.queue.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => queue.clear()}
+                    className="text-xs font-semibold"
+                    style={{ color: "var(--home-ink-muted)" }}
+                  >
+                    Clear
+                  </button>
+                )}
               </div>
-              <div className="mt-4 grid gap-3">
-                {currentSliceUnavailable ? (
-                  <p className="text-sm" style={{ color: "var(--home-ink-muted)" }}>
-                    Tier summaries are unavailable for this board.
-                  </p>
-                ) : tierSummaries.length === 0 ? (
-                  <p className="text-sm" style={{ color: "var(--home-ink-muted)" }}>
-                    Tier summaries will appear when the snapshot loads.
+              <div className="mt-4 grid gap-2">
+                {queuedPlayers.length === 0 ? (
+                  <p className="text-sm leading-7" style={{ color: "var(--home-ink-muted)" }}>
+                    Star players from the board to build a watchlist. It travels with you into the draft assistant.
                   </p>
                 ) : (
-                  tierSummaries.map(([tier, count]) => (
+                  queuedPlayers.slice(0, 12).map((player) => (
                     <div
-                      key={`tier-${tier}`}
-                      className="flex items-center justify-between rounded-[1.2rem] border px-4 py-3"
+                      key={player.id}
+                      className="flex items-center gap-2 rounded-[1.1rem] border px-3 py-2"
                       style={{
                         borderColor: "var(--home-rule)",
                         background: "color-mix(in srgb, var(--home-paper-alt) 55%, var(--home-elev-mix))",
                       }}
                     >
-                      <span className="text-sm font-semibold">Tier {tier}</span>
-                      <span className="text-sm" style={{ color: "var(--home-ink-muted)" }}>
-                        {count} players
-                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setDetailPlayer(player)}
+                        className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                      >
+                        <span className={FANTASY_CHIP_CLASS} style={getPositionTone(player.position)}>
+                          {player.position}
+                        </span>
+                        <span className="min-w-0 truncate text-sm font-semibold">{player.name}</span>
+                        <span className="ml-auto shrink-0 text-xs" style={{ color: "var(--home-ink-muted)" }}>
+                          {player.team}
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => queue.remove(player.id)}
+                        aria-label={`Remove ${player.name} from queue`}
+                        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border"
+                        style={{ borderColor: "var(--home-rule)" }}
+                      >
+                        <X size={13} aria-hidden="true" />
+                      </button>
                     </div>
                   ))
+                )}
+                {queuedPlayers.length > 12 && (
+                  <p className="text-xs" style={{ color: "var(--home-ink-muted)" }}>
+                    +{queuedPlayers.length - 12} more on your watchlist
+                  </p>
                 )}
               </div>
             </article>
@@ -949,17 +903,13 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
               <p className="home-kicker mb-1">Draft Assistant</p>
               <h3 className="text-xl font-semibold">Track the room without leaving the board.</h3>
               <p className="mt-3 text-sm leading-7" style={{ color: "var(--home-ink-muted)" }}>
-                Use the same snapshot inside the draft assistant, log picks manually, and let it flag
-                steals, reaches, and position runs against the same attributed ADP shown here.
+                Use the same snapshot inside the draft assistant, log picks manually, and let it flag steals,
+                reaches, and position runs against the same attributed ADP shown here.
               </p>
               <Link
                 href="/fantasy-football/draft-tracker"
                 className="mt-5 inline-flex min-h-[48px] items-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold transition-[background-color,border-color,color,box-shadow] duration-200"
-                style={{
-                  borderColor: "var(--home-ink)",
-                  background: "var(--home-ink)",
-                  color: "var(--home-paper)",
-                }}
+                style={{ borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }}
               >
                 Launch draft assistant
                 <ArrowUpRight className="h-4 w-4" />
@@ -968,6 +918,17 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
           </aside>
         </div>
       </div>
+
+      <PlayerDetailDrawer
+        player={detailPlayer}
+        publishedRank={detailPlayer ? getPublishedBoardRank(detailPlayer, routeState.position) : undefined}
+        boardTierCount={maxTier > 0 ? maxTier : undefined}
+        onClose={() => setDetailPlayer(null)}
+      />
+      <CompareTray
+        resolvePlayer={(id) => playerLookup.get(id)}
+        publishedRank={(player) => getPublishedBoardRank(player, routeState.position)}
+      />
     </section>
   );
 }

--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -352,6 +352,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
   // Reset the window whenever the board, scoring, view, or search changes so a
   // narrowed list never starts deep into a stale offset.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset on filter change
     setVisibleCount(RANKINGS_PAGE_SIZE);
   }, [routeState.position, routeState.scoring, routeState.view, searchQuery]);
 
@@ -384,7 +385,6 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
     [queue.queue, playerLookup]
   );
 
-  const trimmedQuery = searchQuery.trim();
   const snapshotWeekLabel = metadata
     ? `${metadata.season} ${getFantasyWeekLabel(metadata.week)}`
     : "Loading";
@@ -730,6 +730,9 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                   players={filteredPlayers}
                   position={routeState.position}
                   getPublishedRank={(player) => getPublishedBoardRank(player, routeState.position)}
+                  onSelectPlayer={setDetailPlayer}
+                  isQueued={(id) => queue.isQueued(id)}
+                  onToggleQueue={(id) => queue.toggle(id)}
                 />
               ) : (
                 <>

--- a/src/components/fantasy/CompareModal.tsx
+++ b/src/components/fantasy/CompareModal.tsx
@@ -5,7 +5,6 @@ import { X } from "lucide-react";
 import { useEffect } from "react";
 
 import {
-  FANTASY_CHIP_CLASS,
   formatAdp,
   formatOwnership,
   formatRankValue,

--- a/src/components/fantasy/CompareModal.tsx
+++ b/src/components/fantasy/CompareModal.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { X } from "lucide-react";
+import { useEffect } from "react";
+
+import {
+  FANTASY_CHIP_CLASS,
+  formatAdp,
+  formatOwnership,
+  formatRankValue,
+  getConsensusSpread,
+  getPositionTone,
+  getValueVsAdp,
+} from "@/lib/fantasyUtils";
+import type { Player } from "@/types";
+
+import { RankDistributionBar } from "./RankDistributionBar";
+
+interface CompareModalProps {
+  players: Player[];
+  publishedRank?: (player: Player) => string;
+  onClose: () => void;
+  onRemove: (id: string) => void;
+}
+
+type Direction = "lower" | "higher" | "none";
+
+function metricValue(player: Player, key: string): number | null {
+  switch (key) {
+    case "posRank":
+      return Number.isFinite(player.positionRank) ? (player.positionRank as number) : null;
+    case "rank":
+      return Number.isFinite(player.rankEcr)
+        ? (player.rankEcr as number)
+        : Number.isFinite(player.averageRank)
+          ? player.averageRank
+          : null;
+    case "tier":
+      return Number.isFinite(player.tier) ? (player.tier as number) : null;
+    case "adp":
+      return Number.isFinite(player.adp) ? (player.adp as number) : null;
+    case "own":
+      return Number.isFinite(player.ownership) ? (player.ownership as number) : null;
+    default:
+      return null;
+  }
+}
+
+/** Index of the player who "wins" a metric row, or -1 when it's a wash. */
+function bestIndex(players: Player[], key: string, direction: Direction): number {
+  if (direction === "none") return -1;
+  let best = -1;
+  let bestVal: number | null = null;
+  players.forEach((player, index) => {
+    const value = metricValue(player, key);
+    if (value === null) return;
+    if (
+      bestVal === null ||
+      (direction === "lower" && value < bestVal) ||
+      (direction === "higher" && value > bestVal)
+    ) {
+      bestVal = value;
+      best = index;
+    }
+  });
+  // A tie (every value equal) isn't a meaningful "win".
+  const distinct = new Set(players.map((p) => metricValue(p, key)).filter((v) => v !== null));
+  return distinct.size > 1 ? best : -1;
+}
+
+export function CompareModal({ players, publishedRank, onClose, onRemove }: CompareModalProps) {
+  const reduceMotion = useReducedMotion();
+
+  useEffect(() => {
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const scaleMin = Math.min(...players.map((p) => (Number.isFinite(p.minRank) ? (p.minRank as number) : Infinity)));
+  const scaleMax = Math.max(...players.map((p) => (Number.isFinite(p.maxRank) ? (p.maxRank as number) : -Infinity)));
+  const hasScale = Number.isFinite(scaleMin) && Number.isFinite(scaleMax);
+
+  const rows: Array<{ key: string; label: string; direction: Direction; render: (p: Player) => React.ReactNode }> = [
+    {
+      key: "rank",
+      label: "Consensus rank",
+      direction: "lower",
+      render: (p) => (publishedRank ? publishedRank(p) : formatRankValue(p.rankEcr ?? p.averageRank)),
+    },
+    {
+      key: "posRank",
+      label: "Position rank",
+      direction: "lower",
+      render: (p) => `${p.position} ${Number.isFinite(p.positionRank) ? p.positionRank : "—"}`,
+    },
+    { key: "tier", label: "Tier", direction: "lower", render: (p) => (Number.isFinite(p.tier) ? p.tier : "—") },
+    {
+      key: "adp",
+      label: "Market ADP",
+      direction: "lower",
+      render: (p) => {
+        const signal = getValueVsAdp(p);
+        return (
+          <span className="inline-flex items-center gap-1.5">
+            {formatAdp(p.adp)}
+            {signal?.signal && (
+              <span
+                className="rounded-full px-1.5 py-0.5 text-3xs font-semibold uppercase"
+                style={{
+                  background:
+                    signal.signal === "value"
+                      ? "color-mix(in srgb, var(--color-success) 16%, var(--home-paper))"
+                      : "color-mix(in srgb, var(--color-warning) 16%, var(--home-paper))",
+                }}
+              >
+                {signal.signal}
+              </span>
+            )}
+          </span>
+        );
+      },
+    },
+    { key: "own", label: "Rostered %", direction: "higher", render: (p) => formatOwnership(p.ownership) },
+    { key: "bye", label: "Bye week", direction: "none", render: (p) => p.byeWeek ?? "—" },
+    {
+      key: "spread",
+      label: "Expert consensus",
+      direction: "none",
+      render: (p) => getConsensusSpread(p)?.label ?? "—",
+    },
+  ];
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="fixed inset-0 z-[70] flex items-center justify-center p-4"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: reduceMotion ? 0 : 0.18 }}
+      >
+        <button
+          type="button"
+          aria-label="Close compare"
+          onClick={onClose}
+          className="absolute inset-0 h-full w-full cursor-default"
+          style={{ background: "color-mix(in srgb, var(--home-ink) 42%, transparent)" }}
+          tabIndex={-1}
+        />
+        <motion.div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Compare players"
+          initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 18, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 18, scale: 0.98 }}
+          transition={{ duration: reduceMotion ? 0 : 0.22, ease: [0.25, 0.46, 0.45, 0.94] }}
+          className="relative max-h-[88vh] w-full max-w-2xl overflow-auto rounded-[1.6rem] border p-5"
+          style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)", boxShadow: "var(--shadow-xl)" }}
+        >
+          <div className="mb-4 flex items-center justify-between">
+            <div>
+              <p className="home-kicker mb-0">Side by side</p>
+              <h2 className="text-xl font-semibold">Compare players</h2>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="inline-flex min-h-touch min-w-touch items-center justify-center rounded-full border"
+              style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)" }}
+            >
+              <X size={18} aria-hidden="true" />
+            </button>
+          </div>
+
+          <div className="overflow-x-auto">
+            <div
+              className="grid min-w-[34rem] gap-x-2"
+              style={{ gridTemplateColumns: `auto repeat(${players.length}, minmax(0, 1fr))` }}
+            >
+              {/* Header row: player identities */}
+              <div />
+              {players.map((player) => (
+                <div
+                  key={player.id}
+                  className="flex flex-col items-start gap-1 rounded-[1rem] border p-2.5"
+                  style={{ borderColor: "var(--home-rule)", background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))" }}
+                >
+                  <div className="flex w-full items-start justify-between gap-1">
+                    <span
+                      className="inline-flex items-center rounded-full border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[0.1em]"
+                      style={getPositionTone(player.position)}
+                    >
+                      {player.position}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => onRemove(player.id)}
+                      aria-label={`Remove ${player.name} from compare`}
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border"
+                      style={{ borderColor: "var(--home-rule)" }}
+                    >
+                      <X size={12} aria-hidden="true" />
+                    </button>
+                  </div>
+                  <span className="text-sm font-semibold leading-tight">{player.name}</span>
+                  <span className="text-2xs" style={{ color: "var(--home-ink-muted)" }}>
+                    {player.team}
+                  </span>
+                </div>
+              ))}
+
+              {/* Metric rows */}
+              {rows.map((row) => {
+                const winner = bestIndex(players, row.key, row.direction);
+                return (
+                  <div key={row.key} className="contents">
+                    <div className="flex items-center py-2 pr-2 text-2xs font-semibold uppercase tracking-[0.1em]" style={{ color: "var(--home-ink-muted)" }}>
+                      {row.label}
+                    </div>
+                    {players.map((player, index) => (
+                      <div
+                        key={player.id}
+                        className="flex items-center border-t py-2 text-sm font-semibold tabular-nums"
+                        style={{
+                          borderColor: "var(--home-rule)",
+                          color: winner === index ? "var(--home-ink)" : "var(--home-ink)",
+                          background:
+                            winner === index
+                              ? "color-mix(in srgb, var(--home-acid) 18%, transparent)"
+                              : "transparent",
+                        }}
+                      >
+                        {row.render(player)}
+                      </div>
+                    ))}
+                  </div>
+                );
+              })}
+
+              {/* Expert range bars (shared scale) */}
+              {hasScale && (
+                <div className="contents">
+                  <div className="flex items-start py-3 pr-2 text-2xs font-semibold uppercase tracking-[0.1em]" style={{ color: "var(--home-ink-muted)" }}>
+                    Range
+                  </div>
+                  {players.map((player) => (
+                    <div key={player.id} className="border-t py-3" style={{ borderColor: "var(--home-rule)" }}>
+                      <RankDistributionBar player={player} scaleMin={scaleMin} scaleMax={scaleMax} compact />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <p className="mt-4 text-2xs" style={{ color: "var(--home-ink-muted)" }}>
+            Highlight marks the stronger value per row (lower rank/ADP, higher rostered %). Range bars share one
+            scale so a wider fill means more expert disagreement.
+          </p>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/fantasy/CompareTray.tsx
+++ b/src/components/fantasy/CompareTray.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { GitCompareArrows, X } from "lucide-react";
+import { useState } from "react";
+
+import { useCompareTray } from "@/hooks/useCompareTray";
+import { getPositionTone } from "@/lib/fantasyUtils";
+import type { Player } from "@/types";
+
+import { CompareModal } from "./CompareModal";
+
+interface CompareTrayProps {
+  resolvePlayer: (id: string) => Player | undefined;
+  publishedRank?: (player: Player) => string;
+}
+
+/**
+ * A docked bottom bar that surfaces the compare selection from anywhere on the
+ * page and opens the side-by-side modal. Renders nothing until at least one
+ * player is pinned, so it never steals space during normal browsing.
+ */
+export function CompareTray({ resolvePlayer, publishedRank }: CompareTrayProps) {
+  const reduceMotion = useReducedMotion();
+  const compare = useCompareTray();
+  const [open, setOpen] = useState(false);
+
+  const players = compare.compareIds
+    .map((id) => resolvePlayer(id))
+    .filter((player): player is Player => Boolean(player));
+
+  const canCompare = players.length >= 2;
+
+  return (
+    <>
+      <AnimatePresence>
+        {players.length > 0 && (
+          <motion.div
+            initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 20 }}
+            transition={{ duration: reduceMotion ? 0 : 0.2 }}
+            className="fixed inset-x-0 bottom-0 z-50 flex justify-center px-3 pb-3"
+          >
+            <div
+              className="flex w-full max-w-3xl flex-wrap items-center gap-2 rounded-[1.4rem] border px-3 py-2.5"
+              style={{
+                borderColor: "var(--home-rule)",
+                background: "color-mix(in srgb, var(--home-paper) 94%, var(--home-elev-mix))",
+                boxShadow: "var(--shadow-lg)",
+                backdropFilter: "blur(8px)",
+              }}
+            >
+              <span className="home-kicker mb-0 hidden sm:block">Compare</span>
+              <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+                {players.map((player) => (
+                  <span
+                    key={player.id}
+                    className="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold"
+                    style={{ borderColor: "var(--home-rule)", ...getPositionTone(player.position) }}
+                  >
+                    <span className="max-w-[8rem] truncate">{player.name}</span>
+                    <button
+                      type="button"
+                      onClick={() => compare.remove(player.id)}
+                      aria-label={`Remove ${player.name} from compare`}
+                      className="inline-flex h-4 w-4 items-center justify-center rounded-full"
+                      style={{ background: "color-mix(in srgb, var(--home-ink) 12%, transparent)" }}
+                    >
+                      <X size={11} aria-hidden="true" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={() => compare.clear()}
+                className="inline-flex min-h-touch items-center rounded-full px-3 text-xs font-semibold"
+                style={{ color: "var(--home-ink-muted)" }}
+              >
+                Clear
+              </button>
+              <button
+                type="button"
+                onClick={() => setOpen(true)}
+                disabled={!canCompare}
+                className="inline-flex min-h-touch items-center gap-2 rounded-full border px-4 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-55"
+                style={{ borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }}
+                title={canCompare ? undefined : "Pin at least two players"}
+              >
+                <GitCompareArrows size={16} aria-hidden="true" />
+                Compare {players.length}
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {open && canCompare && (
+        <CompareModal
+          players={players}
+          publishedRank={publishedRank}
+          onClose={() => setOpen(false)}
+          onRemove={(id) => {
+            compare.remove(id);
+            if (players.length <= 2) setOpen(false);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/fantasy/PlayerDetailDrawer.tsx
+++ b/src/components/fantasy/PlayerDetailDrawer.tsx
@@ -66,6 +66,7 @@ export function PlayerDetailDrawer({ player, publishedRank, boardTierCount, onCl
   // Reset the note draft whenever a different player opens the drawer.
   useEffect(() => {
     if (player) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- seed local draft from the persisted note on open
       setDraftNote(notes.getNote(player.id));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/fantasy/PlayerDetailDrawer.tsx
+++ b/src/components/fantasy/PlayerDetailDrawer.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { GitCompareArrows, Star, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { useCompareTray } from "@/hooks/useCompareTray";
+import { usePlayerNotes } from "@/hooks/usePlayerNotes";
+import { usePlayerQueue } from "@/hooks/usePlayerQueue";
+import {
+  FANTASY_CHIP_CLASS,
+  formatAdp,
+  formatOwnership,
+  getConsensusSpread,
+  getPositionTone,
+  getValueVsAdp,
+} from "@/lib/fantasyUtils";
+import type { Player } from "@/types";
+
+import { RankDistributionBar } from "./RankDistributionBar";
+
+interface PlayerDetailDrawerProps {
+  player: Player | null;
+  /** Headline rank string already formatted by the calling board. */
+  publishedRank?: string;
+  /** Total tier count on the active board, for "Tier N of M" context. */
+  boardTierCount?: number;
+  onClose: () => void;
+}
+
+function StatCell({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div
+      className="rounded-[1rem] border px-3 py-2.5"
+      style={{
+        borderColor: "var(--home-rule)",
+        background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+      }}
+    >
+      <p className="text-2xs font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--home-ink-muted)" }}>
+        {label}
+      </p>
+      <p className="mt-0.5 text-base font-semibold tabular-nums">{children}</p>
+    </div>
+  );
+}
+
+/**
+ * A shared player detail surface — right-side drawer on desktop, bottom sheet on
+ * mobile — used by both the rankings board and the draft assistant. It renders
+ * only fields the snapshot actually populates (rank, tier, expert range,
+ * consensus spread, ownership, bye, ADP) plus the cross-surface watchlist,
+ * notes, and compare controls. No projections/headshots: that data is empty.
+ */
+export function PlayerDetailDrawer({ player, publishedRank, boardTierCount, onClose }: PlayerDetailDrawerProps) {
+  const reduceMotion = useReducedMotion();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  const queue = usePlayerQueue();
+  const compare = useCompareTray();
+  const notes = usePlayerNotes();
+
+  const [draftNote, setDraftNote] = useState("");
+
+  // Reset the note draft whenever a different player opens the drawer.
+  useEffect(() => {
+    if (player) {
+      setDraftNote(notes.getNote(player.id));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [player?.id]);
+
+  // Capture focus on open, trap Tab within the panel, and restore on close.
+  useEffect(() => {
+    if (!player) return;
+    restoreFocusRef.current = document.activeElement as HTMLElement | null;
+
+    const panel = panelRef.current;
+    panel?.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab" || !panel) return;
+
+      const focusable = panel.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), textarea, input, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      restoreFocusRef.current?.focus?.();
+    };
+  }, [player, onClose]);
+
+  const isOpen = Boolean(player);
+  const valueSignal = player ? getValueVsAdp(player) : null;
+  const spread = player ? getConsensusSpread(player) : null;
+  const isQueued = player ? queue.isQueued(player.id) : false;
+  const inCompare = player ? compare.inCompare(player.id) : false;
+  const compareDisabled = !inCompare && compare.isFull;
+
+  return (
+    <AnimatePresence>
+      {isOpen && player && (
+        <motion.div
+          className="fixed inset-0 z-[60] flex items-end justify-center sm:items-stretch sm:justify-end"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: reduceMotion ? 0 : 0.18 }}
+        >
+          <button
+            type="button"
+            aria-label="Close player detail"
+            onClick={onClose}
+            className="absolute inset-0 h-full w-full cursor-default"
+            style={{ background: "color-mix(in srgb, var(--home-ink) 38%, transparent)" }}
+            tabIndex={-1}
+          />
+          <motion.div
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label={`${player.name} detail`}
+            tabIndex={-1}
+            initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 24 }}
+            transition={{ duration: reduceMotion ? 0 : 0.24, ease: [0.25, 0.46, 0.45, 0.94] }}
+            className="relative flex max-h-[88vh] w-full flex-col gap-4 overflow-y-auto rounded-t-[1.6rem] border p-5 outline-none sm:max-h-none sm:h-full sm:w-[26rem] sm:rounded-l-[1.6rem] sm:rounded-tr-none"
+            style={{
+              borderColor: "var(--home-rule)",
+              background: "var(--home-paper)",
+              boxShadow: "var(--shadow-xl)",
+            }}
+          >
+            {/* Header */}
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span
+                    className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-2xs font-semibold uppercase tracking-[0.12em]"
+                    style={getPositionTone(player.position)}
+                  >
+                    {player.position}
+                    {Number.isFinite(player.positionRank) ? ` ${player.positionRank}` : ""}
+                  </span>
+                  {publishedRank && (
+                    <span className="text-2xs font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--home-ink-muted)" }}>
+                      Rank {publishedRank}
+                    </span>
+                  )}
+                </div>
+                <h2 className="mt-1.5 truncate text-2xl font-semibold tracking-tight">{player.name}</h2>
+                <p className="text-sm" style={{ color: "var(--home-ink-muted)" }}>
+                  {player.team || "Free agent"}
+                  {player.byeWeek ? ` · Bye ${player.byeWeek}` : ""}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                className="inline-flex min-h-touch min-w-touch shrink-0 items-center justify-center rounded-full border"
+                style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)" }}
+              >
+                <X size={18} aria-hidden="true" />
+              </button>
+            </div>
+
+            {/* Quick actions */}
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => queue.toggle(player.id)}
+                aria-pressed={isQueued}
+                className="inline-flex min-h-touch flex-1 items-center justify-center gap-2 rounded-full border px-4 text-sm font-semibold"
+                style={
+                  isQueued
+                    ? {
+                        borderColor: "color-mix(in srgb, var(--home-acid) 60%, var(--home-rule))",
+                        background: "color-mix(in srgb, var(--home-acid) 30%, var(--home-paper))",
+                        color: "var(--home-ink)",
+                      }
+                    : { borderColor: "var(--home-rule)", background: "var(--home-paper)", color: "var(--home-ink)" }
+                }
+              >
+                <Star size={16} fill={isQueued ? "currentColor" : "none"} aria-hidden="true" />
+                {isQueued ? "Queued" : "Add to queue"}
+              </button>
+              <button
+                type="button"
+                onClick={() => compare.toggle(player.id)}
+                aria-pressed={inCompare}
+                disabled={compareDisabled}
+                title={compareDisabled ? `Compare holds ${compare.limit} players` : undefined}
+                className="inline-flex min-h-touch flex-1 items-center justify-center gap-2 rounded-full border px-4 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-55"
+                style={
+                  inCompare
+                    ? { borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }
+                    : { borderColor: "var(--home-rule)", background: "var(--home-paper)", color: "var(--home-ink)" }
+                }
+              >
+                <GitCompareArrows size={16} aria-hidden="true" />
+                {inCompare ? "Comparing" : "Compare"}
+              </button>
+            </div>
+
+            {/* Stats grid */}
+            <div className="grid grid-cols-2 gap-2">
+              <StatCell label="Position rank">
+                {player.position}
+                {Number.isFinite(player.positionRank) ? ` ${player.positionRank}` : " —"}
+              </StatCell>
+              <StatCell label="Tier">
+                {Number.isFinite(player.tier)
+                  ? `${player.tier}${boardTierCount ? ` of ${boardTierCount}` : ""}`
+                  : "—"}
+              </StatCell>
+              <StatCell label="Bye week">{player.byeWeek ?? "—"}</StatCell>
+              <StatCell label="Rostered">{formatOwnership(player.ownership)}</StatCell>
+            </div>
+
+            {/* ADP + value signal */}
+            {Number.isFinite(player.adp) && (
+              <div
+                className="flex items-center justify-between rounded-[1rem] border px-3 py-2.5"
+                style={{
+                  borderColor: "var(--home-rule)",
+                  background: "color-mix(in srgb, var(--home-paper) 88%, var(--home-elev-mix))",
+                }}
+              >
+                <div>
+                  <p className="text-2xs font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--home-ink-muted)" }}>
+                    Market ADP
+                  </p>
+                  <p className="text-base font-semibold tabular-nums">{formatAdp(player.adp)}</p>
+                </div>
+                {valueSignal?.signal && (
+                  <span
+                    className={FANTASY_CHIP_CLASS}
+                    style={
+                      valueSignal.signal === "value"
+                        ? {
+                            borderColor: "color-mix(in srgb, var(--color-success) 30%, var(--home-rule))",
+                            background: "color-mix(in srgb, var(--color-success) 12%, var(--home-paper))",
+                            color: "var(--home-ink)",
+                          }
+                        : {
+                            borderColor: "color-mix(in srgb, var(--color-warning) 32%, var(--home-rule))",
+                            background: "color-mix(in srgb, var(--color-warning) 12%, var(--home-paper))",
+                            color: "var(--home-ink)",
+                          }
+                    }
+                  >
+                    {valueSignal.signal === "value" ? "Value" : "Reach"} {valueSignal.delta > 0 ? "+" : ""}
+                    {valueSignal.delta}
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Expert consensus spread */}
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <p className="home-kicker mb-0">Expert spread</p>
+                {spread && (
+                  <span className="text-2xs font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--home-ink-muted)" }}>
+                    {spread.label}
+                  </span>
+                )}
+              </div>
+              <RankDistributionBar player={player} />
+            </div>
+
+            {/* Private note */}
+            <div>
+              <label
+                htmlFor="player-note"
+                className="home-kicker mb-2 block"
+              >
+                Private note
+              </label>
+              <textarea
+                id="player-note"
+                value={draftNote}
+                maxLength={notes.maxLength}
+                onChange={(event) => {
+                  setDraftNote(event.target.value);
+                  notes.setNote(player.id, event.target.value);
+                }}
+                rows={2}
+                placeholder="Handcuff for Hall… target round 6… avoid."
+                className="w-full resize-none rounded-[1rem] border px-3 py-2 text-sm outline-none"
+                style={{
+                  borderColor: "var(--home-rule)",
+                  background: "color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))",
+                  color: "var(--home-ink)",
+                }}
+              />
+              <p className="mt-1 text-right text-2xs" style={{ color: "var(--home-ink-muted)" }}>
+                {draftNote.length}/{notes.maxLength} · saved to this browser
+              </p>
+            </div>
+
+            <p className="text-2xs" style={{ color: "var(--home-ink-muted)" }}>
+              Ranks, tiers, and expert ranges come from the published FantasyPros consensus snapshot. Queue,
+              notes, and compare stay on this device.
+            </p>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/fantasy/PositionFilterBar.tsx
+++ b/src/components/fantasy/PositionFilterBar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { CSSProperties } from "react";
+
+import { getPositionTone } from "@/lib/fantasyUtils";
+
+export interface PositionFilterOption<T extends string> {
+  value: T;
+  label: string;
+  /** Snapshot position (e.g. "QB") used to tint the active pill; omit for "All". */
+  position?: string;
+  /** When false the pill is rendered disabled with a muted "NA" hint. */
+  available?: boolean;
+  /** Optional short reason shown in the title attribute when unavailable. */
+  unavailableLabel?: string;
+}
+
+interface PositionFilterBarProps<T extends string> {
+  options: PositionFilterOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  ariaLabel: string;
+  disabled?: boolean;
+}
+
+/**
+ * The position pill row shared by the rankings board and the draft board. It was
+ * duplicated (with near-identical styling) in both surfaces; consolidating keeps
+ * the tones, touch targets, and a11y semantics from forking. On narrow screens
+ * the row scroll-snaps horizontally instead of wrapping to three stacked rows.
+ */
+export function PositionFilterBar<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  disabled = false,
+}: PositionFilterBarProps<T>) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="-mx-1 flex snap-x snap-mandatory gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:mx-0 sm:flex-wrap sm:overflow-visible sm:px-0 sm:pb-0"
+    >
+      {options.map((option) => {
+        const isActive = option.value === value;
+        const isUnavailable = option.available === false;
+        const isDisabled = disabled || isUnavailable;
+
+        let style: CSSProperties;
+        if (isActive) {
+          style = {
+            borderColor: "var(--home-ink)",
+            background: "var(--home-ink)",
+            color: "var(--home-paper)",
+          };
+        } else if (isUnavailable) {
+          style = {
+            borderColor: "color-mix(in srgb, var(--color-warning) 30%, var(--home-rule))",
+            background: "color-mix(in srgb, var(--color-warning) 8%, var(--home-paper))",
+            color: "var(--home-ink-muted)",
+          };
+        } else {
+          style = {
+            borderColor: "var(--home-rule)",
+            background: "color-mix(in srgb, var(--home-paper-alt) 52%, var(--home-elev-mix))",
+            color: "var(--home-ink)",
+            // A faint position tint on the inactive pill ties the control to the board.
+            boxShadow: option.position
+              ? `inset 0 0 0 999px ${getPositionTone(option.position).background as string}`
+              : undefined,
+          };
+        }
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            aria-label={
+              isUnavailable
+                ? `${option.label} — ${option.unavailableLabel ?? "not available"}`
+                : option.label
+            }
+            title={isUnavailable ? option.unavailableLabel : undefined}
+            disabled={isDisabled}
+            onClick={() => !isDisabled && onChange(option.value)}
+            className="inline-flex min-h-touch shrink-0 snap-start items-center gap-1.5 rounded-full border px-3.5 text-sm font-semibold transition-colors disabled:cursor-not-allowed"
+            style={style}
+          >
+            <span>{option.label}</span>
+            {isUnavailable && (
+              <span className="text-2xs font-semibold uppercase tracking-[0.12em] opacity-80">
+                NA
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/fantasy/RankDistributionBar.tsx
+++ b/src/components/fantasy/RankDistributionBar.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { formatRankValue, getConsensusSpread } from "@/lib/fantasyUtils";
+import type { Player } from "@/types";
+
+interface RankDistributionBarProps {
+  player: Player;
+  /** Optional shared scale so several bars line up (used by the compare modal). */
+  scaleMin?: number;
+  scaleMax?: number;
+  /** Hide the best/avg/worst tick labels for a compact inline variant. */
+  compact?: boolean;
+}
+
+const SPREAD_FILL: Record<string, string> = {
+  tight: "color-mix(in srgb, var(--color-success) 34%, var(--home-paper))",
+  mixed: "color-mix(in srgb, var(--home-acid) 46%, var(--home-paper))",
+  volatile: "color-mix(in srgb, var(--color-warning) 38%, var(--home-paper))",
+};
+
+/**
+ * Visualizes how widely the experts disagree about a player by plotting his
+ * best→worst rank span as a filled track with the consensus average marked.
+ * A wide fill = lots of disagreement; the fill color encodes the same
+ * `standardDeviation`-derived consensus-spread bucket shown elsewhere. This is
+ * the headline use of the otherwise-unsurfaced `standardDeviation` field.
+ */
+export function RankDistributionBar({ player, scaleMin, scaleMax, compact = false }: RankDistributionBarProps) {
+  const min = player.minRank;
+  const max = player.maxRank;
+  const avg =
+    typeof player.averageRank === "number" && Number.isFinite(player.averageRank)
+      ? player.averageRank
+      : typeof player.rankEcr === "number" && Number.isFinite(player.rankEcr)
+        ? player.rankEcr
+        : undefined;
+
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    return (
+      <p className="text-xs" style={{ color: "var(--home-ink-muted)" }}>
+        Expert range unavailable for this board.
+      </p>
+    );
+  }
+
+  const lo = scaleMin ?? (min as number);
+  const hi = scaleMax ?? (max as number);
+  const span = hi - lo || 1;
+  const pct = (value: number) => Math.max(0, Math.min(100, ((value - lo) / span) * 100));
+
+  const left = pct(min as number);
+  const right = pct(max as number);
+  const spread = getConsensusSpread(player);
+  const fill = SPREAD_FILL[spread?.level ?? "mixed"] ?? SPREAD_FILL.mixed;
+
+  return (
+    <div className="w-full">
+      <div
+        className="relative h-2.5 w-full overflow-hidden rounded-full"
+        style={{ background: "color-mix(in srgb, var(--home-ink) 8%, var(--home-paper))" }}
+        role="img"
+        aria-label={`Expert rank range ${formatRankValue(min)} to ${formatRankValue(max)}${
+          avg !== undefined ? `, average ${formatRankValue(avg)}` : ""
+        }`}
+      >
+        <span
+          className="absolute inset-y-0 rounded-full"
+          style={{ left: `${left}%`, width: `${Math.max(right - left, 2)}%`, background: fill }}
+        />
+        {avg !== undefined && (
+          <span
+            className="absolute inset-y-0 w-[2px] rounded-full"
+            style={{ left: `calc(${pct(avg)}% - 1px)`, background: "var(--home-ink)" }}
+          />
+        )}
+      </div>
+      {!compact && (
+        <div
+          className="mt-1 flex items-center justify-between text-2xs font-semibold uppercase tracking-[0.1em]"
+          style={{ color: "var(--home-ink-muted)" }}
+        >
+          <span>Best {formatRankValue(min)}</span>
+          {avg !== undefined && <span style={{ color: "var(--home-ink)" }}>Avg {formatRankValue(avg)}</span>}
+          <span>Worst {formatRankValue(max)}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/fantasy/RankingsListRow.tsx
+++ b/src/components/fantasy/RankingsListRow.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { GitCompareArrows, Star, StickyNote } from "lucide-react";
+import type { ReactNode } from "react";
+
+import {
+  FANTASY_CHIP_CLASS,
+  formatAdp,
+  formatOwnership,
+  formatRange,
+  getPositionTone,
+  getValueVsAdp,
+} from "@/lib/fantasyUtils";
+import type { Player } from "@/types";
+
+interface RankingsListRowProps {
+  player: Player;
+  publishedRank: string;
+  descriptor: ReactNode;
+  adpAvailable: boolean;
+  compact: boolean;
+  isQueued: boolean;
+  hasNote: boolean;
+  inCompare: boolean;
+  compareDisabled: boolean;
+  onOpenDetail: () => void;
+  onToggleQueue: () => void;
+  onToggleCompare: () => void;
+}
+
+function Metric({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-2xs font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--home-ink-muted)" }}>
+        {label}
+      </p>
+      <p className="text-sm font-semibold tabular-nums">{children}</p>
+    </div>
+  );
+}
+
+/**
+ * A single rankings-board row with a clear primary line (rank + name) over a
+ * muted secondary line, a reflowing metric strip, and an always-visible action
+ * cluster (queue, compare, open detail). Hover lifts the row; a queued row
+ * carries an acid left accent so the watchlist reads inline.
+ */
+export function RankingsListRow({
+  player,
+  publishedRank,
+  descriptor,
+  adpAvailable,
+  compact,
+  isQueued,
+  hasNote,
+  inCompare,
+  compareDisabled,
+  onOpenDetail,
+  onToggleQueue,
+  onToggleCompare,
+}: RankingsListRowProps) {
+  const valueVsAdp = adpAvailable ? getValueVsAdp(player) : null;
+
+  return (
+    <li
+      className="group relative overflow-hidden rounded-[1.25rem] border border-[color:var(--home-rule)] transition-[border-color,box-shadow,transform] hover:border-[color:var(--home-ink)] hover:shadow-[var(--shadow-md)] motion-safe:hover:-translate-y-0.5"
+      style={{ background: "color-mix(in srgb, var(--home-paper-alt) 42%, var(--home-elev-mix))" }}
+    >
+      {isQueued && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 w-1"
+          style={{ background: "var(--home-acid)" }}
+        />
+      )}
+      <div className="flex items-stretch">
+        <button
+          type="button"
+          onClick={onOpenDetail}
+          aria-label={`Open ${player.name} detail — ${player.position}, rank ${publishedRank}`}
+          className={`flex min-w-0 flex-1 flex-col gap-2 text-left md:flex-row md:items-center md:gap-4 ${
+            compact ? "px-4 py-2.5" : "px-4 py-3.5"
+          }`}
+        >
+          <div className="flex min-w-0 items-center gap-3 md:flex-1">
+            <span
+              className={`inline-flex shrink-0 items-center justify-center tabular-nums ${
+                compact ? "text-xl" : "text-2xl"
+              } font-semibold`}
+              style={{ minWidth: compact ? "2.25rem" : "2.75rem" }}
+              title="Published FantasyPros consensus rank on this board"
+            >
+              {publishedRank}
+            </span>
+            <div className="min-w-0">
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <span className="min-w-0 truncate text-base font-semibold">{player.name}</span>
+                <span className={FANTASY_CHIP_CLASS} style={getPositionTone(player.position)}>
+                  {player.position}
+                </span>
+                {hasNote && (
+                  <StickyNote
+                    size={13}
+                    aria-label="Has a private note"
+                    style={{ color: "var(--home-ink-muted)" }}
+                  />
+                )}
+              </div>
+              <p className="mt-0.5 truncate text-sm" style={{ color: "var(--home-ink-muted)" }}>
+                {descriptor}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-1 md:shrink-0 md:justify-end">
+            <Metric label="Expert range">{formatRange(player)}</Metric>
+            {adpAvailable && (
+              <div className="min-w-0">
+                <p className="text-2xs font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--home-ink-muted)" }}>
+                  ADP
+                </p>
+                <p className="flex items-center gap-1.5 text-sm font-semibold tabular-nums">
+                  {formatAdp(player.adp)}
+                  {valueVsAdp?.signal && (
+                    <span
+                      className={FANTASY_CHIP_CLASS}
+                      style={
+                        valueVsAdp.signal === "value"
+                          ? {
+                              borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
+                              background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
+                            }
+                          : {
+                              borderColor: "color-mix(in srgb, var(--color-warning) 30%, var(--home-rule))",
+                              background: "color-mix(in srgb, var(--color-warning) 12%, var(--home-paper))",
+                            }
+                      }
+                    >
+                      {valueVsAdp.signal === "value" ? "Value" : "Reach"}{" "}
+                      {valueVsAdp.delta > 0 ? `+${valueVsAdp.delta}` : valueVsAdp.delta}
+                    </span>
+                  )}
+                </p>
+              </div>
+            )}
+            <Metric label="Rostered">
+              <span>{formatOwnership(player.ownership)}</span>
+              <span className="ml-2 text-2xs font-medium" style={{ color: "var(--home-ink-muted)" }}>
+                {player.byeWeek ? `Bye ${player.byeWeek}` : ""}
+              </span>
+            </Metric>
+          </div>
+        </button>
+
+        <div className="flex shrink-0 items-center gap-1 pr-2">
+          <button
+            type="button"
+            onClick={onToggleQueue}
+            aria-pressed={isQueued}
+            aria-label={isQueued ? `Remove ${player.name} from queue` : `Add ${player.name} to queue`}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border transition-colors"
+            style={
+              isQueued
+                ? {
+                    borderColor: "color-mix(in srgb, var(--home-acid) 55%, var(--home-rule))",
+                    background: "color-mix(in srgb, var(--home-acid) 28%, var(--home-paper))",
+                    color: "var(--home-ink)",
+                  }
+                : { borderColor: "var(--home-rule)", background: "transparent", color: "var(--home-ink-muted)" }
+            }
+          >
+            <Star size={15} fill={isQueued ? "currentColor" : "none"} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={onToggleCompare}
+            aria-pressed={inCompare}
+            disabled={compareDisabled}
+            aria-label={inCompare ? `Remove ${player.name} from compare` : `Add ${player.name} to compare`}
+            className="hidden h-9 w-9 items-center justify-center rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-45 sm:inline-flex"
+            style={
+              inCompare
+                ? { borderColor: "var(--home-ink)", background: "var(--home-ink)", color: "var(--home-paper)" }
+                : { borderColor: "var(--home-rule)", background: "transparent", color: "var(--home-ink-muted)" }
+            }
+          >
+            <GitCompareArrows size={15} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/components/fantasy/TierBreakSeparator.tsx
+++ b/src/components/fantasy/TierBreakSeparator.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+interface TierBreakSeparatorProps {
+  tier: number;
+  /** Rank cliff to the previous tier, when known — surfaced as a "↓ N" hint. */
+  gap?: number;
+}
+
+/**
+ * A thin labeled rule inserted between list rows whenever consecutive players
+ * cross a tier boundary. It turns the otherwise-flat list into the same
+ * tier-chunked read the dedicated tier view gives, without leaving list view.
+ */
+export function TierBreakSeparator({ tier, gap }: TierBreakSeparatorProps) {
+  return (
+    <li role="presentation" className="flex items-center gap-3 px-1 py-1.5">
+      <span
+        className="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-2xs font-semibold uppercase tracking-[0.14em]"
+        style={{
+          borderColor: "color-mix(in srgb, var(--home-acid) 40%, var(--home-rule))",
+          background: "color-mix(in srgb, var(--home-acid) 18%, var(--home-paper))",
+          color: "var(--home-ink)",
+        }}
+      >
+        Tier {tier}
+      </span>
+      <span className="h-px flex-1" style={{ background: "var(--home-rule)" }} aria-hidden="true" />
+      {gap && gap > 0 ? (
+        <span className="text-2xs font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--home-ink-muted)" }}>
+          ↓ {gap} {gap === 1 ? "rank" : "ranks"}
+        </span>
+      ) : null}
+    </li>
+  );
+}

--- a/src/components/fantasy/TierBreakdown.tsx
+++ b/src/components/fantasy/TierBreakdown.tsx
@@ -1,15 +1,19 @@
 "use client";
 
 import { useMemo } from "react";
+import { Star } from "lucide-react";
 
 import { FANTASY_POSITION_LABELS, type FantasyRoutePosition } from "@/lib/fantasy";
-import { formatAdp, formatRankValue, getPositionTone } from "@/lib/fantasyUtils";
+import { formatAdp, formatRankValue, getPositionTone, getTierGap } from "@/lib/fantasyUtils";
 import type { Player } from "@/types";
 
 interface TierBreakdownProps {
   players: Player[];
   position: FantasyRoutePosition;
   getPublishedRank: (player: Player) => string;
+  onSelectPlayer?: (player: Player) => void;
+  isQueued?: (id: string) => boolean;
+  onToggleQueue?: (id: string) => void;
 }
 
 interface TierGroup {
@@ -58,7 +62,14 @@ function tierAccent(index: number, total: number): string {
   return `${mixed.toFixed(0)}%`;
 }
 
-export function TierBreakdown({ players, position, getPublishedRank }: TierBreakdownProps) {
+export function TierBreakdown({
+  players,
+  position,
+  getPublishedRank,
+  onSelectPlayer,
+  isQueued,
+  onToggleQueue,
+}: TierBreakdownProps) {
   const groups = useMemo(() => groupByTier(players), [players]);
 
   if (groups.length === 0) {
@@ -81,6 +92,10 @@ export function TierBreakdown({ players, position, getPublishedRank }: TierBreak
   const tieredGroups = groups.filter((group) => group.tier !== "untiered");
   const positionLabel = FANTASY_POSITION_LABELS[position];
 
+  // Numeric published rank for the first/last player in a group, used to surface
+  // the "cliff" between tiers.
+  const numericRank = (player: Player): number => Number.parseFloat(getPublishedRank(player));
+
   return (
     <div className="grid scroll-mt-28 gap-4" aria-label={`${positionLabel} tier breakdown`}>
       {groups.map((group, index) => {
@@ -90,6 +105,17 @@ export function TierBreakdown({ players, position, getPublishedRank }: TierBreak
         const description = isUntiered
           ? "Players without an assigned tier"
           : `${group.players.length} ${group.players.length === 1 ? "player" : "players"}`;
+
+        // Cliff to the previous tier: ranks dropped from the last player of the
+        // prior group to the first player of this one.
+        const previousGroup = index > 0 ? groups[index - 1] : null;
+        const cliff =
+          !isUntiered && previousGroup && previousGroup.tier !== "untiered"
+            ? getTierGap(
+                numericRank(previousGroup.players[previousGroup.players.length - 1]),
+                numericRank(group.players[0])
+              )
+            : 0;
 
         return (
           <section
@@ -107,6 +133,15 @@ export function TierBreakdown({ players, position, getPublishedRank }: TierBreak
                 <p className="text-sm font-semibold" style={{ color: "var(--home-ink-muted)" }}>
                   {description}
                 </p>
+                {cliff > 0 && (
+                  <span
+                    className="text-2xs font-semibold uppercase tracking-[0.12em]"
+                    title="Rank cliff from the previous tier"
+                    style={{ color: "var(--home-ink-muted)" }}
+                  >
+                    ↓ {cliff} {cliff === 1 ? "rank" : "ranks"} from prior tier
+                  </span>
+                )}
               </div>
               {!isUntiered && (() => {
                 // Skip players whose published rank is "--" or otherwise
@@ -138,46 +173,75 @@ export function TierBreakdown({ players, position, getPublishedRank }: TierBreak
               })()}
             </header>
 
-            <ul role="list" className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-              {group.players.map((player) => (
-                <li key={player.id} className="min-w-0">
-                  <span
-                    className="grid min-h-[38px] grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-full border px-3 py-1.5 text-sm"
-                    style={{
-                      borderColor: "var(--home-rule)",
-                      background: "var(--home-paper-raised)",
-                      color: "var(--home-ink)",
-                    }}
-                  >
-                    <span
-                      className="inline-flex min-w-[2rem] items-center justify-center rounded-full border px-2 py-0.5 text-2xs font-semibold tabular-nums"
-                      style={getPositionTone(player.position)}
-                      aria-hidden="true"
+            <ul role="list" className="mt-4 grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(15rem,1fr))]">
+              {group.players.map((player) => {
+                const queued = isQueued?.(player.id) ?? false;
+                const interactive = Boolean(onSelectPlayer);
+                const Pill = interactive ? "button" : "span";
+
+                return (
+                  <li key={player.id} className="min-w-0">
+                    <div
+                      className="flex items-center gap-1.5 rounded-full border pr-1.5"
+                      style={{
+                        borderColor: queued
+                          ? "color-mix(in srgb, var(--home-acid) 55%, var(--home-rule))"
+                          : "var(--home-rule)",
+                        background: "var(--home-paper-raised)",
+                      }}
                     >
-                      {getPublishedRank(player)}
-                    </span>
-                    <span className="min-w-0 truncate font-semibold">{player.name}</span>
-                    {player.team && (
-                      <span
-                        className="shrink-0 text-xs font-medium uppercase tracking-[0.1em]"
-                        style={{ color: "var(--home-ink-muted)" }}
+                      <Pill
+                        {...(interactive
+                          ? { type: "button" as const, onClick: () => onSelectPlayer?.(player), "aria-label": `Open ${player.name} detail` }
+                          : {})}
+                        className={`grid min-h-[38px] min-w-0 flex-1 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-full px-3 py-1.5 text-sm ${
+                          interactive ? "text-left" : ""
+                        }`}
+                        style={{ color: "var(--home-ink)" }}
                       >
-                        {player.team}
-                        {player.byeWeek ? ` · Bye ${player.byeWeek}` : ""}
-                      </span>
-                    )}
-                    {Number.isFinite(player.adp) && (
-                      <span
-                        className="text-2xs"
-                        title="Average draft position from recent mock drafts"
-                        style={{ color: "var(--home-ink-muted)" }}
-                      >
-                        ADP {formatAdp(player.adp)}
-                      </span>
-                    )}
-                  </span>
-                </li>
-              ))}
+                        <span
+                          className="inline-flex min-w-[2rem] items-center justify-center rounded-full border px-2 py-0.5 text-2xs font-semibold tabular-nums"
+                          style={getPositionTone(player.position)}
+                          aria-hidden="true"
+                        >
+                          {getPublishedRank(player)}
+                        </span>
+                        <span className="min-w-0 truncate font-semibold">{player.name}</span>
+                        {player.team && (
+                          <span
+                            className="shrink-0 text-xs font-medium uppercase tracking-[0.1em]"
+                            style={{ color: "var(--home-ink-muted)" }}
+                          >
+                            {player.team}
+                            {player.byeWeek ? ` · Bye ${player.byeWeek}` : ""}
+                          </span>
+                        )}
+                      </Pill>
+                      {Number.isFinite(player.adp) && (
+                        <span
+                          className="shrink-0 text-2xs"
+                          title="Average draft position from recent mock drafts"
+                          style={{ color: "var(--home-ink-muted)" }}
+                        >
+                          ADP {formatAdp(player.adp)}
+                        </span>
+                      )}
+                      {onToggleQueue && (
+                        <button
+                          type="button"
+                          onClick={() => onToggleQueue(player.id)}
+                          aria-pressed={queued}
+                          aria-label={queued ? `Remove ${player.name} from queue` : `Add ${player.name} to queue`}
+                          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
+                          style={{ color: queued ? "var(--home-ink)" : "var(--home-ink-muted)" }}
+                        >
+                          <Star size={14} fill={queued ? "currentColor" : "none"} aria-hidden="true" />
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
             </ul>
           </section>
         );

--- a/src/components/fantasy/index.ts
+++ b/src/components/fantasy/index.ts
@@ -1,1 +1,8 @@
 export { TierBreakdown } from "./TierBreakdown";
+export { PositionFilterBar, type PositionFilterOption } from "./PositionFilterBar";
+export { RankingsListRow } from "./RankingsListRow";
+export { TierBreakSeparator } from "./TierBreakSeparator";
+export { PlayerDetailDrawer } from "./PlayerDetailDrawer";
+export { RankDistributionBar } from "./RankDistributionBar";
+export { CompareTray } from "./CompareTray";
+export { CompareModal } from "./CompareModal";

--- a/src/hooks/useCompareTray.ts
+++ b/src/hooks/useCompareTray.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+
+import {
+  FANTASY_COMPARE_LIMIT,
+  FANTASY_COMPARE_STORAGE_KEY,
+  loadIdList,
+  parseIdList,
+  saveIdList,
+  toggleIdCapped,
+} from "@/lib/fantasyLocal";
+import { emitLocalStoreChange, useLocalStorageString } from "@/hooks/useLocalStorageString";
+
+/**
+ * The compare tray: up to three player ids pinned for a side-by-side look.
+ * Browser-local and shared across surfaces like the queue.
+ */
+export function useCompareTray() {
+  const raw = useLocalStorageString(FANTASY_COMPARE_STORAGE_KEY, "[]");
+  const compareIds = useMemo(() => parseIdList(raw).slice(0, FANTASY_COMPARE_LIMIT), [raw]);
+  const compareSet = useMemo(() => new Set(compareIds), [compareIds]);
+
+  const commit = useCallback((updater: (current: string[]) => string[]) => {
+    const next = updater(loadIdList(FANTASY_COMPARE_STORAGE_KEY)).slice(0, FANTASY_COMPARE_LIMIT);
+    saveIdList(FANTASY_COMPARE_STORAGE_KEY, next);
+    emitLocalStoreChange(FANTASY_COMPARE_STORAGE_KEY);
+  }, []);
+
+  const inCompare = useCallback((id: string) => compareSet.has(id), [compareSet]);
+  const isFull = compareIds.length >= FANTASY_COMPARE_LIMIT;
+
+  const toggle = useCallback(
+    (id: string) => commit((current) => toggleIdCapped(current, id, FANTASY_COMPARE_LIMIT)),
+    [commit],
+  );
+
+  const remove = useCallback(
+    (id: string) => commit((current) => current.filter((entry) => entry !== id)),
+    [commit],
+  );
+
+  const clear = useCallback(() => commit(() => []), [commit]);
+
+  return { compareIds, compareSet, inCompare, isFull, limit: FANTASY_COMPARE_LIMIT, toggle, remove, clear };
+}

--- a/src/hooks/useLocalStorageString.ts
+++ b/src/hooks/useLocalStorageString.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * Low-level glue for reading a single localStorage key reactively, shared by the
+ * fantasy queue / notes / compare hooks. The browser `storage` event only fires
+ * in *other* tabs, so same-tab writes notify through an explicit
+ * `emitLocalStoreChange` call — the same module-level listener pattern as
+ * `useWineCellar`, generalized to any key.
+ */
+
+const listenersByKey = new Map<string, Set<() => void>>();
+let storageBound = false;
+
+function ensureStorageListener() {
+  if (storageBound || typeof window === "undefined") return;
+  storageBound = true;
+  window.addEventListener("storage", (event) => {
+    if (event.key === null) {
+      // A full clear() — wake every subscriber.
+      listenersByKey.forEach((set) => set.forEach((listener) => listener()));
+      return;
+    }
+    listenersByKey.get(event.key)?.forEach((listener) => listener());
+  });
+}
+
+/** Notify same-tab subscribers after a write (cross-tab is handled by `storage`). */
+export function emitLocalStoreChange(key: string) {
+  listenersByKey.get(key)?.forEach((listener) => listener());
+}
+
+function subscribe(key: string, listener: () => void) {
+  ensureStorageListener();
+  let set = listenersByKey.get(key);
+  if (!set) {
+    set = new Set();
+    listenersByKey.set(key, set);
+  }
+  set.add(listener);
+  return () => {
+    set!.delete(listener);
+  };
+}
+
+export function useLocalStorageString(key: string, serverFallback = ""): string {
+  return useSyncExternalStore(
+    (listener) => subscribe(key, listener),
+    () => {
+      if (typeof window === "undefined") return serverFallback;
+      try {
+        return window.localStorage.getItem(key) ?? serverFallback;
+      } catch {
+        return serverFallback;
+      }
+    },
+    () => serverFallback,
+  );
+}

--- a/src/hooks/usePlayerNotes.ts
+++ b/src/hooks/usePlayerNotes.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+
+import {
+  FANTASY_NOTE_MAX_LENGTH,
+  FANTASY_NOTES_STORAGE_KEY,
+  loadNotes,
+  parseNotes,
+  saveNotes,
+  setNoteEntry,
+} from "@/lib/fantasyLocal";
+import { emitLocalStoreChange, useLocalStorageString } from "@/hooks/useLocalStorageString";
+
+/**
+ * Short, browser-local notes keyed by player id ("handcuff for Hall", "avoid",
+ * "target round 6"). Shared by the rankings board and the draft assistant.
+ */
+export function usePlayerNotes() {
+  const raw = useLocalStorageString(FANTASY_NOTES_STORAGE_KEY, "{}");
+  const notes = useMemo(() => parseNotes(raw), [raw]);
+  const notedIds = useMemo(() => new Set(Object.keys(notes)), [notes]);
+
+  const getNote = useCallback((id: string) => notes[id] ?? "", [notes]);
+  const hasNote = useCallback((id: string) => notedIds.has(id), [notedIds]);
+
+  const setNote = useCallback((id: string, text: string) => {
+    const next = setNoteEntry(loadNotes(), id, text);
+    saveNotes(next);
+    emitLocalStoreChange(FANTASY_NOTES_STORAGE_KEY);
+  }, []);
+
+  return { notes, notedIds, getNote, hasNote, setNote, maxLength: FANTASY_NOTE_MAX_LENGTH };
+}

--- a/src/hooks/usePlayerQueue.ts
+++ b/src/hooks/usePlayerQueue.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+
+import {
+  FANTASY_QUEUE_STORAGE_KEY,
+  loadIdList,
+  parseIdList,
+  reorderIds,
+  saveIdList,
+  toggleId,
+} from "@/lib/fantasyLocal";
+import { emitLocalStoreChange, useLocalStorageString } from "@/hooks/useLocalStorageString";
+
+/**
+ * A single browser-local watchlist of player ids, shared by the rankings board
+ * and the draft assistant (player ids are stable across both surfaces, so
+ * starring a player on one page flags him on the other for free).
+ */
+export function usePlayerQueue() {
+  const raw = useLocalStorageString(FANTASY_QUEUE_STORAGE_KEY, "[]");
+  const queue = useMemo(() => parseIdList(raw), [raw]);
+  const queuedSet = useMemo(() => new Set(queue), [queue]);
+
+  const commit = useCallback((updater: (current: string[]) => string[]) => {
+    const next = updater(loadIdList(FANTASY_QUEUE_STORAGE_KEY));
+    saveIdList(FANTASY_QUEUE_STORAGE_KEY, next);
+    emitLocalStoreChange(FANTASY_QUEUE_STORAGE_KEY);
+  }, []);
+
+  const isQueued = useCallback((id: string) => queuedSet.has(id), [queuedSet]);
+
+  const toggle = useCallback(
+    (id: string) => commit((current) => toggleId(current, id)),
+    [commit],
+  );
+
+  const remove = useCallback(
+    (id: string) => commit((current) => current.filter((entry) => entry !== id)),
+    [commit],
+  );
+
+  const reorder = useCallback(
+    (from: number, to: number) => commit((current) => reorderIds(current, from, to)),
+    [commit],
+  );
+
+  const clear = useCallback(() => commit(() => []), [commit]);
+
+  return { queue, queuedSet, isQueued, toggle, remove, reorder, clear };
+}

--- a/src/lib/__tests__/fantasyConsensus.test.ts
+++ b/src/lib/__tests__/fantasyConsensus.test.ts
@@ -1,0 +1,63 @@
+import { getConsensusSpread, getTierGap, withTierBreaks } from "@/lib/fantasyUtils";
+import type { Player } from "@/types";
+
+function player(overrides: Partial<Player>): Player {
+  return {
+    id: "p",
+    name: "Test Player",
+    team: "FA",
+    position: "RB",
+    averageRank: 10,
+    standardDeviation: 1,
+    ...overrides,
+  } as Player;
+}
+
+describe("getConsensusSpread", () => {
+  it("labels a settled elite player as tight", () => {
+    const result = getConsensusSpread(player({ rankEcr: 1, standardDeviation: 1 }));
+    expect(result?.level).toBe("tight");
+  });
+
+  it("labels a high-disagreement player as volatile", () => {
+    const result = getConsensusSpread(player({ rankEcr: 24, standardDeviation: 13 }));
+    expect(result?.level).toBe("volatile");
+  });
+
+  it("returns null when there is no usable rank or spread", () => {
+    expect(
+      getConsensusSpread(player({ rankEcr: undefined, averageRank: NaN, standardDeviation: 5 }))
+    ).toBeNull();
+    expect(getConsensusSpread(player({ rankEcr: 5, standardDeviation: NaN }))).toBeNull();
+  });
+});
+
+describe("withTierBreaks", () => {
+  it("marks the first row of each tier as a break", () => {
+    const rows = withTierBreaks([
+      player({ id: "a", tier: 1 }),
+      player({ id: "b", tier: 1 }),
+      player({ id: "c", tier: 2 }),
+      player({ id: "d", tier: 2 }),
+    ]);
+
+    expect(rows.map((r) => r.startsTier)).toEqual([true, false, true, false]);
+    expect(rows[2].tier).toBe(2);
+  });
+
+  it("never starts a break on an untiered row", () => {
+    const rows = withTierBreaks([player({ id: "a", tier: undefined }), player({ id: "b", tier: undefined })]);
+    expect(rows.every((r) => !r.startsTier)).toBe(true);
+  });
+});
+
+describe("getTierGap", () => {
+  it("returns the rounded downward step between tiers", () => {
+    expect(getTierGap(8, 17)).toBe(9);
+  });
+
+  it("returns 0 for non-downward or invalid input", () => {
+    expect(getTierGap(20, 10)).toBe(0);
+    expect(getTierGap(undefined, 10)).toBe(0);
+  });
+});

--- a/src/lib/__tests__/fantasyLocal.test.ts
+++ b/src/lib/__tests__/fantasyLocal.test.ts
@@ -1,0 +1,66 @@
+import {
+  FANTASY_COMPARE_LIMIT,
+  FANTASY_NOTE_MAX_LENGTH,
+  parseIdList,
+  parseNotes,
+  reorderIds,
+  setNoteEntry,
+  toggleId,
+  toggleIdCapped,
+} from "@/lib/fantasyLocal";
+
+describe("fantasyLocal id lists", () => {
+  it("parses a clean list and de-duplicates preserving order", () => {
+    expect(parseIdList('["a","b","a","c"]')).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns an empty list for malformed or non-string payloads", () => {
+    expect(parseIdList(null)).toEqual([]);
+    expect(parseIdList("not json")).toEqual([]);
+    expect(parseIdList('[1,2,3]')).toEqual([]);
+    expect(parseIdList('{"a":1}')).toEqual([]);
+  });
+
+  it("toggles ids in and out", () => {
+    expect(toggleId(["a"], "b")).toEqual(["a", "b"]);
+    expect(toggleId(["a", "b"], "a")).toEqual(["b"]);
+  });
+
+  it("respects the cap when toggling the compare tray", () => {
+    const full = ["a", "b", "c"];
+    expect(full).toHaveLength(FANTASY_COMPARE_LIMIT);
+    // Adding a fourth is a no-op.
+    expect(toggleIdCapped(full, "d", FANTASY_COMPARE_LIMIT)).toEqual(full);
+    // Removing an existing one always works, even at the cap.
+    expect(toggleIdCapped(full, "b", FANTASY_COMPARE_LIMIT)).toEqual(["a", "c"]);
+  });
+
+  it("reorders within bounds and clamps the target", () => {
+    expect(reorderIds(["a", "b", "c"], 0, 2)).toEqual(["b", "c", "a"]);
+    expect(reorderIds(["a", "b", "c"], 2, 0)).toEqual(["c", "a", "b"]);
+    // Out-of-range source is a no-op (same reference).
+    const list = ["a", "b"];
+    expect(reorderIds(list, 5, 0)).toBe(list);
+  });
+});
+
+describe("fantasyLocal notes", () => {
+  it("parses notes, dropping non-string and empty values", () => {
+    expect(parseNotes('{"a":"keep","b":"","c":42}')).toEqual({ a: "keep" });
+  });
+
+  it("returns an empty map for malformed payloads", () => {
+    expect(parseNotes(null)).toEqual({});
+    expect(parseNotes("[]")).toEqual({});
+    expect(parseNotes("oops")).toEqual({});
+  });
+
+  it("sets and clears a note, trimming to the max length", () => {
+    const long = "x".repeat(FANTASY_NOTE_MAX_LENGTH + 50);
+    const withNote = setNoteEntry({}, "p1", long);
+    expect(withNote.p1).toHaveLength(FANTASY_NOTE_MAX_LENGTH);
+
+    const cleared = setNoteEntry(withNote, "p1", "   ");
+    expect(cleared.p1).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/getEmergingRun.test.ts
+++ b/src/lib/__tests__/getEmergingRun.test.ts
@@ -1,0 +1,44 @@
+import { EMERGING_RUN_MIN_COUNT, getEmergingRun } from "@/lib/draftAnalytics";
+import type { DraftPick, Player, Position } from "@/types";
+
+function pick(pickNumber: number, position: Position): DraftPick {
+  const player = {
+    id: `p-${pickNumber}`,
+    name: `Player ${pickNumber}`,
+    team: "FA",
+    position,
+    averageRank: pickNumber,
+    standardDeviation: 1,
+  } as Player;
+  return {
+    pickNumber,
+    round: Math.ceil(pickNumber / 10),
+    teamNumber: ((pickNumber - 1) % 10) + 1,
+    player,
+    timestamp: new Date(),
+  };
+}
+
+describe("getEmergingRun", () => {
+  it("flags two same-position picks forming inside the window", () => {
+    const picks = [pick(8, "WR"), pick(9, "RB"), pick(10, "RB")];
+    const run = getEmergingRun(picks, 11);
+    expect(run?.position).toBe("RB");
+    expect(run?.count).toBe(EMERGING_RUN_MIN_COUNT);
+  });
+
+  it("does not flag a confirmed three-pick run as emerging", () => {
+    const picks = [pick(8, "RB"), pick(9, "RB"), pick(10, "RB")];
+    expect(getEmergingRun(picks, 11)).toBeNull();
+  });
+
+  it("ignores picks outside the trailing window", () => {
+    const picks = [pick(1, "RB"), pick(2, "RB")];
+    expect(getEmergingRun(picks, 11)).toBeNull();
+  });
+
+  it("returns null when nothing is clustering", () => {
+    const picks = [pick(8, "WR"), pick(9, "QB"), pick(10, "TE")];
+    expect(getEmergingRun(picks, 11)).toBeNull();
+  });
+});

--- a/src/lib/draftAnalytics.ts
+++ b/src/lib/draftAnalytics.ts
@@ -248,6 +248,56 @@ export function computeDraftAnalytics(picks: DraftPick[], teams: TeamRoster[]): 
   };
 }
 
+/** Same-position picks inside the window needed to flag an *emerging* run. */
+export const EMERGING_RUN_MIN_COUNT = 2;
+
+export interface EmergingRun {
+  position: Position;
+  count: number;
+  endPick: number;
+}
+
+/**
+ * A softer, earlier sibling to {@link detectPositionRuns}: two same-position
+ * picks already off the board inside the trailing window — a run *forming*
+ * before it hardens into the confirmed three-pick run. Returns null once a
+ * position reaches the full-run count (that's the hard signal's job) so the two
+ * never describe the same cluster.
+ */
+export function getEmergingRun(
+  picks: DraftPick[],
+  currentPick: number,
+  options: { windowSize?: number } = {}
+): EmergingRun | null {
+  const windowSize = options.windowSize ?? POSITION_RUN_WINDOW;
+  const recent = picks.filter(
+    (pick) => pick.pickNumber < currentPick && pick.pickNumber > currentPick - 1 - windowSize
+  );
+
+  const counts = new Map<Position, { count: number; endPick: number }>();
+  for (const pick of recent) {
+    const position = pick.player.position;
+    if (position === "FLEX" || position === "OVERALL") {
+      continue;
+    }
+    const entry = counts.get(position) ?? { count: 0, endPick: 0 };
+    entry.count += 1;
+    entry.endPick = Math.max(entry.endPick, pick.pickNumber);
+    counts.set(position, entry);
+  }
+
+  let best: EmergingRun | null = null;
+  for (const [position, { count, endPick }] of counts) {
+    if (count >= EMERGING_RUN_MIN_COUNT && count < POSITION_RUN_MIN_COUNT) {
+      if (!best || endPick > best.endPick) {
+        best = { position, count, endPick };
+      }
+    }
+  }
+
+  return best;
+}
+
 /**
  * The most recent flagged pick and any run still forming at the current pick,
  * for the live sidebar during an active draft.

--- a/src/lib/fantasyLocal.ts
+++ b/src/lib/fantasyLocal.ts
@@ -1,0 +1,162 @@
+/**
+ * Browser-local stores shared by the fantasy rankings board and the draft
+ * assistant. Both surfaces read the same FantasyPros snapshot, so a player id
+ * is stable across them — which lets a single watchlist, a single notes map,
+ * and a single compare tray power both pages at once.
+ *
+ * The storage glue mirrors `src/lib/wineCellar.ts`: pure parse/serialize plus
+ * best-effort read/write here, with the React `useSyncExternalStore` wiring in
+ * the matching hooks. Keeping the list math pure makes it unit-testable without
+ * a DOM.
+ */
+
+export const FANTASY_QUEUE_STORAGE_KEY = "fantasy-player-queue-v1";
+export const FANTASY_NOTES_STORAGE_KEY = "fantasy-player-notes-v1";
+export const FANTASY_COMPARE_STORAGE_KEY = "fantasy-compare-v1";
+
+/** A player can sit in the compare tray alongside at most two others. */
+export const FANTASY_COMPARE_LIMIT = 3;
+/** Notes stay short on purpose — a draft-day reminder, not an essay. */
+export const FANTASY_NOTE_MAX_LENGTH = 280;
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+/**
+ * Parses a persisted ordered id list (queue or compare tray). Tolerates any
+ * malformed payload by returning an empty list, and de-duplicates while
+ * preserving first-seen order so a corrupted write can never wedge the UI.
+ */
+export function parseIdList(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!isStringArray(parsed)) return [];
+    return dedupe(parsed);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parses the persisted notes map (player id → note). Drops any entry whose
+ * value is not a string and trims notes to the max length.
+ */
+export function parseNotes(raw: string | null | undefined): Record<string, string> {
+  if (!raw) return {};
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+
+    const result: Record<string, string> = {};
+    for (const [id, note] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof note === "string" && note.trim().length > 0) {
+        result[id] = note.slice(0, FANTASY_NOTE_MAX_LENGTH);
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function dedupe(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const id of ids) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      result.push(id);
+    }
+  }
+  return result;
+}
+
+/** Adds the id if absent, removes it if present. Returns a new array. */
+export function toggleId(ids: string[], id: string): string[] {
+  return ids.includes(id) ? ids.filter((entry) => entry !== id) : [...ids, id];
+}
+
+/**
+ * Toggles an id within a capped list (used by the compare tray). Adding when
+ * the list is already full is a no-op so the cap is never exceeded.
+ */
+export function toggleIdCapped(ids: string[], id: string, limit: number): string[] {
+  if (ids.includes(id)) {
+    return ids.filter((entry) => entry !== id);
+  }
+  if (ids.length >= limit) {
+    return ids;
+  }
+  return [...ids, id];
+}
+
+/**
+ * Moves the item at `from` to `to`, clamping both indices into range. Returns
+ * the original array reference when the move is a no-op so callers can skip a
+ * write.
+ */
+export function reorderIds(ids: string[], from: number, to: number): string[] {
+  if (from === to) return ids;
+  if (from < 0 || from >= ids.length) return ids;
+
+  const next = [...ids];
+  const [moved] = next.splice(from, 1);
+  const target = Math.max(0, Math.min(to, next.length));
+  next.splice(target, 0, moved);
+  return next;
+}
+
+/** Sets or clears a single note, trimming to the max length. Returns a new map. */
+export function setNoteEntry(
+  notes: Record<string, string>,
+  id: string,
+  text: string,
+): Record<string, string> {
+  const trimmed = text.trim().slice(0, FANTASY_NOTE_MAX_LENGTH);
+  const next = { ...notes };
+  if (trimmed.length === 0) {
+    delete next[id];
+  } else {
+    next[id] = trimmed;
+  }
+  return next;
+}
+
+function readRaw(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeRaw(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Best-effort: storage may be full or disabled (private mode). Failing a
+    // write should never crash a draft, so swallow it.
+  }
+}
+
+export function loadIdList(key: string): string[] {
+  return parseIdList(readRaw(key));
+}
+
+export function saveIdList(key: string, ids: string[]): void {
+  writeRaw(key, JSON.stringify(ids));
+}
+
+export function loadNotes(): Record<string, string> {
+  return parseNotes(readRaw(FANTASY_NOTES_STORAGE_KEY));
+}
+
+export function saveNotes(notes: Record<string, string>): void {
+  writeRaw(FANTASY_NOTES_STORAGE_KEY, JSON.stringify(notes));
+}

--- a/src/lib/fantasyUtils.ts
+++ b/src/lib/fantasyUtils.ts
@@ -243,3 +243,84 @@ export function getSourceKindLabel(
       return "Unavailable";
   }
 }
+
+export type FantasyConsensusSpread = "tight" | "mixed" | "volatile";
+
+/**
+ * Expert disagreement (`standardDeviation`) naturally grows with rank — the
+ * top of the board is settled, the deep pool is noisy — so a flat threshold
+ * would mislabel almost every late pick as "volatile". Normalizing the spread
+ * against the player's own rank (with a floor that tames the very top) yields a
+ * scale-aware read on how much the experts actually agree. Thresholds were
+ * tuned against the live PPR board so the labels split roughly 55/40/6.
+ *
+ * Returns null when there is no usable rank or spread to judge.
+ */
+const CONSENSUS_SPREAD_FLOOR = 12;
+const CONSENSUS_SPREAD_MIXED = 0.12;
+const CONSENSUS_SPREAD_VOLATILE = 0.22;
+
+export function getConsensusSpread(
+  player: Player,
+): { level: FantasyConsensusSpread; label: string; ratio: number } | null {
+  const rank =
+    typeof player.rankEcr === "number" && Number.isFinite(player.rankEcr)
+      ? player.rankEcr
+      : typeof player.averageRank === "number" && Number.isFinite(player.averageRank)
+        ? player.averageRank
+        : null;
+
+  if (rank === null || !Number.isFinite(player.standardDeviation)) {
+    return null;
+  }
+
+  const ratio = player.standardDeviation / (rank + CONSENSUS_SPREAD_FLOOR);
+  if (ratio < CONSENSUS_SPREAD_MIXED) {
+    return { level: "tight", label: "Tight consensus", ratio };
+  }
+  if (ratio < CONSENSUS_SPREAD_VOLATILE) {
+    return { level: "mixed", label: "Mixed reads", ratio };
+  }
+  return { level: "volatile", label: "Volatile", ratio };
+}
+
+/**
+ * One ordered list row paired with whether it opens a new tier. The board
+ * renders a labeled separator above any row where `startsTier` is true (the
+ * caller decides whether to suppress the very first one). Players without a
+ * tier never start a break, so an untiered tail flows together.
+ */
+export interface FantasyTierRow {
+  player: Player;
+  tier: number | null;
+  startsTier: boolean;
+}
+
+export function withTierBreaks(players: Player[]): FantasyTierRow[] {
+  let previousTier: number | null = null;
+  return players.map((player) => {
+    const tier = typeof player.tier === "number" && Number.isFinite(player.tier) ? player.tier : null;
+    const startsTier = tier !== null && tier !== previousTier;
+    if (tier !== null) {
+      previousTier = tier;
+    }
+    return { player, tier, startsTier };
+  });
+}
+
+/**
+ * The "cliff" between two tiers: how many ranks drop between the last player of
+ * one tier and the first of the next. A large gap is the classic signal to
+ * reach for the tail of the current tier before it empties. Returns 0 when the
+ * inputs don't describe a real downward step.
+ */
+export function getTierGap(
+  lastRankInTier: number | undefined,
+  firstRankInNextTier: number | undefined,
+): number {
+  if (!Number.isFinite(lastRankInTier) || !Number.isFinite(firstRankInNextTier)) {
+    return 0;
+  }
+  const gap = Math.round((firstRankInNextTier as number) - (lastRankInTier as number));
+  return gap > 0 ? gap : 0;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,10 +356,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@esbuild/darwin-arm64@0.27.7":
+"@esbuild/linux-x64@0.27.7":
   version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz"
-  integrity sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz"
+  integrity sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==
 
 "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
@@ -469,17 +469,29 @@
   resolved "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz"
   integrity sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==
 
-"@img/sharp-darwin-arm64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz"
-  integrity sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-arm64" "1.2.4"
-
-"@img/sharp-libvips-darwin-arm64@1.2.4":
+"@img/sharp-libvips-linux-x64@1.2.4":
   version "1.2.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz"
-  integrity sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz"
+  integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
+
+"@img/sharp-libvips-linuxmusl-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz"
+  integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
+
+"@img/sharp-linux-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz"
+  integrity sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.2.4"
+
+"@img/sharp-linuxmusl-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz"
+  integrity sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
 
 "@inquirer/ansi@^1.0.2":
   version "1.0.2"
@@ -845,10 +857,10 @@
   resolved "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz"
   integrity sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==
 
-"@next/env@16.2.4":
-  version "16.2.4"
-  resolved "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz"
-  integrity sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==
+"@next/env@16.2.7":
+  version "16.2.7"
+  resolved "https://registry.npmjs.org/@next/env/-/env-16.2.7.tgz"
+  integrity sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==
 
 "@next/eslint-plugin-next@16.2.4":
   version "16.2.4"
@@ -857,10 +869,10 @@
   dependencies:
     fast-glob "3.3.1"
 
-"@next/swc-darwin-arm64@16.2.4":
-  version "16.2.4"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz"
-  integrity sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==
+"@next/swc-linux-x64-gnu@16.2.7":
+  version "16.2.7"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.7.tgz"
+  integrity sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1219,10 +1231,15 @@
     source-map-js "^1.2.1"
     tailwindcss "4.2.2"
 
-"@tailwindcss/oxide-darwin-arm64@4.2.2":
+"@tailwindcss/oxide-linux-x64-gnu@4.2.2":
   version "4.2.2"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz"
-  integrity sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==
+  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz"
+  integrity sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==
+
+"@tailwindcss/oxide-linux-x64-musl@4.2.2":
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz"
+  integrity sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==
 
 "@tailwindcss/oxide@4.2.2":
   version "4.2.2"
@@ -1792,10 +1809,15 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@unrs/resolver-binding-darwin-arm64@1.11.1":
+"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
   version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
-  integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz"
+  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
+
+"@unrs/resolver-binding-linux-x64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz"
+  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -3515,16 +3537,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.3, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
-fsevents@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -4701,10 +4713,15 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-lightningcss-darwin-arm64@1.32.0:
+lightningcss-linux-x64-gnu@1.32.0:
   version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz"
-  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz"
+  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
+
+lightningcss-linux-x64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz"
+  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
 
 lightningcss@1.32.0:
   version "1.32.0"
@@ -5400,25 +5417,25 @@ next-themes@^0.4.6:
   integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
 
 next@*, "next@^12.2.5 || ^13 || ^14 || ^15 || ^16", next@^16.2.4, next@>=13.4.0:
-  version "16.2.4"
-  resolved "https://registry.npmjs.org/next/-/next-16.2.4.tgz"
-  integrity sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==
+  version "16.2.7"
+  resolved "https://registry.npmjs.org/next/-/next-16.2.7.tgz"
+  integrity sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==
   dependencies:
-    "@next/env" "16.2.4"
+    "@next/env" "16.2.7"
     "@swc/helpers" "0.5.15"
     baseline-browser-mapping "^2.9.19"
     caniuse-lite "^1.0.30001579"
     postcss "8.4.31"
     styled-jsx "5.1.6"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "16.2.4"
-    "@next/swc-darwin-x64" "16.2.4"
-    "@next/swc-linux-arm64-gnu" "16.2.4"
-    "@next/swc-linux-arm64-musl" "16.2.4"
-    "@next/swc-linux-x64-gnu" "16.2.4"
-    "@next/swc-linux-x64-musl" "16.2.4"
-    "@next/swc-win32-arm64-msvc" "16.2.4"
-    "@next/swc-win32-x64-msvc" "16.2.4"
+    "@next/swc-darwin-arm64" "16.2.7"
+    "@next/swc-darwin-x64" "16.2.7"
+    "@next/swc-linux-arm64-gnu" "16.2.7"
+    "@next/swc-linux-arm64-musl" "16.2.7"
+    "@next/swc-linux-x64-gnu" "16.2.7"
+    "@next/swc-linux-x64-musl" "16.2.7"
+    "@next/swc-win32-arm64-msvc" "16.2.7"
+    "@next/swc-win32-x64-msvc" "16.2.7"
     sharp "^0.34.5"
 
 node-exports-info@^1.6.0:
@@ -7153,9 +7170,9 @@ write-file-atomic@^5.0.1:
     signal-exit "^4.0.1"
 
 ws@^8.18.0, ws@^8.19.0:
-  version "8.20.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz"
-  integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
+  version "8.20.1"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
 xml-name-validator@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## What & why

A full UX/UI/functionality overhaul of the rankings board (`/fantasy-football`) and the draft assistant (`/fantasy-football/draft-tracker`). Both surfaces were correct but undifferentiated — a tall hero, an always-on 8-cell stats panel, then controls, then the board, with flat equal-weight rows and several modeled-but-dead capabilities (`timerSeconds`, `teamName`, `undoHistory`). This tightens use of space, adds a real player-detail surface, and ties the two pages together with one shared watchlist/notes/compare store.

Everything is built **only on fields the snapshot actually populates** (rank, tier, expert range, `standardDeviation`, ownership, bye, ADP). Projections/headshots/blurbs are empty in the data, so no UI depends on them — and the tests that assert their absence still pass.

## Shared building blocks (Phase 0)
- `usePlayerQueue` / `usePlayerNotes` / `useCompareTray` — browser-local stores on a shared `useLocalStorageString` glue, mirroring the `useWineCellar` pattern. One watchlist/notes/compare set works across both pages (player ids are stable).
- `PlayerDetailDrawer` — right-drawer / bottom-sheet with rank, tier-of-N, a `standardDeviation`-derived **rank-distribution bar**, ownership, bye, ADP + value signal, notes, queue, and compare. Reused on both surfaces.
- `CompareTray` + `CompareModal` — side-by-side comparison on a shared rank scale, best-value highlighting per row.
- `PositionFilterBar`, `RankingsListRow`, `TierBreakSeparator`, `RankDistributionBar`.
- Pure helpers in `fantasyUtils`: `getConsensusSpread`, `withTierBreaks`, `getTierGap`.

## Rankings page (Phase A)
- Condensed hero, collapsible "Board at a glance", merged controls with a clear-search button.
- Redesigned list rows (primary/secondary hierarchy, hover lift, inline queue/compare/details), **tier-break separators** in list view, windowed rendering + "Load more" + result count.
- Tier view: drawer-opening pills, queue stars, tier-gap "cliff" indicators, auto-fill grid.
- A "My Queue" rail replacing the redundant Tier Snapshot card; freshness rail kept.

## Draft assistant (Phase B)
- Multi-level undo (tap a recent pick to undo back to it), **redo** with a redo stack that clears on a fresh pick.
- Advisory **per-pick timer** (`useDraftTimer`, wires the unused `timerSeconds`).
- **Team-name personalization** threaded through the board, recap, roster, and recent picks.
- Richer exports: picks CSV gains value delta / steal-reach class / team name / your note; new **team-recap CSV**; wired **JSON** export.
- DraftBoard: shared filter bar, windowed best-available + count, per-row queue/compare/details, and a **"your queue · still available"** strip.
- Earlier **emerging-run** signal in the analytics panel; condensed hero + collapsible stats; the shared drawer + compare tray.

## Verification
- `npx tsc --noEmit` — 0 errors.
- `npm run lint` — clean.
- `npm test` — **854 passed / 173 suites**, including the existing rankings, draft-tracker, `useDraftState`, `draftAnalytics`, `fantasy-state`, and `useFantasySnapshot` suites (the test-locked `^ADP$`/`^Proj. Pts$` absence and headings preserved). New unit tests cover the local stores, consensus/tier helpers, `getEmergingRun`, and the redo/multi-undo/team-name logic.
- Dev server smoke test: `/fantasy-football`, `?position=rb&scoring=half_ppr&view=tiers`, and `/fantasy-football/draft-tracker` all return 200 with the new UI rendering and no runtime errors.

## Notes / risks
- SEO server shells untouched; deep-link state (`?position`/`?scoring`/`?view`) and the draft localStorage key (`fantasy-draft-tracker-v2-{season}`) preserved; ADP-null hiding and data-availability states intact.
- Mobile is kept solid/responsive (bottom-sheet drawer, scroll-snap filters) but desktop was the priority per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHY2oWCqfRQZm9vjvSjUU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHY2oWCqfRQZm9vjvSjUU1)_