### PR TITLE
fix(investments): make live-quote allowlist survive the deployed function bundle

### DIFF
--- a/src/app/api/investments/data/[symbol]/route.ts
+++ b/src/app/api/investments/data/[symbol]/route.ts
@@ -62,7 +62,7 @@ export async function GET(
     // Reject symbols outside the curated universe BEFORE doing any
     // filesystem access. The allowlist is loaded once at module init and
     // shared with the quote proxies.
-    if (!isAllowedSymbol(symbol)) {
+    if (!(await isAllowedSymbol(symbol))) {
       return NextResponse.json(
         { error: "Symbol not found" },
         { status: 404, headers: NO_STORE_HEADERS }

--- a/src/app/api/investments/quotes/route.ts
+++ b/src/app/api/investments/quotes/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { StockQuote } from "@/types/investment";
-import { isAllowedSymbol, fetchFinnhubQuote } from "@/lib/finnhub";
+import { getAllowedSymbols, fetchFinnhubQuote } from "@/lib/finnhub";
 import { apiRateLimiter, rateLimitResponse } from "@/lib/rateLimit";
 import { logger } from "@/lib/logger";
 
@@ -64,9 +64,10 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const validSymbols = symbolArray.filter(isAllowedSymbol);
+    const allowlist = await getAllowedSymbols();
+    const validSymbols = symbolArray.filter((s) => allowlist.has(s));
     const invalidQuotes: StockQuote[] = symbolArray
-      .filter((s) => !isAllowedSymbol(s))
+      .filter((s) => !allowlist.has(s))
       .map((s) => ({
         symbol: s,
         price: 0,

--- a/src/app/api/stocks/route.ts
+++ b/src/app/api/stocks/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isAllowedSymbol, fetchFinnhubQuote } from "@/lib/finnhub";
+import { getAllowedSymbols, fetchFinnhubQuote } from "@/lib/finnhub";
 import { apiRateLimiter, rateLimitResponse } from "@/lib/rateLimit";
 import { logger } from "@/lib/logger";
 
@@ -61,8 +61,9 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const validSymbols = symbolArray.filter(isAllowedSymbol);
-    const invalidSymbols = symbolArray.filter((s) => !isAllowedSymbol(s));
+    const allowlist = await getAllowedSymbols();
+    const validSymbols = symbolArray.filter((s) => allowlist.has(s));
+    const invalidSymbols = symbolArray.filter((s) => !allowlist.has(s));
 
     const invalidQuotes = invalidSymbols.map((s) => ({
       symbol: s,

--- a/src/lib/__tests__/finnhub.allowlist.test.ts
+++ b/src/lib/__tests__/finnhub.allowlist.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment node
+ *
+ * Regression coverage for the curated-symbol allowlist that gates the Finnhub
+ * quote proxies. The bug this guards against: inside the deployed Netlify
+ * function, public/data/investments/index.json is stripped from the bundle, so
+ * the old readFileSync-only loader failed closed and every symbol was rejected
+ * as "not eligible for live pricing" — even with a valid Finnhub key. The
+ * allowlist must fall back to the committed public asset over HTTP.
+ */
+jest.mock("fs", () => ({ readFileSync: jest.fn() }));
+
+import { readFileSync } from "fs";
+import {
+  getAllowedSymbols,
+  isAllowedSymbol,
+  __resetAllowlistCacheForTests,
+} from "@/lib/finnhub";
+
+const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
+const realFetch = global.fetch;
+
+function enoent(): NodeJS.ErrnoException {
+  return Object.assign(new Error("ENOENT: no such file or directory"), {
+    code: "ENOENT",
+  });
+}
+
+function mockPublicAsset(symbols: string[]) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ symbols }),
+  }) as unknown as typeof fetch;
+}
+
+describe("finnhub allowlist resolution", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetAllowlistCacheForTests();
+    delete process.env.URL;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it("uses the local file when present and never hits the network", async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ symbols: ["AAPL", "MSFT"] }));
+    global.fetch = jest.fn() as unknown as typeof fetch;
+
+    const allowlist = await getAllowedSymbols();
+
+    expect(allowlist.has("AAPL")).toBe(true);
+    expect(await isAllowedSymbol("MSFT")).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the public asset over HTTP when the local file is absent", async () => {
+    // Simulate the deployed function: the bundled file is gone.
+    mockReadFileSync.mockImplementation(() => {
+      throw enoent();
+    });
+    process.env.URL = "https://isaacavazquez.com";
+    mockPublicAsset(["AAPL", "MSFT"]);
+
+    const allowlist = await getAllowedSymbols();
+
+    expect(allowlist.has("AAPL")).toBe(true);
+    expect(await isAllowedSymbol("MSFT")).toBe(true);
+    expect(await isAllowedSymbol("ZZZZZ")).toBe(false);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://isaacavazquez.com/data/investments/index.json",
+      expect.objectContaining({ cache: "force-cache" })
+    );
+  });
+
+  it("rejects malformed symbols even when they are not in the allowlist", async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ symbols: ["AAPL"] }));
+
+    expect(await isAllowedSymbol("BAD SYMBOL")).toBe(false);
+    expect(await isAllowedSymbol(".AAPL")).toBe(false);
+  });
+
+  it("fails closed on a total miss but does not cache the empty result", async () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw enoent();
+    });
+    // No origin configured → no HTTP fallback available this call.
+    const firstAttempt = await getAllowedSymbols();
+    expect(firstAttempt.size).toBe(0);
+
+    // A later request (origin now resolvable) must recover rather than stay
+    // wedged on a cached empty set for the life of the process.
+    process.env.URL = "https://isaacavazquez.com";
+    mockPublicAsset(["AAPL"]);
+    const secondAttempt = await getAllowedSymbols();
+    expect(secondAttempt.has("AAPL")).toBe(true);
+  });
+
+  it("does not re-fetch once a non-empty allowlist is cached", async () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw enoent();
+    });
+    process.env.URL = "https://isaacavazquez.com";
+    mockPublicAsset(["AAPL", "MSFT"]);
+
+    await getAllowedSymbols();
+    await getAllowedSymbols();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/finnhub.ts
+++ b/src/lib/finnhub.ts
@@ -11,6 +11,7 @@
 import { readFileSync } from "fs";
 import path from "path";
 import type { StockQuote } from "@/types/investment";
