### PR TITLE
fix(spacex): live within the anonymous Launch Library rate limit (no API key)

### DIFF
--- a/.github/workflows/update-spacex.yml
+++ b/.github/workflows/update-spacex.yml
@@ -37,14 +37,19 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --fund=false
 
-      - name: Refresh SpaceX image snapshots
-        run: npm run update:spacex-images
+      # Refresh the launch board BEFORE hydrating images. The anonymous Launch
+      # Library tier allows only 15 calls/hour per IP; the board refresh needs
+      # ~3 calls to update and clear the freshness gate, so running it first
+      # means the board stays current even when the image step exhausts the
+      # remaining budget and falls back to existing image artifacts.
+      - name: Refresh SpaceX data snapshot
+        run: npm run update:spacex
         env:
           NODE_ENV: production
           SPACEDEVS_API_TOKEN: ${{ secrets.SPACEDEVS_API_TOKEN }}
 
-      - name: Refresh SpaceX data snapshot
-        run: npm run update:spacex
+      - name: Refresh SpaceX image snapshots
+        run: npm run update:spacex-images
         env:
           NODE_ENV: production
           SPACEDEVS_API_TOKEN: ${{ secrets.SPACEDEVS_API_TOKEN }}

--- a/scripts/buildSpaceXImageSnapshots.ts
+++ b/scripts/buildSpaceXImageSnapshots.ts
@@ -650,10 +650,29 @@ export async function buildSpaceXImageSnapshots(
 
   const draftReferences: Array<{ draft: DraftLaunchImageReference; complete: boolean }> = [];
   const currentWindowUrls = new Set<string>();
+  // Launches already captured in the reference index are carried over as-is
+  // rather than re-hydrated. The anonymous Launch Library tier allows only 15
+  // calls/hour per IP, so this spends the detail-call budget only on launches
+  // we have not indexed yet.
+  const carriedReferences = new Map<string, SpaceXLaunchImageReference>();
 
   for (const { launch: listLaunch, window } of launchesById.values()) {
     const launchId = listLaunch.id?.trim();
     if (!launchId) {
+      continue;
+    }
+
+    // Already indexed? Carry the existing reference (and keep its image URLs in
+    // the current window so the manifest and files are preserved) without
+    // spending an API call to re-hydrate it.
+    const carriedReference = existingReferenceIndex[launchId];
+    if (carriedReference) {
+      carriedReferences.set(launchId, carriedReference);
+      for (const role of IMAGE_ROLES) {
+        for (const entry of carriedReference.images[role] ?? []) {
+          currentWindowUrls.add(entry.remoteUrl);
+        }
+      }
       continue;
     }
 
@@ -750,6 +769,13 @@ export async function buildSpaceXImageSnapshots(
   const materializedReferences = new Map<string, SpaceXLaunchImageReference>();
   for (const { draft } of draftReferences) {
     materializedReferences.set(draft.launchId, materializeLaunchReference(draft, finalManifest));
+  }
+  // Re-include carried-over launches so skipping their re-hydration never drops
+  // them (or deletes their image files) on a non-partial rebuild.
+  for (const [carriedLaunchId, carriedReference] of carriedReferences) {
+    if (!materializedReferences.has(carriedLaunchId)) {
+      materializedReferences.set(carriedLaunchId, carriedReference);
+    }
   }
 
   let finalReferenceIndex: SpaceXImageReferenceIndex;

--- a/src/lib/spacexData.ts
+++ b/src/lib/spacexData.ts
@@ -35,7 +35,11 @@ const LAUNCH_DETAIL_CACHE_TTL_MS = 300 * 1000;
 const STALE_FALLBACK_TTL_MS = 30 * 60 * 1000;
 const RATE_LIMIT_BASE_BACKOFF_MS = 60 * 1000;
 const RATE_LIMIT_MAX_BACKOFF_MS = 5 * 60 * 1000;
-const SNAPSHOT_DETAIL_LIMIT_PER_STATUS = 10;
+// Per-status cap on hydrated launch details in the snapshot. The anonymous
+// Launch Library tier allows only 15 calls/hour per IP, and each detail is one
+// call (on top of the 2 list calls + 1 agency call). The quality gate needs 5
+// details, so 3 per status keeps the full refresh comfortably under budget.
+const SNAPSHOT_DETAIL_LIMIT_PER_STATUS = 3;
 
 type LaunchCollectionMode = "upcoming" | "previous";
 type MissionControlDataSource = "auto" | "live" | "snapshot";


### PR DESCRIPTION
## Why

The SpaceX board has been frozen at **2026-04-29** for ~50 days. Root cause (corrected from the earlier "needs an API key" diagnosis): **no key is required** — the anonymous Launch Library 2 tier is open at 15 calls/hour per IP. The refresh was simply spending that budget in the wrong order.

- The **image** step runs first and re-hydrates *every* launch in the window (one `/launch/{id}/` detail call each, ~24+ calls), tripping the 429 partway through.
- The **data** step runs second. `buildMissionControlSnapshot()` only needs its first ~3 calls (upcoming + previous + agency) to refresh the board and `generatedAt`, but on the same IP in the same hour those calls were already rate-limited → it fell back to the old snapshot → `generatedAt` never advanced → the 4-day freshness gate failed every run.

If a shared-runner-IP collision were the cause you'd see occasional successes over 50 days; seeing zero matches a self-inflicted over-budget every run.

## Changes (free, no key)

1. **`update-spacex.yml`** — refresh the data snapshot *before* the images, so the cheap board refresh lands inside the fresh hourly budget.
2. **`spacexData.ts`** — `SNAPSHOT_DETAIL_LIMIT_PER_STATUS` 10 → 3 (the gate needs 5 details total), cutting the data step to ~9 calls.
3. **`buildSpaceXImageSnapshots.ts`** — carry over launches already in the reference index instead of re-hydrating them, spending the remaining budget only on *new* launches. Carried launches keep their manifest entries and image files, so nothing is dropped on a non-partial rebuild.

Net: a full refresh now sits comfortably under 15 calls/hour, and the board updates even if the image step later exhausts what's left.

## Verification
- [x] `tsc --noEmit` clean
- [x] ESLint clean on changed files
- [x] `spacexData.test.ts` — 11/11 pass
- [x] YAML valid
- [ ] **Live refresh** — can only run from the GitHub runner (this dev environment blocks egress to `ll.thespacedevs.com`). The real proof is the next **Refresh SpaceX Snapshots** run; on success it auto-closes #218.

Closes the root cause behind #218 (pending a successful live run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W28cMGWXszMXLDjXoTtw5p)_