### PR TITLE
Sync source-of-truth docs with the codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Operational context for agents working in this repo. Start here, then read `CLAUDE.md` for deeper implementation context.
 
-**Last updated:** 2026-06-16
+**Last updated:** 2026-06-19
 
 ---
 
@@ -155,6 +155,7 @@ Footer variants:
 - Shared portfolio-shell primitives must not use `transition-all`. Transition specific properties instead.
 - Portfolio-shell routes must keep the primary message and main CTA visible in the initial mobile viewport whenever the route has a hero.
 - Portfolio and writing cards should surface role, problem space, and impact in the default scan state.
+- The `/portfolio` index is rendered by `src/components/portfolio/PortfolioV3.tsx`, which carries a client-side project search (tokenized AND match over title, description, role, timeline, metrics, summary, category, and tools) and a marquee band that sits between the project grid and the pager.
 - `/api/search` is still limited and mostly hardcoded. Do not describe it as comprehensive site search.
 - `ProjectsContent.tsx` and `WritingPreview.tsx` still exist, but they are not the primary live path for the current shell.
 
@@ -215,6 +216,10 @@ npm run dev
 - Use `npm test` or targeted Jest runs while iterating.
 - Use `npm run test:e2e` for default Playwright end-to-end coverage; use `npm run test:e2e:full` for the full browser matrix.
 - Use `npm run build` before shipping route, config, or deployment-affecting changes.
+
+### Fantasy surface
+
+The fantasy-football surface pairs a FantasyPros consensus rankings board at `/fantasy-football` (client `fantasy-football-client.tsx`) with a manual draft assistant at `/fantasy-football/draft-tracker`, both reading one snapshot through `useFantasySnapshot`. The rankings board offers a deep-linkable position pill bar and PPR/Half-PPR/Standard scoring selector (`?position=`, `?scoring=`), per-board search, a List/Tiers view toggle (`?view=tiers`), a Comfortable/Compact density control, and ADP Value/Reach chips. Shared presentation components live in `src/components/fantasy/` (barrel `index.ts`); three cross-surface browser-local stores live in `src/hooks/use{PlayerQueue,PlayerNotes,CompareTray}.ts` over `useLocalStorageString.ts`, with parse/serialize helpers and key constants in `src/lib/fantasyLocal.ts`. Board math/formatting/legend copy is in `src/lib/fantasyUtils.ts`; the pure draft signal engine is `src/lib/draftAnalytics.ts`. New localStorage keys: `fantasy-player-queue-v1`, `fantasy-player-notes-v1`, `fantasy-compare-v1`, `fantasy-board-density`; per-season draft state persists under `fantasy-draft-tracker-v2-<season>`.
 
 ### Fantasy data workflow
 
@@ -411,7 +416,7 @@ Current behavior:
 - `update-github-trending.yml` runs on manual dispatch and daily at `07:45 UTC`, then commits `src/data/githubTrendingSnapshot.ts` when tracked repositories change
 - `update-formula-1.yml` runs on manual dispatch and daily at `08:10 UTC`, then commits `src/data/formula1Snapshot.ts` when it changes
 - `update-spacex.yml` runs on manual dispatch and daily at `09:25 UTC` and `21:25 UTC`, then commits SpaceX data, manifest, image reference, and cached image artifacts when they change
-- `update-mlb.yml` runs on manual dispatch and daily April through October at `10:05 UTC`, then commits `src/data/mlbSnapshot.ts` when it changes
+- `update-mlb.yml` runs on manual dispatch and daily March through November at `10:05 UTC`, then commits `src/data/mlbSnapshot.ts` when it changes
 - `update-nba.yml` runs on manual dispatch and daily from mid-October through June at `10:20 UTC`, then commits `src/data/nbaSnapshot.ts` when it changes
 - `update-nfl.yml` runs on manual dispatch and Tuesdays September through February at `10:35 UTC`, then commits `src/data/nflSnapshot.ts` when it changes
 - `update-golf.yml` runs on manual dispatch and daily at `08:40 UTC`, then commits `src/data/golfSnapshot.ts` when it changes
@@ -419,6 +424,7 @@ Current behavior:
 - `update-bay-area-transit.yml` runs on manual dispatch and every six hours year-round, then commits `src/data/bayAreaTransitSnapshot.ts` when it changes
 - `update-earthquake.yml` runs on manual dispatch and hourly (minute 20), then commits `src/data/earthquakeSnapshot.ts` when it changes
 - The tech startup tracker has no workflow by design — its dataset is editorially curated, so refreshes happen by editing the seed and running `npm run update:tech-startups` locally
+- All 14 snapshot `update-*.yml` workflows commit and push through the shared `scripts/ci/commit-and-push-snapshot.sh` helper (usage: `commit-and-push-snapshot.sh <commit-message> <pathspec...>`). It sets the `github-actions[bot]` identity, exits cleanly on a no-op refresh, and pushes to `HEAD:main` with a fetch/`rebase --autostash` retry loop (default 8 attempts, `SNAPSHOT_PUSH_ATTEMPTS` override) plus capped exponential backoff to absorb concurrent snapshot-bot pushes. Behavior is asserted by `.github/workflows/__tests__/snapshot-workflows.test.ts` and `update-investments.test.ts`.
 - A daily cron-job.org ping to the Netlify build hook triggers production deploys; `prebuild` refreshes Premier League and La Liga league-level snapshots with `tsx scripts/updateFootballSnapshots.ts --league-only`
 - `purge-cache.ts` is protected by `Authorization: Bearer <CRON_SECRET>` or `x-cron-secret` and calls Netlify Durable Cache purge; query-string secrets are intentionally rejected
 - Historical caveat: `vercel.json` still declares a cron for `/api/scheduled-update`, but no matching route exists. Treat that config as historical until confirmed.

--- a/API.md
+++ b/API.md
@@ -2,7 +2,7 @@
 
 Current API route inventory for the app.
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -60,7 +60,7 @@ Current API route inventory for the app.
 
 | Route | Methods | Notes |
 |------|---------|-------|
-| `/api/mba-jobs` | GET | Aggregates MBA-relevant postings across Greenhouse, Lever, Ashby, and direct-HTML job boards for 32 tech companies; filters via `src/lib/mba-job-matching.ts`; accepts optional `?companies=` filter |
+| `/api/mba-jobs` | GET | Aggregates MBA-relevant postings across Greenhouse, Lever, Ashby, SmartRecruiters, and direct-HTML job boards (plus optional Adzuna external leads). `src/constants/mba-companies.ts` tracks 39 companies, ~28 actively fetched (the `manual` entries are catalogued, not live-fetched); filters via `src/lib/mba-job-matching.ts`; accepts optional `?companies=` filter |
 | `/api/mba-jobs/email` | POST | Sends a grouped digest of supplied `{ jobs, to }` via Resend; requires `RESEND_API_KEY` and `MBA_DIGEST_ALLOWED_RECIPIENTS` |
 
 ### Content and utilities

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 High-level system architecture for the current live application.
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -60,6 +60,7 @@ src/app/layout.tsx
 - generated static snapshots in `public/data/fantasy/`
 - `/api/fantasy-data` server fallback over the same snapshot files
 - weekly GitHub Actions refresh through `npm run update:fantasy`
+- the rankings board (`/fantasy-football`) and draft assistant (`/fantasy-football/draft-tracker`) share three browser-local stores layered over `src/hooks/useLocalStorageString.ts`, with pure parse/serialize and key constants in `src/lib/fantasyLocal.ts`: a player watchlist (`usePlayerQueue`), per-player notes (`usePlayerNotes`), and the compare selection (`useCompareTray`); list density also persists locally. Shared presentation components live in `src/components/fantasy/`
 
 ### Investments
 
