### PR TITLE
ci: add a third E2E shard to speed up PR feedback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,11 +83,13 @@ jobs:
     name: E2E Tests (chromium)
     runs-on: ubuntu-latest
     needs: build
-    # Shard the spec files across N runners. Bump the matrix length to scale.
+    # Shard the spec files across N runners. Bump the matrix length to scale;
+    # the run step derives the divisor from `strategy.job-total`, so adding a
+    # shard number here is the only change needed.
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What

Bumps the chromium E2E matrix in `.github/workflows/test.yml` from **2 shards to 3**.

## Why

The E2E suite (~65 tests across 11 spec files) was already well-parallelized — `fullyParallel: true`, 4 workers per runner, sharded across CI runners, with the build artifact, `node_modules`, and Playwright browsers all cached. The cheapest remaining lever for faster PR feedback is splitting the spec files across one more runner.

## How

The run step already uses `--shard=${{ matrix.shard }}/${{ strategy.job-total }}`, and the report artifact is keyed per-shard, so adding `3` to the matrix array is the only change required — everything else auto-scales.

Each shard pays ~1–2 min of fixed overhead (artifact download + `next start`), so returns diminish beyond this; 3 shards is a sensible balance for a suite this size.

## Notes

- Affects PR feedback only (chromium-only path). The post-merge full browser matrix is unchanged.
- If `e2e-tests` is a required status check via branch protection, note the matrix expands the check name per shard — branch protection may need the new shard's check added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVfdSBibP7MctwdPTkaWjB)_