### PR TITLE
test+ci: fix mobile-viewport e2e scoping and track full-matrix failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,11 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
+    # Allow the failure-notification step to open/update a tracking issue.
+    permissions:
+      contents: read
+      issues: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -227,6 +232,82 @@ jobs:
           name: playwright-report-full-matrix
           path: playwright-report/
           retention-days: 14
+
+      # The full matrix runs post-merge only, so a WebKit/Firefox regression
+      # otherwise turns main red with no signal to act. File (or update) a
+      # tracking issue on failure, mirroring the data-refresh workflows.
+      - name: Notify on failure via GitHub issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().slice(0, 10);
+            const title = 'E2E full matrix (WebKit / Firefox) failing on main';
+            const body = [
+              `The **E2E Tests (full matrix)** job failed on \`main\`.`,
+              ``,
+              `**Run:** ${runUrl}`,
+              `**Commit:** ${context.sha}`,
+              ``,
+              `This job runs the WebKit, Firefox, and mobile browser projects that PR`,
+              `checks skip (PRs run chromium only). A failure here means a browser-`,
+              `specific regression landed on main. Download the \`playwright-report-`,
+              `full-matrix\` artifact from the run for traces and screenshots.`,
+              ``,
+              `This issue is updated on each subsequent failure and auto-closed on`,
+              `the first fully green full-matrix run.`,
+            ].join('\n');
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'e2e-matrix-failure',
+              per_page: 5,
+            });
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body: `Failed again on ${today}. Run: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['e2e-matrix-failure', 'automation'],
+              });
+            }
+
+      - name: Close resolved failure issues
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'e2e-matrix-failure',
+              per_page: 10,
+            });
+            for (const issue of existing.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Full matrix green at ${new Date().toISOString()}. Auto-closing.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }
 
   lint:
     name: Lint

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -26,6 +26,14 @@ test.describe('Homepage', () => {
   })
 
   test('should have functional desktop navigation', async ({ page }) => {
+    // The desktop primary nav is hidden below the md breakpoint, where the
+    // hamburger menu takes over (covered by the mobile navigation test below).
+    const viewport = page.viewportSize()
+    test.skip(
+      !!viewport && viewport.width < 768,
+      'Desktop-only nav; the mobile menu is covered by the mobile navigation test'
+    )
+
     await page.goto('/')
 
     await expect(

--- a/e2e/investments.spec.ts
+++ b/e2e/investments.spec.ts
@@ -376,7 +376,15 @@ test.describe("Investments", () => {
     const shell = page.locator('[data-testid="investments-shell"]');
     const before = await shell.boundingBox();
 
-    await page.getByRole("link", { name: /^research$/i }).click();
+    // The section sidebar is desktop-only (it collapses to display:none at
+    // mobile widths). Click the nav link where it exists; otherwise reach the
+    // section the way a mobile visitor does, by scrolling it into view.
+    const researchLink = page.getByRole("link", { name: /^research$/i });
+    if (await researchLink.isVisible()) {
+      await researchLink.click();
+    } else {
+      await page.locator("#research-section").scrollIntoViewIfNeeded();
+    }
     await expect(page.locator("#research-section")).toBeInViewport();
 
     const after = await shell.boundingBox();


### PR DESCRIPTION
## What & why

The post-merge **"E2E Tests (full matrix)"** job (added 2026-06-15) has failed on every push to `main` since it was introduced — it has **never been green**. It runs the WebKit / Firefox / mobile browser projects that PR checks skip (PRs run chromium only), so browser-specific issues land on `main` and turn its commit status red with **no signal to act** (unlike the data-refresh workflows, which file tracking issues).

This PR addresses the part that's verifiable in CI and makes the rest tractable.

### Test fixes (verified on chromium + Mobile Chrome / Pixel 5)
Two of the 46 failures are desktop-layout tests running on the mobile project:

- **`homepage.spec.ts` "should have functional desktop navigation"** — the desktop primary nav is hidden below the `md` breakpoint (the hamburger menu, covered by the separate mobile-nav test, takes over). Now skipped on mobile viewports.
- **`investments.spec.ts` "keeps the shell stable … avoids horizontal overflow"** — the section sidebar is `display:none` at mobile widths, so the "Research" link can't be clicked there. Now clicks the link on desktop and scrolls the section into view on mobile, keeping the horizontal-overflow assertion meaningful on every project.

### CI: track full-matrix failures
The full-matrix job now files/updates a tracking issue (label `e2e-matrix-failure`) on failure and auto-closes it on the first green run, mirroring the SpaceX / data-refresh workflows.

## Not in this PR
The remaining ~44 failures are **WebKit-engine only** (`webkit` + `Mobile Safari`) and could not be reproduced or verified in this environment (the Playwright browser CDN is blocked by the network egress policy, so WebKit/Firefox cannot be installed here). They are enumerated in the companion tracking issue for follow-up on a WebKit-capable runner. Likely-real candidates flagged there include the `/search` `ssr:false` hydration timeout and mobile horizontal overflow on the polling/SpaceX surface.

## Test plan
- [x] `homepage.spec.ts:28` — skips on Mobile Chrome, passes on desktop chromium
- [x] `investments.spec.ts:370` — passes on Mobile Chrome (scroll path) and desktop chromium (click path)
- [x] `test.yml` validates as YAML
- [ ] Full WebKit matrix verification (requires a WebKit-capable runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W28cMGWXszMXLDjXoTtw5p)_