### PR TITLE
Fix investments live pricing + allocation donut alignment

### DIFF
--- a/src/components/investments/AllocationChart.tsx
+++ b/src/components/investments/AllocationChart.tsx
@@ -44,8 +44,8 @@ export function AllocationChart({ holdings }: Props) {
     ).format(totalForLabel)}. Top: ${summaryParts.join(", ")}.`;
 
     const svg = select(svgRef.current)
-      .attr("width", size)
-      .attr("height", size)
+      .attr("viewBox", `0 0 ${size} ${size}`)
+      .attr("preserveAspectRatio", "xMidYMid meet")
       .attr("role", "img")
       .attr("aria-label", summary);
 
@@ -130,9 +130,9 @@ export function AllocationChart({ holdings }: Props) {
           Position weights based on current market value.
         </p>
       </div>
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-start">
-        <div className="relative shrink-0 self-center">
-          <svg ref={svgRef} />
+      <div className="flex flex-col items-center gap-4 xl:flex-row xl:items-center xl:gap-6">
+        <div className="relative aspect-square w-[200px] shrink-0 sm:w-[220px]">
+          <svg ref={svgRef} className="h-full w-full" />
           <div
             ref={tooltipRef}
             style={{ display: "none", position: "absolute", pointerEvents: "none" }}

--- a/src/lib/__tests__/finnhub.allowlist.test.ts
+++ b/src/lib/__tests__/finnhub.allowlist.test.ts
@@ -85,11 +85,14 @@ describe("finnhub allowlist resolution", () => {
     mockReadFileSync.mockImplementation(() => {
       throw enoent();
     });
-    // No origin configured → no HTTP fallback available this call.
+    // The bundled file is gone and the public-asset fetch fails too → total miss.
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
     const firstAttempt = await getAllowedSymbols();
     expect(firstAttempt.size).toBe(0);
 
-    // A later request (origin now resolvable) must recover rather than stay
+    // A later request (asset now reachable) must recover rather than stay
     // wedged on a cached empty set for the life of the process.
     process.env.URL = "https://isaacavazquez.com";
     mockPublicAsset(["AAPL"]);

--- a/src/lib/investmentsAssetOrigin.ts
+++ b/src/lib/investmentsAssetOrigin.ts
@@ -3,6 +3,9 @@ export interface AssetOriginOptions {
   assetOrigin?: string | null;
 }
 
+/** The site's canonical production origin (matches seo.ts). */
+const CANONICAL_PRODUCTION_ORIGIN = "https://isaacavazquez.com";
+
 /**
  * Resolve the origin to fetch committed `/public/data/investments` assets from
  * when they are not present on the local filesystem.
@@ -14,8 +17,10 @@ export interface AssetOriginOptions {
  * is the single source of truth for that origin so the precedence can't drift
  * between the curated-data loader and the Finnhub allowlist.
  *
- * Returns `null` when no origin can be determined (e.g. local dev with the file
- * present on disk, where the HTTP fallback is unnecessary).
+ * Always resolves to an origin: an explicit override or env var when present,
+ * otherwise the canonical production origin. (The disk-first callers only reach
+ * the HTTP fallback when the bundled file is missing, i.e. in the deployed
+ * function, so a non-null origin in local dev is harmless.)
  */
 export function getInvestmentsAssetOrigin(
   options: AssetOriginOptions = {}
@@ -27,7 +32,15 @@ export function getInvestmentsAssetOrigin(
     process.env.DEPLOY_URL ??
     process.env.SITE_URL ??
     process.env.NEXT_PUBLIC_SITE_URL ??
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null);
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null) ??
+    // Canonical production origin as a last resort. Inside the deployed Netlify
+    // function none of the env vars above are present at runtime, so the origin
+    // resolved to null and the curated-investments loaders failed closed: the
+    // allowlist came back empty (every symbol "not eligible for live pricing")
+    // and the index route 503'd. The committed public assets are identical on
+    // every deploy, so the canonical origin is always a safe source. Mirrors
+    // the same hardcoded fallback in seo.ts.
+    CANONICAL_PRODUCTION_ORIGIN;
 
   return configuredOrigin ? configuredOrigin.replace(/\/$/, "") : null;
 }


### PR DESCRIPTION
## Live prices / tracking were dead in production
Reproduced: `/api/investments/index` → **503**, and `/api/investments/quotes?symbols=AAPL,MSFT` → every symbol `price: 0` with `"This symbol is not eligible for live pricing."` (even AAPL).

Root cause: inside the deployed Netlify function the curated snapshot (`public/data/investments/index.json`) is stripped from the bundle, so the loaders fall back to fetching the committed public asset over HTTP via `getInvestmentsAssetOrigin()`. That resolver only checked `URL`/`DEPLOY_*`/`SITE_URL`/`NEXT_PUBLIC_SITE_URL`/`VERCEL_URL`, **none of which are set at function runtime**, so it returned `null`. The Finnhub allowlist then came back empty (every symbol rejected before any Finnhub call) and the curated-dataset loader 503'd. The static asset itself is served fine (200).

Fix: add a canonical production-origin fallback (`https://isaacavazquez.com`, mirroring `seo.ts`) so the function can always reach its own public assets. The disk-first callers only hit this path in the deployed function, so local dev/tests are unaffected. Updated the allowlist regression test (the old "no origin" state no longer exists; a total miss now comes from a failed fetch).

## Allocation donut alignment
The D3 SVG had fixed `220x220` attrs and **no `viewBox`**, so it couldn't scale and sat off-center beside the legend. Switched to a `viewBox` + responsive square box and centered the chart/legend flex container (matching the responsive pattern already used by `ComparisonRadarChart`). The tooltip uses live mouse coordinates, so scaling is safe.

## Note
This restores the allowlist + curated data. Live quotes also require `FINNHUB_API_KEY` to be set in the Netlify function env — I couldn't verify that without dumping the secret. After deploy I'll curl the quotes API: real prices = key present; a Finnhub error = the key still needs setting.

## Verification
- Lint clean, 63 investments/allowlist tests pass.