### PR TITLE
test: make dashboard leader tests data-driven (unbreak main)

### DIFF
--- a/src/app/la-liga/__tests__/la-liga-client.test.tsx
+++ b/src/app/la-liga/__tests__/la-liga-client.test.tsx
@@ -48,7 +48,15 @@ describe("LaLigaClient", () => {
       />
     );
 
-    expect(screen.getByRole("heading", { name: "Real Betis Balompié" })).toBeInTheDocument();
+    // Derive the expected club from the pinned club id ("bet") rather than a
+    // hardcoded name, mirroring the client's selectedClub ?? clubs[0] fallback,
+    // so the test survives snapshot refreshes (club renames / relegation).
+    const expectedClub =
+      laLigaSnapshot.clubs.find((club) => club.id === "bet") ??
+      laLigaSnapshot.clubs[0];
+    expect(
+      screen.getByRole("heading", { name: expectedClub.name })
+    ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /relegation fight/i }));
 

--- a/src/app/premier-league/__tests__/premier-league-client.test.tsx
+++ b/src/app/premier-league/__tests__/premier-league-client.test.tsx
@@ -32,7 +32,14 @@ describe("PremierLeagueClient", () => {
       />
     );
 
-    expect(screen.getByRole("heading", { name: "Arsenal FC" })).toBeInTheDocument();
+    // Assert against the actual league leader rather than a hardcoded club so
+    // the test survives standings refreshes — the leader sidebar renders
+    // summary.standings[0].team.name in the default state.
+    expect(
+      screen.getByRole("heading", {
+        name: premierLeagueSnapshot.summary.standings[0].team.name,
+      })
+    ).toBeInTheDocument();
     await waitFor(() => expect(mockReplace).not.toHaveBeenCalled());
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #225. That PR merged a Premier League standings refresh and the snapshot-workflow refactor together, but `premier-league-client.test.tsx` hardcoded the league leader as `"Arsenal FC"`. The refreshed standings moved **AFC Bournemouth** to the top, so the leader-sidebar heading (`summary.standings[0].team.name`) no longer matches — **`main`'s Unit Tests are currently failing.**

This makes the two snapshot-driven dashboard tests data-driven so they survive standings refreshes:

- **premier-league** — assert `premierLeagueSnapshot.summary.standings[0].team.name` (the actual leader) instead of `"Arsenal FC"`.
- **la-liga** — derive the expected club from the pinned id (`"bet"`) via the client's own `selectedClub ?? clubs[0]` fallback, instead of the literal `"Real Betis Balompié"` (proactive — this one wasn't failing yet, but removes the last hardcoded club string).

## Verification

`npx jest` on both client suites → **2 suites / 5 tests pass** on top of current `main`. No production code changed — test-only.
