### PR TITLE
security: stage global CSP via report-only header

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -220,12 +220,43 @@ const nextConfig = {
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
   },
   // Site-wide security headers. Applied to all routes.
-  // TODO: Add a global Content-Security-Policy header in a future, separately
-  // staged change. CSP requires careful inventory of inline scripts, third-party
-  // tag managers, and analytics endpoints; rolling it out without staging would
-  // break those surfaces. Tracked separately.
+  //
+  // CSP is staged via Content-Security-Policy-Report-Only (below). Report-Only
+  // enforces nothing — the browser still loads every resource and only reports
+  // what a future enforcing policy *would* block. This is the standard, safe
+  // way to inventory inline scripts, third-party tags, and analytics endpoints
+  // before flipping to an enforcing `Content-Security-Policy` header.
+  //
+  // The directives reflect this site's actual runtime surface:
+  //   - fonts are self-hosted by next/font (no runtime fonts.gstatic.com)
+  //   - all external data APIs run at build time, so browser connect is 'self'
+  //   - next-themes + Next bootstrap + JSON-LD need inline <script>
+  //   - Framer Motion + style attributes need inline styles
+  //   - team crests/logos load from many remote CDNs via <img> (img-src https:)
+  //
+  // Once reports confirm no legitimate surface is flagged (and inline scripts
+  // are moved to nonces/hashes to drop 'unsafe-inline'), graduate this to an
+  // enforcing `Content-Security-Policy` header.
   async headers() {
+    const contentSecurityPolicy = [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "object-src 'none'",
+      "frame-ancestors 'none'",
+      "form-action 'self'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self'",
+      "connect-src 'self'",
+      "manifest-src 'self'",
+    ].join("; ");
+
     const securityHeaders = [
+      {
+        key: "Content-Security-Policy-Report-Only",
+        value: contentSecurityPolicy,
+      },
       {
         key: "Strict-Transport-Security",
         value: "max-age=63072000; includeSubDomains; preload",


### PR DESCRIPTION
## What

Implements the long-standing CSP `TODO` in `next.config.mjs` by adding a global **`Content-Security-Policy-Report-Only`** header.

## Why this is the right (and safe) step

The TODO deliberately deferred a global CSP because "rolling it out without staging would break those surfaces." Report-Only **is** that staging mechanism: it enforces nothing — the browser still loads every resource and only *reports* what an enforcing policy would block. So this PR is functionally non-breaking while making concrete, observable progress on the tracked item.

## Directives & how they were derived

The policy reflects the site's actual runtime surface, verified against the code:

| Directive | Value | Rationale |
|---|---|---|
| `default-src` | `'self'` | baseline |
| `script-src` | `'self' 'unsafe-inline'` | next-themes inline theme script + Next bootstrap + JSON-LD (`dangerouslySetInnerHTML`); no external script CDNs |
| `style-src` | `'self' 'unsafe-inline'` | Framer Motion + inline `style` attributes |
| `img-src` | `'self' data: blob: https:` | remote team crests/logos load via `<img>` from many CDNs; plus Unsplash/Cloudinary |
| `font-src` | `'self'` | fonts are self-hosted by `next/font` (no runtime `fonts.gstatic.com`) |
| `connect-src` | `'self'` | all external data APIs run at **build time**, not in the browser |
| `base-uri` / `object-src` / `frame-ancestors` / `form-action` | locked down | hardening; `frame-ancestors 'none'` mirrors the existing `X-Frame-Options: DENY` |

## Next step (out of scope here)

Once reports confirm no legitimate surface is flagged — and inline scripts are migrated to nonces/hashes so `'unsafe-inline'` can be dropped — graduate this to an enforcing `Content-Security-Policy` header.

## Testing

- `next.config.mjs` loads and emits the header (verified by importing the config and inspecting `headers()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqEwrAMAaDvcMxKRZeRXQd)_