### PR TITLE
Explain fantasy "Value"/"Reach" with a board legend and inline hovers

### DIFF
--- a/src/app/fantasy-football/fantasy-football-client.tsx
+++ b/src/app/fantasy-football/fantasy-football-client.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/lib/fantasyUtils";
 import {
   CompareTray,
+  FantasyBoardLegend,
   PlayerDetailDrawer,
   PositionFilterBar,
   RankingsListRow,
@@ -255,6 +256,7 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
   const [searchQuery, setSearchQuery] = useState("");
   const [detailPlayer, setDetailPlayer] = useState<Player | null>(null);
   const [showStats, setShowStats] = useState(false);
+  const [showLegend, setShowLegend] = useState(false);
   const [visibleCount, setVisibleCount] = useState(RANKINGS_PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
@@ -554,6 +556,20 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
                   style={{ transform: showStats ? "rotate(180deg)" : "none" }}
                 />
               </button>
+              <button
+                type="button"
+                onClick={() => setShowLegend((open) => !open)}
+                aria-expanded={showLegend}
+                aria-controls="fantasy-board-legend"
+                className="inline-flex min-h-[44px] items-center gap-1.5 rounded-full border px-4 text-sm font-semibold"
+                style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)", color: "var(--home-ink)" }}
+              >
+                How to read the board
+                <ChevronDown
+                  className="h-4 w-4 transition-transform"
+                  style={{ transform: showLegend ? "rotate(180deg)" : "none" }}
+                />
+              </button>
             </div>
           </div>
         </motion.div>
@@ -566,6 +582,8 @@ export function FantasyFootballClient({ initialState }: FantasyFootballClientPro
             cells={fantasyStatsCells}
           />
         )}