@@ -155,6 +156,7 @@ These are committed TypeScript files rebuilt by `scripts/buildPremierLeagueSnaps
 - generated public JSON snapshots in `public/data/fantasy/`
 - snapshot reader in `src/lib/fantasySnapshotServer.ts`
 - public API fallback at `/api/fantasy-data`
+- browser-local user state (watchlist, notes, compare selection) in `src/lib/fantasyLocal.ts` with `use{PlayerQueue,PlayerNotes,CompareTray}` hooks; not part of the committed snapshot
 
 ### Investments
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -2,7 +2,7 @@
 
 Current component map for the live application.
 
-**Last updated:** 2026-06-16
+**Last updated:** 2026-06-19
 
 > The homepage, about, portfolio, contact, and writing-archive surfaces moved to
 > dedicated `*V3` composition roots in the 2026-05-31 refresh (commit `66063bb`).
@@ -58,9 +58,24 @@ Representative live components:
 - `src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx`
 - `src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx`
 - `src/app/fantasy-football/draft-tracker/components/DraftSetup.tsx`
-- `src/components/fantasy/TierBreakdown.tsx`
 
 These are used across `/fantasy-football/*` routes.
+
+Shared fantasy presentation components live in `src/components/fantasy/`
+(exported via `index.ts`) and are reused by both the rankings board and the
+draft assistant:
+
+| Component | File | Role |
+|----------|------|------|
+| `TierBreakdown` | `src/components/fantasy/TierBreakdown.tsx` | Tiers view: FantasyPros tier-grouped sections with player counts, rank ranges, and rank-cliff hints |
+| `FantasyBoardLegend` | `src/components/fantasy/FantasyBoardLegend.tsx` | Collapsible "How to read this board" key, sourced from `FANTASY_BOARD_LEGEND` |
+| `PositionFilterBar` | `src/components/fantasy/PositionFilterBar.tsx` | Generic position pill radiogroup with per-slice availability/NA states, shared by rankings and draft boards |
+| `RankingsListRow` | `src/components/fantasy/RankingsListRow.tsx` | Single List-view row: published rank, position chip, note indicator, metric strip, and star/compare toggles |
+| `TierBreakSeparator` | `src/components/fantasy/TierBreakSeparator.tsx` | Labeled rule injected into the List view at tier boundaries with rank-cliff hints |
+| `PlayerDetailDrawer` | `src/components/fantasy/PlayerDetailDrawer.tsx` | Shared focus-trapped player detail drawer/bottom-sheet with tier context, ADP, distribution bar, queue/compare toggles, and editable note |
+| `RankDistributionBar` | `src/components/fantasy/RankDistributionBar.tsx` | Visualizes expert best→worst rank spread with the average marked and tight/mixed/volatile color coding |
+| `CompareTray` | `src/components/fantasy/CompareTray.tsx` | Docked bottom bar surfacing the compare selection (up to 3 players) that opens the `CompareModal` |
+| `CompareModal` | `src/components/fantasy/CompareModal.tsx` | Side-by-side comparison dialog with per-row winner highlighting and shared-scale range bars |
 
 ### Investments
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 Current development setup and workflow notes.
 
-**Last updated:** 2026-06-08
+**Last updated:** 2026-06-19
 
 ---
 
@@ -46,8 +46,13 @@ npm run update:mlb
 npm run update:nba
 npm run update:nfl
 npm run update:formula-1
+npm run update:golf
+npm run update:earthquake
+npm run update:world-cup
+npm run update:bay-area-transit
 npm run update:frontier-models
 npm run update:github-trending
+npm run update:tech-startups
 npm run update:spacex
 npm run update:spacex-images
 ```
@@ -161,7 +166,7 @@ npm run update:nba
 npm run update:nfl
 ```
 
-These commands use public data sources and do not require auth tokens. Golf is manually maintained in `src/data/golfSnapshot.ts`; there is no golf update script.
+These commands use public data sources and do not require auth tokens. Golf, Formula 1, the World Cup, Earthquake Pulse, and Bay Area Transit follow the same pattern with their own update scripts (`npm run update:golf`, `npm run update:formula-1`, `npm run update:world-cup`, `npm run update:earthquake`, `npm run update:bay-area-transit`), each against a public source with no auth token.
 
 ---
 
@@ -184,6 +189,7 @@ There is no live `/admin/analytics` page in the current route tree.
 - `next-sitemap` runs during postbuild
 - `typescript.ignoreBuildErrors` is still enabled in `next.config.mjs`
 - build-time tracing excludes large optional assets and packages
+- the snapshot-refresh GitHub Actions workflows (all `.github/workflows/update-*.yml`) commit and push their refreshed snapshots through the shared `scripts/ci/commit-and-push-snapshot.sh` helper, which sets the `github-actions[bot]` identity, no-ops cleanly when nothing changed, and retries the push with rebase + backoff so concurrent snapshot bots do not collide on `main`
 
 ---
 

--- a/PAGES.md
+++ b/PAGES.md
@@ -3,7 +3,7 @@
 Current route inventory and page ownership for the live app.
 
 **Framework:** Next.js 16 App Router
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -15,7 +15,7 @@ Current route inventory and page ownership for the live app.
 |------|------|-------|
 | `/` | `src/app/page.tsx` | Composes hero, featured projects, product-thinking preview, and homepage contact section |
 | `/about` | `src/app/about/page.tsx` | Renders `About` tabbed client UI |
-| `/portfolio` | `src/app/portfolio/page.tsx` | Renders project cards directly from route code |
+| `/portfolio` | `src/app/portfolio/page.tsx` | Renders project cards directly from route code; `PortfolioV3.tsx` adds a client-side project search/filter, with the marquee band sitting between the project grid and the pager |
 | `/portfolio/[slug]` | `src/app/portfolio/[slug]/page.tsx` | Project detail page |
 | `/resume` | `src/app/resume/page.tsx` | Resume route with client-rendered resume shell |
 | `/contact` | `src/app/contact/page.tsx` | Contact page using `ContactContent` |
@@ -54,7 +54,7 @@ Current route inventory and page ownership for the live app.
 | `/polling-aggregator` | `src/app/polling-aggregator/page.tsx` | Snapshot-backed political polling dashboard |
 | `/fintech-tools/budget-planner` | `src/app/fintech-tools/budget-planner/page.tsx` | Budget planner tool |
 | `/fintech-tools/interchange-iq` | `src/app/fintech-tools/interchange-iq/page.tsx` | Interchange fee analyzer |
-| `/mba-internship-notifications` | `src/app/mba-internship-notifications/page.tsx` | Live MBA role tracker polling 32 tech companies for internships and full-time business roles |
+| `/mba-internship-notifications` | `src/app/mba-internship-notifications/page.tsx` | Live MBA role tracker polling ~28 of 39 tracked companies for internships and full-time business roles |
 | `/decision-lab` | `src/app/decision-lab/page.tsx` | Decision-modeling sandbox |
 | `/food-map` | `src/app/food-map/page.tsx` | Food map |
 | `/recipe-finder` | `src/app/recipe-finder/page.tsx` | Recipe finder |
@@ -66,7 +66,7 @@ Current route inventory and page ownership for the live app.
 
 | Route | File | Notes |
 |------|------|-------|
-| `/fantasy-football` | `src/app/fantasy-football/page.tsx` | Fantasy football landing page |
+| `/fantasy-football` | `src/app/fantasy-football/page.tsx` | FantasyPros consensus rankings board (`fantasy-football-client.tsx`): deep-linkable position pill bar, PPR/Half-PPR/Standard scoring selector, per-board search, List/Tiers view toggle (`?view=tiers`), Comfortable/Compact density, infinite-scroll windowing, shared player detail drawer, compare tray, watchlist queue, private notes, and a freshness/ADP-source sidebar |
 | `/fantasy-football/tiers/[position]` | `src/app/fantasy-football/tiers/[position]/page.tsx` | Redirects to the canonical fantasy board with query parameters |
 | `/fantasy-football/rb-tiers` | `src/app/fantasy-football/rb-tiers/page.tsx` | Redirects to the canonical RB board with query parameters |
 | `/fantasy-football/draft-tracker` | `src/app/fantasy-football/draft-tracker/page.tsx` | Draft tracker |

--- a/RETIREMENT_PLANNER_ENGINE.md
+++ b/RETIREMENT_PLANNER_ENGINE.md
@@ -5,7 +5,7 @@ Technical reference for the retirement projection engine in
 DOM, no fetch) so it is unit-testable and could run server-side. The UI never
 does math — it calls `project()` and renders the result.
 
-**Last updated:** 2026-06-16
+**Last updated:** 2026-06-19
 
 Surfaced as the `#retirement` band inside the investments dashboard
 (`InvestmentsDashboard.tsx`), backed by browser-local state. Output is
@@ -101,9 +101,10 @@ internally in **nominal** dollars and exposes real values alongside.
 6. **Levers** (`project` only). Four dials, each reporting its marginal effect on
    the success rate and — where it's a clean single dial — how far to push it to
    reach the threshold: `save-more`, `retire-later`, `spend-less`, `more-stocks`.
-   Lever rows run at the headline simulation count (`LEVER_SIMS = 1000`) so their
-   absolute success figures agree with the gauge; only the threshold-solving
-   binary search uses a cheaper `TO_REACH_SIMS = 250`.
+   Lever rows run at the plan's own simulation count
+   (`input.assumptions.simulations`, default **1,000**) so their absolute success
+   figures agree with the gauge; only the threshold-solving binary search uses a
+   cheaper `TO_REACH_SIMS = 250`.
 
 ---
 

--- a/SEO.md
+++ b/SEO.md
@@ -2,7 +2,7 @@
 
 Reference for the SEO architecture in this Next.js 16 App Router project.
 
-**Last updated:** 2026-04-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -317,34 +317,27 @@ The root layout provides the baseline for every page:
 
 ---
 
-## Sitemap — `next-sitemap.config.js`
+## Sitemap — `next-sitemap.config.js` + `src/lib/sitemap.js`
 
-Runs automatically via `postbuild` script. Generates `public/sitemap.xml`.
+Runs automatically via the `postbuild` script (`next-sitemap && node scripts/patch-nft-sharp.mjs`). Generates `public/sitemap.xml`.
 
-### Priority tiers
+The sitemap is **allowlist-driven**. `next-sitemap.config.js` is a thin wrapper that delegates to `src/lib/sitemap.js`, which builds the canonical entry list (`PUBLIC_SITEMAP_ENTRIES`) and the matching path set (`PUBLIC_SITEMAP_PATHS`). The config's `transform` returns `null` for any URL not in `PUBLIC_SITEMAP_PATHS`, and `additionalPaths` re-emits the curated list, so only explicitly-listed routes ship.
 
-| Priority | Pages |
-|---|---|
-| 1.0 | `/` |
-| 0.95 | `/portfolio` |
-| 0.9 | `/about`, `/resume` |
-| 0.85 | `/investments`, `/writing`, blog posts with "product"/"mba"/"berkeley" in slug |
-| 0.75 | `/march-madness-2026`, standalone dashboards, blog posts with "qa"/"testing"/"quality" in slug |
-| 0.7 | `/contact`, all other blog posts |
-| 0.6 | `/fantasy-football` |
-| 0.5 | `/fantasy-football/tiers/*`, `/fantasy-football/draft-tracker`, `/accessibility` |
+### Output fields
 
-### Dynamic blog discovery
+Each entry emits only `loc` and `lastmod`. There are **no `priority` or `changefreq` values** — the config sets `autoLastmod: false` and the helper supplies an explicit `lastmod` per route. (Earlier versions of this doc described priority tiers; that scheme no longer exists.)
 
-Blog posts are discovered from `content/blog/*.mdx` at build time. Slug keywords determine priority (see above).
+### How `src/lib/sitemap.js` builds the list
 
-### Standalone route note
+`getPublicSitemapEntries()` merges three sources, dedupes by `loc`, and sorts alphabetically:
 
-Routes such as `/premier-league`, `/la-liga`, `/news-pulse`, `/spacex-mission-control`, `/polling-aggregator`, `/fintech-tools/budget-planner`, and `/fintech-tools/interchange-iq` are live app routes. Check `next-sitemap.config.js` and generated sitemap output before assuming each has explicit additional-path configuration.
+1. **Static routes** — the `STATIC_ROUTE_LASTMOD` map. Routes whose content is snapshot-driven derive their `lastmod` from the live snapshot (e.g. `readPremierLeagueLastmod`, `readInvestmentsLastmod`, `readFantasyLastmod`, `readEarthquakeLastmod`); the rest carry a hardcoded date. To add a new static route to the sitemap, add it to this map.
+2. **Portfolio case studies** — `getPortfolioSlugEntries()` regex-extracts top-level slug keys from `src/constants/caseStudies.ts`, skipping any entry with a top-level `link:` redirect (those `[slug]` routes `redirect()` instead of rendering a page).
+3. **Blog posts** — `getBlogRouteEntries()` discovers `content/blog/*.{mdx,md}` at build time, using `updatedAt || publishedAt` for `lastmod` and excluding future-dated posts (their `publishedAt` is later than today).
 
 ### Excluded paths
 
-`/api/*`, `/_next/*`, `/404`, `/admin/*`
+`exclude` in `next-sitemap.config.js`: `/api/*`, `/_next/*`, `/404`, `/admin`, `/admin/*`, `/search`. Combined with the allowlist, anything not in `PUBLIC_SITEMAP_PATHS` is dropped regardless.
 
 ---
 
@@ -562,6 +555,7 @@ const minutes = calculateReadingTime(post.content); // e.g. 4
 | `src/app/metadata.ts` | Homepage metadata config |
 | `src/app/writing/[slug]/page.tsx` | Article pattern reference |
 | `src/app/portfolio/[slug]/page.tsx` | Case study pattern reference |
-| `next-sitemap.config.js` | Sitemap generation and priorities |
+| `next-sitemap.config.js` | Sitemap config wrapper — delegates to `src/lib/sitemap.js` |
+| `src/lib/sitemap.js` | Builds the allowlisted sitemap entries (`loc` + `lastmod`) |
 | `public/robots.txt` | Crawl directives (manually maintained) |
 | `WRITING_VOICE.md` | Voice and tone rules for all user-facing text including meta content |

--- a/SNAPSHOT_DRIVEN_DASHBOARDS.md
+++ b/SNAPSHOT_DRIVEN_DASHBOARDS.md
@@ -4,7 +4,7 @@ How the site's data dashboards work. This is the single most-repeated
 architecture in the repo — 15+ public surfaces share it — so it gets one
 reference instead of being re-explained per route.
 
-**Last updated:** 2026-06-16
+**Last updated:** 2026-06-19
 
 The short version: **no dashboard calls an external API at request time.** A
 local script fetches data, transforms it, and writes a committed snapshot file. A
@@ -23,7 +23,7 @@ For a dashboard `x`:
 |------|------|------|
 | **Seed snapshot** | `src/data/<x>Snapshot.ts` | Committed `export const <x>Snapshot: <Type> = {…}`. Ships with a seed (empty or hand-authored) so the page works before the first refresh. |
 | **Builder** | `scripts/build<X>Snapshot.ts` (often via a `src/lib/<x>Data.ts` fetch/transform) | Fetches the upstream source, shapes it, writes the snapshot file. Run by `npm run update:<x>`. |
-| **GitHub Action** | `.github/workflows/update-<x>.yml` | Runs the builder on a schedule (+ manual dispatch) and commits the snapshot only when it changes. |
+| **GitHub Action** | `.github/workflows/update-<x>.yml` | Runs the builder on a schedule (+ manual dispatch) and commits the snapshot only when it changes, via the shared `scripts/ci/commit-and-push-snapshot.sh`. |
 | **Accessors** | `src/lib/<x>Snapshot.ts` | Pure read helpers the app and API routes call (`get<X>Summary()`, per-entity getters, id validation, empty-state factories). |
 | **API route(s)** | `src/app/api/<x>/summary/route.ts` (+ optional `[id]`) | Thin handlers that return accessor output. They read the committed snapshot, never the upstream source. |
 
@@ -78,6 +78,41 @@ response falls back to the committed snapshot.
 
 ---
 
+## The shared commit/push step (every Action)
+
+All 14 `update-*.yml` workflows route their git commit + push through one shared
+helper, `scripts/ci/commit-and-push-snapshot.sh`, instead of inlining their own
+git plumbing:
+
+```yaml
+- run: |
+    bash scripts/ci/commit-and-push-snapshot.sh \
+      "chore: refresh golf snapshot [automated] [skip ci]" \
+      src/data/golfSnapshot.ts
+```
+
+Usage is `commit-and-push-snapshot.sh <commit-message> <pathspec...>`. The script:
+
+1. Sets the `github-actions[bot]` git identity.
+2. Stages the given pathspecs and **exits 0 cleanly on a no-op refresh** — if
+   `git diff --cached --quiet` finds nothing staged, there's no commit to make.
+3. Commits, then pushes to `HEAD:main` with a **retry loop** (default 8 attempts,
+   override via `SNAPSHOT_PUSH_ATTEMPTS`). On each push rejection it
+   `git fetch origin main` and `git rebase --autostash origin/main`, then retries
+   with capped exponential backoff (`attempt² × 2`, capped at 30s) plus `RANDOM`
+   jitter.
+
+The retry loop exists because `main` moves constantly — many snapshot bots
+(earthquake hourly, world cup, transit, etc.) push to the same branch and collide.
+A refresh commit only touches its own snapshot files, so a rebase never truly
+conflicts; the failure mode is just losing the race repeatedly. The script bails
+(exit 1) only on a **genuine rebase conflict** (it aborts the rebase) or after
+exhausting all attempts. Tests in
+`.github/workflows/__tests__/snapshot-workflows.test.ts` and
+`update-investments.test.ts` assert every workflow uses it.
+
+---
+
 ## Worked example: `/golf` (the simplest one)
 
 1. **Source:** ESPN's public golf leaderboard endpoint, no token.
@@ -85,7 +120,8 @@ response falls back to the committed snapshot.
    from `src/lib/golfData.ts`, JSON-stringifies the result into
    `src/data/golfSnapshot.ts`, with the `readGeneratedSnapshot` fallback above.
 3. **Action:** `.github/workflows/update-golf.yml` runs daily at 08:40 UTC and
-   commits `src/data/golfSnapshot.ts` when it changes.
+   commits `src/data/golfSnapshot.ts` when it changes, via
+   `scripts/ci/commit-and-push-snapshot.sh`.
 4. **Accessors:** `src/lib/golfSnapshot.ts` exposes `getGolfSummary()`,
    `getGolfPlayerSnapshot(id)`, `createEmptyGolfSummary()`, and id validation.
 5. **API:** `/api/golf/summary` and `/api/golf/players/[playerId]`.
@@ -116,7 +152,7 @@ by BART abbr, world-cup `/teams/[teamId]` by team slug.
 | `/premier-league` | `src/data/premierLeagueSnapshot.ts` | `buildPremierLeagueSnapshot.ts` · `update:premier-league` / `update:football` | `update-premier-league.yml` | football-data.org (token) | daily 06:15 UTC, Aug–May |
 | `/la-liga` | `src/data/laLigaSnapshot.ts` | `updateLaLigaSnapshot.ts` · `update:la-liga` / `update:football` | `update-la-liga.yml` | football-data.org (token) | daily 06:30 UTC, Aug–May |
 | `/nfl` | `src/data/nflSnapshot.ts` | `updateNflSnapshot.ts` · `update:nfl` | `update-nfl.yml` | NFLverse CSVs | Tue 10:35 UTC, Sep–Feb |
-| `/mlb` | `src/data/mlbSnapshot.ts` | `updateMlbSnapshot.ts` · `update:mlb` | `update-mlb.yml` | MLB Stats API | daily 10:05 UTC, Apr–Oct |
+| `/mlb` | `src/data/mlbSnapshot.ts` | `updateMlbSnapshot.ts` · `update:mlb` | `update-mlb.yml` | MLB Stats API | daily 10:05 UTC, Mar–Nov |
 | `/nba` | `src/data/nbaSnapshot.ts` | `updateNbaSnapshot.ts` · `update:nba` | `update-nba.yml` | ESPN NBA | daily 10:20 UTC, mid-Oct–Jun |
 | `/golf` | `src/data/golfSnapshot.ts` | `buildGolfSnapshot.ts` · `update:golf` | `update-golf.yml` | ESPN golf | daily 08:40 UTC |
 | `/formula-1`, `/fantasy-formula-1` | `src/data/formula1Snapshot.ts` | `buildFormula1Snapshot.ts` · `update:formula-1` | `update-formula-1.yml` | OpenF1 | daily 08:10 UTC |
@@ -188,7 +224,8 @@ the snapshot type **and** render an on-page disclosure card (mirror `tech-startu
    deep-linkable state; add `src/app/<x>/error.tsx` **and** `src/app/<x>/loading.tsx`
    (curated/unverified data also needs `verified: false` + `asOf` + an on-page disclosure card).
 9. **Action** — `.github/workflows/update-<x>.yml` on a sensible cron + manual
-   dispatch, committing the snapshot only when it changes.
+   dispatch, committing the snapshot only when it changes via the shared
+   `scripts/ci/commit-and-push-snapshot.sh`.
 10. **Docs** — add a row to the table above and to
     `docs/DATA_UPDATE_OPERATIONS.md`; register in `AGENTS.md` Automation Surfaces.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 Current testing setup for the repo.
 
-**Last updated:** 2026-04-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -31,6 +31,7 @@ npm run test:watch
 npm run test:coverage
 npm run test:ci
 npm run test:e2e
+npm run test:e2e:full
 npm run test:e2e:ui
 npm run test:e2e:debug
 ```
@@ -56,6 +57,7 @@ Do not document or assume older 70% thresholds.
 
 - `src/components/**/__tests__`
 - `src/hooks/**/__tests__`
+- `src/lib/__tests__/` — pure-logic unit tests (fantasy snapshot/ADP/consensus builders, the investments live-quote allowlist in `finnhub.allowlist.test.ts`, and more)
 - `src/app/fantasy-football/__tests__/` — route state integration tests, including fantasy football client and fantasy state tests
 - `src/app/premier-league/__tests__/` and `src/app/la-liga/__tests__/` — dashboard client and route-state regression tests
 - `src/app/news-pulse/__tests__/`, `src/app/spacex-mission-control/__tests__/`, and `src/app/fintech-tools/budget-planner/__tests__/` — standalone tool coverage
@@ -80,7 +82,9 @@ Defined in `playwright.config.ts`:
 - Mobile Chrome
 - Mobile Safari
 
-Some local environments may only have a subset of browsers installed, so targeted project runs are common during local work.
+By default (CI and local), only Chromium runs so PR feedback stays fast. Set `E2E_FULL_MATRIX=1` — or run `npm run test:e2e:full` — to run the full matrix (Firefox, WebKit, and the mobile projects), used for main-branch / nightly coverage.
+
+Some local environments may only have a subset of browsers installed, so targeted project runs are also common during local work.
 
 ---
 

--- a/WRITING_VOICE.md
+++ b/WRITING_VOICE.md
@@ -1,6 +1,6 @@
 # Writing Voice
 
-**Last updated:** 2026-04-03
+**Last updated:** 2026-06-19
 
 This document governs all writing across the site — UI copy, page descriptions, bios, article content under `content/blog/`, and any other user-facing text. Any agent or collaborator editing, creating, or rewriting text must follow these rules exactly.
 
@@ -55,4 +55,4 @@ The articles below demonstrate the voice correctly. Read them before editing or 
 - `content/blog/rb-vs-wr-draft-strategy-modeling-positional-value.mdx` — data woven into prose, clear positional argument
 - `content/blog/building-an-investment-research-platform.mdx` — product rationale in first person, restraint as a feature
 
-All 22 articles in `content/blog/` were rewritten to this voice in April 2026 and can be used as references.
+The original 22 articles in `content/blog/` were rewritten to this voice in April 2026; the directory has since grown well beyond that. Every article in `content/blog/` follows this voice and can be used as a reference.

--- a/docs/DATA_UPDATE_OPERATIONS.md
+++ b/docs/DATA_UPDATE_OPERATIONS.md
@@ -9,7 +9,7 @@ architecture or the per-workflow prose:
 - Per-script and per-workflow detail: `AUTOMATION_SCRIPTS.md`, `CRON_SETUP.md`,
   and the **Automation Surfaces** section of `../AGENTS.md`
 
-**Last updated:** 2026-06-16
+**Last updated:** 2026-06-19
 
 All `update:*` commands write a **committed** artifact (TS snapshot or JSON);
 nothing here runs at request time. A failed/empty fetch **keeps the previous
@@ -28,7 +28,7 @@ changes.
 | Premier League | `update:premier-league` | `buildPremierLeagueSnapshot.ts` | football-data.org *(token)* | `src/data/premierLeagueSnapshot.ts` | `update-premier-league.yml` | daily 06:15 UTC, Aug–May |
 | La Liga | `update:la-liga` | `updateLaLigaSnapshot.ts` | football-data.org *(token)* | `src/data/laLigaSnapshot.ts` | `update-la-liga.yml` | daily 06:30 UTC, Aug–May |
 | NFL | `update:nfl` | `updateNflSnapshot.ts` | NFLverse CSVs | `src/data/nflSnapshot.ts` | `update-nfl.yml` | Tue 10:35 UTC, Sep–Feb |
-| MLB | `update:mlb` | `updateMlbSnapshot.ts` | MLB Stats API | `src/data/mlbSnapshot.ts` | `update-mlb.yml` | daily 10:05 UTC, Apr–Oct |
+| MLB | `update:mlb` | `updateMlbSnapshot.ts` | MLB Stats API | `src/data/mlbSnapshot.ts` | `update-mlb.yml` | daily 10:05 UTC, Mar–Nov |
 | NBA | `update:nba` | `updateNbaSnapshot.ts` | ESPN NBA | `src/data/nbaSnapshot.ts` | `update-nba.yml` | daily 10:20 UTC, mid-Oct–Jun |
 | Golf | `update:golf` | `buildGolfSnapshot.ts` | ESPN golf | `src/data/golfSnapshot.ts` | `update-golf.yml` | daily 08:40 UTC |
 | Formula 1 | `update:formula-1` | `buildFormula1Snapshot.ts` | OpenF1 | `src/data/formula1Snapshot.ts` | `update-formula-1.yml` | daily 08:10 UTC |
@@ -83,6 +83,35 @@ git push
 
 The same shape applies to any surface: run `npm run update:<x>`, then commit the
 changed artifact under `src/data/` or `public/data/`.
+
+---
+
+## How workflows commit (shared CI helper)
+
+All 14 snapshot `update-*.yml` workflows route their git commit + push through one
+shared helper, `scripts/ci/commit-and-push-snapshot.sh`, rather than each
+hand-rolling its own git steps:
+
+```bash
+bash scripts/ci/commit-and-push-snapshot.sh "<commit message>" <pathspec> [pathspec ...]
+```
+
+It sets the `github-actions[bot]` git identity, stages the given pathspecs, and
+**exits 0 cleanly if nothing is staged** (a no-op refresh). On a real diff it
+commits, then pushes to `HEAD:main` with a retry loop (default 8 attempts;
+override via `SNAPSHOT_PUSH_ATTEMPTS`). On each push rejection it
+`git fetch origin main` and `git rebase --autostash origin/main`, then retries
+with capped exponential backoff plus jitter — this absorbs the contention from
+many snapshot bots (earthquake hourly, world cup, transit, etc.) pushing to
+`main` concurrently. It bails (exit 1) only on a genuine rebase conflict or after
+exhausting every attempt. Usage is asserted by
+`.github/workflows/__tests__/snapshot-workflows.test.ts` (and the investments
+variant).
+
+The 14 callers: `update-bay-area-transit`, `update-earthquake`, `update-fantasy`,
+`update-formula-1`, `update-github-trending`, `update-golf`, `update-investments`,
+`update-la-liga`, `update-mlb`, `update-nba`, `update-nfl`, `update-premier-league`,
+`update-spacex`, `update-world-cup`.
 
 ---
 

--- a/docs/ai-context/COMPONENTS.md
+++ b/docs/ai-context/COMPONENTS.md
@@ -2,7 +2,7 @@
 
 Current component ownership reference.
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -119,15 +119,42 @@ Page-level clients live at `src/app/premier-league/premier-league-client.tsx` an
 
 ## Fantasy Football
 
-Representative live components:
+Route clients:
 
-- `src/app/fantasy-football/fantasy-football-client.tsx`
-- `src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx`
+- `src/app/fantasy-football/fantasy-football-client.tsx` — rankings board (List/Tiers, position/scoring/search filters, density toggle, infinite-scroll windowing, sidebar, stats panel, legend)
+- `src/app/fantasy-football/draft-tracker/draft-tracker-client.tsx` — draft assistant (reuses snapshot + shared drawer/compare/notes/queue)
 - `src/app/fantasy-football/draft-tracker/components/DraftBoard.tsx`
 - `src/app/fantasy-football/draft-tracker/components/DraftSetup.tsx`
-- `src/components/fantasy/TierBreakdown.tsx`
+- `src/app/fantasy-football/draft-tracker/components/DraftAnalyticsPanel.tsx` — live signals card + completion recap, backed by the pure `draftAnalytics` engine
 
-These work with the generated fantasy snapshots and `/api/fantasy-data` route described elsewhere in `docs/ai-context`.
+Shared presentation components in `src/components/fantasy/` (barrel-exported via `index.ts`):
+
+- `TierBreakdown` — Tiers view (tier-grouped sections, counts, rank ranges, rank-cliff hints)
+- `RankingsListRow` — single List-view row (published rank, position chip, expert range, ADP Value/Reach chip, rostered %/bye, queue + compare toggles, `compact` density)
+- `TierBreakSeparator` — labeled tier-boundary rule injected into the List view
+- `PositionFilterBar` (+ `PositionFilterOption` type) — shared position pill radiogroup with per-slice availability/NA states
+- `FantasyBoardLegend` — collapsible "How to read this board" key keyed to `FANTASY_BOARD_LEGEND`
+- `PlayerDetailDrawer` — shared focus-trapped detail drawer/bottom-sheet (position rank, tier N of M, ADP, distribution bar, editable private note, queue/compare toggles)
+- `RankDistributionBar` — expert best→worst spread with consensus marker and tight/mixed/volatile coloring
+- `CompareTray` — docked bottom bar for the pinned compare selection (up to 3)
+- `CompareModal` — side-by-side compare dialog with per-row winner highlighting
+
+Cross-surface browser-local stores (shared by both clients) in `src/hooks/`:
+
+- `usePlayerQueue` — starred watchlist of player ids (`fantasy-player-queue-v1`)
+- `usePlayerNotes` — private per-player notes, 280-char cap (`fantasy-player-notes-v1`)
+- `useCompareTray` — compare selection, max 3 (`fantasy-compare-v1`)
+- `useLocalStorageString` — low-level reactive single-key localStorage reader the three stores build on
+- list density preference lives inline in `fantasy-football-client.tsx` via `useSyncExternalStore` (`fantasy-board-density`)
+- draft state persists per-season under `fantasy-draft-tracker-v2-<season>`
+
+Supporting libs:
+
+- `src/lib/fantasyUtils.ts` — board math, formatting, and legend copy (`getValueVsAdp`, `getConsensusSpread`, `withTierBreaks`, freshness helpers, `FANTASY_BOARD_LEGEND`)
+- `src/lib/draftAnalytics.ts` — pure steal/reach/position-run engine consumed by `DraftAnalyticsPanel`
+- `src/lib/fantasyLocal.ts` — parse/serialize helpers + storage-key constants for the queue/notes/compare stores
+
+These work with the generated fantasy snapshots (loaded through `useFantasySnapshot`) and `/api/fantasy-data` route described elsewhere in `docs/ai-context`.
 
 ---
 

--- a/docs/ai-context/CONFIG.md
+++ b/docs/ai-context/CONFIG.md
@@ -2,7 +2,7 @@
 
 Current config-file reference.
 
-**Last updated:** 2026-04-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -26,12 +26,20 @@ Current config-file reference.
 
 Important current behavior:
 
-- redirects for `/projects`, `/work`, `/blog`, fantasy shortcuts, and typo routes
+- redirects (`async redirects()`) cover:
+  - `/projects`, `/projects/:path*`, `/work` → `/portfolio`
+  - legacy portfolio slugs → `/investments` and `/writing/*` case studies
+  - fantasy shortcuts (`/ff`, `/rankings`, `/qb`, `/rb`, `/wr`, `/te`) and typo routes (`/fantsy-football/*`, `/fantasy-footbal/*`, `/quatrerback`)
+  - `/blog`, `/blog/:slug`, `/blog/posts/:slug`, `/articles/:slug` → `/writing`
+  - contact variations (`/get-in-touch`, `/hire-me`) and resume variations (`/cv`, `/resume.pdf`)
+- `poweredByHeader = false`
+- site-wide security headers via `async headers()` (HSTS, X-Content-Type-Options, X-Frame-Options DENY, Referrer-Policy, Permissions-Policy, X-DNS-Prefetch-Control); a global CSP is still a TODO
+- `compiler.removeConsole` in production
 - `typescript.ignoreBuildErrors = true`
 - `serverExternalPackages = ['better-sqlite3', 'sharp']`
 - tracing excludes heavy image and investments data assets from server bundles
-- image remote patterns include Unsplash and Cloudinary
-- `optimizePackageImports` includes `@tabler/icons-react`, `lucide-react`, and `framer-motion`
+- image remote patterns include Unsplash and Cloudinary; `dangerouslyAllowSVG` is on with an image-scoped CSP (`script-src 'none'; sandbox`) for remote crest/logo SVGs
+- `optimizePackageImports` includes `@tabler/icons-react`, `lucide-react`, and `framer-motion`; `experimental.scrollRestoration` is enabled
 
 If you update routes or package behavior, this file is one of the first places to check.
 
@@ -65,9 +73,9 @@ Important facts:
 
 - `strict: true`
 - `noEmit: true`
-- `module` and `moduleResolution` are `node16`
+- `target: es2022`; `module: esnext`; `moduleResolution: bundler`
 - path alias: `@/* -> ./src/*`
-- excludes `src/data/backup/**/*`
+- excludes `node_modules` and `src/data/backup/**/*`
 
 ---
 
@@ -105,6 +113,15 @@ Posts are discovered from `content/blog/`.
 
 ---
 
+## Build Steps (`package.json`)
+
+- `prebuild`: `tsx scripts/updateFootballSnapshots.ts --league-only` — refreshes Premier League + La Liga standings/scorers/fixtures on every Netlify deploy (~2 min)
+- `build`: `next build --webpack`
+- `postbuild`: `next-sitemap && node scripts/patch-nft-sharp.mjs` — regenerates the sitemap, then patches the function bundle so the optional `sharp` native module never ships
+- `dev` and `build` both pass `--webpack` (Turbopack is not used)
+
+---
+
 ## Middleware
 
-`middleware.ts` only handles `/blog` -> `/writing` redirect coverage. It is not a broad security middleware layer.
+There is no `middleware.ts` in the repo. All redirects (including `/blog` -> `/writing`) are declared in `next.config.mjs` via `async redirects()`. Security headers are likewise applied through `next.config.mjs` `async headers()`, not a middleware layer.

--- a/docs/ai-context/DATA-PIPELINE.md
+++ b/docs/ai-context/DATA-PIPELINE.md
@@ -2,7 +2,7 @@
 
 Current high-level data flow reference.
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -100,11 +100,29 @@ The 2026 World Cup hub uses `src/data/worldCupSnapshot.ts`, rebuilt by `npm run 
 
 ---
 