+import { getInvestmentsAssetOrigin } from "@/lib/investmentsAssetOrigin";
 
 const FINNHUB_API_KEY = process.env.FINNHUB_API_KEY ?? "";
 const TIMEOUT_MS = 8_000;
@@ -42,11 +43,18 @@ export function isValidSymbol(symbol: string): boolean {
 // ---------------------------------------------------------------------------
 // Allowlist of curated symbols
 // ---------------------------------------------------------------------------
-// Loaded once from public/data/investments/index.json at module init time
-// (server-only) and cached for the life of the process. The allowlist is the
-// authoritative gate for the unauthenticated /api/investments/quotes and
-// /api/stocks proxies — only symbols Isaac has chosen to research can hit
-// the paid Finnhub key.
+// The allowlist is the authoritative gate for the unauthenticated
+// /api/investments/quotes and /api/stocks proxies — only symbols Isaac has
+// chosen to research can hit the paid Finnhub key.
+//
+// It is sourced from public/data/investments/index.json. In dev and tests that
+// file is on disk, but inside the deployed Netlify function it is stripped from
+// the bundle (excluded from output file tracing in next.config.mjs and removed
+// by the netlify.toml build command), so a plain readFileSync throws ENOENT and
+// the allowlist would otherwise fail closed for every symbol. We therefore fall
+// back to fetching the committed public asset over HTTP — exactly how the
+// curated-data loader (investmentsData.ts) resolves the same file.
+const INDEX_RELATIVE_PATH = "/data/investments/index.json";
 const INDEX_JSON_PATH = path.join(
   process.cwd(),
   "public",
@@ -57,38 +65,81 @@ const INDEX_JSON_PATH = path.join(
 
 let cachedAllowlist: Set<string> | null = null;
 
-function loadAllowlist(): Set<string> {
-  if (cachedAllowlist) {
-    return cachedAllowlist;
-  }
-  try {
-    const raw = readFileSync(INDEX_JSON_PATH, "utf8");
-    const parsed = JSON.parse(raw) as { symbols?: unknown };
-    const symbols = Array.isArray(parsed.symbols)
-      ? parsed.symbols.filter((s): s is string => typeof s === "string")
-      : [];
-    cachedAllowlist = new Set(symbols.map((s) => s.toUpperCase()));
-  } catch (error) {
-    // If the index is missing or unreadable we fail closed — no symbols
-    // are allowed through the proxy.
-    console.error("finnhub: failed to load investments allowlist:", error);
-    cachedAllowlist = new Set<string>();
-  }
-  return cachedAllowlist;
+function toSymbolSet(parsed: { symbols?: unknown }): Set<string> {
+  const symbols = Array.isArray(parsed.symbols)
+    ? parsed.symbols.filter((s): s is string => typeof s === "string")
+    : [];
+  return new Set(symbols.map((s) => s.toUpperCase()));
 }
 
-export function isAllowedSymbol(symbol: string): boolean {
+function readAllowlistFromDisk(): Set<string> {
+  try {
+    return toSymbolSet(JSON.parse(readFileSync(INDEX_JSON_PATH, "utf8")));
+  } catch {
+    // Not on the function filesystem — the HTTP fallback handles it.
+    return new Set<string>();
+  }
+}
+
+async function fetchAllowlistFromPublicAsset(): Promise<Set<string>> {
+  const origin = getInvestmentsAssetOrigin();
+  if (!origin) {
+    return new Set<string>();
+  }
+  try {
+    const response = await fetch(new URL(INDEX_RELATIVE_PATH, origin).toString(), {
+      cache: "force-cache",
+    });
+    if (!response.ok) {
+      return new Set<string>();
+    }
+    return toSymbolSet(await response.json());
+  } catch {
+    return new Set<string>();
+  }
+}
+
+/**
+ * Resolve the curated-symbol allowlist. Tries the bundled file first (present
+ * in dev and tests), then falls back to the committed public asset over HTTP
+ * (the only source available inside the deployed function).
+ *
+ * A non-empty result is cached for the life of the process. A total miss is
+ * deliberately NOT cached, so a transient failure can recover on the next
+ * request instead of wedging the allowlist closed for the whole process.
+ */
+export async function getAllowedSymbols(): Promise<ReadonlySet<string>> {
+  if (cachedAllowlist && cachedAllowlist.size > 0) {
+    return cachedAllowlist;
+  }
+
+  const fromDisk = readAllowlistFromDisk();
+  if (fromDisk.size > 0) {
+    cachedAllowlist = fromDisk;
+    return cachedAllowlist;
+  }
+
+  const fromPublic = await fetchAllowlistFromPublicAsset();
+  if (fromPublic.size > 0) {
+    cachedAllowlist = fromPublic;
+    return cachedAllowlist;
+  }
+
+  console.error(
+    "finnhub: failed to resolve investments allowlist from disk or public asset"
+  );
+  return new Set<string>();
+}
+
+export async function isAllowedSymbol(symbol: string): Promise<boolean> {
   if (!isValidSymbol(symbol)) {
     return false;
   }
-  return loadAllowlist().has(symbol.toUpperCase());
+  const allowlist = await getAllowedSymbols();
+  return allowlist.has(symbol.toUpperCase());
 }
 
-export function getAllowedSymbols(): ReadonlySet<string> {
-  return loadAllowlist();
-}
-
-// Test-only: reset the cached allowlist so tests can force a re-read.
+// Test-only: reset the cached allowlist so tests can force a re-resolve.
 // Not exported through the module's public consumers.
 export function __resetAllowlistCacheForTests(): void {
   cachedAllowlist = null;

--- a/src/lib/investmentsAssetOrigin.ts
+++ b/src/lib/investmentsAssetOrigin.ts
@@ -1,0 +1,33 @@
+export interface AssetOriginOptions {
+  /** Explicit origin override (e.g. the current request origin). */
+  assetOrigin?: string | null;
+}
+
+/**
+ * Resolve the origin to fetch committed `/public/data/investments` assets from
+ * when they are not present on the local filesystem.
+ *
+ * Inside the deployed Netlify function the investments snapshots are stripped
+ * from the bundle (`outputFileTracingExcludes` in `next.config.mjs` plus the
+ * `rm -rf` of the standalone `public/data` directory in `netlify.toml`), so the
+ * only way server code can read them is over HTTP from the deploy origin. This
+ * is the single source of truth for that origin so the precedence can't drift
+ * between the curated-data loader and the Finnhub allowlist.
+ *
+ * Returns `null` when no origin can be determined (e.g. local dev with the file
+ * present on disk, where the HTTP fallback is unnecessary).
+ */
+export function getInvestmentsAssetOrigin(
+  options: AssetOriginOptions = {}
+): string | null {
+  const configuredOrigin =
+    options.assetOrigin ??
+    process.env.URL ??
+    process.env.DEPLOY_PRIME_URL ??
+    process.env.DEPLOY_URL ??
+    process.env.SITE_URL ??
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null);
+
+  return configuredOrigin ? configuredOrigin.replace(/\/$/, "") : null;
+}

--- a/src/lib/investmentsData.ts
+++ b/src/lib/investmentsData.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/types/investment";
 import { normalizeInvestmentSnapshot } from "@/lib/investmentFreshness";
 import { normalizeInvestmentsIndex } from "@/lib/investmentsIndex";
+import { getInvestmentsAssetOrigin } from "@/lib/investmentsAssetOrigin";
 
 type PrefetchedReadStatus = "hit" | "missing" | "skipped";
 
@@ -99,19 +100,6 @@ async function readJsonFile<T>(
   }
 }
 
-function getPublicAssetOrigin(options: InvestmentsDataOptions = {}): string | null {
-  const configuredOrigin =
-    options.assetOrigin ??
-    process.env.URL ??
-    process.env.DEPLOY_PRIME_URL ??
-    process.env.DEPLOY_URL ??
-    process.env.SITE_URL ??
-    process.env.NEXT_PUBLIC_SITE_URL ??
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null);
-
-  return configuredOrigin ? configuredOrigin.replace(/\/$/, "") : null;
-}
-
 async function fetchPublicJsonFile<T>(
   relativePath: string,
   options: InvestmentsDataOptions = {}
@@ -120,7 +108,7 @@ async function fetchPublicJsonFile<T>(
   status: PrefetchedReadStatus;
   httpStatus?: number;
 }> {
-  const origin = getPublicAssetOrigin(options);
+  const origin = getInvestmentsAssetOrigin(options);
   if (!origin) {
     return {
       data: null,
@@ -166,7 +154,7 @@ async function readInvestmentJson<T>(
       source: "filesystem",
       diagnostics: {
         relativePath,
-        assetOrigin: getPublicAssetOrigin(options),
+        assetOrigin: getInvestmentsAssetOrigin(options),
         filesystem: localFile.status,
         publicAsset: "skipped",
       },
@@ -179,7 +167,7 @@ async function readInvestmentJson<T>(
     source: publicFile.data !== null ? "public" : null,
     diagnostics: {
       relativePath,
-      assetOrigin: getPublicAssetOrigin(options),
+      assetOrigin: getInvestmentsAssetOrigin(options),
       filesystem: localFile.status,
       publicAsset: publicFile.status,
       publicStatus: publicFile.httpStatus,


### PR DESCRIPTION
## Why live pricing was broken in production

Live prices on `/investments` silently fell back to cost basis for **every** symbol, even though `FINNHUB_API_KEY` is correctly set in Netlify and the key itself is valid (verified against Finnhub's API directly).

Root cause: the `/api/investments/quotes` and `/api/stocks` proxies only call Finnhub for symbols on a curated allowlist, which `src/lib/finnhub.ts` loaded from `public/data/investments/index.json` via a bare `readFileSync`. That file is **intentionally stripped from the Netlify serverless function bundle**:

- `outputFileTracingExcludes` in `next.config.mjs` excludes `**/public/data/investments/**`
- the `netlify.toml` build command `rm -rf`s the standalone `public/data` directory

(Both exist to keep the function under Netlify's 250 MB limit — the investments data is served as static CDN assets instead.)

So at runtime the read threw `ENOENT`, `loadAllowlist()` failed **closed** to an empty set, and **every** symbol was rejected as `"This symbol is not eligible for live pricing."` before Finnhub was ever called — then that empty set was cached for the life of the process. Locally the file is on disk, so this only ever manifested in production ("works on my machine").

The curated-research loader (`investmentsData.ts`) already handled this correctly with a filesystem → HTTP fallback. The allowlist never got that treatment.

## The fix

- **`src/lib/finnhub.ts`** — `getAllowedSymbols()` / `isAllowedSymbol()` are now async and resolve the allowlist with a disk → HTTP fallback: try the bundled file first (dev/tests), then fetch the committed public asset (`/data/investments/index.json`) from the deploy origin (production). Non-empty results are cached; a total miss is **not** cached, so a transient failure can recover on the next request instead of wedging the allowlist closed for the whole process.
- **`src/lib/investmentsAssetOrigin.ts`** (new) — shared deploy-origin resolver, so the env precedence (`URL` / `DEPLOY_PRIME_URL` / …) is a single source of truth and can't drift between the two loaders.
- **`src/lib/investmentsData.ts`** — reuse the shared resolver (no behavior change).
- **Route updates** — `quotes`, `stocks`, and `data/[symbol]` await the resolved allowlist.
- **Regression test** (`src/lib/__tests__/finnhub.allowlist.test.ts`) — covers the file-absent (deployed-function) case: falls back to HTTP, rejects unknown/malformed symbols, fails closed without caching empty, and doesn't re-fetch once cached.

## Verification

- `jest` across `investments|finnhub|stocks`: **14 suites / 44 tests pass**
- `tsc --noEmit`: clean
- `eslint` on all changed files: clean

> Note: this restores live pricing assuming the production `FINNHUB_API_KEY` is valid. The key value was shared in chat during debugging, so it's worth rotating it on Finnhub as a precaution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjJFe9zD6Qcpq6t4RAn4W5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjJFe9zD6Qcpq6t4RAn4W5)_