### PR TITLE
content: backfill changelog with historical context

### DIFF
--- a/content/changelog/2026-01-30-nextjs-16-rebuild.mdx
+++ b/content/changelog/2026-01-30-nextjs-16-rebuild.mdx
@@ -1,0 +1,19 @@
+---
+title: Rebuilt on Next.js 16 — the foundation
+publishedAt: "2026-01-30"
+category: Foundation
+summary: The ground-up rebuild that everything since is built on — Next.js 16 App Router, a fantasy football analytics platform with D3 tier charts, and a switch from the old warm-orange theme to the blue/slate system.
+tags:
+  - foundation
+  - platform
+---
+
+This is where the current site starts. The whole thing was rebuilt from the ground up rather than patched:
+
+- **Next.js 16 (App Router)** with TypeScript strict mode and Tailwind CSS v4 — the runtime everything since has been built against.
+- **Fantasy football analytics** came back as a first-class platform feature, with D3-powered tier charts, Gaussian mixture clustering for the tiers (`src/lib/gaussianMixture.ts`), and a unified data pipeline behind the rankings.
+- **A new design system** — the old warm orange/sunset palette gave way to the modern blue/slate theme that later became the editorial system.
+
+The plumbing landed at the same time: NextAuth for the `/admin` route, `next-sitemap` in the build pipeline, and Lighthouse and Core Web Vitals monitoring so regressions show up early.
+
+Most of this is invisible from the outside, but every later entry in this log assumes it.

--- a/content/changelog/2026-02-10-portfolio-and-investments.mdx
+++ b/content/changelog/2026-02-10-portfolio-and-investments.mdx
@@ -1,0 +1,18 @@
+---
+title: Portfolio, resume, writing, and the first investments page
+publishedAt: "2026-02-10"
+category: Launch
+summary: The first real content wave on the rebuilt platform — new portfolio, resume, and writing surfaces, structured-data helpers, the first investments page with Yahoo Finance research, and fantasy draft tooling.
+tags:
+  - portfolio
+  - investments
+  - launch
+---
+
+With the platform rebuilt, this was the first wave of things people could actually use:
+
+- **Portfolio, resume, and writing** — rebuilt [`/portfolio`](/portfolio), [`/resume`](/resume), and [`/writing`](/writing) experiences, plus the structured-data helpers (`StructuredData`, `AIStructuredData`) that keep these pages legible to search and AI crawlers.
+- **The first [investments](/investments) page** — stock research panels backed by Yahoo Finance, including the portfolio tracker, DCF, fundamentals, growth, valuation, news, and industry views. This is the seed that eventually became the curated, snapshot-driven research surface.
+- **Fantasy football tooling** — RB tiers, the draft tracker, and sample API responses, with the Netlify build hook wired up for scheduled data refreshes.
+
+A lot of this got reworked later — the investments page in particular was heavier and more live than it is now — but this is the version that first went out.

--- a/content/changelog/2026-03-19-investments-static-and-fantasy-rebuild.mdx
+++ b/content/changelog/2026-03-19-investments-static-and-fantasy-rebuild.mdx
@@ -1,0 +1,16 @@
+---
+title: Investments goes static, fantasy gets a canonical board
+publishedAt: "2026-03-19"
+category: Update
+summary: Two pieces of foundational rework — the investments research surface moved from heavy live fetches to curated static snapshots (~240 MB down to ~2.2 MB), and fantasy football was rebuilt around one canonical rankings board.
+tags:
+  - investments
+  - fantasy-football
+---
+
+A stretch of less glamorous but important rework that the rest of the site still relies on:
+
+- **Investments went static.** The research surface stopped fanning out through live section APIs and instead reads one curated snapshot per symbol from `/data/investments/*`. Capping price history to a year, trimming news, and dropping transcript artifacts took the published dataset from roughly **240 MB to roughly 2.2 MB**. The page was also repositioned as a public fintech proof point with proper metadata and structured data, and the workspace became URL-backed so research context survives reloads and shares.
+- **Fantasy got a canonical board.** The fantasy experience was rebuilt around a single [`/fantasy-football`](/fantasy-football) rankings board and a simplified [draft tracker](/fantasy-football/draft-tracker), both powered by checked-in snapshots instead of runtime fetch chains. Full PPR, half-PPR, and standard position boards came back, with `FLEX` derived from eligible positions and schema-versioned normalization so stale cached payloads can't crash the app.
+
+The theme across both is the same one that defines the site now: read from a committed snapshot, render fast, keep nothing live that doesn't have to be.


### PR DESCRIPTION
## What

The public `/changelog` began mid-story at **2026-03-02** (an investments upgrade), with no founding entries. The site's real early history — the ground-up rebuild and the first launches — lived only in the internal root `CHANGELOG.md` and was invisible to anyone reading the public log.

This backfills three curated historical entries so the public changelog carries its origin story, matching the established editorial voice and the existing entries' bold-label bullet format:

- **2026-01-30 — Rebuilt on Next.js 16 (Foundation):** the ground-up rebuild — Next.js 16 App Router, the D3 + Gaussian-mixture fantasy platform, and the warm-orange → blue/slate design switch.
- **2026-02-10 — Portfolio, resume, writing, and the first investments page (Launch):** the first content/feature wave on the rebuilt platform, including the original Yahoo Finance-backed investments page.
- **2026-03-19 — Investments goes static, fantasy gets a canonical board (Update):** the static-snapshot migration (~240 MB → ~2.2 MB) and the canonical fantasy rankings board.

These are drawn from the dated entries already recorded in the root `CHANGELOG.md`, condensed to the public changelog's curated, first-person style.

## Why

The `/changelog` page reads "What shipped, in order" but was missing the beginning. New readers landed in the middle of the story.

## Verification

- New entries are valid MDX with correct frontmatter; they parse via `gray-matter`.
- `getAllChangelogEntries()` returns 22 entries, correctly ordered (the two foundational entries now anchor the bottom of the page), and renders sanitized HTML.
- `npx jest src/lib/__tests__/changelog.test.ts` passes.
- No code changes — content-only addition under `content/changelog/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDAVZRDFL8GdhGNHzTtFef

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDAVZRDFL8GdhGNHzTtFef)_