+## Shared Snapshot Commit/Push Step
+
+Every scheduled snapshot workflow ends by committing and pushing the refreshed snapshot through one shared helper:
+
+- `scripts/ci/commit-and-push-snapshot.sh <commit-message> <pathspec...>`
+
+What it does:
+
+- sets the `github-actions[bot]` git identity, stages the given pathspecs, and exits cleanly (no-op) when nothing is staged
+- on a real diff it commits, then pushes to `HEAD:main` with a retry loop (default 8 attempts, override via `SNAPSHOT_PUSH_ATTEMPTS`)
+- on each push rejection it `git fetch origin main` and `git rebase --autostash origin/main`, then retries with capped exponential backoff plus jitter — this absorbs contention from the many snapshot bots pushing to `main` concurrently (e.g. earthquake hourly, world cup, transit)
+- bails (exit 1) only on a genuine rebase conflict or after exhausting all attempts
+
+All 14 `.github/workflows/update-*.yml` workflows route their commit+push through this helper: `update-bay-area-transit`, `update-earthquake`, `update-fantasy`, `update-formula-1`, `update-github-trending`, `update-golf`, `update-investments`, `update-la-liga`, `update-mlb`, `update-nba`, `update-nfl`, `update-premier-league`, `update-spacex`, and `update-world-cup`. The behavior is asserted by `.github/workflows/__tests__/snapshot-workflows.test.ts` and `update-investments.test.ts`.
+
+---
+
 ## Fantasy Football Pipeline
 
 The fantasy stack is generated snapshot first:
 
 - `scripts/buildFantasyPositionData.ts`
