### PR TITLE
a11y: fix mobile-menu focus order, compare-modal focus trap, filter state

### DIFF
--- a/docs/accessibility-audit-2026-06.md
+++ b/docs/accessibility-audit-2026-06.md
@@ -1,0 +1,60 @@
+# Accessibility Audit — June 2026
+
+**Standard:** WCAG 2.1 AA (with AAA where practical)
+**Scope:** Code-level audit of `src/` (components + App Router routes)
+**Method:** Manual code review of the shell, navigation, modals, forms, images, and global styles. No automated scanner (axe/Lighthouse) is wired into the repo yet — see "Recommended follow-ups."
+
+This is the current accessibility reference. The root-level `ACCESSIBILITY_AUDIT.md` is a November 2025 snapshot kept for history only; it describes components that have since been removed (`FloatingNav`, `ModernButton`) and the old monochrome palette, so do not treat it as current.
+
+---
+
+## Summary
+
+The site has strong accessibility foundations already in place:
+
+- `lang="en"` on `<html>` and a working **skip link** to `#main-content` (`src/app/layout.tsx`).
+- Real landmarks (`<header>`, `<nav>`, `<main>`, `<footer>`) and a single `<h1>` per page (enforced by `e2e/accessibility.spec.ts`).
+- `prefers-reduced-motion` is honored globally in CSS (`src/app/globals.css`) **and** per-component via Framer Motion's `useReducedMotion()` in the animated surfaces (`ProjectDetailModal`, `PlayerDetailDrawer`, `CompareModal`, etc.).
+- `:focus-visible` rings on all interactive elements; pointer focus is suppressed but keyboard focus is always shown.
+- 44px minimum touch targets across nav, controls, and the theme toggle.
+- Icon-only buttons carry `aria-label`s (e.g. `ThemeToggle`, mobile menu toggle, modal close buttons).
+- Images use descriptive `alt`, with `alt=""` + `aria-hidden` for decorative graphics.
+- External `target="_blank"` links consistently use `rel="noopener noreferrer"`.
+- Most overlays (`PlayerDetailDrawer`, `EmailDigestDialog`, `ApplicationEditDialog`) implement a full focus trap, `Escape` to close, `role="dialog"` + `aria-modal`, and focus restoration on close.
+
+The audit found a small number of concrete gaps. The high-confidence ones were fixed in this change; the remainder are documented below as follow-ups.
+
+---
+
+## Fixed in this change
+
+### 1. Mobile nav menu kept collapsed links in the tab order — `src/components/StaticHeader.tsx`
+The mobile menu stays mounted for its height/opacity transition. When collapsed (`max-h-0 opacity-0`) its links were still reachable by `Tab` and exposed to screen readers, so keyboard users on desktop tabbed into invisible navigation (WCAG 2.4.3 Focus Order, 1.3.2 Meaningful Sequence).
+**Fix:** added `inert` and `aria-hidden` on the menu container while closed, removing the collapsed links from both the tab order and the accessibility tree.
+
+### 2. `CompareModal` lacked a focus trap and focus restoration — `src/components/fantasy/CompareModal.tsx`
+The compare overlay already had `role="dialog"`, `aria-modal`, `aria-label`, and `Escape` handling, but — unlike its sibling modals — it did not move focus into the dialog, trap `Tab` within it, or restore focus to the trigger on close (WCAG 2.4.3, 2.1.2 No Keyboard Trap / focus management).
+**Fix:** mirrored the established `PlayerDetailDrawer` pattern — capture the active element on open, focus the panel, wrap `Tab`/`Shift+Tab` within the dialog, and restore focus on unmount.
+
+### 3. Search filter pills did not announce their active state — `src/components/search/SearchFilters.tsx`
+The content-type and category filter pills are toggles styled only by color/background, with no programmatic state, so screen-reader users could not tell which filter was active (WCAG 1.3.1 Info and Relationships, 4.1.2 Name, Role, Value).
+**Fix:** added `aria-pressed` reflecting the selected state to both pill groups.
+
+---
+
+## Recommended follow-ups (not changed here)
+
+These are lower-severity or need a product decision, so they're left for a follow-up rather than changed blindly:
+
+- **`WarmCard` clickable semantics (`src/components/ui/WarmCard.tsx`).** The component accepts an `onClick` and renders a `<div role="article">`, which would be keyboard-inaccessible if used as a button. **No current caller passes `onClick`**, so this is latent, not a live defect. If a clickable variant is ever needed, render a real `<button>` (or add `role="button"`, `tabIndex={0}`, and `Enter`/`Space` handlers).
+- **"Opens in a new tab" cue for external links.** External links secure the tab with `rel="noopener noreferrer"` but most rely on a visual icon only. Consider a visually-hidden "(opens in a new tab)" string for screen-reader users, matching the pattern already used on the W3C link in `src/app/accessibility/page.tsx`.
+- **Manual contrast verification of muted tokens.** `--home-ink-muted` and the `color-mix()`-derived `--home-ink-soft` / `--text-tertiary` are documented as tuned for AA, but should be re-verified with a contrast checker in both light and dark mode, especially for small text.
+- **Wire up an automated scanner.** `e2e/accessibility.spec.ts` does hand-rolled checks and its own comment notes "in production, you'd use axe-core." Adding `@axe-core/playwright` to that spec, and/or `eslint-plugin-jsx-a11y`, would catch regressions automatically. Neither is currently installed.
+
+---
+
+## Verification
+
+- `npx tsc --noEmit` — passes
+- `npx eslint` on the three changed files — clean
+- `npx jest src/components/fantasy src/components/ui/__tests__/WarmCard.test.tsx` — passes

