### PR TITLE
perf: keep large sports snapshots out of client bundles + trim image runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,7 @@
         "remark-html": "^16.0.1",
         "resend": "^6.12.2",
         "tailwind-merge": "^3.5.0",
-        "tailwindcss-animate": "^1.0.7",
-        "web-vitals": "^5.2.0"
+        "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -15018,12 +15017,6 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
-    },
-    "node_modules/web-vitals": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
-      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
-      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "remark-html": "^16.0.1",
     "resend": "^6.12.2",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss-animate": "^1.0.7",
-    "web-vitals": "^5.2.0"
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/app/la-liga/la-liga-client.tsx
+++ b/src/app/la-liga/la-liga-client.tsx
@@ -34,14 +34,15 @@ import type {
   LaLigaView,
 } from "@/types/la-liga";
 import {
-  buildLaLigaHref,
-  canonicalizeLaLigaClubId,
-  DEFAULT_LA_LIGA_STATE,
-  filterClubsForView,
-  getDefaultClubForView,
+  buildClubAliasMap,
+  buildHref,
+  canonicalizeClubId,
+  filterClubs,
+  getDefaultClub,
   LA_LIGA_ROUTE,
-  normalizeLaLigaState,
-} from "./la-liga-state";
+  normalizeState,
+  resolveDefaultState,
+} from "./la-liga-state.core";
 
 interface LaLigaClientProps {
   initialState: LaLigaRouteState;
@@ -100,6 +101,8 @@ export function LaLigaClient({
   const currentQuery = searchParams.toString();
   const currentHref = `${LA_LIGA_ROUTE}${currentQuery ? `?${currentQuery}` : ""}`;
   const clubs = summary.clubs;
+  const aliasMap = useMemo(() => buildClubAliasMap(summary.teams), [summary.teams]);
+  const defaultState = useMemo(() => resolveDefaultState(summary.clubs), [summary.clubs]);
   const clubById = useMemo(() => new Map(clubs.map((club) => [club.id, club])), [clubs]);
   const clubLookup = useMemo(
     () => new Map(clubs.map((club) => [club.id, club.shortName])),
@@ -125,11 +128,11 @@ export function LaLigaClient({
   const crestByClubId = useMemo(() => (
     new Map(
       summary.teams.map((team) => [
-        canonicalizeLaLigaClubId(team.id) ?? team.id,
+        canonicalizeClubId(team.id, aliasMap) ?? team.id,
         team.crest,
       ] as const)
     )
-  ), [summary.teams]);
+  ), [summary.teams, aliasMap]);
   const snapshotDateLabel = useMemo(() => (
     new Intl.DateTimeFormat("en-US", {
       month: "short",
@@ -139,11 +142,13 @@ export function LaLigaClient({
   ), [summary.updatedAt]);
   const hasManagedParams =
     searchParams.get("view") !== null || searchParams.get("club") !== null;
-  const routeState = hasManagedParams ? normalizeLaLigaState(searchParams) : initialState;
-  const visibleClubs = filterClubsForView(routeState.view);
+  const routeState = hasManagedParams
+    ? normalizeState(searchParams, defaultState, aliasMap)
+    : initialState;
+  const visibleClubs = filterClubs(summary.clubs, routeState.view);
   const selectedClubId = visibleClubs.some((club) => club.id === routeState.club)
     ? routeState.club
-    : getDefaultClubForView(routeState.view);
+    : getDefaultClub(summary.clubs, routeState.view, defaultState.club);
   const selectedClub = clubById.get(selectedClubId) ?? clubs[0];
   const [teamSnapshots, setTeamSnapshots] = useState<Record<string, LaLigaTeamSnapshot>>(
     () => (selectedClubId && initialTeamSnapshot ? { [selectedClubId]: initialTeamSnapshot } : {})
@@ -152,11 +157,13 @@ export function LaLigaClient({
   const [teamSnapshotError, setTeamSnapshotError] = useState<string | null>(null);
   const teamSnapshot = selectedClub ? teamSnapshots[selectedClub.id] ?? null : null;
   const isTeamSnapshotLoading = selectedClub ? loadingClubId === selectedClub.id : false;
-  const desiredHref = buildLaLigaHref(
+  const desiredHref = buildHref(
     {
       view: routeState.view,
       club: selectedClubId,
     },
+    defaultState,
+    aliasMap,
     searchParams
   );
 
@@ -171,7 +178,7 @@ export function LaLigaClient({
   }, [currentHref, desiredHref, router]);
 
   function navigate(nextState: LaLigaRouteState) {
-    const href = buildLaLigaHref(nextState, searchParams);
+    const href = buildHref(nextState, defaultState, aliasMap, searchParams);
     if (href === currentHref) {
       return;
     }
@@ -182,10 +189,10 @@ export function LaLigaClient({
   }
 
   function handleViewChange(view: LaLigaView) {
-    const nextClubs = filterClubsForView(view);
+    const nextClubs = filterClubs(summary.clubs, view);
     const nextClub = nextClubs.some((club) => club.id === selectedClubId)
       ? selectedClubId
-      : nextClubs[0]?.id ?? DEFAULT_LA_LIGA_STATE.club;
+      : nextClubs[0]?.id ?? defaultState.club;
 
     navigate({ view, club: nextClub });
   }
@@ -193,7 +200,7 @@ export function LaLigaClient({
   function handleClubChange(clubId: string) {
     navigate({
       view: routeState.view,
-      club: canonicalizeLaLigaClubId(clubId) ?? DEFAULT_LA_LIGA_STATE.club,
+      club: canonicalizeClubId(clubId, aliasMap) ?? defaultState.club,
     });
   }
 
@@ -451,7 +458,7 @@ export function LaLigaClient({
                     style={getViewButtonStyle(isActive)}
                   >
                     <span className="text-[var(--home-ink)]">{option.label}</span>
-                    <span className="text-xs text-[var(--home-ink-soft)]">{filterClubsForView(option.id).length}</span>
+                    <span className="text-xs text-[var(--home-ink-soft)]">{filterClubs(summary.clubs, option.id).length}</span>
                   </button>
                 );
               })}

--- a/src/app/la-liga/la-liga-state.core.ts
+++ b/src/app/la-liga/la-liga-state.core.ts
@@ -1,0 +1,132 @@
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import type { LaLigaClub, LaLigaRouteState, LaLigaView } from "@/types/la-liga";
+
+// Pure, snapshot-free route-state core for /la-liga. Importing this module never
+// pulls the multi-thousand-line `laLigaSnapshot` into the bundle, so the client
+// can derive route state from the lean `summary` prop it already receives
+// instead of dragging the full snapshot into browser JS. The snapshot-bound
+// wrappers in `la-liga-state.ts` reuse these helpers for server + test code.
+
+export const LA_LIGA_ROUTE = "/la-liga";
+
+/** Ultimate static fallback club id when no standings data exists. */
+export const LA_LIGA_FALLBACK_CLUB = "barcelona";
+
+const VALID_VIEWS = new Set<LaLigaView>(["table", "title-race", "europe", "relegation"]);
+
+export type SearchParamInput =
+  | URLSearchParams
+  | ReadonlyURLSearchParams
+  | Record<string, string | string[] | undefined | null>;
+
+type SearchParamRecord = Record<string, string | string[] | undefined | null>;
+
+type ClubAliasSource = { id: string; tla: string | null };
+
+export function buildClubAliasMap(teams: readonly ClubAliasSource[]): Map<string, string> {
+  return new Map(
+    teams.flatMap((team) => {
+      const canonicalClubId = team.tla?.toLowerCase() || team.id;
+      return [
+        [team.id.toLowerCase(), canonicalClubId],
+        [canonicalClubId, canonicalClubId],
+      ] as const;
+    })
+  );
+}
+
+export function canonicalizeClubId(
+  clubId: string | null | undefined,
+  aliasMap: Map<string, string>
+): string | null {
+  if (!clubId) {
+    return null;
+  }
+
+  return aliasMap.get(clubId.trim().toLowerCase()) ?? null;
+}
+
+export function readParam(input: SearchParamInput, key: string): string | null {
+  if ("get" in input && typeof input.get === "function") {
+    return input.get(key);
+  }
+
+  const rawValue = (input as SearchParamRecord)[key];
+  if (Array.isArray(rawValue)) {
+    return rawValue[0] ?? null;
+  }
+
+  return rawValue ?? null;
+}
+
+export function filterClubs(clubs: readonly LaLigaClub[], view: LaLigaView): LaLigaClub[] {
+  switch (view) {
+    case "title-race":
+      return clubs.slice(0, 4);
+    case "europe":
+      return clubs.slice(0, 6);
+    case "relegation":
+      return clubs.slice(-5);
+    case "table":
+    default:
+      return [...clubs];
+  }
+}
+
+export function getDefaultClub(
+  clubs: readonly LaLigaClub[],
+  view: LaLigaView,
+  fallback: string
+): string {
+  return filterClubs(clubs, view)[0]?.id ?? fallback;
+}
+
+export function resolveDefaultState(clubs: readonly LaLigaClub[]): LaLigaRouteState {
+  return {
+    view: "table",
+    club: clubs[0]?.id ?? LA_LIGA_FALLBACK_CLUB,
+  };
+}
+
+export function normalizeState(
+  input: SearchParamInput,
+  defaultState: LaLigaRouteState,
+  aliasMap: Map<string, string>
+): LaLigaRouteState {
+  const view = readParam(input, "view");
+  const club = canonicalizeClubId(readParam(input, "club"), aliasMap);
+
+  return {
+    view: VALID_VIEWS.has((view ?? "") as LaLigaView)
+      ? (view as LaLigaView)
+      : defaultState.view,
+    club: club ?? defaultState.club,
+  };
+}
+
+export function buildHref(
+  state: LaLigaRouteState,
+  defaultState: LaLigaRouteState,
+  aliasMap: Map<string, string>,
+  baseSearchParams?: URLSearchParams | ReadonlyURLSearchParams
+): string {
+  const params = new URLSearchParams(
+    baseSearchParams ? Array.from(baseSearchParams.entries()) : []
+  );
+  const canonicalClubId = canonicalizeClubId(state.club, aliasMap) ?? defaultState.club;
+
+  if (state.view === defaultState.view) {
+    params.delete("view");
+  } else {
+    params.set("view", state.view);
+  }
+
+  if (canonicalClubId === defaultState.club && state.view === defaultState.view) {
+    params.delete("club");
+  } else {
+    params.set("club", canonicalClubId);
+  }
+
+  const query = params.toString();
+  return `${LA_LIGA_ROUTE}${query ? `?${query}` : ""}`;
+}

--- a/src/app/la-liga/la-liga-state.ts
+++ b/src/app/la-liga/la-liga-state.ts
@@ -1,104 +1,40 @@
 import type { ReadonlyURLSearchParams } from "next/navigation";
 import { laLigaSnapshot } from "@/data/laLigaSnapshot";
 import type { LaLigaClub, LaLigaRouteState, LaLigaView } from "@/types/la-liga";
+import * as core from "./la-liga-state.core";
 
-export const LA_LIGA_ROUTE = "/la-liga";
+// Snapshot-bound wrappers. These keep the original public API used by the
+// server page and the unit tests, but the heavy `laLigaSnapshot` import lives
+// ONLY here (server side). The client imports the pure `la-liga-state.core`
+// module instead and feeds it the lean `summary` data it already has.
 
-const VALID_VIEWS = new Set<LaLigaView>(["table", "title-race", "europe", "relegation"]);
-const LA_LIGA_CLUB_ID_BY_ALIAS = new Map<string, string>(
-  laLigaSnapshot.teams.flatMap((team) => {
-    const canonicalClubId = team.tla?.toLowerCase() || team.id;
-    return [
-      [team.id.toLowerCase(), canonicalClubId],
-      [canonicalClubId, canonicalClubId],
-    ] as const;
-  })
+export const LA_LIGA_ROUTE = core.LA_LIGA_ROUTE;
+
+const ALIAS_MAP = core.buildClubAliasMap(laLigaSnapshot.teams);
+
+export const DEFAULT_LA_LIGA_STATE: LaLigaRouteState = core.resolveDefaultState(
+  laLigaSnapshot.clubs
 );
 
-type SearchParamInput =
-  | URLSearchParams
-  | ReadonlyURLSearchParams
-  | Record<string, string | string[] | undefined | null>;
-
-type SearchParamRecord = Record<string, string | string[] | undefined | null>;
-
-export const DEFAULT_LA_LIGA_STATE: LaLigaRouteState = {
-  view: "table",
-  club: laLigaSnapshot.clubs[0]?.id ?? "barcelona",
-};
-
 export function canonicalizeLaLigaClubId(clubId: string | null): string | null {
-  if (!clubId) {
-    return null;
-  }
-
-  return LA_LIGA_CLUB_ID_BY_ALIAS.get(clubId.trim().toLowerCase()) ?? null;
-}
-
-function readParam(input: SearchParamInput, key: string): string | null {
-  if ("get" in input && typeof input.get === "function") {
-    return input.get(key);
-  }
-
-  const rawValue = (input as SearchParamRecord)[key];
-  if (Array.isArray(rawValue)) {
-    return rawValue[0] ?? null;
-  }
-
-  return rawValue ?? null;
+  return core.canonicalizeClubId(clubId, ALIAS_MAP);
 }
 
 export function filterClubsForView(view: LaLigaView): LaLigaClub[] {
-  switch (view) {
-    case "title-race":
-      return laLigaSnapshot.clubs.slice(0, 4);
-    case "europe":
-      return laLigaSnapshot.clubs.slice(0, 6);
-    case "relegation":
-      return laLigaSnapshot.clubs.slice(-5);
-    case "table":
-    default:
-      return laLigaSnapshot.clubs;
-  }
+  return core.filterClubs(laLigaSnapshot.clubs, view);
 }
 
 export function getDefaultClubForView(view: LaLigaView): string {
-  return filterClubsForView(view)[0]?.id ?? DEFAULT_LA_LIGA_STATE.club;
+  return core.getDefaultClub(laLigaSnapshot.clubs, view, DEFAULT_LA_LIGA_STATE.club);
 }
 
-export function normalizeLaLigaState(input: SearchParamInput): LaLigaRouteState {
-  const view = readParam(input, "view");
-  const club = canonicalizeLaLigaClubId(readParam(input, "club"));
-
-  return {
-    view: VALID_VIEWS.has((view ?? "") as LaLigaView)
-      ? (view as LaLigaView)
-      : DEFAULT_LA_LIGA_STATE.view,
-    club: club ?? DEFAULT_LA_LIGA_STATE.club,
-  };
+export function normalizeLaLigaState(input: core.SearchParamInput): LaLigaRouteState {
+  return core.normalizeState(input, DEFAULT_LA_LIGA_STATE, ALIAS_MAP);
 }
 
 export function buildLaLigaHref(
   state: LaLigaRouteState,
   baseSearchParams?: URLSearchParams | ReadonlyURLSearchParams
 ): string {
-  const params = new URLSearchParams(
-    baseSearchParams ? Array.from(baseSearchParams.entries()) : []
-  );
-  const canonicalClubId = canonicalizeLaLigaClubId(state.club) ?? DEFAULT_LA_LIGA_STATE.club;
-
-  if (state.view === DEFAULT_LA_LIGA_STATE.view) {
-    params.delete("view");
-  } else {
-    params.set("view", state.view);
-  }
-
-  if (canonicalClubId === DEFAULT_LA_LIGA_STATE.club && state.view === DEFAULT_LA_LIGA_STATE.view) {
-    params.delete("club");
-  } else {
-    params.set("club", canonicalClubId);
-  }
-
-  const query = params.toString();
-  return `${LA_LIGA_ROUTE}${query ? `?${query}` : ""}`;
+  return core.buildHref(state, DEFAULT_LA_LIGA_STATE, ALIAS_MAP, baseSearchParams);
 }

--- a/src/app/mlb/mlb-client.tsx
+++ b/src/app/mlb/mlb-client.tsx
@@ -36,14 +36,15 @@ import type {
   MlbView,
 } from "@/types/mlb";
 import {
-  buildMlbHref,
-  canonicalizeMlbTeamId,
-  DEFAULT_MLB_STATE,
-  filterStandingsForView,
-  getDefaultTeamForView,
+  buildHref,
+  buildTeamAliasMap,
+  canonicalizeTeamId,
+  filterStandings,
+  getDefaultTeam,
   MLB_ROUTE,
-  normalizeMlbState,
-} from "./mlb-state";
+  normalizeState,
+  resolveDefaultState,
+} from "./mlb-state.core";
 
 interface MlbClientProps {
   initialState: MlbRouteState;
@@ -107,6 +108,13 @@ export function MlbClient({ initialState, summary, initialTeamSnapshot }: MlbCli
   const currentHref = `${MLB_ROUTE}${currentQuery ? `?${currentQuery}` : ""}`;
 
   const standings = summary.standings;
+  // Route-state helpers operate on the lean `summary` data the server already
+  // sent, so the full mlbSnapshot never enters the client bundle.
+  const aliasMap = useMemo(() => buildTeamAliasMap(summary.teams), [summary.teams]);
+  const defaultState = useMemo(
+    () => resolveDefaultState(standings, summary.teams),
+    [standings, summary.teams]
+  );
   const teamLookup = useMemo(
     () => new Map(summary.teams.map((team) => [team.id, team])),
     [summary.teams]
@@ -163,11 +171,13 @@ export function MlbClient({ initialState, summary, initialTeamSnapshot }: MlbCli
 
   const hasManagedParams =
     searchParams.get("view") !== null || searchParams.get("team") !== null;
-  const routeState = hasManagedParams ? normalizeMlbState(searchParams) : initialState;
-  const visibleStandings = filterStandingsForView(routeState.view);
+  const routeState = hasManagedParams
+    ? normalizeState(searchParams, defaultState, aliasMap)
+    : initialState;
+  const visibleStandings = filterStandings(standings, routeState.view);
   const selectedTeamId = visibleStandings.some((row) => row.id === routeState.team)
     ? routeState.team
-    : getDefaultTeamForView(routeState.view);
+    : getDefaultTeam(standings, routeState.view, defaultState.team);
   const selectedRow = standingsById.get(selectedTeamId) ?? standings[0];
   const selectedTeam = teamLookup.get(selectedRow?.id ?? "") ?? null;
 
@@ -182,8 +192,10 @@ export function MlbClient({ initialState, summary, initialTeamSnapshot }: MlbCli
   const teamSnapshot = selectedRow ? teamSnapshots[selectedRow.id] ?? null : null;
   const isTeamSnapshotLoading = selectedRow ? loadingTeamId === selectedRow.id : false;
 
-  const desiredHref = buildMlbHref(
+  const desiredHref = buildHref(
     { view: routeState.view, team: selectedTeamId },
+    defaultState,
+    aliasMap,
     searchParams
   );
 
@@ -230,7 +242,7 @@ export function MlbClient({ initialState, summary, initialTeamSnapshot }: MlbCli
   }, [selectedRow, teamSnapshots]);
 
   function navigate(nextState: MlbRouteState) {
-    const href = buildMlbHref(nextState, searchParams);
+    const href = buildHref(nextState, defaultState, aliasMap, searchParams);
     if (href === currentHref) return;
     startTransition(() => {
       router.push(href, { scroll: false });
@@ -238,17 +250,17 @@ export function MlbClient({ initialState, summary, initialTeamSnapshot }: MlbCli
   }
 
   function handleViewChange(view: MlbView) {
-    const next = filterStandingsForView(view);
+    const next = filterStandings(standings, view);
     const nextTeam = next.some((row) => row.id === selectedTeamId)
       ? selectedTeamId
-      : next[0]?.id ?? DEFAULT_MLB_STATE.team;
+      : next[0]?.id ?? defaultState.team;
     navigate({ view, team: nextTeam });
   }
 
   function handleTeamChange(teamId: string) {
     navigate({
       view: routeState.view,
-      team: canonicalizeMlbTeamId(teamId) ?? DEFAULT_MLB_STATE.team,
+      team: canonicalizeTeamId(teamId, aliasMap) ?? defaultState.team,
     });
   }
 
@@ -471,7 +483,7 @@ export function MlbClient({ initialState, summary, initialTeamSnapshot }: MlbCli
                   >
                     <span className="text-[var(--home-ink)]">{option.label}</span>
                     <span className="text-xs text-[var(--home-ink-soft)]">
-                      {filterStandingsForView(option.id).length}
+                      {filterStandings(standings, option.id).length}
                     </span>
                   </button>
                 );

--- a/src/app/mlb/mlb-state.core.ts
+++ b/src/app/mlb/mlb-state.core.ts
@@ -1,0 +1,149 @@
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import type { MlbRouteState, MlbStandingsRow, MlbView } from "@/types/mlb";
+
+// Pure, snapshot-free route-state core for /mlb. Importing this module never
+// pulls the multi-thousand-line `mlbSnapshot` into the bundle, so the client
+// can derive route state from the lean `summary` prop it already receives
+// instead of dragging the full snapshot into browser JS. The snapshot-bound
+// wrappers in `mlb-state.ts` reuse these helpers for server + test code.
+
+export const MLB_ROUTE = "/mlb";
+
+/** Ultimate static fallback team id (NYY) when no standings data exists. */
+export const MLB_FALLBACK_TEAM = "147";
+
+const VALID_VIEWS = new Set<MlbView>(["all", "al", "nl", "wildcard"]);
+
+export type SearchParamInput =
+  | URLSearchParams
+  | ReadonlyURLSearchParams
+  | Record<string, string | string[] | undefined | null>;
+
+type SearchParamRecord = Record<string, string | string[] | undefined | null>;
+
+type TeamAliasSource = { id: string; abbreviation: string };
+
+export function buildTeamAliasMap(teams: readonly TeamAliasSource[]): Map<string, string> {
+  return new Map(
+    teams.flatMap((team) => {
+      const canonical = team.id;
+      return [
+        [team.id.toLowerCase(), canonical],
+        [team.abbreviation.toLowerCase(), canonical],
+      ] as const;
+    })
+  );
+}
+
+export function canonicalizeTeamId(
+  teamId: string | null | undefined,
+  aliasMap: Map<string, string>
+): string | null {
+  if (!teamId) return null;
+  return aliasMap.get(teamId.trim().toLowerCase()) ?? null;
+}
+
+export function readParam(input: SearchParamInput, key: string): string | null {
+  if ("get" in input && typeof input.get === "function") {
+    return input.get(key);
+  }
+  const rawValue = (input as SearchParamRecord)[key];
+  if (Array.isArray(rawValue)) {
+    return rawValue[0] ?? null;
+  }
+  return rawValue ?? null;
+}
+
+function sortByDivisionRank(a: MlbStandingsRow, b: MlbStandingsRow): number {
+  if (a.league !== b.league) return a.league.localeCompare(b.league);
+  if (a.division !== b.division) return a.division.localeCompare(b.division);
+  return a.divisionRank - b.divisionRank;
+}
+
+function sortByWildCard(a: MlbStandingsRow, b: MlbStandingsRow): number {
+  const aRank = a.wildCardRank ?? 99;
+  const bRank = b.wildCardRank ?? 99;
+  if (aRank !== bRank) return aRank - bRank;
+  return b.pct - a.pct;
+}
+
+export function filterStandings(
+  standings: readonly MlbStandingsRow[],
+  view: MlbView
+): MlbStandingsRow[] {
+  switch (view) {
+    case "al":
+      return standings.filter((row) => row.league === "AL").sort(sortByDivisionRank);
+    case "nl":
+      return standings.filter((row) => row.league === "NL").sort(sortByDivisionRank);
+    case "wildcard":
+      return standings
+        .filter((row) => row.divisionRank > 1 && row.wildCardRank !== null && row.wildCardRank <= 6)
+        .sort((a, b) => {
+          if (a.league !== b.league) return a.league.localeCompare(b.league);
+          return sortByWildCard(a, b);
+        });
+    case "all":
+    default:
+      return [...standings].sort(sortByDivisionRank);
+  }
+}
+
+export function getDefaultTeam(
+  standings: readonly MlbStandingsRow[],
+  view: MlbView,
+  fallback: string
+): string {
+  return filterStandings(standings, view)[0]?.id ?? fallback;
+}
+
+export function resolveDefaultState(
+  standings: readonly MlbStandingsRow[],
+  teams: readonly { id: string }[]
+): MlbRouteState {
+  return {
+    view: "all",
+    team: standings[0]?.id ?? teams[0]?.id ?? MLB_FALLBACK_TEAM,
+  };
+}
+
+export function normalizeState(
+  input: SearchParamInput,
+  defaultState: MlbRouteState,
+  aliasMap: Map<string, string>
+): MlbRouteState {
+  const view = readParam(input, "view");
+  const team = canonicalizeTeamId(readParam(input, "team"), aliasMap);
+
+  return {
+    view: VALID_VIEWS.has((view ?? "") as MlbView) ? (view as MlbView) : defaultState.view,
+    team: team ?? defaultState.team,
+  };
+}
+
+export function buildHref(
+  state: MlbRouteState,
+  defaultState: MlbRouteState,
+  aliasMap: Map<string, string>,
+  baseSearchParams?: URLSearchParams | ReadonlyURLSearchParams
+): string {
+  const params = new URLSearchParams(
+    baseSearchParams ? Array.from(baseSearchParams.entries()) : []
+  );
+  const canonical = canonicalizeTeamId(state.team, aliasMap) ?? defaultState.team;
+
+  if (state.view === defaultState.view) {
+    params.delete("view");
+  } else {
+    params.set("view", state.view);
+  }
+
+  if (canonical === defaultState.team && state.view === defaultState.view) {
+    params.delete("team");
+  } else {
+    params.set("team", canonical);
+  }
+
+  const query = params.toString();
+  return `${MLB_ROUTE}${query ? `?${query}` : ""}`;
+}

--- a/src/app/mlb/mlb-state.ts
+++ b/src/app/mlb/mlb-state.ts
@@ -1,117 +1,41 @@
 import type { ReadonlyURLSearchParams } from "next/navigation";
 import { mlbSnapshot } from "@/data/mlbSnapshot";
 import type { MlbRouteState, MlbStandingsRow, MlbView } from "@/types/mlb";
+import * as core from "./mlb-state.core";
 
-export const MLB_ROUTE = "/mlb";
+// Snapshot-bound wrappers. These keep the original public API used by the
+// server page and the unit tests, but the heavy `mlbSnapshot` import lives
+// ONLY here (server side). The client imports the pure `mlb-state.core`
+// module instead and feeds it the lean `summary` data it already has.
 
-const VALID_VIEWS = new Set<MlbView>(["all", "al", "nl", "wildcard"]);
+export const MLB_ROUTE = core.MLB_ROUTE;
 
-const TEAM_ID_BY_ALIAS = new Map<string, string>(
-  mlbSnapshot.teams.flatMap((team) => {
-    const canonical = team.id;
-    return [
-      [team.id.toLowerCase(), canonical],
-      [team.abbreviation.toLowerCase(), canonical],
-    ] as const;
-  })
+const ALIAS_MAP = core.buildTeamAliasMap(mlbSnapshot.teams);
+
+export const DEFAULT_MLB_STATE: MlbRouteState = core.resolveDefaultState(
+  mlbSnapshot.standings,
+  mlbSnapshot.teams
 );
 
-type SearchParamInput =
-  | URLSearchParams
-  | ReadonlyURLSearchParams
-  | Record<string, string | string[] | undefined | null>;
-
-type SearchParamRecord = Record<string, string | string[] | undefined | null>;
-
-export const DEFAULT_MLB_STATE: MlbRouteState = {
-  view: "all",
-  team: mlbSnapshot.standings[0]?.id ?? mlbSnapshot.teams[0]?.id ?? "147",
-};
-
 export function canonicalizeMlbTeamId(teamId: string | null): string | null {
-  if (!teamId) return null;
-  return TEAM_ID_BY_ALIAS.get(teamId.trim().toLowerCase()) ?? null;
-}
-
-function readParam(input: SearchParamInput, key: string): string | null {
-  if ("get" in input && typeof input.get === "function") {
-    return input.get(key);
-  }
-  const rawValue = (input as SearchParamRecord)[key];
-  if (Array.isArray(rawValue)) {
-    return rawValue[0] ?? null;
-  }
-  return rawValue ?? null;
-}
-
-function sortByDivisionRank(a: MlbStandingsRow, b: MlbStandingsRow): number {
-  if (a.league !== b.league) return a.league.localeCompare(b.league);
-  if (a.division !== b.division) return a.division.localeCompare(b.division);
-  return a.divisionRank - b.divisionRank;
-}
-
-function sortByWildCard(a: MlbStandingsRow, b: MlbStandingsRow): number {
-  const aRank = a.wildCardRank ?? 99;
-  const bRank = b.wildCardRank ?? 99;
-  if (aRank !== bRank) return aRank - bRank;
-  return b.pct - a.pct;
+  return core.canonicalizeTeamId(teamId, ALIAS_MAP);
 }
 
 export function filterStandingsForView(view: MlbView): MlbStandingsRow[] {
-  const all = mlbSnapshot.standings;
-  switch (view) {
-    case "al":
-      return all.filter((row) => row.league === "AL").sort(sortByDivisionRank);
-    case "nl":
-      return all.filter((row) => row.league === "NL").sort(sortByDivisionRank);
-    case "wildcard":
-      return all
-        .filter((row) => row.divisionRank > 1 && row.wildCardRank !== null && row.wildCardRank <= 6)
-        .sort((a, b) => {
-          if (a.league !== b.league) return a.league.localeCompare(b.league);
-          return sortByWildCard(a, b);
-        });
-    case "all":
-    default:
-      return [...all].sort(sortByDivisionRank);
-  }
+  return core.filterStandings(mlbSnapshot.standings, view);
 }
 
 export function getDefaultTeamForView(view: MlbView): string {
-  return filterStandingsForView(view)[0]?.id ?? DEFAULT_MLB_STATE.team;
+  return core.getDefaultTeam(mlbSnapshot.standings, view, DEFAULT_MLB_STATE.team);
 }
 
-export function normalizeMlbState(input: SearchParamInput): MlbRouteState {
-  const view = readParam(input, "view");
-  const team = canonicalizeMlbTeamId(readParam(input, "team"));
-
-  return {
-    view: VALID_VIEWS.has((view ?? "") as MlbView) ? (view as MlbView) : DEFAULT_MLB_STATE.view,
-    team: team ?? DEFAULT_MLB_STATE.team,
-  };
+export function normalizeMlbState(input: core.SearchParamInput): MlbRouteState {
+  return core.normalizeState(input, DEFAULT_MLB_STATE, ALIAS_MAP);
 }
 
 export function buildMlbHref(
   state: MlbRouteState,
   baseSearchParams?: URLSearchParams | ReadonlyURLSearchParams
 ): string {
-  const params = new URLSearchParams(
-    baseSearchParams ? Array.from(baseSearchParams.entries()) : []
-  );
-  const canonical = canonicalizeMlbTeamId(state.team) ?? DEFAULT_MLB_STATE.team;
-
-  if (state.view === DEFAULT_MLB_STATE.view) {
-    params.delete("view");
-  } else {
-    params.set("view", state.view);
-  }
-
-  if (canonical === DEFAULT_MLB_STATE.team && state.view === DEFAULT_MLB_STATE.view) {
-    params.delete("team");
-  } else {
-    params.set("team", canonical);
-  }
-
-  const query = params.toString();
-  return `${MLB_ROUTE}${query ? `?${query}` : ""}`;
+  return core.buildHref(state, DEFAULT_MLB_STATE, ALIAS_MAP, baseSearchParams);
 }

--- a/src/app/nba/nba-client.tsx
+++ b/src/app/nba/nba-client.tsx
@@ -40,14 +40,15 @@ import type {
   NbaView,
 } from "@/types/nba";
 import {
-  buildNbaHref,
-  canonicalizeNbaTeamId,
-  DEFAULT_NBA_STATE,
-  filterTeamsForView,
-  getDefaultTeamForView,
+  buildHref,
+  buildTeamAliasMap,
+  canonicalizeTeamId,
+  filterTeams,
+  getDefaultTeam,
   NBA_ROUTE,
-  normalizeNbaState,
-} from "./nba-state";
+  normalizeState,
+  resolveDefaultState,
+} from "./nba-state.core";
 
 interface NbaClientProps {
   initialState: NbaRouteState;
@@ -82,10 +83,13 @@ export function NbaClient({ initialState, summary, initialTeamSnapshot }: NbaCli
   const currentQuery = searchParams.toString();
   const currentHref = `${NBA_ROUTE}${currentQuery ? `?${currentQuery}` : ""}`;
 
-  const allTeams = useMemo<NbaTeam[]>(
-    () => [...summary.teamsByConference.east, ...summary.teamsByConference.west],
-    [summary.teamsByConference]
-  );
+  const east = summary.teamsByConference.east;
+  const west = summary.teamsByConference.west;
+  const allTeams = useMemo<NbaTeam[]>(() => [...east, ...west], [east, west]);
+  // Route-state helpers operate on the lean `summary` data the server already
+  // sent, so the full nbaSnapshot never enters the client bundle.
+  const aliasMap = useMemo(() => buildTeamAliasMap(allTeams), [allTeams]);
+  const defaultState = useMemo(() => resolveDefaultState(east, west), [east, west]);
   const teamById = useMemo(() => new Map(allTeams.map((team) => [team.id, team])), [allTeams]);
   const teamLookup = useMemo(
     () => new Map(allTeams.map((team) => [team.id, team.shortName])),
@@ -114,11 +118,11 @@ export function NbaClient({ initialState, summary, initialTeamSnapshot }: NbaCli
     () =>
       new Map(
         summary.teams.map((team) => [
-          canonicalizeNbaTeamId(team.id) ?? team.id,
+          canonicalizeTeamId(team.id, aliasMap) ?? team.id,
           team.logo,
         ] as const)
       ),
-    [summary.teams]
+    [summary.teams, aliasMap]
   );
   const snapshotDateLabel = useMemo(
     () =>
@@ -132,11 +136,13 @@ export function NbaClient({ initialState, summary, initialTeamSnapshot }: NbaCli
 
   const hasManagedParams =
     searchParams.get("view") !== null || searchParams.get("team") !== null;
-  const routeState = hasManagedParams ? normalizeNbaState(searchParams) : initialState;
-  const visibleTeams = filterTeamsForView(routeState.view);
+  const routeState = hasManagedParams
+    ? normalizeState(searchParams, defaultState, aliasMap)
+    : initialState;
+  const visibleTeams = filterTeams(east, west, routeState.view);
   const selectedTeamId = visibleTeams.some((team) => team.id === routeState.team)
     ? routeState.team
-    : getDefaultTeamForView(routeState.view);
+    : getDefaultTeam(east, west, routeState.view, defaultState.team);
   const fallbackTeam = allTeams[0];
   const selectedTeam = teamById.get(selectedTeamId) ?? fallbackTeam;
 
@@ -148,8 +154,10 @@ export function NbaClient({ initialState, summary, initialTeamSnapshot }: NbaCli
   const [activeDetailTab, setActiveDetailTab] = useState<"team" | "schedule" | "leaders">("team");
   const teamSnapshot = selectedTeam ? teamSnapshots[selectedTeam.id] ?? null : null;
   const isTeamSnapshotLoading = selectedTeam ? loadingTeamId === selectedTeam.id : false;
-  const desiredHref = buildNbaHref(
+  const desiredHref = buildHref(
     { view: routeState.view, team: selectedTeamId },
+    defaultState,
+    aliasMap,
     searchParams
   );
 
@@ -161,7 +169,7 @@ export function NbaClient({ initialState, summary, initialTeamSnapshot }: NbaCli
   }, [currentHref, desiredHref, router]);
 
   function navigate(nextState: NbaRouteState) {
-    const href = buildNbaHref(nextState, searchParams);
+    const href = buildHref(nextState, defaultState, aliasMap, searchParams);
     if (href === currentHref) return;
     startTransition(() => {
       router.push(href, { scroll: false });
@@ -169,17 +177,17 @@ export function NbaClient({ initialState, summary, initialTeamSnapshot }: NbaCli
   }
 
   function handleViewChange(view: NbaView) {
-    const nextTeams = filterTeamsForView(view);
+    const nextTeams = filterTeams(east, west, view);
     const nextTeam = nextTeams.some((team) => team.id === selectedTeamId)
       ? selectedTeamId
-      : nextTeams[0]?.id ?? DEFAULT_NBA_STATE.team;
+      : nextTeams[0]?.id ?? defaultState.team;
     navigate({ view, team: nextTeam });
   }
 
   function handleTeamChange(teamId: string) {
     navigate({
       view: routeState.view,
-      team: canonicalizeNbaTeamId(teamId) ?? DEFAULT_NBA_STATE.team,
+      team: canonicalizeTeamId(teamId, aliasMap) ?? defaultState.team,
     });
   }
 
@@ -234,8 +242,8 @@ export function NbaClient({ initialState, summary, initialTeamSnapshot }: NbaCli
     );
   }
 
-  const eastTeams = summary.teamsByConference.east;
-  const westTeams = summary.teamsByConference.west;
+  const eastTeams = east;
+  const westTeams = west;
   const conferenceTeams = selectedTeam.conference === "east" ? eastTeams : westTeams;
   const conferenceContext = buildConferenceContext(conferenceTeams);
   const selectedZone = getTeamZone(selectedTeam.conferenceSeed);
@@ -446,7 +454,7 @@ export function NbaClient({ initialState, summary, initialTeamSnapshot }: NbaCli
                   >
                     <span className="text-[var(--home-ink)]">{option.label}</span>
                     <span className="text-xs text-[var(--home-ink-soft)]">
-                      {filterTeamsForView(option.id).length}
+                      {filterTeams(east, west, option.id).length}
                     </span>
                   </button>
                 );

--- a/src/app/nba/nba-state.core.ts
+++ b/src/app/nba/nba-state.core.ts
@@ -1,0 +1,145 @@
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import type { NbaConference, NbaRouteState, NbaTeam, NbaView } from "@/types/nba";
+
+// Pure, snapshot-free route-state core for /nba. Importing this module never
+// pulls the multi-thousand-line `nbaSnapshot` into the bundle, so the client
+// can derive route state from the lean `summary` prop it already receives
+// instead of dragging the full snapshot into browser JS. The snapshot-bound
+// wrappers in `nba-state.ts` reuse these helpers for server + test code.
+
+export const NBA_ROUTE = "/nba";
+
+/** Ultimate static fallback team id (BOS) when no standings data exists. */
+export const NBA_FALLBACK_TEAM = "bos";
+
+const VALID_VIEWS = new Set<NbaView>(["east", "west", "playoff", "play-in"]);
+
+export type SearchParamInput =
+  | URLSearchParams
+  | ReadonlyURLSearchParams
+  | Record<string, string | string[] | undefined | null>;
+
+type SearchParamRecord = Record<string, string | string[] | undefined | null>;
+
+type TeamAliasSource = { id: string; abbreviation: string };
+
+export function buildTeamAliasMap(teams: readonly TeamAliasSource[]): Map<string, string> {
+  return new Map(
+    teams.flatMap((team) => {
+      const canonical = team.id.toLowerCase();
+      return [
+        [team.id.toLowerCase(), canonical],
+        [team.abbreviation.toLowerCase(), canonical],
+      ] as const;
+    })
+  );
+}
+
+export function canonicalizeTeamId(
+  teamId: string | null | undefined,
+  aliasMap: Map<string, string>
+): string | null {
+  if (!teamId) return null;
+  return aliasMap.get(teamId.trim().toLowerCase()) ?? null;
+}
+
+export function readParam(input: SearchParamInput, key: string): string | null {
+  if ("get" in input && typeof input.get === "function") {
+    return input.get(key);
+  }
+  const rawValue = (input as SearchParamRecord)[key];
+  if (Array.isArray(rawValue)) return rawValue[0] ?? null;
+  return rawValue ?? null;
+}
+
+export function getConferenceForView(view: NbaView): NbaConference | "both" {
+  switch (view) {
+    case "west":
+      return "west";
+    case "east":
+      return "east";
+    case "playoff":
+    case "play-in":
+    default:
+      return "both";
+  }
+}
+
+export function filterTeams(
+  east: readonly NbaTeam[],
+  west: readonly NbaTeam[],
+  view: NbaView
+): NbaTeam[] {
+  switch (view) {
+    case "east":
+      return [...east];
+    case "west":
+      return [...west];
+    case "playoff":
+      return [...east.slice(0, 6), ...west.slice(0, 6)];
+    case "play-in":
+      return [...east.slice(6, 10), ...west.slice(6, 10)];
+    default:
+      return [...east, ...west];
+  }
+}
+
+export function getDefaultTeam(
+  east: readonly NbaTeam[],
+  west: readonly NbaTeam[],
+  view: NbaView,
+  fallback: string
+): string {
+  return filterTeams(east, west, view)[0]?.id ?? fallback;
+}
+
+export function resolveDefaultState(
+  east: readonly NbaTeam[],
+  west: readonly NbaTeam[]
+): NbaRouteState {
+  return {
+    view: "east",
+    team: east[0]?.id ?? west[0]?.id ?? NBA_FALLBACK_TEAM,
+  };
+}
+
+export function normalizeState(
+  input: SearchParamInput,
+  defaultState: NbaRouteState,
+  aliasMap: Map<string, string>
+): NbaRouteState {
+  const view = readParam(input, "view");
+  const team = canonicalizeTeamId(readParam(input, "team"), aliasMap);
+
+  return {
+    view: VALID_VIEWS.has((view ?? "") as NbaView) ? (view as NbaView) : defaultState.view,
+    team: team ?? defaultState.team,
+  };
+}
+
+export function buildHref(
+  state: NbaRouteState,
+  defaultState: NbaRouteState,
+  aliasMap: Map<string, string>,
+  baseSearchParams?: URLSearchParams | ReadonlyURLSearchParams
+): string {
+  const params = new URLSearchParams(
+    baseSearchParams ? Array.from(baseSearchParams.entries()) : []
+  );
+  const canonical = canonicalizeTeamId(state.team, aliasMap) ?? defaultState.team;
+
+  if (state.view === defaultState.view) {
+    params.delete("view");
+  } else {
+    params.set("view", state.view);
+  }
+
+  if (canonical === defaultState.team && state.view === defaultState.view) {
+    params.delete("team");
+  } else {
+    params.set("team", canonical);
+  }
+
+  const query = params.toString();
+  return `${NBA_ROUTE}${query ? `?${query}` : ""}`;
+}

--- a/src/app/nba/nba-state.ts
+++ b/src/app/nba/nba-state.ts
@@ -1,120 +1,45 @@
 import type { ReadonlyURLSearchParams } from "next/navigation";
 import { nbaSnapshot } from "@/data/nbaSnapshot";
 import type { NbaConference, NbaRouteState, NbaTeam, NbaView } from "@/types/nba";
+import * as core from "./nba-state.core";
 
-export const NBA_ROUTE = "/nba";
+// Snapshot-bound wrappers. These keep the original public API used by the
+// server page and the unit tests, but the heavy `nbaSnapshot` import lives
+// ONLY here (server side). The client imports the pure `nba-state.core`
+// module instead and feeds it the lean `summary` data it already has.
 
-const VALID_VIEWS = new Set<NbaView>(["east", "west", "playoff", "play-in"]);
+export const NBA_ROUTE = core.NBA_ROUTE;
 
-const allTeams: NbaTeam[] = [
-  ...nbaSnapshot.teamsByConference.east,
-  ...nbaSnapshot.teamsByConference.west,
-];
+const east = nbaSnapshot.teamsByConference.east;
+const west = nbaSnapshot.teamsByConference.west;
 
-const NBA_TEAM_ID_BY_ALIAS = new Map<string, string>(
-  allTeams.flatMap((team) => {
-    const canonical = team.id.toLowerCase();
-    const aliases = [team.id.toLowerCase(), team.abbreviation.toLowerCase()];
-    return aliases.map((alias) => [alias, canonical] as const);
-  })
-);
+const ALIAS_MAP = core.buildTeamAliasMap([...east, ...west]);
 
-type SearchParamInput =
-  | URLSearchParams
-  | ReadonlyURLSearchParams
-  | Record<string, string | string[] | undefined | null>;
-
-type SearchParamRecord = Record<string, string | string[] | undefined | null>;
-
-export const DEFAULT_NBA_STATE: NbaRouteState = {
-  view: "east",
-  team:
-    nbaSnapshot.teamsByConference.east[0]?.id ??
-    nbaSnapshot.teamsByConference.west[0]?.id ??
-    allTeams[0]?.id ??
-    "bos",
-};
+export const DEFAULT_NBA_STATE: NbaRouteState = core.resolveDefaultState(east, west);
 
 export function canonicalizeNbaTeamId(teamId: string | null): string | null {
-  if (!teamId) return null;
-  return NBA_TEAM_ID_BY_ALIAS.get(teamId.trim().toLowerCase()) ?? null;
-}
-
-function readParam(input: SearchParamInput, key: string): string | null {
-  if ("get" in input && typeof input.get === "function") {
-    return input.get(key);
-  }
-  const rawValue = (input as SearchParamRecord)[key];
-  if (Array.isArray(rawValue)) return rawValue[0] ?? null;
-  return rawValue ?? null;
+  return core.canonicalizeTeamId(teamId, ALIAS_MAP);
 }
 
 export function getConferenceForView(view: NbaView): NbaConference | "both" {
-  switch (view) {
-    case "west":
-      return "west";
-    case "east":
-      return "east";
-    case "playoff":
-    case "play-in":
-    default:
-      return "both";
-  }
+  return core.getConferenceForView(view);
 }
 
 export function filterTeamsForView(view: NbaView): NbaTeam[] {
-  const east = nbaSnapshot.teamsByConference.east;
-  const west = nbaSnapshot.teamsByConference.west;
-
-  switch (view) {
-    case "east":
-      return east;
-    case "west":
-      return west;
-    case "playoff":
-      return [...east.slice(0, 6), ...west.slice(0, 6)];
-    case "play-in":
-      return [...east.slice(6, 10), ...west.slice(6, 10)];
-    default:
-      return [...east, ...west];
-  }
+  return core.filterTeams(east, west, view);
 }
 
 export function getDefaultTeamForView(view: NbaView): string {
-  return filterTeamsForView(view)[0]?.id ?? DEFAULT_NBA_STATE.team;
+  return core.getDefaultTeam(east, west, view, DEFAULT_NBA_STATE.team);
 }
 
-export function normalizeNbaState(input: SearchParamInput): NbaRouteState {
-  const view = readParam(input, "view");
-  const team = canonicalizeNbaTeamId(readParam(input, "team"));
-
-  return {
-    view: VALID_VIEWS.has((view ?? "") as NbaView) ? (view as NbaView) : DEFAULT_NBA_STATE.view,
-    team: team ?? DEFAULT_NBA_STATE.team,
-  };
+export function normalizeNbaState(input: core.SearchParamInput): NbaRouteState {
+  return core.normalizeState(input, DEFAULT_NBA_STATE, ALIAS_MAP);
 }
 
 export function buildNbaHref(
   state: NbaRouteState,
   baseSearchParams?: URLSearchParams | ReadonlyURLSearchParams
 ): string {
-  const params = new URLSearchParams(
-    baseSearchParams ? Array.from(baseSearchParams.entries()) : []
-  );
-  const canonicalTeamId = canonicalizeNbaTeamId(state.team) ?? DEFAULT_NBA_STATE.team;
-
-  if (state.view === DEFAULT_NBA_STATE.view) {
-    params.delete("view");
-  } else {
-    params.set("view", state.view);
-  }
-
-  if (canonicalTeamId === DEFAULT_NBA_STATE.team && state.view === DEFAULT_NBA_STATE.view) {
-    params.delete("team");
-  } else {
-    params.set("team", canonicalTeamId);
-  }
-
-  const query = params.toString();
-  return `${NBA_ROUTE}${query ? `?${query}` : ""}`;
+  return core.buildHref(state, DEFAULT_NBA_STATE, ALIAS_MAP, baseSearchParams);
 }

--- a/src/app/nfl/nfl-client.tsx
+++ b/src/app/nfl/nfl-client.tsx
@@ -42,14 +42,15 @@ import type {
   NFLView,
 } from "@/types/nfl";
 import {
-  buildNflHref,
-  canonicalizeNflTeamId,
-  DEFAULT_NFL_STATE,
-  filterTeamsForView,
-  getDefaultTeamForView,
+  buildHref,
+  buildTeamAliasMap,
+  canonicalizeTeamId,
+  filterTeams,
+  getDefaultTeam,
   NFL_ROUTE,
-  normalizeNflState,
-} from "./nfl-state";
+  normalizeState,
+  resolveDefaultState,
+} from "./nfl-state.core";
 
 interface NflClientProps {
   initialState: NFLRouteState;
@@ -123,6 +124,8 @@ export function NflClient({
   const currentHref = `${NFL_ROUTE}${currentQuery ? `?${currentQuery}` : ""}`;
 
   const teams = summary.teams;
+  const aliasMap = useMemo(() => buildTeamAliasMap(summary.teams), [summary.teams]);
+  const defaultState = useMemo(() => resolveDefaultState(summary.teams), [summary.teams]);
   const teamById = useMemo(() => new Map(teams.map((team) => [team.id, team])), [teams]);
   const teamShortNameById = useMemo(
     () => new Map(teams.map((team) => [team.id, team.shortName])),
@@ -172,11 +175,13 @@ export function NflClient({
 
   const hasManagedParams =
     searchParams.get("view") !== null || searchParams.get("team") !== null;
-  const routeState = hasManagedParams ? normalizeNflState(searchParams) : initialState;
-  const visibleTeams = filterTeamsForView(routeState.view);
+  const routeState = hasManagedParams
+    ? normalizeState(searchParams, defaultState, aliasMap)
+    : initialState;
+  const visibleTeams = filterTeams(summary.teams, routeState.view);
   const selectedTeamId = visibleTeams.some((team) => team.id === routeState.team)
     ? routeState.team
-    : getDefaultTeamForView(routeState.view);
+    : getDefaultTeam(summary.teams, routeState.view, defaultState.team);
   const selectedTeam = teamById.get(selectedTeamId) ?? teams[0];
   const [teamSnapshots, setTeamSnapshots] = useState<Record<string, NFLTeamSnapshot>>(
     () =>
@@ -188,11 +193,13 @@ export function NflClient({
   const [teamSnapshotError, setTeamSnapshotError] = useState<string | null>(null);
   const teamSnapshot = selectedTeam ? teamSnapshots[selectedTeam.id] ?? null : null;
   const isTeamSnapshotLoading = selectedTeam ? loadingTeamId === selectedTeam.id : false;
-  const desiredHref = buildNflHref(
+  const desiredHref = buildHref(
     {
       view: routeState.view,
       team: selectedTeamId,
     },
+    defaultState,
+    aliasMap,
     searchParams
   );
 
@@ -204,7 +211,7 @@ export function NflClient({
   }, [currentHref, desiredHref, router]);
 
   function navigate(nextState: NFLRouteState) {
-    const href = buildNflHref(nextState, searchParams);
+    const href = buildHref(nextState, defaultState, aliasMap, searchParams);
     if (href === currentHref) return;
     startTransition(() => {
       router.push(href, { scroll: false });
@@ -212,17 +219,17 @@ export function NflClient({
   }
 
   function handleViewChange(view: NFLView) {
-    const nextTeams = filterTeamsForView(view);
+    const nextTeams = filterTeams(summary.teams, view);
     const nextTeam = nextTeams.some((team) => team.id === selectedTeamId)
       ? selectedTeamId
-      : nextTeams[0]?.id ?? DEFAULT_NFL_STATE.team;
+      : nextTeams[0]?.id ?? defaultState.team;
     navigate({ view, team: nextTeam });
   }
 
   function handleTeamChange(teamId: string) {
     navigate({
       view: routeState.view,
-      team: canonicalizeNflTeamId(teamId) ?? DEFAULT_NFL_STATE.team,
+      team: canonicalizeTeamId(teamId, aliasMap) ?? defaultState.team,
     });
   }
 
@@ -495,7 +502,7 @@ export function NflClient({
                   >
                     <span className="text-[var(--home-ink)]">{option.label}</span>
                     <span className="text-xs text-[var(--home-ink-soft)]">
-                      {filterTeamsForView(option.id).length}
+                      {filterTeams(summary.teams, option.id).length}
                     </span>
                   </button>
                 );

--- a/src/app/nfl/nfl-state.core.ts
+++ b/src/app/nfl/nfl-state.core.ts
@@ -1,0 +1,130 @@
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import type { NFLRouteState, NFLTeamStanding, NFLView } from "@/types/nfl";
+
+// Pure, snapshot-free route-state core for /nfl. Importing this module never
+// pulls the multi-thousand-line `nflSnapshot` into the bundle, so the client
+// can derive route state from the lean `summary` prop it already receives
+// instead of dragging the full snapshot into browser JS. The snapshot-bound
+// wrappers in `nfl-state.ts` reuse these helpers for server + test code.
+
+export const NFL_ROUTE = "/nfl";
+
+/** Ultimate static fallback team id (DEN) when no standings data exists. */
+export const NFL_FALLBACK_TEAM = "den";
+
+const VALID_VIEWS = new Set<NFLView>(["league", "afc", "nfc", "playoffs"]);
+
+export type SearchParamInput =
+  | URLSearchParams
+  | ReadonlyURLSearchParams
+  | Record<string, string | string[] | undefined | null>;
+
+type SearchParamRecord = Record<string, string | string[] | undefined | null>;
+
+type TeamAliasSource = { id: string; abbr: string };
+
+export function buildTeamAliasMap(teams: readonly TeamAliasSource[]): Map<string, string> {
+  return new Map(
+    teams.flatMap((team) => {
+      const canonical = team.id;
+      return [
+        [team.id.toLowerCase(), canonical],
+        [team.abbr.toLowerCase(), canonical],
+      ] as const;
+    })
+  );
+}
+
+export function canonicalizeTeamId(
+  teamId: string | null | undefined,
+  aliasMap: Map<string, string>
+): string | null {
+  if (!teamId) return null;
+  return aliasMap.get(teamId.trim().toLowerCase()) ?? null;
+}
+
+export function readParam(input: SearchParamInput, key: string): string | null {
+  if ("get" in input && typeof input.get === "function") {
+    return input.get(key);
+  }
+  const rawValue = (input as SearchParamRecord)[key];
+  if (Array.isArray(rawValue)) {
+    return rawValue[0] ?? null;
+  }
+  return rawValue ?? null;
+}
+
+export function filterTeams(
+  teams: readonly NFLTeamStanding[],
+  view: NFLView
+): NFLTeamStanding[] {
+  switch (view) {
+    case "afc":
+      return teams.filter((team) => team.conference === "AFC");
+    case "nfc":
+      return teams.filter((team) => team.conference === "NFC");
+    case "playoffs":
+      return teams.filter((team) => team.seed !== null && team.seed >= 1 && team.seed <= 7);
+    case "league":
+    default:
+      return [...teams];
+  }
+}
+
+export function getDefaultTeam(
+  teams: readonly NFLTeamStanding[],
+  view: NFLView,
+  fallback: string
+): string {
+  return filterTeams(teams, view)[0]?.id ?? fallback;
+}
+
+export function resolveDefaultState(teams: readonly NFLTeamStanding[]): NFLRouteState {
+  return {
+    view: "league",
+    team: teams[0]?.id ?? NFL_FALLBACK_TEAM,
+  };
+}
+
+export function normalizeState(
+  input: SearchParamInput,
+  defaultState: NFLRouteState,
+  aliasMap: Map<string, string>
+): NFLRouteState {
+  const view = readParam(input, "view");
+  const team = canonicalizeTeamId(readParam(input, "team"), aliasMap);
+
+  return {
+    view: VALID_VIEWS.has((view ?? "") as NFLView)
+      ? (view as NFLView)
+      : defaultState.view,
+    team: team ?? defaultState.team,
+  };
+}
+
+export function buildHref(
+  state: NFLRouteState,
+  defaultState: NFLRouteState,
+  aliasMap: Map<string, string>,
+  baseSearchParams?: URLSearchParams | ReadonlyURLSearchParams
+): string {
+  const params = new URLSearchParams(
+    baseSearchParams ? Array.from(baseSearchParams.entries()) : []
+  );
+  const canonicalTeamId = canonicalizeTeamId(state.team, aliasMap) ?? defaultState.team;
+
+  if (state.view === defaultState.view) {
+    params.delete("view");
+  } else {
+    params.set("view", state.view);
+  }
+
+  if (canonicalTeamId === defaultState.team && state.view === defaultState.view) {
+    params.delete("team");
+  } else {
+    params.set("team", canonicalTeamId);
+  }
+
+  const query = params.toString();
+  return `${NFL_ROUTE}${query ? `?${query}` : ""}`;
+}

--- a/src/app/nfl/nfl-state.ts
+++ b/src/app/nfl/nfl-state.ts
@@ -1,97 +1,40 @@
 import type { ReadonlyURLSearchParams } from "next/navigation";
 import { nflSnapshot } from "@/data/nflSnapshot";
 import type { NFLRouteState, NFLTeamStanding, NFLView } from "@/types/nfl";
+import * as core from "./nfl-state.core";
 
-export const NFL_ROUTE = "/nfl";
+// Snapshot-bound wrappers. These keep the original public API used by the
+// server page and the unit tests, but the heavy `nflSnapshot` import lives
+// ONLY here (server side). The client imports the pure `nfl-state.core`
+// module instead and feeds it the lean `summary` data it already has.
 
-const VALID_VIEWS = new Set<NFLView>(["league", "afc", "nfc", "playoffs"]);
+export const NFL_ROUTE = core.NFL_ROUTE;
 
-const NFL_TEAM_ID_BY_ALIAS = new Map<string, string>(
-  nflSnapshot.teams.flatMap((team) => [
-    [team.id.toLowerCase(), team.id],
-    [team.abbr.toLowerCase(), team.id],
-  ] as const)
+const ALIAS_MAP = core.buildTeamAliasMap(nflSnapshot.teams);
+
+export const DEFAULT_NFL_STATE: NFLRouteState = core.resolveDefaultState(
+  nflSnapshot.teams
 );
 
-type SearchParamInput =
-  | URLSearchParams
-  | ReadonlyURLSearchParams
-  | Record<string, string | string[] | undefined | null>;
-
-type SearchParamRecord = Record<string, string | string[] | undefined | null>;
-
-export const DEFAULT_NFL_STATE: NFLRouteState = {
-  view: "league",
-  team: nflSnapshot.teams[0]?.id ?? "den",
-};
-
 export function canonicalizeNflTeamId(teamId: string | null | undefined): string | null {
-  if (!teamId) return null;
-  return NFL_TEAM_ID_BY_ALIAS.get(teamId.trim().toLowerCase()) ?? null;
-}
-
-function readParam(input: SearchParamInput, key: string): string | null {
-  if ("get" in input && typeof input.get === "function") {
-    return input.get(key);
-  }
-  const rawValue = (input as SearchParamRecord)[key];
-  if (Array.isArray(rawValue)) {
-    return rawValue[0] ?? null;
-  }
-  return rawValue ?? null;
+  return core.canonicalizeTeamId(teamId, ALIAS_MAP);
 }
 
 export function filterTeamsForView(view: NFLView): NFLTeamStanding[] {
-  const all = nflSnapshot.teams;
-  switch (view) {
-    case "afc":
-      return all.filter((team) => team.conference === "AFC");
-    case "nfc":
-      return all.filter((team) => team.conference === "NFC");
-    case "playoffs":
-      return all.filter((team) => team.seed !== null && team.seed >= 1 && team.seed <= 7);
-    case "league":
-    default:
-      return all;
-  }
+  return core.filterTeams(nflSnapshot.teams, view);
 }
 
 export function getDefaultTeamForView(view: NFLView): string {
-  return filterTeamsForView(view)[0]?.id ?? DEFAULT_NFL_STATE.team;
+  return core.getDefaultTeam(nflSnapshot.teams, view, DEFAULT_NFL_STATE.team);
 }
 
-export function normalizeNflState(input: SearchParamInput): NFLRouteState {
-  const view = readParam(input, "view");
-  const team = canonicalizeNflTeamId(readParam(input, "team"));
-  return {
-    view: VALID_VIEWS.has((view ?? "") as NFLView)
-      ? (view as NFLView)
-      : DEFAULT_NFL_STATE.view,
-    team: team ?? DEFAULT_NFL_STATE.team,
-  };
+export function normalizeNflState(input: core.SearchParamInput): NFLRouteState {
+  return core.normalizeState(input, DEFAULT_NFL_STATE, ALIAS_MAP);
 }
 
 export function buildNflHref(
   state: NFLRouteState,
   baseSearchParams?: URLSearchParams | ReadonlyURLSearchParams
 ): string {
-  const params = new URLSearchParams(
-    baseSearchParams ? Array.from(baseSearchParams.entries()) : []
-  );
-  const canonicalTeamId = canonicalizeNflTeamId(state.team) ?? DEFAULT_NFL_STATE.team;
-
-  if (state.view === DEFAULT_NFL_STATE.view) {
-    params.delete("view");
-  } else {
-    params.set("view", state.view);
-  }
-
-  if (canonicalTeamId === DEFAULT_NFL_STATE.team && state.view === DEFAULT_NFL_STATE.view) {
-    params.delete("team");
-  } else {
-    params.set("team", canonicalTeamId);
-  }
-
-  const query = params.toString();
-  return `${NFL_ROUTE}${query ? `?${query}` : ""}`;
+  return core.buildHref(state, DEFAULT_NFL_STATE, ALIAS_MAP, baseSearchParams);
 }

--- a/src/components/ui/OptimizedImage.tsx
+++ b/src/components/ui/OptimizedImage.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
-import { motion, useReducedMotion } from 'framer-motion';
 
 interface OptimizedImageProps {
   src: string;
@@ -41,7 +40,6 @@ export function OptimizedImage({
   onLoad,
   onError,
 }: OptimizedImageProps) {
-  const shouldReduceMotion = useReducedMotion();
   const [isLoaded, setIsLoaded] = useState(false);
   const [isInView, setIsInView] = useState(!lazy);
   const [hasError, setHasError] = useState(false);
@@ -124,13 +122,13 @@ export function OptimizedImage({
         />
       )}
 
-      {/* Image */}
+      {/* Image — fade-in is pure CSS (opacity transition); a plain div avoids
+          pulling the framer-motion runtime into every page that renders an
+          image. motion-reduce disables the transition for reduced-motion users. */}
       {isInView && (
-        <motion.div
-          initial={{ opacity: shouldReduceMotion ? 1 : 0 }}
-          animate={{ opacity: isLoaded ? 1 : 0 }}
-          transition={{ duration: shouldReduceMotion ? 0 : 0.3 }}
-          className="relative w-full h-full"
+        <div
+          className="relative w-full h-full transition-opacity duration-300 ease-out motion-reduce:transition-none"
+          style={{ opacity: isLoaded ? 1 : 0 }}
         >
           <Image
             src={src}
@@ -150,7 +148,7 @@ export function OptimizedImage({
             onLoad={handleLoad}
             onError={handleError}
           />
-        </motion.div>
+        </div>
       )}
 
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7009,11 +7009,6 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-web-vitals@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz"
-  integrity sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==
-
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz"


### PR DESCRIPTION
## Performance audit — initial page-load fixes

This implements the highest-impact findings from a file-size / loading audit of the codebase. The dominant issue: four snapshot-driven dashboards were shipping their **entire committed data snapshots to the browser**, and the shared image component pulled the whole framer-motion runtime just to fade an image in.

### 1–4. Stop bundling sports snapshots into client JS (biggest win)

Each of `/mlb`, `/nfl`, `/nba`, `/la-liga` has a `"use client"` `*-client.tsx` that imported route-state helpers from `*-state.ts`. Those helpers did `import { <sport>Snapshot } from "@/data/<sport>Snapshot"`. Because a **client** module transitively imported the snapshot, webpack bundled the *whole* multi-thousand-line snapshot into the browser bundle — even though the server already passes a lean `summary` prop containing the same data.

| Route | Snapshot lines shipped to client (before) |
|---|---|
| `/mlb` | 10,785 |
| `/nfl` | 6,746 |
| `/nba` | 4,173 |
| `/la-liga` | 3,319 |

**Fix (same pattern per route):**
- Extracted a pure, snapshot-free `*-state.core.ts` whose helpers (`filterStandings`/`filterTeams`/`filterClubs`, `canonicalize…`, `buildHref`, `normalizeState`, alias-map + default-state builders) take the data as **parameters**.
- Rewrote `*-state.ts` as a thin snapshot-bound wrapper that builds the alias map / default state from the snapshot and re-exports the **exact original public API**, so the server `page.tsx` and the existing unit tests are unchanged.
- The clients now derive their alias map + default state from the `summary` prop they already receive (via `useMemo`) and call the pure core. The raw snapshot is no longer reachable from the client import graph.

This removes hundreds of KB of data-as-JS (parsed + executed on the client) from each of those routes' first load, with no behavior change.

### 5. `OptimizedImage`: framer-motion fade → CSS

The shared image component used a framer-motion `motion.div` purely to animate opacity on load, pulling the animation runtime into the image render path. Replaced with a plain `div` + CSS opacity transition (`motion-reduce:` disables it for reduced-motion users). Same visual behavior, no framer-motion.

### Housekeeping
- Removed the unused `web-vitals` dependency (not imported anywhere in the repo), including its lockfile entries.

### Verification
- `tsc --noEmit` — **clean, 0 errors** project-wide
- `jest src/app/{mlb,nfl,nba,la-liga}` — **22 tests / 8 suites pass** (test files unchanged)
- Confirmed no `*-client.tsx` transitively imports a raw `@/data/*Snapshot`, and the `*-state.core.ts` modules are snapshot-free while the wrappers retain the (server-only) snapshot import.

### Notes / further opportunities (not in this PR)
- `src/app/globals.css` is ~124 KB and render-blocking on every route — a candidate for a dead-CSS pass with build coverage data.
- Large source images (`public/images/writing/world-cup-team-photos/*` ≈ 4 MB, SpaceX images up to 3 MB) are served via `next/image` so delivery is CDN-optimized, but re-encoding the sources would cut repo + origin weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEbaoBcBS6jWodzEYtXdba

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEbaoBcBS6jWodzEYtXdba)_