+- `scripts/buildFantasyAdpData.ts`
 - `scripts/buildFantasySnapshots.ts`
 - `src/app/api/fantasy-data/route.ts`
 - `src/lib/fantasySnapshotServer.ts`
@@ -113,6 +131,7 @@ The fantasy stack is generated snapshot first:
 Public generated outputs include:
 
 - `src/data/fantasyPositionData.generated.ts`
+- `src/data/fantasyAdpData.generated.ts`
 - `src/data/fantasySnapshotRevision.generated.ts`
 - `public/data/fantasy/ppr.json`
 - `public/data/fantasy/half_ppr.json`

--- a/docs/ai-context/HOOKS-AND-STATE.md
+++ b/docs/ai-context/HOOKS-AND-STATE.md
@@ -2,7 +2,7 @@
 
 Current hook inventory and state ownership.
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -11,13 +11,17 @@ Current hook inventory and state ownership.
 | Hook | File | Main Use |
 |------|------|----------|
 | `useBudgetPlanner` | `src/hooks/useBudgetPlanner.ts` | Budget planner state and calculations |
+| `useCompareTray` | `src/hooks/useCompareTray.ts` | Browser-local fantasy compare selection (up to 3 player ids), shared across the rankings board and draft assistant |
 | `useDebounce` | `src/hooks/useDebounce.ts` | Debounced inputs |
 | `useFantasySnapshot` | `src/hooks/useFantasySnapshot.ts` | Published fantasy snapshot loading |
 | `useInvestments` | `src/hooks/useInvestments.ts` | Portfolio holdings + quote enrichment |
 | `useLiveQuote` | `src/hooks/useLiveQuote.ts` | Current quote fetch state |
