### PR TITLE
Resolve investments allowlist from the request origin

### DIFF
--- a/src/app/api/investments/data/[symbol]/route.ts
+++ b/src/app/api/investments/data/[symbol]/route.ts
@@ -62,7 +62,7 @@ export async function GET(
     // Reject symbols outside the curated universe BEFORE doing any
     // filesystem access. The allowlist is loaded once at module init and
     // shared with the quote proxies.
-    if (!(await isAllowedSymbol(symbol))) {
+    if (!(await isAllowedSymbol(symbol, { assetOrigin: request.nextUrl.origin }))) {
       return NextResponse.json(
         { error: "Symbol not found" },
         { status: 404, headers: NO_STORE_HEADERS }

--- a/src/app/api/investments/quotes/route.ts
+++ b/src/app/api/investments/quotes/route.ts
@@ -64,7 +64,9 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const allowlist = await getAllowedSymbols();
+    const allowlist = await getAllowedSymbols({
+      assetOrigin: request.nextUrl.origin,
+    });
     const validSymbols = symbolArray.filter((s) => allowlist.has(s));
     const invalidQuotes: StockQuote[] = symbolArray
       .filter((s) => !allowlist.has(s))

--- a/src/app/api/stocks/route.ts
+++ b/src/app/api/stocks/route.ts
@@ -61,7 +61,9 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const allowlist = await getAllowedSymbols();
+    const allowlist = await getAllowedSymbols({
+      assetOrigin: request.nextUrl.origin,
+    });
     const validSymbols = symbolArray.filter((s) => allowlist.has(s));
     const invalidSymbols = symbolArray.filter((s) => !allowlist.has(s));
 

--- a/src/lib/finnhub.ts
+++ b/src/lib/finnhub.ts
@@ -11,7 +11,10 @@
 import { readFileSync } from "fs";
 import path from "path";
 import type { StockQuote } from "@/types/investment";
-import { getInvestmentsAssetOrigin } from "@/lib/investmentsAssetOrigin";
+import {
+  getInvestmentsAssetOrigin,
+  type AssetOriginOptions,
+} from "@/lib/investmentsAssetOrigin";
 
 const FINNHUB_API_KEY = process.env.FINNHUB_API_KEY ?? "";
 const TIMEOUT_MS = 8_000;
@@ -81,8 +84,10 @@ function readAllowlistFromDisk(): Set<string> {
   }
 }
 
-async function fetchAllowlistFromPublicAsset(): Promise<Set<string>> {
-  const origin = getInvestmentsAssetOrigin();
+async function fetchAllowlistFromPublicAsset(
+  options?: AssetOriginOptions
+): Promise<Set<string>> {
+  const origin = getInvestmentsAssetOrigin(options);
   if (!origin) {
     return new Set<string>();
   }
@@ -108,7 +113,9 @@ async function fetchAllowlistFromPublicAsset(): Promise<Set<string>> {
  * deliberately NOT cached, so a transient failure can recover on the next
  * request instead of wedging the allowlist closed for the whole process.
  */
-export async function getAllowedSymbols(): Promise<ReadonlySet<string>> {
+export async function getAllowedSymbols(
+  options?: AssetOriginOptions
+): Promise<ReadonlySet<string>> {
   if (cachedAllowlist && cachedAllowlist.size > 0) {
     return cachedAllowlist;
   }
@@ -119,7 +126,7 @@ export async function getAllowedSymbols(): Promise<ReadonlySet<string>> {
     return cachedAllowlist;
   }
 
-  const fromPublic = await fetchAllowlistFromPublicAsset();
+  const fromPublic = await fetchAllowlistFromPublicAsset(options);
   if (fromPublic.size > 0) {
     cachedAllowlist = fromPublic;
     return cachedAllowlist;
@@ -131,11 +138,14 @@ export async function getAllowedSymbols(): Promise<ReadonlySet<string>> {
   return new Set<string>();
 }
 
-export async function isAllowedSymbol(symbol: string): Promise<boolean> {
+export async function isAllowedSymbol(
+  symbol: string,
+  options?: AssetOriginOptions
+): Promise<boolean> {
   if (!isValidSymbol(symbol)) {
     return false;
   }
-  const allowlist = await getAllowedSymbols();
+  const allowlist = await getAllowedSymbols(options);
   return allowlist.has(symbol.toUpperCase());
 }
 


### PR DESCRIPTION
Follow-up to #257. The index route worked because it passes `request.nextUrl.origin`; quotes/data/stocks called `getAllowedSymbols()` with no origin and fell through to `process.env.URL` (set at runtime to a host that doesn't serve the static asset), so every symbol stayed 'not eligible for live pricing'. Thread the request origin through `getAllowedSymbols`/`isAllowedSymbol` like the index route. Lint clean, 14 finnhub/quotes/stocks/data tests pass.