### PR TITLE
Restyle 404 page with a retro 90s aesthetic

### DIFF
--- a/src/app/not-found.module.css
+++ b/src/app/not-found.module.css
@@ -1,0 +1,220 @@
+/*
+ * Deliberately retro 90s "GeoCities" styling for the 404 page.
+ * This is an intentional one-off that ignores the site's editorial token
+ * system for comedic effect, so the loud hardcoded colors are scoped to this
+ * module and never leak into the global palette. Motion is gated behind
+ * prefers-reduced-motion per the repo accessibility rules.
+ */
+
+.page {
+  /* Classic tiled "stars on black" backdrop, drawn with CSS so we ship no GIF. */
+  background-color: #000033;
+  background-image:
+    radial-gradient(1px 1px at 20px 30px, #fff, transparent),
+    radial-gradient(1px 1px at 70px 80px, #ffff00, transparent),
+    radial-gradient(2px 2px at 120px 40px, #fff, transparent),
+    radial-gradient(1px 1px at 160px 120px, #00ffff, transparent),
+    radial-gradient(1px 1px at 200px 60px, #fff, transparent);
+  background-size: 220px 160px;
+  color: #00ff00;
+  font-family: "Times New Roman", Times, Georgia, serif;
+  min-height: 100vh;
+  padding: 24px 12px 48px;
+  text-align: center;
+  image-rendering: pixelated;
+}
+
+.frame {
+  max-width: 760px;
+  margin: 0 auto;
+  border: 6px ridge #c0c0c0;
+  background: #000080;
+  padding: 16px;
+}
+
+/* WordArt-ish rainbow 404 */
+.bigError {
+  font-family: "Impact", "Arial Black", sans-serif;
+  font-size: clamp(5rem, 22vw, 11rem);
+  line-height: 0.9;
+  margin: 8px 0;
+  letter-spacing: 0.05em;
+  background: linear-gradient(
+    90deg,
+    #ff0000,
+    #ff7f00,
+    #ffff00,
+    #00ff00,
+    #0000ff,
+    #4b0082,
+    #9400d3
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-stroke: 2px #ffffff;
+  text-shadow: 4px 4px 0 #000000;
+}
+
+.heading {
+  font-family: "Comic Sans MS", "Chalkboard SE", cursive, sans-serif;
+  font-size: clamp(1.4rem, 4.5vw, 2.2rem);
+  color: #ffff00;
+  text-shadow: 2px 2px 0 #ff00ff;
+  margin: 12px 0;
+}
+
+.blink {
+  font-family: "Comic Sans MS", cursive, sans-serif;
+  font-weight: bold;
+  font-size: 1.25rem;
+  color: #ff0000;
+  background: #ffff00;
+  padding: 2px 8px;
+  display: inline-block;
+  animation: blink 1s steps(2, start) infinite;
+}
+
+@keyframes blink {
+  to {
+    visibility: hidden;
+  }
+}
+
+/* CSS reimplementation of the dear departed <marquee> */
+.marqueeBar {
+  overflow: hidden;
+  white-space: nowrap;
+  background: #800080;
+  border-top: 3px outset #c0c0c0;
+  border-bottom: 3px outset #c0c0c0;
+  margin: 16px 0;
+  padding: 6px 0;
+}
+
+.marqueeTrack {
+  display: inline-block;
+  padding-left: 100%;
+  color: #00ffff;
+  font-family: "Comic Sans MS", cursive, sans-serif;
+  font-weight: bold;
+  font-size: 1.1rem;
+  animation: scrollLeft 14s linear infinite;
+}
+
+@keyframes scrollLeft {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
+.construction {
+  font-family: "Comic Sans MS", cursive, sans-serif;
+  color: #000000;
+  background: repeating-linear-gradient(
+    45deg,
+    #ffcc00,
+    #ffcc00 14px,
+    #000000 14px,
+    #000000 28px
+  );
+  border: 4px ridge #ffcc00;
+  padding: 10px;
+  margin: 16px auto;
+  font-weight: bold;
+  font-size: 1.05rem;
+  max-width: 520px;
+}
+
+.constructionInner {
+  background: #ffff99;
+  padding: 8px;
+  display: block;
+}
+
+.bodyText {
+  font-size: 1.05rem;
+  color: #ffffff;
+  line-height: 1.5;
+  max-width: 60ch;
+  margin: 14px auto;
+}
+
+.linkRow {
+  margin: 18px 0;
+}
+
+.retroLink {
+  color: #00ffff;
+  font-family: "Comic Sans MS", cursive, sans-serif;
+  font-size: 1.1rem;
+  text-decoration: underline;
+  display: inline-block;
+  margin: 6px 10px;
+}
+
+.retroLink:hover {
+  color: #ff00ff;
+  background: #ffff00;
+}
+
+.retroLink:visited {
+  color: #ff69b4;
+}
+
+.divider {
+  display: block;
+  width: 90%;
+  height: 6px;
+  margin: 18px auto;
+  background: linear-gradient(90deg, #ff0000, #00ff00, #0000ff, #ff00ff);
+}
+
+.counter {
+  font-family: "Courier New", monospace;
+  background: #000000;
+  border: 3px inset #00ff00;
+  color: #00ff00;
+  display: inline-block;
+  padding: 4px 10px;
+  letter-spacing: 4px;
+  font-size: 1.3rem;
+  font-weight: bold;
+}
+
+.counterLabel {
+  font-family: "Comic Sans MS", cursive, sans-serif;
+  color: #ffffff;
+  margin: 14px 0 6px;
+}
+
+.footerNote {
+  font-family: "Comic Sans MS", cursive, sans-serif;
+  color: #c0c0c0;
+  font-size: 0.85rem;
+  margin-top: 22px;
+}
+
+.webring {
+  font-family: "Times New Roman", serif;
+  color: #ffff00;
+  margin: 14px 0;
+  font-size: 0.95rem;
+}
+
+/* Respect users who don't want motion: freeze the blink and marquee. */
+@media (prefers-reduced-motion: reduce) {
+  .blink {
+    animation: none;
+  }
+  .marqueeTrack {
+    animation: none;
+    padding-left: 0;
+  }
+  .marqueeBar {
+    white-space: normal;
+  }
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,58 +1,69 @@
 import Link from "next/link";
-import { ArrowLeft, Home } from "@/components/ui/ServerIcons";
-import { ModernButton } from "@/components/ui/ModernButton";
+import styles from "./not-found.module.css";
 
+// A deliberately over-the-top 90s "GeoCities" 404 page. It intentionally
+// breaks from the site's editorial design system for comedic effect; all of
+// its styling is scoped to not-found.module.css so nothing leaks elsewhere.
 export default function NotFound() {
   return (
-    <section className="home-page home-section min-h-screen">
-      <div className="home-shell home-shell-tight flex min-h-[60vh] flex-col items-center justify-center text-center">
-        <p className="home-kicker mb-6">Error · 404</p>
-        <h1
-          className="mb-6"
-          style={{
-            fontFamily: "var(--font-home-sans)",
-            fontSize: "clamp(4rem, 14vw, 9rem)",
-            fontWeight: 600,
-            lineHeight: 0.9,
-            letterSpacing: "-0.08em",
-            color: "var(--home-ink)",
-          }}
-        >
-          404
-        </h1>
-        <h2
-          className="mb-5 max-w-[28ch] text-balance"
-          style={{
-            fontFamily: "var(--font-home-sans)",
-            fontSize: "clamp(1.35rem, 2.4vw, 1.75rem)",
-            fontWeight: 600,
-            letterSpacing: "-0.02em",
-            color: "var(--home-ink)",
-          }}
-        >
-          I don&apos;t have a page at that address.
-        </h2>
-        <p
-          className="mb-10 max-w-[44ch] text-base leading-7"
-          style={{ fontFamily: "var(--font-home-sans)", color: "var(--home-ink-muted)" }}
-        >
-          The URL you followed isn&apos;t in my current route map. It may have moved, or the
-          link might be a little old. Jump back to the home page or browse the portfolio.
-        </p>
-        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-          <ModernButton href="/" variant="primary" size="lg">
-            <Home className="h-5 w-5" />
-            Return home
-          </ModernButton>
+    <div className={styles.page}>
+      <div className={styles.frame}>
+        <p className={styles.blink}>* ERROR 404 * PAGE NOT FOUND *</p>
 
-          <Link href="/portfolio">
-            <ModernButton variant="outline" size="lg">
-              <ArrowLeft className="h-5 w-5" />
-              Browse projects
-            </ModernButton>
+        <h1 className={styles.bigError}>404</h1>
+
+        <h2 className={styles.heading}>~*~ Oops! You Broke The Internet ~*~</h2>
+
+        <div className={styles.marqueeBar}>
+          <span className={styles.marqueeTrack}>
+            Welcome 2 my homepage!!! The page u r looking 4 has wandered off
+            into cyberspace... try the links below!!! &lt;3 &lt;3 &lt;3
+          </span>
+        </div>
+
+        <div className={styles.construction}>
+          <span className={styles.constructionInner}>
+            🚧 THIS PAGE IS UNDER CONSTRUCTION 🚧
+          </span>
+        </div>
+
+        <p className={styles.bodyText}>
+          The URL you typed isn&apos;t on the server (or maybe it never was?).
+          Don&apos;t worry though &mdash; grab a Surge, fire up Netscape
+          Navigator, and pick one of these totally rad destinations:
+        </p>
+
+        <span className={styles.divider} />
+
+        <div className={styles.linkRow}>
+          <Link href="/" className={styles.retroLink}>
+            🏠 Back 2 Home Page
+          </Link>
+          <Link href="/portfolio" className={styles.retroLink}>
+            💾 My Kool Projects
+          </Link>
+          <Link href="/writing" className={styles.retroLink}>
+            📖 Read My Web Log
+          </Link>
+          <Link href="/contact" className={styles.retroLink}>
+            📧 E-Mail Me!
           </Link>
         </div>
+
+        <span className={styles.divider} />
+
+        <p className={styles.counterLabel}>You are visitor number:</p>
+        <span className={styles.counter}>0000404</span>
+
+        <p className={styles.webring}>
+          [ Best viewed in Netscape Navigator 4.0 @ 800&times;600 ]
+        </p>
+
+        <p className={styles.footerNote}>
+          Sign my guestbook! &middot; This site is a proud member of the
+          WebRing &middot; Made with &lt;BLINK&gt; and a 56k modem
+        </p>
       </div>
-    </section>
+    </div>
   );
 }


### PR DESCRIPTION
## What

Replaces the editorial-styled `not-found` page with a deliberately over-the-top **90s "GeoCities" tribute** 404 page.

The retro scene includes:
- 🌈 Rainbow WordArt-style `404` with Impact font + text stroke
- ✨ A CSS-drawn starfield backdrop (no GIFs shipped)
- 🔴 `<BLINK>`-style blinking error banner
- 🎠 A CSS reimplementation of the dear departed `<marquee>`
- 🚧 An "UNDER CONSTRUCTION" caution-tape banner
- 🔢 A fake "you are visitor number `0000404`" hit counter
- 🔗 Comic Sans navigation links back to Home / Projects / Writing / Contact
- A "Best viewed in Netscape Navigator @ 800×600" web-ring footer

## Implementation notes

- All styling lives in a scoped `not-found.module.css` so the intentionally loud hardcoded colors **never leak into the site's editorial token system**.
- It remains a server component (pure CSS animations, no hooks).
- Blink + marquee animations are disabled under `prefers-reduced-motion`, honoring the repo's accessibility rules.
- The site header/footer (rendered by the global layout) stay as-is; only the page body adopts the retro look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzCKFuBwBrRgUmopX77yhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzCKFuBwBrRgUmopX77yhC)_