### PR TITLE
UX review: surface live tools, make search findable, fix homepage freshness

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -457,6 +457,76 @@ async function getAllSearchableContent(): Promise<SearchableContent[]> {
       category: 'Personal',
       tags: ['Austin', 'Food', 'Restaurants', 'City Guide'],
     },
+    {
+      id: 'page-recipe-finder',
+      title: 'Recipe Finder',
+      excerpt:
+        'Browse a curated recipe collection filterable by cuisine, diet, meal, and the ingredients you already have on hand.',
+      content:
+        'Recipe finder cooking recipes cuisine diet meal ingredients kitchen pantry browser local storage personal',
+      url: '/recipe-finder',
+      type: 'project',
+      category: 'Personal',
+      tags: ['Recipes', 'Cooking', 'Food', 'Personal'],
+    },
+    {
+      id: 'page-wine-cellar',
+      title: 'Wine Cellar',
+      excerpt:
+        'Browser-persisted wine cellar log for tracking bottles, regions, vintages, and tasting notes.',
+      content:
+        'Wine cellar bottles tracker regions varietals vintages tasting notes ratings personal collection browser local storage',
+      url: '/wine-cellar',
+      type: 'project',
+      category: 'Personal',
+      tags: ['Wine', 'Cellar', 'Tasting Notes', 'Personal'],
+    },
+    {
+      id: 'page-frontier-models',
+      title: 'Frontier Models Tracker',
+      excerpt:
+        'Curated tracker of frontier AI models across providers — context windows, pricing, modalities, and release timing.',
+      content:
+        'Frontier models AI LLM tracker OpenAI Anthropic Google Meta context window pricing modality benchmarks providers release dates',
+      url: '/frontier-models',
+      type: 'project',
+      category: 'AI Tools',
+      tags: ['AI', 'LLMs', 'Frontier Models', 'Dashboard'],
+    },
+    {
+      id: 'page-decision-lab',
+      title: 'Decision Lab',
+      excerpt:
+        'Interactive decision-support workspace for weighing options against criteria with transparent, adjustable scoring.',
+      content:
+        'Decision lab decision making weighted scoring criteria options tradeoffs analysis framework presets decision support tool',
+      url: '/decision-lab',
+      type: 'project',
+      category: 'Decision Tools',
+      tags: ['Decision Support', 'Analysis', 'Frameworks', 'Tool'],
+    },
+    {
+      id: 'page-now',
+      title: 'Now',
+      excerpt:
+        'What I am focused on right now — current projects, reading, and priorities.',
+      content:
+        'now page current focus projects priorities reading what I am working on status update',
+      url: '/now',
+      type: 'page',
+      category: 'Site',
+    },
+    {
+      id: 'page-changelog',
+      title: 'Changelog',
+      excerpt:
+        'A running log of notable changes, new tools, and updates shipped across the site.',
+      content:
+        'changelog updates releases new tools shipped changes history site log',
+      url: '/changelog',
+      type: 'page',
+      category: 'Site',
+    },
   ];
 
   // De-duplicate by URL when a project case study and a static page entry

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -601,6 +601,77 @@
   color: var(--h-muted);
 }
 
+/* ============== Live tools directory (compact bordered grid) ============== */
+.h-tools-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--h-ink);
+  border-left: 1px solid var(--h-ink);
+}
+.h-tool {
+  grid-column: span 3;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  text-decoration: none;
+  color: inherit;
+  border-right: 1px solid var(--h-ink);
+  border-bottom: 1px solid var(--h-ink);
+  padding: clamp(1rem, 1.6vw, 1.4rem);
+  background: var(--h-paper);
+  transition: background 200ms ease;
+  min-height: 7.5rem;
+}
+@media (max-width: 980px) {
+  .h-tool {
+    grid-column: span 4;
+  }
+}
+@media (max-width: 660px) {
+  .h-tool {
+    grid-column: span 6;
+  }
+}
+.h-tool:hover {
+  background: var(--h-paper-soft);
+}
+.h-tool .cat {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--h-muted);
+}
+.h-tool h3 {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 500;
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+  color: var(--h-ink);
+  margin: 0;
+  text-wrap: balance;
+  font-variation-settings: "opsz" 32;
+}
+.h-tool .go {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--h-haze);
+  transition: gap 160ms ease;
+}
+.h-tool:hover .go {
+  gap: 10px;
+}
+
 /* ============== Manifesto section (inverted ink with giant numeral) ============== */
 .h-manifesto {
   background: var(--h-ink);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import {
   getPortfolioProjects,
 } from "@/constants/caseStudies";
 import { getAllBlogPostPreviews } from "@/lib/blog";
+import { getLiveToolGroups } from "@/constants/toolCategories";
 import { profile, profileSameAs } from "@/lib/profile";
 
 export { metadata } from "./metadata";
@@ -18,7 +19,14 @@ export default function Home() {
   // hosted destination set on the case study.
   const allPosts = getAllBlogPostPreviews();
   const allProjects = getPortfolioProjects();
-  const liveTools = allProjects.filter((p) => Boolean(p.link)).length;
+  // The "Live tools" directory groups every project that ships a real
+  // destination (on-site route or hosted app) by category, so the homepage
+  // surfaces the full breadth of live surfaces rather than the 3 featured cards.
+  const liveToolGroups = getLiveToolGroups(allProjects);
+  const liveTools = liveToolGroups.reduce(
+    (total, group) => total + group.tools.length,
+    0,
+  );
   const heroIndex = {
     projectCount: allProjects.length,
     essayCount: allPosts.length,
@@ -31,6 +39,7 @@ export default function Home() {
         featuredProjects={featuredProjects}
         recentPosts={allPosts}
         heroIndex={heroIndex}
+        liveToolGroups={liveToolGroups}
       />
 
       <StructuredData type="ProfilePage" />

--- a/src/components/StaticHeader.tsx
+++ b/src/components/StaticHeader.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { navLinks } from "@/constants/navlinks";
-import { Menu2, X } from "@/components/ui/ServerIcons";
+import { Menu2, Search, X } from "@/components/ui/ServerIcons";
 import { DeferredThemeToggle } from "@/components/ui/DeferredThemeToggle";
 import { cn } from "@/lib/utils";
 
@@ -17,6 +17,7 @@ export function StaticHeader() {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const pathname = usePathname();
+  const router = useRouter();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -34,6 +35,41 @@ export function StaticHeader() {
       document.body.style.overflow = "";
     };
   }, [isMobileMenuOpen]);
+
+  // Global search shortcuts: Cmd/Ctrl+K is the conventional "open search"
+  // chord, and "/" is the single-key shortcut common on content sites. "/" is
+  // ignored while the user is typing in a field so it never swallows input.
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const isTypingTarget =
+        !!target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT" ||
+          target.isContentEditable);
+
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        router.push("/search");
+        return;
+      }
+
+      if (
+        event.key === "/" &&
+        !isTypingTarget &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey
+      ) {
+        event.preventDefault();
+        router.push("/search");
+      }
+    };
+
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [router]);
 
   const closeMobileMenu = () => setIsMobileMenuOpen(false);
 
