### PR TITLE
docs: front-end design audit, best-practices checklist, and fix backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,18 +154,28 @@ localStorage via dedicated hooks. Reference: `PERSONAL_INTEREST_TOOLS.md`.
 
 Tokens and helpers live in `src/app/globals.css`. The editorial system is the
 site-wide standard for every live route except `/admin` (which keeps its own aesthetic).
-Reference: `STYLING.md`.
+Reference: `STYLING.md`. **Before merging any UI, run the single pre-merge `DESIGN_CHECKLIST.md`.**
 
 - New code uses the `--home-*` editorial palette directly (`var(--home-paper)`,
   `var(--home-ink)`, `var(--home-haze)`, `var(--home-acid)`). Legacy aliases
-  (`--surface-*`, `--text-*`, `--border-*`, `--color-primary`) exist for compatibility
-  but must not be introduced in new code or docs.
+  (`--surface-*`, `--text-*`, `--border-*`, `--color-primary`, and the
+  `--color-success/-error/-warning` names) exist for compatibility but must not be
+  introduced in new code or docs — use `--home-positive/-negative/-warning` for status.
 - Never hardcode hex colors in components — use the CSS variables.
+- For raised surfaces use `var(--home-paper-raised)` or mix toward `var(--home-elev-mix)`;
+  **never `color-mix(…, white)`** — it lightens in both themes and breaks dark mode.
+- D3/SVG charts resolve token colors at render time via `getComputedStyle` (see
+  `PortfolioPerformanceChart`); never bake a token's hex into a constant.
+- No arbitrary `text-[Npx]` micro-type — use `text-3xs`/`text-2xs` (see `STYLING.md`).
+- CSS-Module surfaces must alias the global tokens (`--x-paper: var(--home-paper)`), never
+  re-declare the palette as fresh hex with its own `.dark` mirror.
 - Use the editorial shell helpers (`.home-page`, `.home-shell`, `.home-section`,
   `.home-card`, `.home-kicker`).
 - Keep light/dark mode support, 44px minimum touch targets, and `prefers-reduced-motion`
   for animated components. Shared portfolio-shell primitives must not use
   `transition-all` — transition specific properties.
+- Framer Motion entrances must honor `useReducedMotion()` — the global CSS guard does
+  **not** stop JS/rAF-driven Framer animation (shared primitives especially, e.g. `PageSummary`).
 
 ---
 
@@ -203,8 +213,8 @@ Current source-of-truth docs:
 
 - `AGENTS.md` (start-here) · `AGENT.md` (compat stub) · `README.md`
 - `PAGES.md` · `COMPONENTS.md` · `ARCHITECTURE.md` · `API.md` · `DEVELOPMENT.md`
-- `TESTING.md` · `STYLING.md` · `SEO.md` · `WRITING_VOICE.md`
-- `docs/README.md` · `docs/ai-context/*`
+- `TESTING.md` · `STYLING.md` · `DESIGN_CHECKLIST.md` · `SEO.md` · `WRITING_VOICE.md`
+- `docs/README.md` · `docs/ai-context/*` · `docs/DESIGN_AUDIT_2026-06.md` (point-in-time audit + fix backlog)
 
 Subsystem references:
 

