### PR TITLE
security: harden admin auth, JSON-LD output, and email rate limiting

### DIFF
--- a/src/app/api/mba-jobs/email/__tests__/route.test.ts
+++ b/src/app/api/mba-jobs/email/__tests__/route.test.ts
@@ -52,7 +52,9 @@ function makeRequest(
     headers: {
       "Content-Type": "application/json",
       "User-Agent": `jest-${client}`,
-      "X-Forwarded-For": `192.0.2.${client.length}`,
+      // The per-IP rate limit is keyed on the trusted client IP, so give each
+      // distinct `client` a distinct IP (and a fixed `client` a stable one).
+      "x-nf-client-connection-ip": `ip-${client}`,
       ...headers,
     },
     body: JSON.stringify(body),

--- a/src/app/api/mba-jobs/email/route.ts
+++ b/src/app/api/mba-jobs/email/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
-import { emailDigestRateLimiter, getClientIdentifier, rateLimitResponse } from "@/lib/rateLimit";
+import { emailDigestRateLimiter, getClientIp, rateLimitResponse } from "@/lib/rateLimit";
 import { logger } from "@/lib/logger";
 
 // ---------------------------------------------------------------------------
@@ -264,7 +264,10 @@ export async function POST(request: NextRequest) {
     return json({ error: "Email digest request is too large." }, { status: 413 });
   }
 
-  const clientId = getClientIdentifier(request);
+  // Key the per-IP send limit on the trusted client IP only. Including the
+  // User-Agent here would let an attacker multiply their allowance by rotating
+  // the UA — unacceptable for an endpoint that sends real email.
+  const clientId = `email:${getClientIp(request)}`;
   const rateLimitResult = emailDigestRateLimiter.check(clientId);
   if (!rateLimitResult.success) {
     return rateLimitResponse(rateLimitResult);

--- a/src/components/AIStructuredData.tsx
+++ b/src/components/AIStructuredData.tsx
@@ -21,6 +21,7 @@ import {
   type FAQItem,
   type BreadcrumbItem,
 } from "@/lib/ai-seo";
+import { safeJsonLd } from "@/lib/seo";
 
 interface AIStructuredDataProps {
   schema:
@@ -117,7 +118,7 @@ export function AIStructuredData({ schema }: AIStructuredDataProps) {
     <script
       type="application/ld+json"
       dangerouslySetInnerHTML={{
-        __html: JSON.stringify(structuredData, null, 0),
+        __html: safeJsonLd(structuredData),
       }}
       suppressHydrationWarning
     />

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -1,4 +1,4 @@
-import { siteConfig } from "@/lib/seo";
+import { siteConfig, safeJsonLd } from "@/lib/seo";
 import { profile, profileSameAs } from "@/lib/profile";
 
 interface StructuredDataProps {
@@ -426,7 +426,7 @@ export function StructuredData({ type = "Person", data = {} }: StructuredDataPro
     <script
       type="application/ld+json"
       dangerouslySetInnerHTML={{
-        __html: JSON.stringify(getStructuredData()),
+        __html: safeJsonLd(getStructuredData()),
       }}
     />
   );

--- a/src/components/navigation/Breadcrumbs.tsx
+++ b/src/components/navigation/Breadcrumbs.tsx
@@ -4,6 +4,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { IconChevronRight, IconHome } from "@tabler/icons-react";
+import { safeJsonLd } from "@/lib/seo";
 
 interface BreadcrumbItem {
   label: string;
@@ -121,7 +122,7 @@ export function Breadcrumbs({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(generateStructuredData())
+          __html: safeJsonLd(generateStructuredData())
         }}
       />
 

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Security tests for the admin CredentialsProvider authorize() logic.
+ *
+ * These lock in two hardening guarantees:
+ *  1. Fail-closed when ADMIN_USERNAME / ADMIN_PASSWORD are not configured
+ *     (no "undefined === undefined" bypass).
+ *  2. Only the exact configured username + password authenticate.
+ */
+
+type AuthorizeFn = (
+  credentials: Record<string, string> | undefined
+) => Promise<unknown>;
+
+function loadAuthorize(): AuthorizeFn {
+  // Re-require with a fresh module registry so env changes take effect.
+  let authOptions: import("next-auth").NextAuthOptions;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    ({ authOptions } = require("../auth"));
+  });
+  // next-auth v4's CredentialsProvider returns a default config whose top-level
+  // `authorize` is a `() => null` stub; the real user-supplied function lives in
+  // `options.authorize` and is what next-auth invokes at runtime. Prefer it.
+  const provider = authOptions!.providers[0] as unknown as {
+    authorize?: AuthorizeFn;
+    options?: { authorize?: AuthorizeFn };
+  };
+  const authorize = provider.options?.authorize ?? provider.authorize;
+  if (!authorize) {
+    throw new Error("Could not locate credentials authorize()");
+  }
+  return authorize;
+}
+
+describe("admin credentials authorize()", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("fails closed when admin credentials are not configured", async () => {
+    delete process.env.ADMIN_USERNAME;
+    delete process.env.ADMIN_PASSWORD;
+    const authorize = loadAuthorize();
+
+    // Empty credentials must NOT authenticate (the old code returned a user
+    // here via undefined === undefined).
+    expect(await authorize({ username: "", password: "" })).toBeNull();
+    expect(await authorize(undefined)).toBeNull();
+    expect(
+      await authorize({ username: "anything", password: "anything" })
+    ).toBeNull();
+  });
+
+  it("rejects wrong credentials when configured", async () => {
+    process.env.ADMIN_USERNAME = "admin";
+    process.env.ADMIN_PASSWORD = "s3cret";
+    const authorize = loadAuthorize();
+
+    expect(await authorize({ username: "admin", password: "wrong" })).toBeNull();
+    expect(await authorize({ username: "nope", password: "s3cret" })).toBeNull();
+    expect(await authorize({ username: "", password: "" })).toBeNull();
+  });
+
+  it("accepts the exact configured username and password", async () => {
+    process.env.ADMIN_USERNAME = "admin";
+    process.env.ADMIN_PASSWORD = "s3cret";
+    const authorize = loadAuthorize();
+
+    const user = await authorize({ username: "admin", password: "s3cret" });
+    expect(user).toMatchObject({ id: "1", name: "Admin" });
+  });
+});

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -1,6 +1,7 @@
 import {
   constructMetadata,
   generateAIOptimizedMetadata,
+  safeJsonLd,
   siteConfig,
 } from "../seo";
 
@@ -93,5 +94,34 @@ describe("generateAIOptimizedMetadata", () => {
     expect((metadata.twitter as { title: string }).title).toBe(
       `About | ${siteConfig.name}`
     );
+  });
+});
+
+describe("safeJsonLd", () => {
+  it("escapes < > & so a value cannot break out of a <script> block", () => {
+    const out = safeJsonLd({ name: "</script><script>alert(1)</script>" });
+    expect(out).not.toContain("<");
+    expect(out).not.toContain(">");
+    expect(out).not.toContain("</script>");
+    expect(out).toContain("\\u003c");
+    expect(out).toContain("\\u003e");
+  });
+
+  it("escapes ampersands", () => {
+    expect(safeJsonLd({ v: "a & b" })).toContain("\\u0026");
+  });
+
+  it("escapes the U+2028/U+2029 JS line terminators", () => {
+    const value = `x${String.fromCharCode(0x2028)}y${String.fromCharCode(0x2029)}z`;
+    const out = safeJsonLd({ value });
+    expect(out).toContain("\\u2028");
+    expect(out).toContain("\\u2029");
+    expect(out).not.toContain(String.fromCharCode(0x2028));
+    expect(out).not.toContain(String.fromCharCode(0x2029));
+  });
+
+  it("remains valid JSON that round-trips to the original value", () => {
+    const data = { name: "</script>", note: "a & b", n: 42 };
+    expect(JSON.parse(safeJsonLd(data))).toEqual(data);
   });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,21 @@
 import { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
+import { createHash, timingSafeEqual } from "crypto";
+
+/**
+ * Constant-time string comparison.
+ *
+ * Both inputs are SHA-256 hashed first so the comparison runs over
+ * fixed-length buffers (timingSafeEqual throws on length mismatch, and
+ * comparing raw lengths would itself leak length information). The hash
+ * keeps the compare time independent of where the first differing byte is,
+ * defeating timing attacks against the credential check.
+ */
+function safeEqual(a: string, b: string): boolean {
+  const ha = createHash("sha256").update(a, "utf8").digest();
+  const hb = createHash("sha256").update(b, "utf8").digest();
+  return timingSafeEqual(ha, hb);
+}
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -10,12 +26,27 @@ export const authOptions: NextAuthOptions = {
         password: { label: "Password", type: "password" }
       },
       async authorize(credentials) {
-        // For security, credentials should be stored in environment variables
-        // This is a basic implementation - in production, use proper password hashing
-        if (
-          credentials?.username === process.env.ADMIN_USERNAME &&
-          credentials?.password === process.env.ADMIN_PASSWORD
-        ) {
+        const expectedUsername = process.env.ADMIN_USERNAME;
+        const expectedPassword = process.env.ADMIN_PASSWORD;
+
+        // Fail closed: if the admin credentials are not configured, no login
+        // is possible. This prevents an "undefined === undefined" bypass when
+        // the env vars are absent, and avoids ever authenticating against an
+        // empty secret.
+        if (!expectedUsername || !expectedPassword) {
+          return null;
+        }
+
+        if (!credentials?.username || !credentials?.password) {
+          return null;
+        }
+
+        // Constant-time comparison to avoid leaking timing information about
+        // the configured username/password.
+        const usernameMatches = safeEqual(credentials.username, expectedUsername);
+        const passwordMatches = safeEqual(credentials.password, expectedPassword);
+
+        if (usernameMatches && passwordMatches) {
           return {
             id: "1",
             name: "Admin",
@@ -32,7 +63,9 @@ export const authOptions: NextAuthOptions = {
   },
   session: {
     strategy: "jwt",
-    maxAge: 30 * 24 * 60 * 60, // 30 days
+    // Admin sessions are stateless JWTs with no server-side revocation, so keep
+    // the window short to limit the blast radius of a leaked token.
+    maxAge: 7 * 24 * 60 * 60, // 7 days
   },
   callbacks: {
     async jwt({ token, user }) {

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -93,16 +93,41 @@ export const emailDigestRateLimiter = new RateLimiter({
   uniqueTokenPerInterval: 3 // 3 email sends per client per hour
 });
 
-// Helper function to get client identifier
-export function getClientIdentifier(request: NextRequest): string {
-  // Try to get IP from various headers
-  const forwarded = request.headers.get("x-forwarded-for");
+/**
+ * Resolve the client IP for rate-limiting.
+ *
+ * Prefers `x-nf-client-connection-ip`, which Netlify sets from the real TCP
+ * peer and a client cannot forge. `x-forwarded-for` / `x-real-ip` are only used
+ * as a fallback for non-Netlify/local runs; note the leftmost `x-forwarded-for`
+ * entry is client-supplied and spoofable, so it is intentionally the last
+ * resort. Returns "unknown" when nothing is available (a single shared bucket).
+ */
+export function getClientIp(request: NextRequest): string {
+  const netlifyIp = request.headers.get("x-nf-client-connection-ip");
+  if (netlifyIp) {
+    return netlifyIp.trim();
+  }
+
   const realIp = request.headers.get("x-real-ip");
-  const ip = forwarded?.split(",")[0] || realIp || "unknown";
-  
-  // You could also use a combination of IP + User-Agent for more granular control
+  if (realIp) {
+    return realIp.trim();
+  }
+
+  const forwarded = request.headers.get("x-forwarded-for");
+  return forwarded?.split(",")[0]?.trim() || "unknown";
+}
+
+// Helper function to get client identifier.
+//
+// NOTE: this appends the User-Agent, which a client controls — so it is only
+// suitable for coarse, non-security-critical throttling (a client can multiply
+// its allowance by rotating the UA). For endpoints where the limit is a real
+// abuse control (e.g. sending email), use `getClientIp` instead so the bucket
+// is keyed on identity the client cannot trivially rotate.
+export function getClientIdentifier(request: NextRequest): string {
+  const ip = getClientIp(request);
   const userAgent = request.headers.get("user-agent") || "unknown";
-  
+
   return `${ip}:${userAgent}`;
 }
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -567,3 +567,27 @@ export function calculateReadingTime(text: string): number {
   const words = text.trim().split(/\s+/).length;
   return Math.ceil(words / wordsPerMinute);
 }
+
+/**
+ * Serialize a value as JSON for safe injection into a
+ * `<script type="application/ld+json">` block via dangerouslySetInnerHTML.
+ *
+ * `JSON.stringify` does NOT escape `<`, `>`, or `&`, so a value containing
+ * `</script>` (e.g. derived from a URL path or other dynamic data) could break
+ * out of the JSON-LD block and inject markup. Escaping these characters to their
+ * unicode equivalents keeps the output valid JSON while making `</script>`
+ * breakout impossible. Also escapes U+2028/U+2029, which are valid in JSON but
+ * illegal in JavaScript string literals.
+ */
+export function safeJsonLd(data: unknown): string {
+  // U+2028 (line separator) and U+2029 (paragraph separator) are valid in JSON
+  // but are line terminators in JavaScript string literals. Build them from
+  // char codes so this source file contains no raw line-terminator characters.
+  const lineSeparators =
+    String.fromCharCode(0x2028) + String.fromCharCode(0x2029);
+  const unsafe = new RegExp(`[<>&${lineSeparators}]`, "g");
+  return JSON.stringify(data).replace(
+    unsafe,
+    (ch) => "\\u" + ch.charCodeAt(0).toString(16).padStart(4, "0")
+  );
+}


### PR DESCRIPTION
## Summary

A focused security review of the API routes, auth, and rendering surfaces. The codebase was already well-defended — symbol allowlists, careful input normalization, escaped XML/HTML in the RSS and email surfaces, strict dynamic-route validation, and no user-controlled `fetch()` targets (no SSRF). This PR closes the few remaining gaps that the review surfaced.

## Changes

### 1. Admin authentication — `src/lib/auth.ts`
- **Fail closed on missing config.** Previously, if `ADMIN_USERNAME`/`ADMIN_PASSWORD` were unset, the `credentials?.x === process.env.x` check became `undefined === undefined` for an absent field and could authenticate an empty/malformed credential submission. Now the provider returns `null` whenever the admin credentials are not configured or the submission is missing a field.
- **Constant-time comparison.** Replaced `===` with a SHA-256 + `timingSafeEqual` compare so the credential check no longer leaks timing information about the configured username/password.
- **Shorter session.** Reduced the stateless (non-revocable) admin JWT lifetime from 30 days to 7 to limit the blast radius of a leaked token.

### 2. JSON-LD injection / reflected XSS — `safeJsonLd()`
`JSON.stringify` does **not** escape `<`, `>`, or `&`, so a value serialized into a `<script type="application/ld+json">` block via `dangerouslySetInnerHTML` could break out with `</script>`. In `Breadcrumbs.tsx` the JSON-LD `name`/`item` fields derive from `usePathname()` (URL-controlled), making it a reflected sink.

Added `safeJsonLd()` in `src/lib/seo.ts` which escapes `<`, `>`, `&` (plus the `U+2028`/`U+2029` JS line terminators) to their `\uXXXX` forms — valid JSON, `</script>` breakout impossible. Applied to `Breadcrumbs`, `StructuredData`, and `AIStructuredData` (the latter two take build-time props today, but share the same sink and are hardened against future dynamic data).

### 3. Email digest rate limiting — `src/app/api/mba-jobs/email`
The per-IP send limiter was keyed on `IP + User-Agent`, letting an attacker rotate the UA to get a fresh bucket per request. It now keys on a trusted client IP only, preferring Netlify's unforgeable `x-nf-client-connection-ip` header (added a shared `getClientIp` helper in `rateLimit.ts`). The hard per-request/per-day recipient ceilings and the recipient allowlist were already in place.

## Tests
- New `src/lib/__tests__/auth.test.ts` — fail-closed behavior, wrong-credential rejection, exact-match acceptance.
- New `safeJsonLd` cases in `src/lib/__tests__/seo.test.ts` — escaping + valid-JSON round-trip.
- Updated the email route test to simulate per-IP identity to match the new keying.
- Full `src/lib` + `src/app/api` suite: **495 passing**. `tsc --noEmit` and ESLint clean on changed files.

## Noted but not changed (lower priority / would need staging)
- `/admin` authorization is enforced client-side only (the dashboard markup ships to any visitor). Blast radius is low today — the dashboard contains only outbound GitHub Actions links — but server-side gating is awkward because the login form is co-located at `/admin`. Worth a follow-up if any sensitive content/server actions are added there.
- No site-wide Content-Security-Policy (already tracked as a TODO in `next.config.mjs`); the per-route CSP in `src/proxy.ts` still allows `'unsafe-inline'` scripts. Both warrant a separately-staged rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvFhXxWhRaigeY7U6ntS4a)_