### PR TITLE
fix(search): align taxonomy, fix filters, and tidy the search UI

### DIFF
--- a/src/app/api/search/__tests__/route.test.ts
+++ b/src/app/api/search/__tests__/route.test.ts
@@ -133,6 +133,28 @@ describe("GET /api/search", () => {
     ).toBe(true);
   });
 
+  it("filters by an exact (case-insensitive) category and echoes it in filters", async () => {
+    // 'Site' is a curated static-page category, present regardless of the blog mock.
+    const response = await GET(makeRequest("?category=site"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.filters.category).toBe("site");
+    expect(body.results.length).toBeGreaterThan(0);
+    for (const result of body.results) {
+      expect(String(result.category).toLowerCase()).toBe("site");
+    }
+  });
+
+  it("returns nothing for a category that is not present in the corpus", async () => {
+    const response = await GET(makeRequest("?category=NotARealCategory"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.results).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
   it("clamps the limit parameter into the 1..100 range", async () => {
     // Seed the corpus with many matching posts so the limit is what caps output.
     const previews = Array.from({ length: 10 }, (_, i) => ({

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -586,16 +586,16 @@ function calculateRelevanceScore(content: SearchableContent, query: string): num
     });
   }
 
-  // Content matches (lowest weight but important for comprehensive search)
+  // Content matches (lowest weight but important for comprehensive search).
+  // Count substring occurrences, mirroring the .includes() matching used by
+  // the fields above. This avoids the ASCII-only `\b` word-boundary regex,
+  // which silently dropped tokens with punctuation or accents (e.g. "c++",
+  // ".net", "café") from the content-field score.
   const contentLower = content.content.toLowerCase();
   queryWords.forEach(word => {
-    // Escape regex metacharacters so queries like "c++" or "(" don't throw
-    // (an unescaped RegExp would crash the whole request with a 500).
-    const escapedWord = word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const regex = new RegExp(`\\b${escapedWord}\\b`, 'gi');
-    const matches = contentLower.match(regex);
-    if (matches) {
-      score += matches.length * 2; // Multiple occurrences increase score
+    const occurrences = contentLower.split(word).length - 1;
+    if (occurrences > 0) {
+      score += occurrences * 2; // Multiple occurrences increase score
     }
   });
 
@@ -614,7 +614,9 @@ function calculateRelevanceScore(content: SearchableContent, query: string): num
   return score;
 }
 
-function searchContent(content: SearchableContent[], query: string, type?: string, category?: string): SearchableContent[] {
+type ScoredContent = SearchableContent & { relevanceScore?: number };
+
+function searchContent(content: SearchableContent[], query: string, type?: string, category?: string): ScoredContent[] {
   let filteredContent = content;
 
   // Apply type filter
@@ -629,12 +631,17 @@ function searchContent(content: SearchableContent[], query: string, type?: strin
     );
   }
 
-  // If no query, return filtered content sorted by date
+  // If no query, return the filtered corpus in a stable total order: dated
+  // entries (blog posts) first by recency, then everything else by title.
+  // (Pages and case studies carry no publishedAt, so a "both have dates"
+  // check alone yielded a non-total, input-order-dependent ordering.)
   if (!query.trim()) {
-    return filteredContent.sort((a, b) => {
+    return filteredContent.slice().sort((a, b) => {
       if (a.publishedAt && b.publishedAt) {
         return new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime();
       }
+      if (a.publishedAt) return -1;
+      if (b.publishedAt) return 1;
       return a.title.localeCompare(b.title);
     });
   }
@@ -679,7 +686,7 @@ export async function GET(request: NextRequest) {
       category: item.category,
       tags: item.tags,
       publishedAt: item.publishedAt,
-      relevanceScore: (item as SearchableContent & { relevanceScore?: number }).relevanceScore,
+      relevanceScore: item.relevanceScore,
     }));
 
     return NextResponse.json({

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -27,9 +27,9 @@ const topicPills = [
 ];
 
 const popularQueries = [
-  '"Agentic AI for product managers"',
-  '"Investment research platform"',
-  '"Writing better PRDs with AI"',
+  "Agentic AI",
+  "Fantasy football rankings",
+  "Investment research",
 ];
 
 const indexedContent = [

--- a/src/components/search/SearchFilters.tsx
+++ b/src/components/search/SearchFilters.tsx
@@ -8,20 +8,27 @@ interface SearchFiltersProps {
   onClearFilters: () => void;
 }
 
+// `id` is sent verbatim as the `type` query param. It must match a type the
+// API actually emits ('post' for writing, 'project', 'page') — see /api/search.
 const contentTypes = [
   { id: 'all', label: 'All Content' },
-  { id: 'blog', label: 'Blog Posts' },
+  { id: 'post', label: 'Writing' },
   { id: 'project', label: 'Projects' },
   { id: 'page', label: 'Pages' },
 ];
 
+// `id` is sent verbatim as the `category` query param and the API matches it by
+// case-insensitive EXACT equality. Every id below must match a `category` value
+// emitted by /api/search, or the filter silently returns nothing. Keep this list
+// in sync with the corpus categories rather than inventing display-friendly labels.
 const categories = [
   { id: 'all', label: 'All Categories' },
-  { id: 'Product Strategy', label: 'Product Strategy' },
+  { id: 'Agentic AI', label: 'Agentic AI' },
+  { id: 'Product Management', label: 'Product Management' },
   { id: 'Fantasy Football Analytics', label: 'Fantasy Football' },
-  { id: 'Analytics', label: 'Analytics' },
-  { id: 'Fintech', label: 'Fintech' },
-  { id: 'Sports Data', label: 'Sports Data' },
+  { id: 'Sports Analytics', label: 'Sports Analytics' },
+  { id: 'QA Engineering', label: 'QA Engineering' },
+  { id: 'Fintech Product', label: 'Fintech' },
 ];
 
 function getPillStyle(active: boolean) {
@@ -67,6 +74,7 @@ export function SearchFilters({
           {contentTypes.map((contentType) => (
             <button
               key={contentType.id}
+              type="button"
               onClick={() => onTypeChange(contentType.id)}
               aria-pressed={type === contentType.id}
               className="inline-flex min-h-[36px] items-center rounded-full px-3 py-1 text-xs font-semibold transition-colors"
@@ -93,6 +101,7 @@ export function SearchFilters({
           {categories.map((cat) => (
             <button
               key={cat.id}
+              type="button"
               onClick={() => onCategoryChange(cat.id)}
               aria-pressed={category === cat.id}
               className="inline-flex min-h-[36px] items-center rounded-full px-3 py-1 text-xs font-semibold transition-colors"
@@ -114,6 +123,7 @@ export function SearchFilters({
           style={{ borderTop: "1px solid var(--home-rule)" }}
         >
           <button
+            type="button"
             onClick={onClearFilters}
             className="text-sm underline underline-offset-2"
             style={{ fontFamily: "var(--font-home-sans)", color: "var(--home-haze)" }}

--- a/src/components/search/SearchInterface.tsx
+++ b/src/components/search/SearchInterface.tsx
@@ -21,11 +21,15 @@ export interface SearchResult {
   title: string;
   excerpt: string;
   url: string;
-  type: 'blog' | 'project' | 'page';
+  type: 'post' | 'project' | 'page';
   category?: string;
   tags?: string[];
   publishedAt?: string;
-  relevanceScore: number;
+}
+
+interface SearchApiResponse {
+  results?: SearchResult[];
+  total?: number;
 }
 
 export interface SearchState {
@@ -76,6 +80,7 @@ export function SearchInterface({
 }: SearchInterfaceProps) {
   const router = useRouter();
   const pendingUrlSyncKeyRef = useRef<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const seededState = readSeededSearchState({
     query: initialQuery,
     type: initialType,
@@ -130,7 +135,7 @@ export function SearchInterface({
   const updateURL = useCallback((query: string, type: string, category: string) => {
     pendingUrlSyncKeyRef.current = getSearchStateKey(query, type, category);
     const params = new URLSearchParams();
-    if (query) params.set('q', query);
+    if (query.trim()) params.set('q', query);
     if (type !== 'all') params.set('type', type);
     if (category !== 'all') params.set('category', category);
 
@@ -164,7 +169,7 @@ export function SearchInterface({
         ...(category !== 'all' && { category })
       })}`);
 
-      const data = await response.json();
+      const data: SearchApiResponse = await response.json();
       const searchTime = Date.now() - startTime;
 
       setSearchState(prev => ({
@@ -261,6 +266,9 @@ export function SearchInterface({
       searchTime: 0
     }));
     updateURL("", "all", "all");
+    // The clear (X) button unmounts the moment the query is empty; move focus
+    // back to the input so keyboard/screen-reader users aren't dropped to <body>.
+    inputRef.current?.focus();
   };
 
   const clearFilters = () => {
@@ -286,11 +294,13 @@ export function SearchInterface({
                 aria-hidden="true"
               />
               <input
+                ref={inputRef}
                 type="text"
                 value={searchState.query}
                 onChange={(e) => handleQueryChange(e.target.value)}
-                placeholder="Search for content..."
+                placeholder="Search writing, projects, and tools…"
                 aria-label="Search content"
+                aria-controls="search-results"
                 className="w-full min-h-[44px] pl-12 pr-12 py-3 rounded-xl transition-colors"
                 style={{
                   fontFamily: "var(--font-home-sans)",
@@ -301,9 +311,10 @@ export function SearchInterface({
               />
               {searchState.query && (
                 <button
+                  type="button"
                   onClick={clearSearch}
                   aria-label="Clear search"
-                  className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center justify-center rounded-md transition-colors"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md transition-colors"
                   style={{ color: "var(--home-ink-muted)" }}
                 >
                   <IconX className="w-5 h-5" />
@@ -312,8 +323,11 @@ export function SearchInterface({
             </div>
 
             <button
+              type="button"
               onClick={() => setShowFilters(!showFilters)}
               aria-label={showFilters ? "Hide filters" : "Show filters"}
+              aria-expanded={showFilters}
+              aria-controls="search-filters"
               className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl p-3 transition-colors"
               style={
                 filterActive
@@ -336,13 +350,15 @@ export function SearchInterface({
 
         {/* Filters */}
         {showFilters && (
-          <SearchFilters
-            type={searchState.type}
-            category={searchState.category}
-            onTypeChange={handleTypeChange}
-            onCategoryChange={handleCategoryChange}
-            onClearFilters={clearFilters}
-          />
+          <div id="search-filters">
+            <SearchFilters
+              type={searchState.type}
+              category={searchState.category}
+              onTypeChange={handleTypeChange}
+              onCategoryChange={handleCategoryChange}
+              onClearFilters={clearFilters}
+            />
+          </div>
         )}
 
         {/* Active Filters Display */}
@@ -378,6 +394,7 @@ export function SearchInterface({
               </span>
             )}
             <button
+              type="button"
               onClick={clearFilters}
               className="text-sm underline underline-offset-2"
               style={{ fontFamily: "var(--font-home-sans)", color: "var(--home-haze)" }}
@@ -388,15 +405,28 @@ export function SearchInterface({
         )}
       </article>
 
+      {/* Politely announce loading / result-count / empty states to assistive tech. */}
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {searchState.isLoading
+          ? "Searching…"
+          : searchState.hasSearched
+            ? searchState.totalResults === 0
+              ? `No results found${searchState.query ? ` for ${searchState.query}` : ""}`
+              : `${searchState.totalResults} result${searchState.totalResults === 1 ? "" : "s"} found`
+            : ""}
+      </div>
+
       {/* Search Results */}
-      <SearchResults
-        query={searchState.query}
-        results={searchState.results}
-        isLoading={searchState.isLoading}
-        hasSearched={searchState.hasSearched}
-        totalResults={searchState.totalResults}
-        searchTime={searchState.searchTime}
-      />
+      <div id="search-results">
+        <SearchResults
+          query={searchState.query}
+          results={searchState.results}
+          isLoading={searchState.isLoading}
+          hasSearched={searchState.hasSearched}
+          totalResults={searchState.totalResults}
+          searchTime={searchState.searchTime}
+        />
+      </div>
 
       {/* Search Tips */}
       {!searchState.hasSearched && !searchState.query && (
@@ -425,6 +455,7 @@ export function SearchInterface({
                 {["product strategy", "fantasy football", "investment research"].map((example) => (
                   <button
                     key={example}
+                    type="button"
                     onClick={() => handleQueryChange(example)}
                     className="block text-left text-sm underline underline-offset-2"
                     style={{ fontFamily: "var(--font-home-sans)", color: "var(--home-haze)" }}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -79,9 +79,9 @@ export function SearchResults({
             style={{ color: "var(--home-ink-muted)" }}
             aria-hidden="true"
           />
-          <h3 className="text-xl mb-0" style={sectionTitleStyle}>
+          <h2 className="text-xl mb-0" style={sectionTitleStyle}>
             No results found
-          </h3>
+          </h2>
           <p className="mb-0 text-base leading-7" style={bodyStyle}>
             {query ? (
               <>
@@ -112,7 +112,9 @@ export function SearchResults({
       <div className="space-y-2">
         <p className="home-kicker mb-0">Results</p>
         <h2 className="text-2xl mb-0" style={sectionTitleStyle}>
-          {totalResults.toLocaleString()} result{totalResults !== 1 ? 's' : ''} found
+          {results.length < totalResults
+            ? `Showing ${results.length.toLocaleString()} of ${totalResults.toLocaleString()} results`
+            : `${totalResults.toLocaleString()} result${totalResults !== 1 ? 's' : ''} found`}
           {query ? (
             <>
               {' '}for &ldquo;<span style={{ color: "var(--home-ink)" }}>{query}</span>&rdquo;
@@ -129,17 +131,6 @@ export function SearchResults({
           <SearchResultCard key={result.id} result={result} query={query} />
         ))}
       </div>
-
-      {results.length < totalResults && (
-        <div className="text-center">
-          <button
-            className="text-sm underline underline-offset-2"
-            style={{ fontFamily: "var(--font-home-sans)", color: "var(--home-haze)" }}
-          >
-            Load more results
-          </button>
-        </div>
-      )}
     </div>
   );
 }
@@ -149,13 +140,20 @@ interface SearchResultCardProps {
   query: string;
 }
 
+const TYPE_LABELS: Record<SearchResult["type"], string> = {
+  post: "Writing",
+  project: "Project",
+  page: "Page",
+};
+
 function SearchResultCard({ result, query }: SearchResultCardProps) {
-  const getTypeIcon = (type: string) => {
+  const getTypeIcon = (type: SearchResult["type"]) => {
     switch (type) {
-      case 'blog':
+      case 'post':
         return <IconFileText className="w-3.5 h-3.5" aria-hidden="true" />;
       case 'project':
         return <IconBriefcase className="w-3.5 h-3.5" aria-hidden="true" />;
+      case 'page':
       default:
         return <IconHome className="w-3.5 h-3.5" aria-hidden="true" />;
     }
@@ -172,8 +170,16 @@ function SearchResultCard({ result, query }: SearchResultCardProps) {
   const highlightQuery = (text: string, q: string): string => {
     const safe = escapeHtml(text);
     if (!q) return safe;
-    const escapedQuery = escapeHtml(q).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const regex = new RegExp(`(${escapedQuery})`, 'gi');
+    // Highlight per word, mirroring the API matcher (which scores each
+    // whitespace-separated word independently). A single contiguous-phrase
+    // regex left word-matched results — e.g. "fantasy football" against
+    // "Football rankings and fantasy tiers" — with no highlight at all.
+    const words = q
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((word) => escapeHtml(word).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    if (words.length === 0) return safe;
+    const regex = new RegExp(`(${words.join('|')})`, 'gi');
     return safe.replace(
       regex,
       '<mark style="background-color: color-mix(in srgb, var(--home-acid) 40%, transparent); color: var(--home-ink); padding: 0 2px; border-radius: 2px;">$1</mark>'
@@ -198,7 +204,7 @@ function SearchResultCard({ result, query }: SearchResultCardProps) {
                 style={typePillStyle}
               >
                 {getTypeIcon(result.type)}
-                {result.type.charAt(0).toUpperCase() + result.type.slice(1)}
+                {TYPE_LABELS[result.type]}
               </span>
               {result.category && (
                 <span

--- a/src/components/search/__tests__/SearchInterface.test.tsx
+++ b/src/components/search/__tests__/SearchInterface.test.tsx
@@ -123,7 +123,11 @@ describe("SearchInterface", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockPush).not.toHaveBeenCalled();
-    expect(screen.getByText(/1 result found/i)).toBeVisible();
+    // Target the heading specifically: the count is intentionally mirrored in a
+    // visually-hidden aria-live region, so a plain getByText would match twice.
+    expect(
+      screen.getByRole("heading", { name: /1 result found/i })
+    ).toBeVisible();
   });
 
   it("syncs debounced searches and filter changes into the URL, then clears back to /search", async () => {
@@ -188,5 +192,30 @@ describe("SearchInterface", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(fetchCallsBeforeClear);
     expect(screen.getByText(/search tips/i)).toBeVisible();
+  });
+
+  it("routes the Writing content-type filter to type=post (matching the API taxonomy)", async () => {
+    const user = userEvent.setup({
+      advanceTimers: jest.advanceTimersByTime,
+    });
+
+    render(<SearchHarness />);
+
+    const input = screen.getByRole("textbox", { name: /search content/i });
+    await user.type(input, "ai");
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: /show filters/i }));
+    await user.click(screen.getByRole("button", { name: /^writing$/i }));
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenLastCalledWith("/search?q=ai&type=post", {
+        scroll: false,
+      })
+    );
   });
 });

--- a/src/components/search/__tests__/SearchResults.test.tsx
+++ b/src/components/search/__tests__/SearchResults.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { SearchResults } from "../SearchResults";
+import type { SearchResult } from "../SearchInterface";
+
+// Render Link as a plain anchor so the component can be tested in isolation.
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const postResult: SearchResult = {
+  id: "post-quantum",
+  title: "Quantum Writing",
+  excerpt: "An article excerpt about search.",
+  url: "/writing/quantum-writing",
+  type: "post",
+  category: "Agentic AI",
+  tags: ["AI"],
+  publishedAt: "2026-06-01",
+};
+
+describe("SearchResults", () => {
+  it("labels writing (post) results 'Writing' and renders the result", () => {
+    render(
+      <SearchResults
+        query=""
+        results={[postResult]}
+        isLoading={false}
+        hasSearched
+        totalResults={1}
+        searchTime={5}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: /1 result found/i })).toBeVisible();
+    // The type pill maps 'post' -> 'Writing' (it previously rendered 'Post').
+    expect(screen.getByText("Writing")).toBeInTheDocument();
+    expect(screen.getByText(/Quantum Writing/)).toBeInTheDocument();
+  });
+
+  it("shows a truncated 'Showing N of M' count and no 'Load more' button when capped", () => {
+    render(
+      <SearchResults
+        query="ai"
+        results={[postResult]}
+        isLoading={false}
+        hasSearched
+        totalResults={5}
+        searchTime={5}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /showing 1 of 5 results/i })
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /load more/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the empty-results heading as an h2 (no h1 -> h3 skip)", () => {
+    render(
+      <SearchResults
+        query="zzz-no-match"
+        results={[]}
+        isLoading={false}
+        hasSearched
+        totalResults={0}
+        searchTime={5}
+      />
+    );
+
+    const heading = screen.getByRole("heading", { name: /no results found/i });
+    expect(heading.tagName).toBe("H2");
+  });
+});


### PR DESCRIPTION
## Summary

Cleanup of the `/search` page, the search components, and `/api/search`. The page and API had drifted apart, leaving filters that returned nothing and dead UI. This fixes the bugs, removes dead code, aligns the taxonomy, and tightens accessibility/types.

The changes were scoped from a multi-agent audit of the search subsystem (six review dimensions → adversarial verification of every finding); the fixes below are the confirmed, in-scope items.

## What was broken

- **"Blog Posts" filter returned nothing.** The content-type filter sent `type=blog`, but the API only ever emits `post`. The same mismatch made every writing result render the generic Home icon (the `IconFileText` branch was unreachable) and the `SearchResult` type lied about the runtime shape.
- **Most category filters returned nothing.** The hardcoded list (`Fintech`, `Sports Data`, `Analytics`, `Product Strategy`) didn't exact-match the real corpus categories (`Fintech Product`, `Sports Data Tools`, …), and the API matches categories by exact (case-insensitive) equality.
- **Dead "Load more results" button** — rendered with no `onClick` and no pagination, while the header could advertise a count larger than what was shown.

## Changes

**Taxonomy**
- `SearchResult` union `'blog' → 'post'`; filter content-type id `blog → post` (label **Writing**); `getTypeIcon` handles `post` and is typed to the union; result type pill maps to a friendly label.
- Category filter now lists real, exact-matching corpus categories, with a comment documenting the exact-match contract so it can't silently drift again. The `Fantasy Football Analytics` entry is preserved (pinned by unit + e2e tests).

**UI**
- Removed the dead "Load more" button; the count now shows an honest `Showing N of M results` when the corpus exceeds the default limit.
- Placeholder and "popular queries" copy updated to realistic, working queries.

**API (`/api/search`)**
- Replaced the ASCII-only `\b` word-boundary content scorer with substring counting — fixes silently-dropped punctuation/accented tokens and is consistent with the other fields.
- Gave the no-query path a stable total ordering (dated entries first by recency, then by title) instead of a non-total comparator.
- Tightened `searchContent`'s return type and removed an unsafe `as` cast.

**Accessibility**
- Added a polite `aria-live` status region announcing loading / result-count / empty states.
- Clear button gets a 44px touch target and returns focus to the input on clear (was dropping focus to `<body>`).
- Filter toggle gets `aria-expanded` / `aria-controls`; empty-state heading fixed (`h3 → h2`); `type="button"` added to non-submit buttons.

**Types / misc**
- Typed the API response at the client boundary; dropped the unused client `relevanceScore` field; trimmed whitespace-only queries out of the URL.

## Tests
- New `SearchResults.test.tsx` (icon/label, honest count, no "Load more", empty-state heading level).
- New `/api/search` route tests for category filtering (positive + negative).
- New unit test pinning the Writing (`post`) content-type filter → `type=post`.

All search suites pass (`jest src/app/api/search src/components/search src/app/search` → 18/18); ESLint clean; `tsc` shows no new errors (the two pre-existing test-file errors are unchanged from `main`).

## Out of scope (noted, not changed)
`WritingPreview.tsx` is the only other `/api/search` consumer. It's already documented as dead/unmounted and is independently broken (`type=blog` + reads `slug`/`readingTime` the API never returns); it's tracked separately in `docs/PROJECTS.md`. Left untouched to avoid doc churn across the files that reference it — happy to address it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmUEhaR7uTspd3Vg67vyx

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmUEhaR7uTspd3Vg67vyx)_