--- a/DARK_MODE_USAGE_GUIDE.md
+++ b/DARK_MODE_USAGE_GUIDE.md
@@ -392,6 +392,40 @@ try {
 transition={{ duration: 0.2 }} // Adjust this value
 ```
 
+### Elevated surface looks wrong in dark mode (mixing toward `white`)
+
+**Problem**: `color-mix(in srgb, var(--home-paper) 92%, white)` lightens the surface in **both**
+themes. In dark mode a raised panel must get *darker*, so this renders inverted.
+
+**Solution**: Use the theme-aware elevation token, which flips white↔black per theme:
+
+```tsx
+// ❌ wrong — lightens in both themes
+className="bg-[color-mix(in_srgb,var(--home-paper)_92%,white)]"
+// ✅ right — theme-aware (--home-elev-mix is white in light, black in dark)
+className="bg-[var(--home-paper-raised)]"
+// custom ratio:
+className="bg-[color-mix(in_srgb,var(--home-paper-alt)_80%,var(--home-elev-mix))]"
+```
+
+The shared football `SurfaceCard` already does this — reuse it before hand-rolling an elevated panel.
+
+### Chart/SVG colors don't adapt to the theme
+
+**Problem**: D3/SVG fills can't read Tailwind classes, and baking a token's hex into a constant
+(e.g. `const COLOR = "#2563EB"`) ignores dark mode and drifts when the token changes.
+
+**Solution**: Resolve the token at render time and re-resolve on theme change:
+
+```tsx
+const color = getComputedStyle(document.documentElement)
+  .getPropertyValue("--home-haze").trim();
+```
+
+`PortfolioPerformanceChart` is the reference implementation; `ComparisonRadarChart` is the
+anti-pattern. Avoid ink-equivalent tones (`#12110F`) for series/logo tiles — they vanish on dark paper.
+See `STYLING.md` → *Charts and D3* and `DESIGN_CHECKLIST.md` → *Dark mode*.
+
 ---
 
 ## 📊 Performance Considerations

--- a/DESIGN_CHECKLIST.md
+++ b/DESIGN_CHECKLIST.md
@@ -1,0 +1,98 @@
+# Design Checklist
+
+The single pre-merge checklist for any new or edited page, component, or surface. If you build UI in
+this repo, run through this before opening a PR. It distills the rules that were previously scattered
+across `STYLING.md`, `CLAUDE.md`, `DARK_MODE_USAGE_GUIDE.md`, and `SNAPSHOT_DRIVEN_DASHBOARDS.md`.
+
+**Last updated:** 2026-06-24 · Derived from the 2026-06 site-wide design audit (`docs/DESIGN_AUDIT_2026-06.md`).
+
+> When in doubt, copy a reference implementation instead of inventing: `PortfolioPerformanceChart`
+> (themeable D3), `github-trending-pulse` (touch targets + scoped transitions + token micro-type),
+> `tech-startup-tracker` (error/loading/verified disclosure + correct row semantics), the football
+> `SurfaceCard`/`StatCard`/`FixtureCard` set (theme-aware surfaces), `EditorialPillButton` (guaranteed 44px).
+
+---
+
+## Color & tokens
+
+- [ ] **No hardcoded hex** in components when a token exists. Use `--home-*` directly (`globals.css`).
+- [ ] **No literal `white`/`black` in `color-mix`.** For raised surfaces use `var(--home-paper-raised)`,
+      or mix toward `var(--home-elev-mix)` (flips white↔black per theme). `color-mix(… , white)` lightens
+      in *both* themes and breaks dark mode. Reuse `SurfaceCard` before hand-rolling an elevated panel.
+- [ ] **Gain/loss/status use semantic `--home-*` tokens**, not green/red hex: `--home-positive`,
+      `--home-negative`, `--home-warning` (each has a `.dark` variant). Do not introduce the legacy
+      `--color-success/-error/-warning` aliases in new code.
+- [ ] **CSS-Module surfaces alias the globals** (`--x-paper: var(--home-paper)`) — never re-declare the
+      palette as fresh hex with its own `.dark` mirror (that creates a parallel source of truth that drifts).
+- [ ] No raw Tailwind color literals (`text-gray-500`, `bg-slate-100`) where a token exists.
+
+## Dark mode
+
+- [ ] Every surface has a `.dark` story — verify the page in both themes, not just light.
+- [ ] **D3 / SVG charts resolve series colors at render time** via
+      `getComputedStyle(document.documentElement).getPropertyValue('--home-…')`, re-resolved on theme
+      change. Never bake a token's hex into a constant. Reference: `PortfolioPerformanceChart`.
+      Anti-pattern: `ComparisonRadarChart` (`#2563EB`, stale vs `--home-haze`).
+- [ ] Avoid ink-equivalent tones (`#12110F`) for logo/series tiles — they vanish on dark paper.
+
+## Typography
+
+- [ ] Editorial type uses `Instrument Sans` (`--font-home-sans`); `Instrument Serif` for display/italic;
+      `Bricolage Grotesque` (`--font-display`) for V3 brutalist headings. (See `STYLING.md` for the full table.)
+- [ ] **No arbitrary `text-[Npx]`.** 10px → `text-3xs`, 11px → `text-2xs`, 12–14px → `text-xs`
+      (fluid). For fixed 12px that must not scale, add/use a fixed `text-1xs` token — don't reintroduce px.
+- [ ] Fluid `--text-*` tokens for everything else; headings keep tight tracking + balanced wrapping.
+
+## Accessibility
+
+- [ ] Exactly **one page-level `<h1>`** that renders at runtime. (Conditional state branches — loading /
+      unavailable / loaded — that each contain an `<h1>` are fine because only one renders; don't add a
+      second `<h1>` that renders *alongside* the first.)
+- [ ] Self-shell routes rely on the single `<main>` owned by `ConditionalLayout`. Leaf sections use
+      `div`/`section` — **never** a nested `<main>`.
+- [ ] **No heading-order skips** (h1 → h3 with no h2).
+- [ ] **44px minimum touch targets** on every button, link, input, select, and icon-button
+      (`min-h-touch`/`min-w-touch` or `min-h-[44px]`). Recurring offenders: filter chips, pager buttons,
+      native `<select>`, icon-only buttons (`h-7`/`h-8`), `min-h-[38px]/[40px]` pills.
+- [ ] Icon-only controls have `aria-label` or `sr-only` text.
+- [ ] Meaningful images have descriptive `alt`; decorative images use `alt=""` + `aria-hidden`.
+- [ ] Form inputs/selects have an associated `<label>` or `aria-label`.
+- [ ] **No `role="button"` on a `<tr>`/`<div>` that wraps a real `<button>`** (duplicate tab stops,
+      invalid nesting). Make the row OR the inner control interactive, not both.
+- [ ] Hover affordances also work on `:focus-visible` (don't drive hover color via JS `onMouseEnter`
+      only — keyboard users get no cue).
+- [ ] Status is never signaled by color alone — pair with text or an icon.
+
+## Motion
+
+- [ ] **Framer Motion entrances call `useReducedMotion()`** (or wrap in `<MotionConfig reducedMotion="user">`).
+      The global CSS `prefers-reduced-motion` guard does **not** stop JS/rAF-driven Framer animation.
+      Shared primitives especially (e.g. `PageSummary`) — fixing once covers many routes.
+- [ ] CSS animations/transitions have a `prefers-reduced-motion` fallback (or use `motion-safe:`).
+- [ ] **No `transition-all`** in shared primitives — transition only the properties that change
+      (`transition-[background-color,transform]`).
+
+## Responsive
+
+- [ ] Mobile-first; verify at ~360px. No horizontal overflow; `white-space: nowrap` display text can't clip.
+- [ ] Wide data tables use the scroll pattern: `overflow-x-auto` wrapper with `role="region"`, `tabIndex`,
+      and a label (progressive column-hiding is a plus).
+- [ ] Grids collapse to one column on mobile (responsive `grid-cols-*`).
+- [ ] In-page section nav has a mobile equivalent (don't `display:none` it away with no replacement).
+- [ ] Hero value-prop + primary CTA stay above the fold on mobile for portfolio/hero routes.
+
+## Snapshot-driven dashboards (data-fetching routes)
+
+- [ ] Ships a per-route **`error.tsx`** (`'use client'`, re-exports `RouteErrorBoundary` with a bespoke
+      `surfaceName`) **and** a `loading.tsx` (`RouteLoadingState`). See `SNAPSHOT_DRIVEN_DASHBOARDS.md`.
+- [ ] Curated/unverified datasets carry `verified: false` + `asOf` and disclose the unverified state
+      on-page (mirror `tech-startup-tracker`).
+- [ ] Compliance disclaimers (retirement/investments) stay intact.
+
+## Consistency
+
+- [ ] Extends the existing visual language rather than inventing a new one; reuses token helpers
+      (`home-card`, `home-kicker`, `SurfaceCard`, etc.) before route-specific styling.
+- [ ] Injected/`dangerouslySetInnerHTML` markup has a defined prose class styling `a/ul/ol/code/strong`
+      with `--home-*` tokens (don't leave links default-blue, e.g. the `.changelog-prose` gap).
+- [ ] `/admin` is the only editorial-exempt route — but a11y/responsive/motion rules still apply to it.

--- a/SNAPSHOT_DRIVEN_DASHBOARDS.md
+++ b/SNAPSHOT_DRIVEN_DASHBOARDS.md
@@ -146,9 +146,10 @@ For the operational view (command → artifact → schedule in one table) see
 
 ## Per-route error boundaries
 
-Snapshot dashboards drop an `error.tsx` that re-exports the shared
-`RouteErrorBoundary` with a `surfaceName`, so a render failure shows an
-editorial, route-specific fallback instead of the global catch-all:
+Every snapshot dashboard **must** ship a per-route `error.tsx` (re-exporting the shared
+`RouteErrorBoundary` with a bespoke `surfaceName`) **and** a `loading.tsx`
+(`RouteLoadingState`), so a render failure shows an editorial, route-specific fallback
+instead of the global catch-all, and the first paint isn't blank:
 
 ```tsx
 // src/app/<x>/error.tsx
@@ -158,6 +159,15 @@ export default function Error(props) {
   return <RouteErrorBoundary {...props} surfaceName="Golf" />;
 }
 ```
+
+> The 2026-06 design audit found 8 routes missing `error.tsx` (polling-aggregator,
+> github-trending-pulse, fantasy-football, fantasy-football/draft-tracker, frontier-models,
+> march-madness-2026, golf, mba-internship-notifications) — see `docs/DESIGN_AUDIT_2026-06.md`
+> P0-1. Treat this section as a hard requirement, not a nicety.
+
+**Curated/unverified surfaces** must additionally carry `verified: false` + an `asOf` date in
+the snapshot type **and** render an on-page disclosure card (mirror `tech-startup-tracker`).
+`/frontier-models` shipped without these (audit P0-3) — don't repeat that.
 
 ---
 
@@ -175,7 +185,8 @@ export default function Error(props) {
 7. **API** — `src/app/api/<x>/summary/route.ts` (+ `[id]` if there's a detail
    panel; return `400` for malformed ids, `404` for unknown).
 8. **Route** — `src/app/<x>/page.tsx` server shell + client component with
-   deep-linkable state; add `src/app/<x>/error.tsx`.
+   deep-linkable state; add `src/app/<x>/error.tsx` **and** `src/app/<x>/loading.tsx`
+   (curated/unverified data also needs `verified: false` + `asOf` + an on-page disclosure card).
 9. **Action** — `.github/workflows/update-<x>.yml` on a sensible cron + manual
    dispatch, committing the snapshot only when it changes.
 10. **Docs** — add a row to the table above and to

--- a/STYLING.md
+++ b/STYLING.md
@@ -54,7 +54,8 @@ For intermediate tones, use `color-mix()`:
 
 ### Semantic tokens (kept for charts and status indicators)
 
-- `--color-success`, `--color-warning`, `--color-error` — still valid for semantic states
+- `--color-success`, `--color-warning`, `--color-error` — back-compat aliases; in new code prefer the
+  canonical `--home-positive` / `--home-warning` / `--home-negative` (see *Semantic status colors* below)
 - `--color-secondary`, `--color-accent` — available but prefer `--home-haze` / `--home-acid`
 
 ### Legacy aliases (deprecated — do not use in new code)
@@ -75,6 +76,49 @@ These are defined in `globals.css` but resolve to `--home-*` equivalents:
 - shadows: `--shadow-sm` through `--shadow-xl`
 
 Do not hardcode hex colors in components when a token exists.
+
+### Dark-mode elevation (raised surfaces)
+
+To lift a surface one step above its background, **use the theme-aware elevation token**, never a
+literal `white`/`black` mix:
+
+- `--home-paper-raised` = `color-mix(in srgb, var(--home-paper) 92%, var(--home-elev-mix))`
+- `--home-elev-mix` flips per theme — `white` in light, `black` in dark (`globals.css` ~L196 / ~L278)
+
+**Anti-pattern (do not introduce):** `color-mix(in srgb, var(--home-paper) 92%, white)`. Mixing toward a
+literal `white` lightens the surface in *both* themes; in dark mode an elevated panel must darken
+(mix toward black), so a white mix renders the surface wrong. When you need a custom ratio, mix toward
+`var(--home-elev-mix)` (e.g. `color-mix(in srgb, var(--home-paper-alt) 80%, var(--home-elev-mix))`),
+not toward `white`/`black` directly. The shared `SurfaceCard` (football) already does this correctly —
+reuse it before hand-rolling an elevated panel.
+
+### Semantic status colors — canonical names
+
+Prefer the `--home-*` semantic tokens in new code; the `--color-*` names are aliases kept for
+back-compat (`globals.css` aliases `--color-success → var(--home-positive)`, etc.):
+
+| Use | New code | Legacy alias (avoid in new code) |
+|-----|----------|----------------------------------|
+| Positive / gain / success | `--home-positive` | `--color-success` |
+| Negative / loss / error | `--home-negative` | `--color-error` |
+| Warning / caution / tie | `--home-warning` | `--color-warning` |
+
+All three have `.dark` counterparts, so use them for theme-aware gain/loss and status — never hardcode
+green/red hex (e.g. `#22A06B`/`#D54E4E`). Decorative, brand, or categorical colors (medal tones, party
+colors, team crests) may stay raw when no token represents them.
+
+### Charts and D3 (theme-aware series colors)
+
+D3/SVG fills can't read Tailwind classes, so charts must resolve token colors **at render time**:
+
+- Resolve via `getComputedStyle(document.documentElement).getPropertyValue('--home-haze')` inside the
+  render/effect (re-resolve on theme change). `PortfolioPerformanceChart` is the reference
+  implementation; `ComparisonRadarChart` (hardcoded `#2563EB`, stale vs `--home-haze` `#5672F8`) is the
+  anti-pattern.
+- Never bake a token's hex into a constant (it drifts when the token changes and ignores dark mode).
+- Avoid ink-equivalent tones (e.g. `#12110F`) for logo/series tiles — they vanish on dark paper.
+- Investments charts should share **one** categorical palette so a holding keeps one color across the
+  donut, table sparkline, and research header.
 
 ---
 
@@ -131,12 +175,17 @@ Use the `home-*` helpers first for new route work. The older semantic helpers re
 
 ## Typography
 
-Fonts are loaded in `src/app/layout.tsx`:
+Fonts are loaded in `src/app/layout.tsx` (five families, each exposed as a CSS variable):
 
-- Inter
-- JetBrains Mono
-- Instrument Sans
-- Instrument Serif
+| Font | Variable | Role |
+|------|----------|------|
+| `Instrument Sans` | `--font-instrument-sans` → `--font-home-sans` | Primary editorial font — UI, nav, body, cards, dashboards |
+| `Instrument Serif` | `--font-instrument-serif` → `--font-home-serif` | Display/manifesto moments and selective italic emphasis only |
+| `Bricolage Grotesque` | `--font-display` | Drives the V3 editorial-brutalist surfaces (home, about, portfolio, contact, writing wordmarks/section titles) |
+| `JetBrains Mono` | `--font-jetbrains-mono` → `--font-mono` | Code blocks and kicker/meta micro-labels |
+| `Inter` | `--font-inter` | Legacy body fallback; not the default for new components |
+
+> `STYLING.md` previously listed only four fonts and omitted **Bricolage Grotesque** (`--font-display`). The V3 composition roots and their CSS Modules (`page.module.css`, `about.module.css`, `portfolio.module.css`, `contact.module.css`, `writing.module.css`, `ContactCta.module.css`) reach for `var(--font-display)` directly — confirm against `layout.tsx`, which is the source of truth.
 
 Typography is fluid and token-based via:
 
@@ -151,6 +200,18 @@ Typography is fluid and token-based via:
 - `--text-4xl`
 - `--text-5xl`
 - `--text-6xl`
+
+**Micro-type policy (10–13px).** Use the fixed micro tokens for small labels, and **never** ship an
+arbitrary `text-[Npx]` value:
+
+- 10px → `text-3xs`, 11px → `text-2xs` (both fixed/non-fluid by design).
+- 12–14px → `text-xs` (fluid `clamp(0.75rem … 0.875rem)`) when the label may scale.
+- **Token gap:** there is no *fixed* 12px or 13px token, yet `text-[12px]` (×26) and `text-[13px]` (×20)
+  are the most common arbitrary values in the codebase (heaviest in `decision-lab`, `interchange-iq`,
+  `budget-planner`, `formula-1`, `travel`, `museum-log`). For dense labels that must **not** scale at 12px,
+  add a fixed `--text-1xs: 0.75rem` token to the `@theme` block (exposed as `text-1xs`) rather than
+  reintroducing arbitrary px. Pick one policy per label: fluid `text-xs` if scaling is fine, the new fixed
+  token if it must stay put. Either way, retire the `text-[Npx]` literals.
 
 Headings use tighter tracking and balanced wrapping by default.
 

--- a/docs/DESIGN_AUDIT_2026-06.md
+++ b/docs/DESIGN_AUDIT_2026-06.md
@@ -191,4 +191,3 @@ re-confirmed). None of these are applied yet — they await go-ahead.
 - **`SNAPSHOT_DRIVEN_DASHBOARDS.md`** — made the `error.tsx` + `loading.tsx` + curated-disclosure
   requirement explicit.
 - **`DARK_MODE_USAGE_GUIDE.md`** — cross-referenced the chart-theming pattern and the elevation rule.
-</content>

--- a/docs/DESIGN_AUDIT_2026-06.md
+++ b/docs/DESIGN_AUDIT_2026-06.md
@@ -1,0 +1,194 @@
+# Front-End Design Audit — June 2026
+
+A site-wide design-quality and best-practice audit of all 49 routes, plus the prioritized fix backlog
+it produced. The durable best-practice rules now live in [`DESIGN_CHECKLIST.md`](../DESIGN_CHECKLIST.md);
+this file is the point-in-time findings + backlog.
+
+**Date:** 2026-06-24 · **Method:** 16 parallel auditors (11 page-group + 4 cross-cutting + 1 docs),
+with the personal-tools and accessibility sweeps re-run, and every P0/P1 claim spot-verified against code.
+
+---
+
+## Executive summary
+
+The site is in **strong design health**. The editorial system (`--home-*` tokens, `.home-*` shell
+helpers, the snapshot-driven dashboard pattern, a single `ConditionalLayout`-owned `<main>`) is
+well-built and consistently applied. Accessibility fundamentals are a genuine strength — one runtime
+`<h1>` per route, clean landmark architecture (no nested `<main>`), idiomatic ARIA tablists/radiogroups,
+`aria-live` status regions, sr-only data tables behind charts, a global `:focus-visible` ring, and
+correct icon-button labeling / form labels / image alt across the board.
+
+The drift is **real but narrow and patterned** — mostly mechanical, and several issues sit in shared
+primitives so one fix clears many routes. 114 findings: **3 critical, 17 high, 42 medium, 52 low.**
+Four themes dominate: (1) the V3 roots + writing archive each duplicate the palette as hardcoded hex
+in CSS Modules; (2) chart/elevated-surface colors mix toward literal `white` and break in dark mode;
+(3) `/march-madness-2026` is a separate dark-only language that bypasses tokens; (4) a long tail of
+sub-44px targets, arbitrary micro-type, and missing dashboard `error.tsx` files.
+
+### Verification corrections to the raw audit
+
+- **"6 routes with multiple `<h1>`" is a FALSE POSITIVE.** On `/admin`, `/bay-area-transit`,
+  `/earthquake-pulse`, `/golf`, `/museum-log` the two `<h1>`s are in **mutually-exclusive conditional
+  branches** (loading/unavailable vs loaded state) — only one renders at runtime. Verified in
+  `golf-client.tsx` (`if (!tournament) return (…h1…)` early-return, then the main `return (…h1…)`).
+  No action required beyond awareness; the audit's "one `<h1>` per route" conclusion stands.
+
+---
+
+## Top themes
+
+| # | Theme | Scope |
+|---|-------|-------|
+| T1 | Palette duplicated as hardcoded hex in CSS Modules instead of aliasing `--home-*` | 5 surfaces: `page/about/portfolio/contact/writing.module.css` |
+| T2 | Dark-mode bug: `color-mix(… , white)` lightens "raised" surfaces in both themes | ~30 hits: nfl/nba/mlb/premier-league/la-liga (20), polling (4), `ModernButton` (4), news-pulse (2), `/now` (2), mba-jobs (2), MissionImageFrame (2) |
+| T3 | Charts bypass tokens / hardcode hex → no dark-mode adaptation | investments (radar, allocation, holdings, research header), frontier chart, formula-1 accents, polling tie color |
+| T4 | Missing per-route `error.tsx` (and some `loading.tsx`) on snapshot dashboards | 8 routes (see P0-1) |
+| T5 | Sub-44px touch targets on interactive controls | ~12 surfaces (chips, pagers, native selects, icon buttons) |
+| T6 | Arbitrary `text-[Npx]` micro-type — partly a real token gap (no fixed 12/13px token) | `text-[12px]` ×26, `text-[13px]` ×20; heaviest travel/museum-log/decision-lab/interchange-iq/budget-planner |
+| T7 | Legacy `--color-success/-error/-warning` aliases used in new code | golf, budget-planner, interchange-iq, + several fantasy files |
+| T8 | `/march-madness-2026` is a self-contained dark-only surface (no light mode, ~50 raw literals) | 1 route, total token bypass |
+
+Plus low-grade: shared primitives using `transition-all`/bare `transition`; a few Framer surfaces
+missing `useReducedMotion`; `role="button"` `<tr>` wrapping a real `<button>`.
+
+---
+
+## Prioritized backlog
+
+Each item is checkable. **Status** = `confirmed` (verified against code) or `verify` (reported, not yet
+re-confirmed). None of these are applied yet — they await go-ahead.
+
+### P0 — Critical / guardrail-blocking
+
+- [ ] **P0-1 · Add missing `error.tsx` (+ `loading.tsx`) to snapshot dashboards.** `confirmed`
+      Missing `error.tsx`: `/polling-aggregator`, `/github-trending-pulse`, `/fantasy-football`,
+      `/fantasy-football/draft-tracker`, `/frontier-models`, `/march-madness-2026`, `/golf`,
+      `/mba-internship-notifications`. Also missing `loading.tsx`: fantasy-football, draft-tracker,
+      frontier-models, march-madness-2026, mba-internship-notifications. Each `error.tsx` is a `'use client'`
+      default re-exporting `RouteErrorBoundary` with a bespoke `surfaceName` (copy `earthquake-pulse/error.tsx`).
+      *Why:* CLAUDE.md guardrail; siblings comply. Mechanical, ~16 small files.
+- [ ] **P0-2 · `/march-madness-2026` ignores the token system entirely.** `confirmed`
+      `march-madness-client.tsx` is hardcoded dark-only (`#06090f` gradients, `text-slate-*`,
+      `border-white/10`, `text-amber-300`) → never adapts to light mode. Re-skin onto
+      `home-page`/`home-card` + `--home-*` with `color-mix` accents (match golf/F1), or — if intentionally
+      seasonal — introduce a scoped `--mm-*` token set so it at least has one source of truth + a `.dark` story.
+- [ ] **P0-3 · `/frontier-models` curated-dataset disclosure missing.** `confirmed`
+      `FrontierModelsSnapshot` lacks `verified`/`asOf`/`disclaimer`, so the unverified state is never
+      disclosed on-page (sibling `tech-startup-tracker` does this). Add the fields + a disclosure card.
+- [ ] **P0-4 · `MetricTooltip` definitions unreachable by keyboard/touch.** `confirmed`
+      The `?` trigger is a non-focusable `<span>` revealed only on `group-hover`. Make it a real
+      `<button>`, reveal on `group-focus-within`, wire `aria-describedby`. Same hover-only pattern affects
+      `PortfolioStatsGrid` / `ResearchAssetHeader` metric hints (native `title=` only).
+
+### P1 — High
+
+- [ ] **P1-1 · Collapse the 5 duplicated palettes to one source of truth.** `confirmed`
+      In `page/about/portfolio/contact/writing.module.css`, redefine the module-local tokens as
+      `var(--home-*)` and delete the redundant `:global(.dark)` palette mirrors. Kills future drift.
+- [ ] **P1-2 · Fix the `color-mix(… , white)` dark-mode bug.** `confirmed`
+      Replace `bg-[color-mix(in_srgb,var(--home-paper)_92%,white)]` with `bg-[var(--home-paper-raised)]`
+      (theme-aware via `--home-elev-mix`). Routes: nfl/nba/mlb/premier-league/la-liga (20), polling (4),
+      news-pulse (2), `/now` (2), mba-jobs (2). **Check `ModernButton` (×4) and `MissionImageFrame` (×2)**
+      — confirm whether those white-mixes are intentional on-accent highlights before changing.
+- [ ] **P1-3 · Make investments charts theme-aware + share one palette.** `confirmed`
+      `ComparisonRadarChart` hardcodes `COLOR_A_HEX="#2563EB"` (stale vs `--home-haze` `#5672F8`) and its
+      legend swatch ≠ text color; `AllocationChart`/`HoldingsTable`/`ResearchAssetHeader` use static
+      palettes (incl. `AAPL "#12110F"` → near-invisible on dark). Resolve via `getComputedStyle` like
+      `PortfolioPerformanceChart`; extract one shared `src/lib/investments/palette.ts`.
+- [ ] **P1-4 · Tokenize gain/loss + tie accents.** `confirmed`
+      `/formula-1` hardcodes `#22A06B`/`#D54E4E`; polling hardcodes tie `#D97706` (×3). Use
+      `--home-positive`/`--home-negative`/`--home-warning`. Decorative medal/party colors stay raw.
+- [ ] **P1-5 · `/investments` section nav vanishes on mobile.** `confirmed`
+      `globals.css` hides `.invest-sidebar` below 900px with no replacement. Render a scrollable chip row
+      or sticky section-jump `<select>` reusing `navItems`.
+- [ ] **P1-6 · Portfolio listing touch targets.** `confirmed`
+      Filter chips (~36px), pager (40px), sort `<select>` (~30px) all < 44px. Add `min-height: 44px`
+      (and `min-width: 44px` on pager) via padding/line-height, not by shrinking the hit area.
+- [ ] **P1-7 · `/changelog` injects markdown into an undefined `.changelog-prose` class.** `confirmed`
+      Class referenced once (`page.tsx:143`), never defined → embedded links render default-blue and ignore
+      dark mode. Define `.changelog-prose` in `globals.css` styling `a/ul/ol/code/strong` with `--home-*`.
+- [ ] **P1-8 · `PageSummary` shared primitive ignores `useReducedMotion`.** `confirmed`
+      Its Framer entrance plays for motion-sensitive users on every route that embeds it. Gate the
+      transition on `useReducedMotion()`. (Fixing the shared primitive covers many routes.)
+
+### P2 — Medium polish
+
+- [ ] **P2-1 · Migrate legacy `--color-*` aliases in new code** → `--home-positive/-negative/-warning`.
+      golf, budget-planner, interchange-iq (+ several fantasy files). Mechanical, no visual change. `confirmed`
+- [ ] **P2-2 · Remaining sub-44px controls.** Fantasy rankings icon buttons (`h-7`) + "Clear"; draft-tracker
+      undo/toggle/inputs; investments search/nav; world-cup team rows (36px); budget-planner chevrons (32px);
+      interchange-iq Reset (32px); search filter pills (36px); writing chips/pager/select. `confirmed`
+- [ ] **P2-3 · `TierBreakdown` tiers have no heading.** Each tier is an `aria-label`'d `<section>` with the
+      label as a `<p>`. Promote to `<h3>` + `aria-labelledby` so tiers are navigable by heading. `confirmed`
+- [ ] **P2-4 · Arbitrary micro-type cleanup** in decision-lab, interchange-iq, budget-planner, formula-1,
+      travel (×37), museum-log (×12), recipe-finder. Migrate 9–11px → `text-3xs`/`text-2xs`; decide the
+      12/13px policy (fluid `text-xs` vs a new fixed `text-1xs` token — see `STYLING.md`). `confirmed`
+- [ ] **P2-5 · Responsive reflow gaps.** About stat strip stays 4-col on mobile; investments 8-col holdings
+      table only horizontal-scrolls; world-cup tables lack the scroll-region wrapper; golf packs 4 StatBlocks
+      into `grid-cols-4`; home wordmark `nowrap` clip risk at 360px. `verify`
+- [ ] **P2-6 · Invalid `role="button"` on `<tr>` wrapping a real `<button>`.** `confirmed (ai-dev-tools)` /
+      `verify (others)` `ai-dev-tools-client.tsx:461` wraps a tabbable `<button>` (:466) → duplicate tab stop.
+      Same pattern reported in polling-aggregator, github-trending-pulse, frontier-models — make the row OR
+      the inner control interactive, not both. Also: ai-dev-tools placeholder GitHub pill links to bare
+      `https://github.com/`.
+- [ ] **P2-7 · Framer entrances on `/resume` and `/admin` lack `useReducedMotion`.** `confirmed`
+- [ ] **P2-8 · `/accessibility` overstates conformance** ("fully conformant WCAG 2.1 AA, no exceptions",
+      "all controls 44px") — contradicted by the 36px search pills. Fix the pills (P2-2) and soften to
+      defensible language. `confirmed`
+- [ ] **P2-9 · More dark-mode color issues:** frontier chart's 7 hardcoded provider hexes (xAI slate
+      `#475569` low-contrast on dark); contact/portfolio `#1a1814` hover not remapped in `.dark` (invisible
+      hover in dark). `confirmed`
+
+### P3 — Low
+
+- [ ] **P3-1 · Shared-primitive `transition-all` / bare `transition` → scoped properties.** MetricCallout,
+      Breadcrumbs, ProfitabilityPanel, FixtureCard, ProjectsContent (×4). `confirmed`
+- [ ] **P3-2 · Mouse-only hover color via inline JS** (no focus state) in AuthorBio + resume-client contact
+      links → move to CSS `:hover, :focus-visible`. `confirmed`
+- [ ] **P3-3 · Migrate `.prose-writing` off legacy aliases** (`--text-*`, `--surface-*`, `--color-primary`)
+      to `--home-*`. `verify`
+- [ ] **P3-4 · Hardcoded content counts in AboutV3** disagree with each other / live data — derive from the
+      same accessors the homepage uses. `verify`
+- [ ] **P3-5 · Consolidate the focus-ring strategy.** Global `button/a:focus-visible` uses `outline` +
+      `box-shadow` (and legacy `--color-primary`/`--border-accent` aliases); several components add inline
+      `focus-visible:ring-2 ring-offset-2` on top → up to three stacked indicators. Pick one approach. `verify`
+- [ ] **P3-6 · Token-fidelity nits:** world-cup inlines `--home-ink-soft` once; writing `#1A1814` raw hex;
+      nfl `shadow-sm` vs `shadow-[var(--shadow-sm)]`; bay-area `#888888`/white-dot fallbacks; CrestAvatar
+      `bg-white` plate; on-accent `#ffffff` literals in charts. `verify`
+- [ ] **P3-7 · Minor a11y/motion:** `/recipe-finder` heading skip (h1 → h3 — add an h2 or promote recipe
+      titles); march-madness chevron not `aria-hidden`; F1 external links missing `rel="noreferrer"`;
+      CSS chevron rotations not `motion-safe:`; retirement-assumptions table missing `overflow-x-auto`;
+      wine-cellar/ai-dev-tools/march-madness wide-table mobile UX. `confirmed (recipe-finder)` / `verify (rest)`
+
+---
+
+## What's already strong (preserve)
+
+- **Editorial token system + shell helpers** — broadly consistent; `/portfolio/[slug]`, `/resume`, the
+  writing reader, and topic pages prove the system works with zero per-route hex.
+- **Accessibility fundamentals** — one runtime `<h1>`/route, clean single-`<main>` architecture, idiomatic
+  ARIA tablists/radiogroups, `aria-live` regions, sr-only data tables behind charts, a global
+  `:focus-visible` ring, correct icon-button labeling, form labels, and image alt.
+- **The global `prefers-reduced-motion` guard** plus targeted blocks for looping animations — most Framer
+  surfaces correctly gate on `useReducedMotion()`.
+- **The snapshot-driven dashboard pattern** with fail-soft refresh and honest curated-data disclosure.
+- **The shared football component set** (`SurfaceCard`, `StatCard`, `FixtureCard`, `TeamResultPill`) —
+  genuinely theme-aware and cleanly reused across 6 routes.
+- **The personal-interest tools** (travel/food-map/recipe-finder/wine-cellar/museum-log) — strong token
+  discipline, form a11y, empty states, and motion handling; their main gap is arbitrary micro-type.
+- **Reference implementations to copy:** `PortfolioPerformanceChart`, `github-trending-pulse`,
+  `tech-startup-tracker`, `EditorialPillButton`, the `scroll-shadow-x` wide-table pattern.
+
+---
+
+## Documentation changes shipped with this audit
+
+- **`DESIGN_CHECKLIST.md`** (new) — single canonical pre-merge checklist.
+- **`STYLING.md`** — corrected the fonts table (added **Bricolage Grotesque** / `--font-display`); added
+  *Dark-mode elevation*, *Semantic status colors*, *Charts/D3 theming*, and the *micro-type policy / 12–13px
+  token gap*.
+- **`CLAUDE.md`** — added `DESIGN_CHECKLIST.md` to the documentation map + new guardrails.
+- **`SNAPSHOT_DRIVEN_DASHBOARDS.md`** — made the `error.tsx` + `loading.tsx` + curated-disclosure
+  requirement explicit.
+- **`DARK_MODE_USAGE_GUIDE.md`** — cross-referenced the chart-theming pattern and the elevation rule.
+</content>


### PR DESCRIPTION
## Summary

A site-wide front-end **design audit of all 49 routes** plus the documentation needed to keep design quality high. The audit ran as parallel auditors (11 page-group reviews + 4 cross-cutting sweeps: accessibility, tokens/color, responsive, motion+dark-mode + a documentation-gap pass), with the personal-tools and accessibility sweeps re-run and **every P0/P1 claim spot-verified against code**.

**Verdict: the site is in strong design health.** The editorial system, single-`<main>` landmark architecture, ARIA patterns, reduced-motion guard, and snapshot-dashboard pattern are well-built and consistent. The drift that exists is narrow, patterned, and mostly mechanical — and several issues live in shared primitives, so one fix clears many routes.

**This PR is documentation only — no component code is changed.** The concrete code fixes are captured as a prioritized backlog awaiting go-ahead.

## What changed (docs)

- **`DESIGN_CHECKLIST.md`** (new) — the single canonical pre-merge checklist: color/tokens, dark mode, typography, accessibility, motion, responsive, and snapshot-dashboard requirements, each with reference implementations and named anti-patterns.
- **`docs/DESIGN_AUDIT_2026-06.md`** (new) — point-in-time findings + the full **P0–P3 fix backlog** (deduped, with `confirmed`/`verify` status), and the corrected **"multiple `<h1>`" false positive** (those are mutually-exclusive conditional state branches).
- **`STYLING.md`** — corrected the fonts table (added **Bricolage Grotesque** / `--font-display`, which the doc had omitted); added **dark-mode elevation** (`--home-paper-raised` / `--home-elev-mix`; ban `color-mix(…, white)`), **semantic status colors** (`--home-positive/-negative/-warning`), **D3 chart theming** via `getComputedStyle`, and the **micro-type policy / 12–13px token gap**.
- **`CLAUDE.md`** — linked the checklist + audit in the documentation map; expanded the styling guardrails.
- **`SNAPSHOT_DRIVEN_DASHBOARDS.md`** — made `error.tsx` + `loading.tsx` + curated `verified`/`asOf` disclosure a **hard requirement** (8 routes currently miss `error.tsx`).
- **`DARK_MODE_USAGE_GUIDE.md`** — added common-issue entries for the white-mix elevation bug and theme-aware chart colors.

## Audit headline numbers

114 findings: **3 critical, 17 high, 42 medium, 52 low.** Dominant themes:

| Theme | Scope |
|-------|-------|
| Palette duplicated as hardcoded hex in 5 CSS Modules instead of aliasing `--home-*` | home/about/portfolio/contact/writing |
| `color-mix(…, white)` breaks raised surfaces in dark mode | ~30 hits incl. nfl/nba/mlb/PL/La Liga, `ModernButton` |
| Charts bypass tokens / hardcode hex → no dark-mode adaptation | investments charts, frontier, formula-1 |
| Missing dashboard `error.tsx` (CLAUDE.md guardrail) | 8 routes |
| Sub-44px touch targets | ~12 surfaces |
| Arbitrary `text-[Npx]` micro-type (real token gap at 12/13px) | `text-[12px]` ×26, `text-[13px]` ×20 |

Full prioritized backlog with routes/files/fixes lives in `docs/DESIGN_AUDIT_2026-06.md`.

## Next step

The backlog items are not applied. On approval I can start with the high-leverage, low-risk P0/P1 fixes (missing `error.tsx` files, the `color-mix(…, white)` → `--home-paper-raised` swap, collapsing the 5 duplicated palettes, theme-aware charts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wpcRuqstyp4zMNt4CrgGT

---
_Generated by [Claude Code](https://claude.ai/code/session_015wpcRuqstyp4zMNt4CrgGT)_