@@ -71,6 +107,15 @@ export function StaticHeader() {
           </Link>
 
           <div className="hidden lg:flex items-center gap-3">
+            <Link
+              href="/search"
+              aria-label="Search the site (press / or Ctrl+K)"
+              title="Search — press / or ⌘K"
+              className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors text-[var(--home-ink)] hover:bg-[var(--home-paper-alt)]"
+              onClick={closeMobileMenu}
+            >
+              <Search className="h-5 w-5" aria-hidden="true" />
+            </Link>
             <ul className="header-home-nav-list flex items-center gap-0" aria-label="Primary navigation">
               {navLinks.map((link) => {
                 const active = isRouteActive(pathname, link.href);
@@ -94,6 +139,14 @@ export function StaticHeader() {
           </div>
 
           <div className="flex items-center gap-2 lg:hidden">
+            <Link
+              href="/search"
+              aria-label="Search the site"
+              className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full border transition-colors header-home-control text-[var(--home-ink)] hover:bg-[var(--home-paper-alt)]"
+              onClick={closeMobileMenu}
+            >
+              <Search className="h-5 w-5" aria-hidden="true" />
+            </Link>
             <DeferredThemeToggle />
             <button
               type="button"

--- a/src/components/__tests__/StaticHeader.test.tsx
+++ b/src/components/__tests__/StaticHeader.test.tsx
@@ -6,6 +6,7 @@ import { StaticHeader } from "@/components/StaticHeader";
 
 jest.mock("next/navigation", () => ({
   usePathname: jest.fn(),
+  useRouter: () => ({ push: jest.fn() }),
 }));
 
 jest.mock("@/components/ui/DeferredThemeToggle", () => ({
@@ -98,6 +99,21 @@ describe("StaticHeader", () => {
     expect(primaryNav?.textContent).toContain("Writing");
     expect(themeButtons.length).toBeGreaterThan(0);
     expect(container.querySelector("header")?.className).toContain("header-home");
+  });
+
+  it("exposes a search affordance outside the navigation link lists", async () => {
+    await act(async () => {
+      root.render(<StaticHeader />);
+    });
+
+    // A visible search trigger must exist (desktop + mobile both link to /search).
+    const searchLinks = container.querySelectorAll('a[href="/search"]');
+    expect(searchLinks.length).toBeGreaterThan(0);
+
+    // It must NOT live inside the labelled nav lists — those stay limited to the
+    // canonical nav entries (asserted by the homepage e2e link-count checks).
+    const primaryNav = container.querySelector('[aria-label="Primary navigation"]');
+    expect(primaryNav?.querySelector('a[href="/search"]')).toBeNull();
   });
 
   it("passes desktop sizing classes to the deferred theme toggle", async () => {

--- a/src/components/home/HomePageV3.tsx
+++ b/src/components/home/HomePageV3.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import type { CaseStudyData } from "@/constants/caseStudies";
+import type { LiveToolGroup } from "@/constants/toolCategories";
 import type { BlogPostPreview } from "@/lib/blog";
 import { publishedDateFormatter } from "@/lib/utils";
 import styles from "@/app/page.module.css";
@@ -13,7 +14,16 @@ interface HomePageV3Props {
     essayCount: number;
     liveToolCount: number;
   };
+  liveToolGroups: LiveToolGroup[];
 }
+
+// Month-and-year label for the most recent published post, used as an honest
+// "Updated" stamp on the practice-stats band (replacing a hardcoded
+// "refreshed today" that was always-on regardless of real freshness).
+const updatedMonthFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  year: "numeric",
+});
 
 // Three cover variants ship in the CSS module. We cycle through them so
 // each "Selected work" card picks up a distinct treatment without us
@@ -129,8 +139,20 @@ export function HomePageV3({
   featuredProjects,
   recentPosts,
   heroIndex,
+  liveToolGroups,
 }: HomePageV3Props) {
   const writingCards = recentPosts.slice(0, 3);
+  const liveTools = liveToolGroups.flatMap((group) => group.tools);
+
+  // Most recent post timestamp drives the practice-stats "Updated" stamp.
+  // Reduce rather than trust array order so the label is correct regardless of
+  // how previews are sorted upstream.
+  const lastUpdatedTs = recentPosts.reduce((latest, post) => {
+    const ts = Date.parse(post.publishedAt);
+    return Number.isNaN(ts) ? latest : Math.max(latest, ts);
+  }, 0);
+  const lastUpdatedLabel =
+    lastUpdatedTs > 0 ? updatedMonthFormatter.format(lastUpdatedTs) : null;
 
   return (
     <div className={styles.page}>
@@ -349,11 +371,67 @@ export function HomePageV3({
         </div>
       </section>
 
+      {/* Live tools directory — surfaces every live surface by category so the
+          breadth isn't buried behind the 3 featured cards or the nav. */}
+      <section className={styles["h-section"]} id="tools" aria-labelledby="home-tools-heading">
+        <div className={styles.shell}>
+          <div className={styles["h-section-head"]}>
+            <div className={styles.left}>
+              <span className={styles["h-section-kicker"]}>
+                <span className={styles.num}>04</span> Live tools
+              </span>
+              <h2 id="home-tools-heading" className={styles["h-section-title"]}>
+                {heroIndex.liveToolCount} live tools you can <em>poke at</em> directly.
+              </h2>
+            </div>
+            <Link className={styles["h-section-link"]} href="/portfolio">
+              All projects
+              <ArrowRightMd />
+            </Link>
+          </div>
+
+          <div className={styles["h-tools-grid"]} data-testid="home-tools">
+            {liveTools.map((tool) => {
+              const inner = (
+                <>
+                  <span className={styles.cat}>{tool.categoryLabel}</span>
+                  <h3>{tool.title}</h3>
+                  <span className={styles.go}>
+                    {tool.isExternal ? "Visit" : "Open"}
+                    <ArrowRightSm />
+                  </span>
+                </>
+              );
+
+              if (tool.isExternal) {
+                return (
+                  <a
+                    key={tool.slug}
+                    className={styles["h-tool"]}
+                    href={tool.href}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {inner}
+                  </a>
+                );
+              }
+
+              return (
+                <Link key={tool.slug} className={styles["h-tool"]} href={tool.href}>
+                  {inner}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
       {/* Manifesto (inverted ink) */}
       <section className={styles["h-manifesto"]} aria-labelledby="home-manifesto-heading">
         <div className={styles.shell}>
           <div className={styles["h-manifesto-grid"]}>
-            <div className={styles["h-manifesto-num"]}>04</div>
+            <div className={styles["h-manifesto-num"]}>05</div>
             <div className={styles["h-manifesto-body"]}>
               <p
                 id="home-manifesto-heading"
@@ -391,7 +469,7 @@ export function HomePageV3({
           <div className={styles["h-section-head"]}>
             <div className={styles.left}>
               <span className={styles["h-section-kicker"]}>
-                <span className={styles.num}>05</span> Proof of work
+                <span className={styles.num}>06</span> Proof of work
               </span>
               <h2 id="home-writing-heading" className={styles["h-section-title"]}>
                 Writing on PM, <em>AI workflows</em>, and fintech tools.
@@ -447,7 +525,7 @@ export function HomePageV3({
           <div className={styles["h-section-head"]}>
             <div className={styles.left}>
               <span className={styles["h-section-kicker"]}>
-                <span className={styles.num}>06</span> Practice at a glance
+                <span className={styles.num}>07</span> Practice at a glance
               </span>
               <h2 id="home-stats-heading" className={styles["h-section-title"]}>
                 The numbers behind the <em>practice</em>.
@@ -462,7 +540,7 @@ export function HomePageV3({
                 color: "var(--h-muted)",
               }}
             >
-              Live &middot; refreshed today
+              {lastUpdatedLabel ? `Updated · ${lastUpdatedLabel}` : "Updated regularly"}
             </span>
           </div>
 

--- a/src/components/portfolio/PortfolioV3.tsx
+++ b/src/components/portfolio/PortfolioV3.tsx
@@ -6,6 +6,12 @@ import {
   type CaseStudyData,
   getProjectCardSummary,
 } from "@/constants/caseStudies";
+import {
+  TOOL_CATEGORY_DEFS as CATEGORY_DEFS,
+  classifyToolSlug as classify,
+  type ToolCategory as Category,
+  type ToolCategoryId,
+} from "@/constants/toolCategories";
 import { useTablistKeyboard } from "@/hooks/useTablistKeyboard";
 import styles from "@/app/portfolio/portfolio.module.css";
 
@@ -15,21 +21,7 @@ interface Props {
 
 type SortMode = "newest" | "alpha" | "live";
 
-type CategoryId =
-  | "all"
-  | "fintech"
-  | "pulse"
-  | "sports"
-  | "ai"
-  | "decision"
-  | "civic"
-  | "lifestyle";
-
-interface Category {
-  id: CategoryId;
-  label: string;
-  slugs: ReadonlySet<string>;
-}
+type CategoryId = "all" | ToolCategoryId;
 
 interface CardMeta {
   category: Exclude<CategoryId, "all">;
@@ -42,61 +34,7 @@ interface CardMeta {
 
 type ToneVariant = "is-acid" | "is-haze" | "is-paper" | "is-outline";
 
-const FINTECH = new Set([
-  "investment-analytics-platform",
-  "interchange-iq",
-  "budget-planner",
-]);
-const PULSE = new Set([
-  "pulse-dashboards",
-  "news-pulse-dashboard",
-  "github-trending-pulse",
-  "bay-area-transit-pulse",
-  "earthquake-pulse",
-  "tech-startup-tracker",
-]);
-const SPORTS = new Set([
-  "premier-league-pulse",
-  "la-liga-pulse",
-  "fantasy-football-analytics",
-  "nfl-pulse",
-  "mlb-pulse",
-  "nba-pulse",
-  "pga-tour-pulse",
-  "formula-1-pulse",
-  "fantasy-formula-1-optimizer",
-  "world-cup-pulse",
-  "march-madness-2026",
-  "spacex-mission-control",
-]);
-const AI = new Set([
-  "frontier-model-tracker",
-  "ai-dev-tool-ecosystem",
-]);
-const DECISION = new Set([
-  "decision-lab",
-  "mba-role-tracker",
-]);
-const CIVIC = new Set(["polling-aggregator"]);
-const LIFESTYLE = new Set([
-  "food-map",
-  "museum-log",
-  "wine-cellar",
-  "recipe-finder",
-  "travel-planner",
-]);
-
-const CATEGORY_DEFS: Category[] = [
-  { id: "fintech", label: "Fintech", slugs: FINTECH },
-  { id: "pulse", label: "Pulse", slugs: PULSE },
-  { id: "sports", label: "Sports", slugs: SPORTS },
-  { id: "ai", label: "AI tooling", slugs: AI },
-  { id: "decision", label: "Decision tools", slugs: DECISION },
-  { id: "civic", label: "Civic / Polls", slugs: CIVIC },
-  { id: "lifestyle", label: "Lifestyle", slugs: LIFESTYLE },
-];
-
-const CAT_TONE: Record<Exclude<CategoryId, "all">, ToneVariant> = {
+const CAT_TONE: Record<ToolCategoryId, ToneVariant> = {
   fintech: "is-acid",
   pulse: "is-haze",
   sports: "is-outline",
@@ -117,16 +55,6 @@ const COVERS = [
 ] as const;
 
 const PAGE_SIZE = 12;
-
-function classify(slug: string): Exclude<CategoryId, "all"> {
-  for (const def of CATEGORY_DEFS) {
-    if (def.slugs.has(slug)) {
-      return def.id as Exclude<CategoryId, "all">;
-    }
-  }
-  // Fallback bucket for slugs that haven't been categorized yet.
-  return "lifestyle";
-}
 
 function getMeta(study: CaseStudyData): CardMeta {
   const category = classify(study.slug);

--- a/src/constants/__tests__/toolCategories.test.ts
+++ b/src/constants/__tests__/toolCategories.test.ts
@@ -1,0 +1,77 @@
+import {
+  classifyToolSlug,
+  getLiveToolGroups,
+  getToolCategoryLabel,
+  TOOL_CATEGORY_DEFS,
+  type ProjectLike,
+} from "@/constants/toolCategories";
+
+describe("classifyToolSlug", () => {
+  it("buckets known slugs into their declared category", () => {
+    expect(classifyToolSlug("investment-analytics-platform")).toBe("fintech");
+    expect(classifyToolSlug("earthquake-pulse")).toBe("pulse");
+    expect(classifyToolSlug("nba-pulse")).toBe("sports");
+    expect(classifyToolSlug("frontier-model-tracker")).toBe("ai");
+    expect(classifyToolSlug("decision-lab")).toBe("decision");
+    expect(classifyToolSlug("polling-aggregator")).toBe("civic");
+    expect(classifyToolSlug("wine-cellar")).toBe("lifestyle");
+  });
+
+  it("falls back to lifestyle for an uncategorized slug", () => {
+    expect(classifyToolSlug("some-brand-new-project")).toBe("lifestyle");
+  });
+});
+
+describe("getToolCategoryLabel", () => {
+  it("returns the human label for each category id", () => {
+    for (const def of TOOL_CATEGORY_DEFS) {
+      expect(getToolCategoryLabel(def.id)).toBe(def.label);
+    }
+  });
+});
+
+describe("getLiveToolGroups", () => {
+  const projects: ProjectLike[] = [
+    { slug: "investment-analytics-platform", title: "Investments", link: "/investments" },
+    { slug: "case-study-only", title: "Case Study", link: null },
+    { slug: "blank-link", title: "Blank", link: "   " },
+    { slug: "nba-pulse", title: "NBA Pulse", link: "/nba" },
+    { slug: "external-tool", title: "External", link: "https://example.com/app" },
+  ];
+
+  it("includes only projects with a real link", () => {
+    const groups = getLiveToolGroups(projects);
+    const slugs = groups.flatMap((g) => g.tools.map((t) => t.slug));
+    expect(slugs).toContain("investment-analytics-platform");
+    expect(slugs).toContain("nba-pulse");
+    expect(slugs).not.toContain("case-study-only");
+    expect(slugs).not.toContain("blank-link");
+  });
+
+  it("flags external links and keeps internal routes internal", () => {
+    const groups = getLiveToolGroups(projects);
+    const tools = groups.flatMap((g) => g.tools);
+    const external = tools.find((t) => t.slug === "external-tool");
+    const internal = tools.find((t) => t.slug === "nba-pulse");
+    expect(external?.isExternal).toBe(true);
+    expect(internal?.isExternal).toBe(false);
+  });
+
+  it("orders groups by the canonical category order", () => {
+    const groups = getLiveToolGroups(projects);
+    const order = groups.map((g) => g.id);
+    const expectedOrder = TOOL_CATEGORY_DEFS.map((d) => d.id).filter((id) =>
+      order.includes(id),
+    );
+    expect(order).toEqual(expectedOrder);
+  });
+
+  it("omits empty categories", () => {
+    const groups = getLiveToolGroups([
+      { slug: "decision-lab", title: "Decision Lab", link: "/decision-lab" },
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].id).toBe("decision");
+    expect(groups[0].tools).toHaveLength(1);
+  });
+});

--- a/src/constants/toolCategories.ts
+++ b/src/constants/toolCategories.ts
@@ -1,0 +1,161 @@
+// Single source of truth for how portfolio projects are bucketed into
+// product categories. Both the /portfolio grid (PortfolioV3) and the homepage
+// "Live tools" directory (HomePageV3) read from here so the two surfaces never
+// drift on which tool lives in which category.
+
+export type ToolCategoryId =
+  | "fintech"
+  | "pulse"
+  | "sports"
+  | "ai"
+  | "decision"
+  | "civic"
+  | "lifestyle";
+
+export interface ToolCategory {
+  id: ToolCategoryId;
+  label: string;
+  slugs: ReadonlySet<string>;
+}
+
+const FINTECH = new Set([
+  "investment-analytics-platform",
+  "interchange-iq",
+  "budget-planner",
+]);
+const PULSE = new Set([
+  "pulse-dashboards",
+  "news-pulse-dashboard",
+  "github-trending-pulse",
+  "bay-area-transit-pulse",
+  "earthquake-pulse",
+  "tech-startup-tracker",
+]);
+const SPORTS = new Set([
+  "premier-league-pulse",
+  "la-liga-pulse",
+  "fantasy-football-analytics",
+  "nfl-pulse",
+  "mlb-pulse",
+  "nba-pulse",
+  "pga-tour-pulse",
+  "formula-1-pulse",
+  "fantasy-formula-1-optimizer",
+  "world-cup-pulse",
+  "march-madness-2026",
+  "spacex-mission-control",
+]);
+const AI = new Set([
+  "frontier-model-tracker",
+  "ai-dev-tool-ecosystem",
+]);
+const DECISION = new Set([
+  "decision-lab",
+  "mba-role-tracker",
+]);
+const CIVIC = new Set(["polling-aggregator"]);
+const LIFESTYLE = new Set([
+  "food-map",
+  "museum-log",
+  "wine-cellar",
+  "recipe-finder",
+  "travel-planner",
+]);
+
+// Display order is intentional: the strongest product surfaces (fintech,
+// pulse, sports) lead, with the lighter lifestyle tools last.
+export const TOOL_CATEGORY_DEFS: ToolCategory[] = [
+  { id: "fintech", label: "Fintech", slugs: FINTECH },
+  { id: "pulse", label: "Pulse", slugs: PULSE },
+  { id: "sports", label: "Sports", slugs: SPORTS },
+  { id: "ai", label: "AI tooling", slugs: AI },
+  { id: "decision", label: "Decision tools", slugs: DECISION },
+  { id: "civic", label: "Civic / Polls", slugs: CIVIC },
+  { id: "lifestyle", label: "Lifestyle", slugs: LIFESTYLE },
+];
+
+/**
+ * Map a project slug to its category. Falls back to "lifestyle" for any slug
+ * that hasn't been bucketed yet, so a newly added project still lands in a
+ * real category rather than throwing.
+ */
+export function classifyToolSlug(slug: string): ToolCategoryId {
+  for (const def of TOOL_CATEGORY_DEFS) {
+    if (def.slugs.has(slug)) {
+      return def.id;
+    }
+  }
+  return "lifestyle";
+}
+
+export function getToolCategoryLabel(id: ToolCategoryId): string {
+  return TOOL_CATEGORY_DEFS.find((c) => c.id === id)?.label ?? "Project";
+}
+
+// ---- Homepage "Live tools" directory ------------------------------------
+
+/** Minimal structural shape so this module never imports the case-study data. */
+export interface ProjectLike {
+  slug: string;
+  title: string;
+  link?: string | null;
+}
+
+export interface LiveToolEntry {
+  slug: string;
+  title: string;
+  href: string;
+  isExternal: boolean;
+  categoryId: ToolCategoryId;
+  categoryLabel: string;
+}
+
+export interface LiveToolGroup {
+  id: ToolCategoryId;
+  label: string;
+  tools: LiveToolEntry[];
+}
+
+function isExternalLink(link: string): boolean {
+  return /^https?:\/\//i.test(link);
+}
+
+/**
+ * Build the homepage live-tools directory from the portfolio projects. A "live
+ * tool" is any project with a `link` (an on-site route or an external app) —
+ * the same definition the hero uses for its "live tools" count, so the count
+ * and the directory always agree. Groups come back in TOOL_CATEGORY_DEFS order
+ * and projects keep their incoming order within each group.
+ */
+export function getLiveToolGroups(projects: ProjectLike[]): LiveToolGroup[] {
+  const byCategory = new Map<ToolCategoryId, LiveToolEntry[]>();
+
+  for (const project of projects) {
+    const link = project.link?.trim();
+    if (!link) continue;
+
+    const categoryId = classifyToolSlug(project.slug);
+    const entry: LiveToolEntry = {
+      slug: project.slug,
+      title: project.title,
+      href: link,
+      isExternal: isExternalLink(link),
+      categoryId,
+      categoryLabel: getToolCategoryLabel(categoryId),
+    };
+
+    const bucket = byCategory.get(categoryId);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      byCategory.set(categoryId, [entry]);
+    }
+  }
+
+  return TOOL_CATEGORY_DEFS.flatMap((def) => {
+    const tools = byCategory.get(def.id);
+    return tools && tools.length > 0
+      ? [{ id: def.id, label: def.label, tools }]
+      : [];
+  });
+}


### PR DESCRIPTION
## What & why

Implements the three **highest-impact** findings from the UX review. Each addresses a problem where the interface under-represented how much the site actually offers, or made a claim it couldn't back up.

### 1. Discoverability — the live tools were nearly invisible
The global nav exposes 8 links, but the site has ~30 live dashboards/tools reachable only by going to "Projects" and filtering. The hero advertised "*N* live tools in production" with no path to them.

- New **"Live tools" directory** section on the homepage that lists every live surface, grouped by category, linking directly to each.
- Backed by a new shared module `src/constants/toolCategories.ts` — a single source of truth for the slug→category mapping. `/portfolio` (PortfolioV3) now reads from it too, **removing the duplicated category maps** that previously lived only in the portfolio client.

### 2. Findable search — search existed but was invisible
There was no search affordance anywhere in the header and no keyboard shortcut; `/search` was reachable only by typing the URL. The index was also missing several live routes.

- Visible **search trigger in the header** (desktop + mobile). Triggers sit *outside* the labelled nav lists, so the `Primary navigation` / `Mobile navigation` link-count contracts (enforced by the homepage e2e specs) stay intact.
- Global **`⌘K` / `Ctrl+K`** and **`/`** shortcuts (the `/` shortcut is ignored while typing in a field).
- Completed the search index with the 6 missing live routes: `recipe-finder`, `wine-cellar`, `frontier-models`, `decision-lab`, `now`, `changelog`.

### 3. Trust — the homepage claimed "refreshed today" unconditionally
The "Practice at a glance" band rendered a hardcoded `Live · refreshed today` regardless of actual freshness.

- Replaced with a real **`Updated · <month year>`** derived from the most recent published post (falls back to "Updated regularly" if no date parses).

## Verification
- `tsc --noEmit` clean
- `eslint src` clean (changed files)
- Full Jest suite: **889 tests pass** (added unit coverage for the tool-category helpers; updated `StaticHeader` test for the new search affordance + `useRouter` mock)
- `next build` succeeds

## Notes / not in this PR
- The **nav asymmetry** (Investments/Fantasy elevated to top-level while the other ~28 tools aren't) is intentionally left alone — the homepage directory + findable search address the core "breadth is invisible" problem without restructuring the global nav. A nav dropdown/mega-menu remains an optional follow-up.
- Two other Tier-1 review items — **uniform data-staleness chips** across the snapshot dashboards and **loading skeletons** for async team-detail panels — are cross-cutting dashboard changes best done as a focused, visually-verified follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPxxqguwPxYFaBBEYLdHCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPxxqguwPxYFaBBEYLdHCm)_