+| `useLocalStorageString` | `src/hooks/useLocalStorageString.ts` | Low-level reactive single-key localStorage reader (`useSyncExternalStore`) shared by the fantasy queue/notes/compare hooks |
 | `useMBAApplications` | `src/hooks/useMBAApplications.ts` | Browser-local application tracking for the MBA role tracker |
 | `useMBAJobs` | `src/hooks/useMBAJobs.ts` | MBA job fetch state plus seen-job and watched-company persistence |
 | `useMuseumLog` | `src/hooks/useMuseumLog.ts` | Browser-local museum visit state for `/museum-log` |
+| `usePlayerNotes` | `src/hooks/usePlayerNotes.ts` | Browser-local fantasy per-player private notes (max 280 chars), shared across the rankings board and draft assistant |
+| `usePlayerQueue` | `src/hooks/usePlayerQueue.ts` | Browser-local fantasy player queue / watchlist of player ids, shared across the rankings board and draft assistant |
 | `useRetirementPlan` | `src/hooks/useRetirementPlan.ts` | Browser-local retirement plan inputs (localStorage key `retirement_plan`) |
 | `useStockData` | `src/hooks/useStockData.ts` | Per-symbol research section data |
 | `useTablistKeyboard` | `src/hooks/useTablistKeyboard.ts` | Roving keyboard navigation for horizontal tablists (WCAG 2.1) |