+
+        {showLegend && <FantasyBoardLegend id="fantasy-board-legend" />}
 
         {error && (
           <article className="home-card p-5 sm:p-6" style={{ borderColor: "var(--color-error)" }}>

--- a/src/components/fantasy/FantasyBoardLegend.tsx
+++ b/src/components/fantasy/FantasyBoardLegend.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { CSSProperties } from "react";
+
+import { FANTASY_BOARD_LEGEND, FANTASY_CHIP_CLASS, type FantasyLegendEntry } from "@/lib/fantasyUtils";
+
+/**
+ * Chip tints for the Value / Reach legend rows. Kept in lockstep with the
+ * inline chips rendered by RankingsListRow so the key visually matches the
+ * board it explains.
+ */
+const TONE_STYLE: Record<NonNullable<FantasyLegendEntry["tone"]>, CSSProperties> = {
+  value: {
+    borderColor: "color-mix(in srgb, var(--color-success) 28%, var(--home-rule))",
+    background: "color-mix(in srgb, var(--color-success) 10%, var(--home-paper))",
+  },
+  reach: {
+    borderColor: "color-mix(in srgb, var(--color-warning) 30%, var(--home-rule))",
+    background: "color-mix(in srgb, var(--color-warning) 12%, var(--home-paper))",
+  },
+};
+
+interface FantasyBoardLegendProps {
+  /** Anchor id, wired to the toggle's aria-controls and the heading's id. */
+  id?: string;
+}
+
+/**
+ * The collapsible "How to read this board" key. Presentational only: it reads
+ * its entries from FANTASY_BOARD_LEGEND so the copy lives next to the logic it
+ * describes and stays testable.
+ */
+export function FantasyBoardLegend({ id }: FantasyBoardLegendProps) {
+  const headingId = id ? `${id}-heading` : undefined;
+
+  return (
+    <section id={id} aria-labelledby={headingId} className="home-card p-5 sm:p-6">
+      <header className="mb-4">
+        <p className="home-kicker mb-1">Reading the board</p>
+        <h2 id={headingId} className="text-xl font-semibold">
+          How to read this board
+        </h2>
+        <p className="mt-2 max-w-[60ch] text-sm leading-7" style={{ color: "var(--home-ink-muted)" }}>
+          A quick key to the ranks, ADP signals, tiers, and freshness cues you will see across the board.
+        </p>
+      </header>
+
+      <dl className="grid gap-x-8 gap-y-4 sm:grid-cols-2">
+        {FANTASY_BOARD_LEGEND.map((entry) => (
+          <div key={entry.term} className="min-w-0">
+            <dt className="flex flex-wrap items-center gap-2 text-sm font-semibold">
+              {entry.tone && (
+                <span className={FANTASY_CHIP_CLASS} style={TONE_STYLE[entry.tone]} aria-hidden="true">
+                  {entry.term}
+                </span>
+              )}
+              {entry.term}
+            </dt>
+            <dd className="mt-1 text-sm leading-7" style={{ color: "var(--home-ink-muted)" }}>
+              {entry.definition}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+export default FantasyBoardLegend;

--- a/src/components/fantasy/RankingsListRow.tsx
+++ b/src/components/fantasy/RankingsListRow.tsx
@@ -5,12 +5,15 @@ import type { ReactNode } from "react";
 
 import {
   FANTASY_CHIP_CLASS,
+  FANTASY_REACH_TOOLTIP,
+  FANTASY_VALUE_TOOLTIP,
   formatAdp,
   formatOwnership,
   formatRange,
   getPositionTone,
   getValueVsAdp,
 } from "@/lib/fantasyUtils";
+import { MetricTooltip } from "@/components/investments/MetricTooltip";
 import type { Player } from "@/types";
 
 interface RankingsListRowProps {
@@ -139,6 +142,13 @@ export function RankingsListRow({
                       {valueVsAdp.signal === "value" ? "Value" : "Reach"}{" "}
                       {valueVsAdp.delta > 0 ? `+${valueVsAdp.delta}` : valueVsAdp.delta}
                     </span>
+                  )}
+                  {valueVsAdp?.signal && (
+                    <MetricTooltip
+                      term={valueVsAdp.signal === "value" ? "Value" : "Reach"}
+                      definition={valueVsAdp.signal === "value" ? FANTASY_VALUE_TOOLTIP : FANTASY_REACH_TOOLTIP}
+                      align="right"
+                    />
                   )}
                 </p>
               </div>

--- a/src/components/fantasy/index.ts
+++ b/src/components/fantasy/index.ts
@@ -1,4 +1,5 @@
 export { TierBreakdown } from "./TierBreakdown";
+export { FantasyBoardLegend } from "./FantasyBoardLegend";
 export { PositionFilterBar, type PositionFilterOption } from "./PositionFilterBar";
 export { RankingsListRow } from "./RankingsListRow";
 export { TierBreakSeparator } from "./TierBreakSeparator";

--- a/src/components/investments/MetricTooltip.tsx
+++ b/src/components/investments/MetricTooltip.tsx
@@ -54,11 +54,20 @@ export const METRIC_DEFINITIONS: Record<string, string> = {
 interface Props {
   term: string;
   definition?: string;
+  /**
+   * Which edge the tooltip anchors to. Defaults to "left" (tooltip extends
+   * rightward). Use "right" when the badge sits near the right edge of its
+   * container, so the bubble extends leftward instead of clipping off-screen.
+   */
+  align?: "left" | "right";
 }
 
-export function MetricTooltip({ term, definition }: Props) {
+export function MetricTooltip({ term, definition, align = "left" }: Props) {
   const text = definition ?? METRIC_DEFINITIONS[term];
   if (!text) return null;
+
+  const bubbleAlign = align === "right" ? "right-0" : "left-0";
+  const arrowAlign = align === "right" ? "right-3" : "left-3";
 
   return (
     <span className="group relative ml-0.5 inline-flex cursor-help items-center">
@@ -67,10 +76,10 @@ export function MetricTooltip({ term, definition }: Props) {
       </span>
       <span
         role="tooltip"
-        className="pointer-events-none absolute bottom-full left-0 z-50 mb-2 w-52 rounded-2xl bg-[var(--home-ink)] px-3 py-2.5 text-2xs leading-snug text-[var(--home-paper)] opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100"
+        className={`pointer-events-none absolute bottom-full ${bubbleAlign} z-50 mb-2 w-52 rounded-2xl bg-[var(--home-ink)] px-3 py-2.5 text-2xs leading-snug text-[var(--home-paper)] opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100`}
       >
         {text}
-        <span className="absolute left-3 top-full border-4 border-transparent border-t-[var(--home-ink)]" />
+        <span className={`absolute ${arrowAlign} top-full border-4 border-transparent border-t-[var(--home-ink)]`} />
       </span>
     </span>
   );

--- a/src/lib/__tests__/fantasyUtils.test.ts
+++ b/src/lib/__tests__/fantasyUtils.test.ts
@@ -1,10 +1,18 @@
 import {
+  FANTASY_BOARD_LEGEND,
+  FANTASY_REACH_TOOLTIP,
+  FANTASY_VALUE_TOOLTIP,
   getFantasyAdpFreshness,
   getSnapshotStaleness,
   getSnapshotStalenessLabel,
+  getValueVsAdp,
 } from "@/lib/fantasyUtils";
+import type { Player } from "@/types";
 
 const MS_PER_DAY = 86_400_000;
+
+/** Minimal Player factory — only the fields getValueVsAdp reads matter here. */
+const playerWith = (fields: Partial<Player>): Player => fields as Player;
 
 describe("getSnapshotStaleness", () => {
   it("buckets a recent date as fresh", () => {
@@ -55,5 +63,65 @@ describe("getFantasyAdpFreshness", () => {
     expect(getFantasyAdpFreshness("2025-09-10T00:00:00.000Z", null)).toBe("current");
     expect(getFantasyAdpFreshness("2025-09-10T00:00:00.000Z", undefined)).toBe("current");
     expect(getFantasyAdpFreshness("not-a-date", 2026)).toBe("current");
+  });
+});
+
+describe("getValueVsAdp", () => {
+  it("flags a value when the market drafts a player later than experts rank him", () => {
+    expect(getValueVsAdp(playerWith({ rankEcr: 20, adp: 35 }))).toEqual({ delta: 15, signal: "value" });
+  });
+
+  it("flags a reach when the market drafts a player earlier than experts rank him", () => {
+    expect(getValueVsAdp(playerWith({ rankEcr: 20, adp: 8 }))).toEqual({ delta: -12, signal: "reach" });
+  });
+
+  it("treats a sub-threshold gap as a delta with no signal", () => {
+    expect(getValueVsAdp(playerWith({ rankEcr: 20, adp: 25 }))).toEqual({ delta: 5, signal: null });
+  });
+
+  it("includes the boundary gap in the signal (>= and <= the threshold)", () => {
+    expect(getValueVsAdp(playerWith({ rankEcr: 20, adp: 30 }))?.signal).toBe("value");
+    expect(getValueVsAdp(playerWith({ rankEcr: 20, adp: 10 }))?.signal).toBe("reach");
+  });
+
+  it("falls back to averageRank when rankEcr is missing", () => {
+    expect(getValueVsAdp(playerWith({ averageRank: 12, adp: 30 }))).toEqual({ delta: 18, signal: "value" });
+  });
+
+  it("returns null when there is no ADP or no usable rank", () => {
+    expect(getValueVsAdp(playerWith({ rankEcr: 20 }))).toBeNull();
+    expect(getValueVsAdp(playerWith({ adp: 30 }))).toBeNull();
+  });
+});
+
+describe("FANTASY_BOARD_LEGEND", () => {
+  it("covers every term a reader meets on the board", () => {
+    const terms = FANTASY_BOARD_LEGEND.map((entry) => entry.term);
+    expect(terms).toEqual(
+      expect.arrayContaining(["Published rank", "Expert range", "Avg", "ADP", "Value", "Reach", "Tiers", "Freshness"])
+    );
+  });
+
+  it("gives every entry a non-empty term and definition", () => {
+    for (const entry of FANTASY_BOARD_LEGEND) {
+      expect(entry.term.trim().length).toBeGreaterThan(0);
+      expect(entry.definition.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps the Value and Reach entries in sync with the inline hover copy", () => {
+    const value = FANTASY_BOARD_LEGEND.find((entry) => entry.term === "Value");
+    const reach = FANTASY_BOARD_LEGEND.find((entry) => entry.term === "Reach");
+    expect(value).toMatchObject({ tone: "value", definition: FANTASY_VALUE_TOOLTIP });
+    expect(reach).toMatchObject({ tone: "reach", definition: FANTASY_REACH_TOOLTIP });
+  });
+
+  it("honors the writing voice (no em dashes, no colon-as-connector labels)", () => {
+    for (const entry of FANTASY_BOARD_LEGEND) {
+      expect(entry.definition).not.toContain("—");
+    }
+    // "Value:" / "Reach:" would be a colon connector; the copy uses "... means ...".
+    expect(FANTASY_VALUE_TOOLTIP).not.toMatch(/^Value:/);
+    expect(FANTASY_REACH_TOOLTIP).not.toMatch(/^Reach:/);
   });
 });

--- a/src/lib/fantasyUtils.ts
+++ b/src/lib/fantasyUtils.ts
@@ -152,6 +152,78 @@ export function getValueVsAdp(
   return { delta, signal };
 }
 
+/**
+ * Hover copy for the green "Value" chip. Explains the ADP-vs-consensus gap in
+ * plain language so a drafter does not have to infer what the chip means. Kept
+ * in sync with the "Value" entry in FANTASY_BOARD_LEGEND below.
+ */
+export const FANTASY_VALUE_TOOLTIP =
+  "Value means drafters take this player later than the experts rank him, so you can often get him at a discount. The number is how many draft slots later than his consensus rank he goes on average.";
+
+/** Hover copy for the amber "Reach" chip, the mirror of FANTASY_VALUE_TOOLTIP. */
+export const FANTASY_REACH_TOOLTIP =
+  "Reach means drafters take this player earlier than the experts rank him, so picking him here likely passes up better value. The number is how many draft slots earlier than his consensus rank he goes on average.";
+
+export interface FantasyLegendEntry {
+  /** Short label, matching the wording that appears on the board itself. */
+  term: string;
+  /** Plain-language definition. One or two flowing sentences, never a listicle. */
+  definition: string;
+  /** When set, the legend renders the matching colored board chip beside the term. */
+  tone?: "value" | "reach";
+}
+
+/**
+ * The full key for reading the rankings board, surfaced through the collapsible
+ * "How to read this board" panel. Reuses the same tooltip strings the inline
+ * hovers use so the panel and the per-row hovers never drift apart.
+ */
+export const FANTASY_BOARD_LEGEND: FantasyLegendEntry[] = [
+  {
+    term: "Published rank",
+    definition:
+      "The number on the left of each row. It is the FantasyPros expert consensus rank for the board you are viewing, whether that is overall, a single position, or flex.",
+  },
+  {
+    term: "Expert range",
+    definition:
+      "The highest and lowest rank the experts gave this player. A wide range means the analysts disagree about where he belongs.",
+  },
+  {
+    term: "Avg",
+    definition: FANTASY_AVG_RANK_TOOLTIP,
+  },
+  {
+    term: "ADP",
+    definition: FANTASY_ADP_TOOLTIP,
+  },
+  {
+    term: "Value",
+    tone: "value",
+    definition: FANTASY_VALUE_TOOLTIP,
+  },
+  {
+    term: "Reach",
+    tone: "reach",
+    definition: FANTASY_REACH_TOOLTIP,
+  },
+  {
+    term: "Tiers",
+    definition:
+      "FantasyPros groups players of roughly interchangeable value into tiers. The drop between one tier and the next is where waiting gets expensive, so it is often smarter to draft across a tier break than to reach within one.",
+  },
+  {
+    term: "Rostered",
+    definition:
+      "The share of leagues where this player is already on a roster. A low number on a well-ranked player can flag a sleeper others have not grabbed yet.",
+  },
+  {
+    term: "Freshness",
+    definition:
+      "The Current, Aging, and Stale chips show how recently the source consensus and this site's snapshot were refreshed, so you can judge how current the board is.",
+  },
+];
+
 export type FantasyAdpFreshness = "current" | "prior-season";
 
 /**


### PR DESCRIPTION
## Why

The green **Value** and amber **Reach** chips on the fantasy rankings board were unexplained, so a drafter couldn't tell what the number next to them meant. This adds two explainers backed by a single source of truth.

## What changed

- **Collapsible "How to read this board" panel** (`FantasyBoardLegend`) covering the full board key: published rank, expert range, Avg, ADP, Value, Reach, tiers, rostered, and freshness. It toggles from the hero next to the existing "Board at a glance" button and shows for both List and Tiers views.
- **Inline hover on each Value/Reach chip** — the established `?` `MetricTooltip` affordance (already used for "Average rank") now sits beside the chip and defines the ADP‑vs‑consensus gap in plain language.
- **Shared copy** lives in `fantasyUtils` (`FANTASY_BOARD_LEGEND` plus `FANTASY_VALUE_TOOLTIP` / `FANTASY_REACH_TOOLTIP`) so the panel and the per‑row hovers can never drift apart. This also wires up the previously **unused** `FANTASY_ADP_TOOLTIP` constant.
- `MetricTooltip` gains an optional `align` prop so the hover anchors to the right edge inside the right‑aligned ADP column instead of clipping off‑screen. Backward‑compatible (defaults to `left`).

## What it means

"Value +15" means the market drafts the player ~15 slots later than the experts rank him (a likely bargain); "Reach −8" means ~8 slots earlier. The threshold for showing a chip is 10 slots (`ADP_SIGNAL_THRESHOLD`).

## Notes

- Copy follows `WRITING_VOICE.md` (no em dashes, no colon‑as‑connector labels); there are unit tests guarding both rules.
- New tests cover `getValueVsAdp` (value / reach / neutral / boundary / fallback / null) and the legend contents.

## Verification

- `npx jest src/lib/__tests__/fantasyUtils.test.ts` — 19 passed
- `npx eslint` on all changed files — clean
- `npx tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CosHVAQGcvSE3dp5L3URok)_