--- a/src/components/StaticHeader.tsx
+++ b/src/components/StaticHeader.tsx
@@ -111,6 +111,11 @@ export function StaticHeader() {
 
       <div
         id="mobile-menu"
+        // Collapsed menu stays in the DOM for the height transition, so mark it
+        // inert + aria-hidden to keep its links out of the tab order and the
+        // accessibility tree until it's actually open.
+        inert={!isMobileMenuOpen}
+        aria-hidden={!isMobileMenuOpen}
         className={cn(
           "overflow-hidden transition-[max-height,opacity] duration-300 ease-out lg:hidden",
           isMobileMenuOpen ? "max-h-[80vh] opacity-100" : "max-h-0 opacity-0"

--- a/src/components/fantasy/CompareModal.tsx
+++ b/src/components/fantasy/CompareModal.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { X } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import {
   formatAdp,
@@ -70,13 +70,45 @@ function bestIndex(players: Player[], key: string, direction: Direction): number
 
 export function CompareModal({ players, publishedRank, onClose, onRemove }: CompareModalProps) {
   const reduceMotion = useReducedMotion();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
 
+  // Capture focus on open, trap Tab within the panel, and restore on close.
   useEffect(() => {
-    function onKey(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
+    restoreFocusRef.current = document.activeElement as HTMLElement | null;
+
+    const panel = panelRef.current;
+    panel?.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab" || !panel) return;
+
+      const focusable = panel.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), textarea, input, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     }
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      restoreFocusRef.current?.focus?.();
+    };
   }, [onClose]);
 
   const scaleMin = Math.min(...players.map((p) => (Number.isFinite(p.minRank) ? (p.minRank as number) : Infinity)));
@@ -151,14 +183,16 @@ export function CompareModal({ players, publishedRank, onClose, onRemove }: Comp
           tabIndex={-1}
         />
         <motion.div
+          ref={panelRef}
           role="dialog"
           aria-modal="true"
           aria-label="Compare players"
+          tabIndex={-1}
           initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 18, scale: 0.98 }}
           animate={{ opacity: 1, y: 0, scale: 1 }}
           exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 18, scale: 0.98 }}
           transition={{ duration: reduceMotion ? 0 : 0.22, ease: [0.25, 0.46, 0.45, 0.94] }}
-          className="relative max-h-[88vh] w-full max-w-2xl overflow-auto rounded-[1.6rem] border p-5"
+          className="relative max-h-[88vh] w-full max-w-2xl overflow-auto rounded-[1.6rem] border p-5 outline-none"
           style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)", boxShadow: "var(--shadow-xl)" }}
         >
           <div className="mb-4 flex items-center justify-between">

--- a/src/components/search/SearchFilters.tsx
+++ b/src/components/search/SearchFilters.tsx
@@ -68,6 +68,7 @@ export function SearchFilters({
             <button
               key={contentType.id}
               onClick={() => onTypeChange(contentType.id)}
+              aria-pressed={type === contentType.id}
               className="inline-flex min-h-[36px] items-center rounded-full px-3 py-1 text-xs font-semibold transition-colors"
               style={{
                 fontFamily: "var(--font-home-sans)",
@@ -93,6 +94,7 @@ export function SearchFilters({
             <button
               key={cat.id}
               onClick={() => onCategoryChange(cat.id)}
+              aria-pressed={category === cat.id}
               className="inline-flex min-h-[36px] items-center rounded-full px-3 py-1 text-xs font-semibold transition-colors"
               style={{
                 fontFamily: "var(--font-home-sans)",


### PR DESCRIPTION
## Accessibility audit (WCAG 2.1 AA)

A code-level accessibility pass over `src/`. The site already had strong foundations — skip link, landmarks, single `<h1>`/page, global + per-component `prefers-reduced-motion`, `:focus-visible` rings, 44px touch targets, labeled icon buttons, and full focus traps on most modals. This PR fixes the highest-confidence gaps that review surfaced and adds a current audit reference doc.

### Fixes
- **`StaticHeader`** — the mobile nav menu stays mounted for its height transition; while collapsed its links were still tabbable and exposed to screen readers. Marked the closed menu `inert` + `aria-hidden` so it leaves the tab order and a11y tree (WCAG 2.4.3, 1.3.2).
- **`CompareModal`** — already had `role="dialog"`/`aria-modal`/Escape, but no focus trap or restoration. Added focus capture on open, `Tab`/`Shift+Tab` wrapping, and focus restore on close, mirroring the existing `PlayerDetailDrawer` pattern (WCAG 2.4.3, 2.1.2).
- **`SearchFilters`** — added `aria-pressed` to the content-type and category filter pills so the active filter is announced (WCAG 1.3.1, 4.1.2).

### Docs
- Added `docs/accessibility-audit-2026-06.md` as the current audit reference (the root `ACCESSIBILITY_AUDIT.md` is a Nov 2025 historical snapshot describing since-removed components). It records findings, the fixes above, and follow-ups: `WarmCard`'s latent `onClick` semantics (no live callers), a screen-reader "opens in a new tab" cue for external links, manual contrast verification of muted tokens, and wiring up axe-core / `eslint-plugin-jsx-a11y`.

### Verification
- `npx tsc --noEmit` — passes
- `npx eslint` on changed files — clean
- `npx jest src/components/fantasy src/components/ui/__tests__/WarmCard.test.tsx` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDKCgjavXLCEP1BZSMGcSY)_