@@ -69,7 +73,25 @@ Owns the browser-local retirement plan inputs consumed by `src/components/invest
 
 ### `useFantasySnapshot`
 
-The single client-side entry point for fantasy data. Loads the published snapshot JSON from `public/data/fantasy/` (cache-busted by `src/data/fantasySnapshotRevision.generated.ts`) and serves the rankings, tier, and draft-tracker surfaces.
+The single client-side entry point for fantasy data. Loads the published snapshot JSON from `public/data/fantasy/` (cache-busted by `src/data/fantasySnapshotRevision.generated.ts`) and serves the rankings, tier, and draft-tracker surfaces. Not localStorage-backed.
+
+### Shared cross-surface browser stores
+
+The rankings board (`/fantasy-football`) and the draft assistant (`/fantasy-football/draft-tracker`) share three browser-local stores, all keyed by stable player ids so an action on one surface flags the player on the other. The hooks wire React state via `useLocalStorageString` (a generic `useSyncExternalStore` reader), with pure parse/serialize and key constants in `src/lib/fantasyLocal.ts`:
+
+- `usePlayerQueue` — single watchlist of player ids (My Queue sidebar card, star toggles). Exposes `queue`, `isQueued`, `toggle`, `remove`, `reorder`, `clear`. Key `fantasy-player-queue-v1`.
+- `usePlayerNotes` — short private notes keyed by player id (max 280 chars), edited in the `PlayerDetailDrawer` and folded into the draft assistant's CSV/recap exports. Exposes `getNote`, `hasNote`, `setNote`, `notedIds`, `maxLength`. Key `fantasy-player-notes-v1`.
+- `useCompareTray` — compare selection of up to 3 player ids powering the docked `CompareTray` and `CompareModal`. Exposes `compareIds`, `inCompare`, `isFull`, `limit` (3), `toggle`, `remove`, `clear`. Key `fantasy-compare-v1`.
+
+`useLocalStorageString` is not itself bound to a key — callers pass the key. Same-tab writes notify subscribers via an explicit `emitLocalStoreChange` call; cross-tab changes arrive through the window `storage` event.
+
+### List density preference
+
+The rankings client also keeps a List-view Comfortable/Compact density preference under key `fantasy-board-density`. It is implemented inline in `src/app/fantasy-football/fantasy-football-client.tsx` (its own `useSyncExternalStore` glue, not a separate hook file).
+
+### Draft tracker state
+
+`useDraftState` (`src/app/fantasy-football/draft-tracker/hooks/useDraftState.ts`) owns the draft assistant state machine (room settings, picks, teams, undo/redo, team names, export). It persists per-season under `fantasy-draft-tracker-v2-<season>` (e.g. `fantasy-draft-tracker-v2-2026`); the legacy unversioned key `fantasy-draft-tracker` is deleted (not migrated) on load.
 
 ---
 

--- a/docs/ai-context/PAGES.md
+++ b/docs/ai-context/PAGES.md
@@ -2,7 +2,7 @@
 
 Fast route reference for the current app.
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -12,7 +12,7 @@ Fast route reference for the current app.
 |------|------|----------------|
 | `/` | `src/app/page.tsx` | Server page composing client sections |
 | `/about` | `src/app/about/page.tsx` | Server page -> `About` client component |
-| `/portfolio` | `src/app/portfolio/page.tsx` | Server page rendering cards directly |
+| `/portfolio` | `src/app/portfolio/page.tsx` | Server page -> `PortfolioV3` client (searchable, filtered project index) |
 | `/portfolio/[slug]` | `src/app/portfolio/[slug]/page.tsx` | Server detail page |
 | `/resume` | `src/app/resume/page.tsx` | Server page -> client resume UI |
 | `/contact` | `src/app/contact/page.tsx` | Server page -> `ContactContent` |
@@ -120,8 +120,8 @@ Footer behavior:
 
 ### `/portfolio`
 
-- uses ordered helpers from `caseStudiesData`
-- renders the full non-`comingSoon` project index directly from the route
+- server page calls `getPortfolioProjects()` and hands the full non-`comingSoon` project index to the `PortfolioV3` client (`src/components/portfolio/PortfolioV3.tsx`)
+- `PortfolioV3` adds a client-side project search, category filter tablist, a featured project, sortable + paginated grid, and a marquee band that sits between the project grid and the pager
 - cards should make role, problem space, and impact scannable before click-through
 - do not document `ProjectsContent.tsx` as the primary live implementation
 
@@ -167,6 +167,16 @@ Footer behavior:
 - server entry provides metadata plus breadcrumb and sports-application structured data
 - client route supports deep-linked `overview`, `fixtures`, `europe`, `relegation`, and club views through query params
 
+### `/fantasy-football`
+
+- server shell (`page.tsx`) supplies metadata + structured data and hands deep-linked state to the `FantasyFootballClient` rankings board; sibling route `/fantasy-football/draft-tracker` is the manual draft assistant
+- both surfaces read one FantasyPros snapshot through `useFantasySnapshot` (`/data/fantasy/{scoring}.json` with an `/api/fantasy-data` fallback) and share three browser-local stores: watchlist (`fantasy-player-queue-v1`), private notes (`fantasy-player-notes-v1`, 280-char cap), and compare selection (`fantasy-compare-v1`, max 3)
+- rankings board: deep-linkable position pill bar (overall/QB/RB/WR/TE/Flex/K/DST via `?position=`), PPR/Half-PPR/Standard scoring selector (`?scoring=`), per-board search, and a List/Tiers view toggle (`?view=tiers`; list is the default and drops the param) managed by `fantasy-state.ts`
+- List view adds a localStorage-backed Comfortable/Compact density control (`fantasy-board-density`) and 60-row infinite-scroll windowing; rows surface published rank, expert range, rostered %, bye, and — when the snapshot carries ADP — an ADP column with green Value / amber Reach chips at a ±10-spot consensus-vs-market gap
+- shared presentation lives in `src/components/fantasy/` (barrel `index.ts`): `TierBreakdown`, `FantasyBoardLegend`, `PositionFilterBar`, `RankingsListRow`, `TierBreakSeparator`, `PlayerDetailDrawer`, `RankDistributionBar`, `CompareTray`, `CompareModal`; cross-surface stores live in `src/hooks/use{PlayerQueue,PlayerNotes,CompareTray}.ts` over `useLocalStorageString`, with key constants in `src/lib/fantasyLocal.ts`
+- board math/formatting/legend copy lives in `src/lib/fantasyUtils.ts`; the pure draft signal engine (steals/reaches/position-runs) lives in `src/lib/draftAnalytics.ts`
+- the draft assistant reuses the same snapshot, watchlist, notes, drawer, and compare tray, adding an advisory pick clock, multi-step undo/redo, per-team naming, CSV/recap-CSV/JSON export, and per-season state under `fantasy-draft-tracker-v2-<season>`
+
 ### Standalone data tools
 
 - `/news-pulse` is a live route backed by `/api/news-pulse`
@@ -181,7 +191,7 @@ Footer behavior:
 - `/ai-dev-tools` and `/frontier-models` are live AI/knowledge surfaces
 - `/decision-lab`, `/food-map`, `/recipe-finder`, `/wine-cellar`, `/museum-log`, `/travel`, `/now`, and `/changelog` are live personal or utility surfaces
 - `/fintech-tools/budget-planner` and `/fintech-tools/interchange-iq` are live fintech tool routes
-- `/mba-internship-notifications` is a live route backed by `/api/mba-jobs` that polls Greenhouse, Lever, Ashby, and direct-HTML job boards across 32 tech companies for MBA internships and full-time business roles
+- `/mba-internship-notifications` is a live route backed by `/api/mba-jobs` that polls Greenhouse, Lever, Ashby, SmartRecruiters, and direct-HTML job boards across ~28 of 39 tracked companies for MBA internships and full-time business roles
 
 ### `/search`
 

--- a/docs/ai-context/REDIRECTS-AND-NAVIGATION.md
+++ b/docs/ai-context/REDIRECTS-AND-NAVIGATION.md
@@ -2,7 +2,7 @@
 
 Current nav model, redirect table, and shell notes.
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -75,6 +75,19 @@ Defined in `next.config.mjs`.
 ### Investments
 
 - `/portfolio/investment-analytics-platform` -> `/investments`
+
+### Retired portfolio case studies -> writing
+
+Old `/portfolio/<slug>` case-study URLs now redirect to their writing posts:
+
+- `/portfolio/textout-platform` -> `/writing/textout-platform`
+- `/portfolio/runningmate-platform` -> `/writing/runningmate-platform-launch`
+- `/portfolio/civic-engagement-platform-scale` -> `/writing/scaling-civic-engagement-platform`
+- `/portfolio/campaign-analytics-dashboard` -> `/writing/campaign-self-service-analytics`
+- `/portfolio/qa-automation-framework` -> `/writing/qa-automation-daily-deploys`
+- `/portfolio/performance-intelligence` -> `/writing/proactive-performance-intelligence`
+- `/portfolio/pricing-strategy-initiative` -> `/writing/pricing-strategy-initiative`
+- `/portfolio/digital-acquisition-strategy` -> `/writing/digital-acquisition-strategy`
 
 ### Contact and resume aliases
 

--- a/docs/ai-context/SEO-AND-METADATA.md
+++ b/docs/ai-context/SEO-AND-METADATA.md
@@ -2,7 +2,7 @@
 
 Current metadata and structured-data reference.
 
-**Last updated:** 2026-04-10
+**Last updated:** 2026-06-19
 
 ---
 
@@ -76,7 +76,7 @@ Use them for:
 
 ## Sitemap
 
-`next-sitemap.config.js` is the source of truth for sitemap generation.
+`next-sitemap.config.js` drives sitemap generation, but it delegates to helpers in `src/lib/sitemap.js` (required at the top of the config). `src/lib/sitemap.js` owns the per-route `lastmod` logic — a static `STATIC_ROUTE_LASTMOD` map plus per-dashboard `read*Lastmod()` readers that pull dates from the committed snapshots. Update both files together when changing sitemap behavior.
 
 Notable routes to verify in generated sitemap output:
 
@@ -117,4 +117,4 @@ Do not imply that the search API is the foundation of discoverability across the
 - canonical routes prefer `/writing` over `/blog`
 - Netlify and Next config handle redirect support for legacy URLs
 
-Check `next.config.mjs`, `next-sitemap.config.js`, and route metadata exports before updating this doc.
+Check `next.config.mjs`, `next-sitemap.config.js`, `src/lib/sitemap.js`, and route metadata exports before updating this doc.


### PR DESCRIPTION
Pushes the previously local-only `docs/sync-current-source-of-truth` branch, rebased onto current main (its `CLAUDE.md` changes were dropped in favor of main's current version; all other doc updates kept).

Touches 19 reference docs (AGENTS.md, API.md, ARCHITECTURE.md, COMPONENTS.md, PAGES.md, SEO.md, SNAPSHOT_DRIVEN_DASHBOARDS.md, TESTING.md, docs/ai-context/*, etc.) to align them with the codebase.

Heads up: this sync was authored ~5 days ago, so it predates this session's changes (header search dropdown, fantasy board updates, portfolio pixel art, Pulse Dashboards removal, dependency bumps). Worth a review pass before merge, or I can do a fresh docs sync on top instead.