### PR TITLE
portfolio: move marquee band between project grid and pager

### DIFF
--- a/src/components/portfolio/PortfolioV3.tsx
+++ b/src/components/portfolio/PortfolioV3.tsx
@@ -601,30 +601,6 @@ export function PortfolioV3({ projects }: Props) {
         </div>
       </div>
 
-      {/* Marquee band */}
-      <div className={styles.band} aria-hidden="true">
-        <div className={styles.bandInner}>
-          <div className={styles.marquee}>
-            <span className="hot">Latest · Budget Planner ships</span>
-            <span>{liveToolsCount} live tools</span>
-            <span>Pulse dashboards · multiple surfaces</span>
-            <span>Decision Lab · 6 presets</span>
-            <span>Interchange IQ · 7 processors</span>
-            <span>Frontier Models · 7 providers</span>
-            <span>GitHub Trending · 14 segments</span>
-            <span className="hot">Snapshot-driven · deep-linkable</span>
-            <span className="hot">Latest · Budget Planner ships</span>
-            <span>{liveToolsCount} live tools</span>
-            <span>Pulse dashboards · multiple surfaces</span>
-            <span>Decision Lab · 6 presets</span>
-            <span>Interchange IQ · 7 processors</span>
-            <span>Frontier Models · 7 providers</span>
-            <span>GitHub Trending · 14 segments</span>
-            <span className="hot">Snapshot-driven · deep-linkable</span>
-          </div>
-        </div>
-      </div>
-
       <div>
         <div className={styles.shell}>
           {/* Archive */}
@@ -670,6 +646,30 @@ export function PortfolioV3({ projects }: Props) {
                   />
                 );
               })}
+            </div>
+
+            {/* Marquee band */}
+            <div className={styles.band} aria-hidden="true">
+              <div className={styles.bandInner}>
+                <div className={styles.marquee}>
+                  <span className="hot">Latest · Budget Planner ships</span>
+                  <span>{liveToolsCount} live tools</span>
+                  <span>Pulse dashboards · multiple surfaces</span>
+                  <span>Decision Lab · 6 presets</span>
+                  <span>Interchange IQ · 7 processors</span>
+                  <span>Frontier Models · 7 providers</span>
+                  <span>GitHub Trending · 14 segments</span>
+                  <span className="hot">Snapshot-driven · deep-linkable</span>
+                  <span className="hot">Latest · Budget Planner ships</span>
+                  <span>{liveToolsCount} live tools</span>
+                  <span>Pulse dashboards · multiple surfaces</span>
+                  <span>Decision Lab · 6 presets</span>
+                  <span>Interchange IQ · 7 processors</span>
+                  <span>Frontier Models · 7 providers</span>
+                  <span>GitHub Trending · 14 segments</span>
+                  <span className="hot">Snapshot-driven · deep-linkable</span>
+                </div>
+              </div>
             </div>
 
             <div className={styles.pager}>


### PR DESCRIPTION
## Summary

Moves the marquee band (`bandInner`, wrapped in its `band` container) on the `/portfolio` page so it now sits **between the project grid and the pager**, instead of above the archive section.

## Details

- The marquee band element (`<div className={styles.band}>` → `bandInner` → `marquee`) was previously a full-width block rendered before the archive `<section>`.
- It is now nested inside the archive section, placed directly between `styles.grid` and `styles.pager`.
- The whole `band` wrapper was moved (not just the inner `bandInner` div) because the wrapper provides the band's background, bottom border, and `overflow: hidden` that the scrolling marquee relies on — moving only the inner div would break the visual.

No content, styles, or behavior changed beyond DOM placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rvhHenrYfqRtmbnWEh5A3

---
_Generated by [Claude Code](https://claude.ai/code/session_018rvhHenrYfqRtmbnWEh5A3)_