### PR TITLE
Refine header alignment and group search with theme toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1712,13 +1712,11 @@
     font-weight: 700;
     letter-spacing: -0.04em;
     text-transform: uppercase;
+    /* line-height:1 collapses the wordmark's line box to the glyph block so it
+       optically centers with the smaller mono nav links — both sides live in
+       equal-height (44px) flex boxes with align-items:center. */
+    line-height: 1;
     color: var(--home-ink);
-    /* Baseline-align the display wordmark with the smaller mono nav links.
-       Both sides are center-aligned in equal-height (44px) boxes, but
-       Bricolage's shorter cap-height (~0.66) at 1.05rem leaves its baseline
-       ~0.94px below JetBrains Mono's (~0.73) at 0.8rem. Nudge the lockup up so
-       the letters share a baseline with the nav. Visual-only (no reflow). */
-    transform: translateY(-0.06rem);
   }
 
   .header-home-brand::before {
@@ -1727,6 +1725,13 @@
     height: 10px;
     background: var(--home-acid);
     flex-shrink: 0;
+  }
+
+  /* Utility cluster (search + theme) sits to the right of the segmented nav,
+     separated by a divider that matches the nav link rules. */
+  .header-home-controls {
+    padding-left: 0.75rem;
+    border-left: 1px solid color-mix(in srgb, var(--home-ink) 8%, transparent);
   }
 
   .header-home-link {

--- a/src/components/StaticHeader.tsx
+++ b/src/components/StaticHeader.tsx
@@ -114,16 +114,7 @@ export function StaticHeader() {
             Isaac Vazquez
           </Link>
 
-          <div className="hidden lg:flex items-center gap-3">
-            <Link
-              href="/search"
-              aria-label="Search the site (press / or Ctrl+K)"
-              title="Search — press / or ⌘K"
-              className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors text-[var(--home-ink)] hover:bg-[var(--home-paper-alt)]"
-              onClick={closeMobileMenu}
-            >
-              <Search className="h-5 w-5" aria-hidden="true" />
-            </Link>
+          <div className="hidden lg:flex items-center gap-2">
             <ul className="header-home-nav-list flex items-center gap-0" aria-label="Primary navigation">
               {navLinks.map((link) => {
                 const active = isRouteActive(pathname, link.href);
@@ -147,10 +138,19 @@ export function StaticHeader() {
                   </li>
                 );
               })}
-              <li>
-                <DeferredThemeToggle className="inline-flex min-h-[44px] items-center px-3" />
-              </li>
             </ul>
+            <div className="header-home-controls flex items-center gap-1">
+              <Link
+                href="/search"
+                aria-label="Search the site (press / or Ctrl+K)"
+                title="Search — press / or ⌘K"
+                className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors text-[var(--home-ink-muted)] hover:bg-[var(--home-paper-alt)] hover:text-[var(--home-ink)]"
+                onClick={closeMobileMenu}
+              >
+                <Search className="h-5 w-5" aria-hidden="true" />
+              </Link>
+              <DeferredThemeToggle />
+            </div>
           </div>
 
           <div className="flex items-center gap-2 lg:hidden">

--- a/src/components/__tests__/StaticHeader.test.tsx
+++ b/src/components/__tests__/StaticHeader.test.tsx
@@ -116,16 +116,20 @@ describe("StaticHeader", () => {
     expect(primaryNav?.querySelector('a[href="/search"]')).toBeNull();
   });
 
-  it("passes desktop sizing classes to the deferred theme toggle", async () => {
+  it("groups the desktop search and theme controls together outside the nav", async () => {
     await act(async () => {
       root.render(<StaticHeader />);
     });
 
-    const desktopThemeButton = container.querySelector(
-      '[aria-label="Primary navigation"] button'
-    );
+    // Search and the theme toggle share one utility cluster to the right of the
+    // segmented nav (the desktop-only `.header-home-controls` group).
+    const controls = container.querySelector(".header-home-controls");
+    expect(controls).not.toBeNull();
+    expect(controls?.querySelector('a[href="/search"]')).not.toBeNull();
+    expect(controls?.querySelector("button")?.textContent).toBe("Theme");
 
-    expect(desktopThemeButton).toHaveClass("min-h-[44px]");
-    expect(desktopThemeButton).toHaveClass("px-3");
+    // The theme toggle no longer lives inside the primary nav link list.
+    const primaryNav = container.querySelector('[aria-label="Primary navigation"]');
+    expect(primaryNav?.querySelector("button")).toBeNull();
   });
 });


### PR DESCRIPTION
## What

Tightens the desktop header alignment and regroups the utility controls.

- **Search moved next to the theme toggle.** The desktop search button previously sat at the *left* of the nav bar (between the wordmark and the links). It now lives in a small utility cluster with the theme toggle on the far right, separated from the nav by a divider that matches the segmented nav link rules. Its colors were nudged to the muted/hover treatment so the two controls read as a consistent pair.
- **Nav menu aligned better.** The theme toggle no longer lives inside the primary `<ul>`, so the segmented nav bar is now just the nav links — a cleaner, evenly-spaced group.
- **Wordmark aligned with the buttons.** Replaced the fragile sub-pixel `translateY(-0.06rem)` baseline nudge with `line-height: 1`, so the "Isaac Vazquez" lockup optically centers with the nav buttons inside the equal-height (44px) flex boxes.

Mobile header layout is unchanged (search + theme were already grouped there).

## Files
- `src/components/StaticHeader.tsx` — restructure desktop nav into `[nav list][controls]`
- `src/app/globals.css` — `.header-home-controls` divider + brand `line-height`

## Verification
- Dev server compiles clean; `/` returns 200 with the new markup.
- `eslint src/components/StaticHeader.tsx` passes.
- ⚠️ Could not capture a visual screenshot — the sandbox network policy blocks the Playwright Chromium download (`cdn.playwright.dev` 403) and no system Chromium is available. Please eyeball the rendered header (desktop + mobile) to confirm the spacing/alignment reads right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N76So66R3YYR8z2ovjjpob)_