### PR TITLE
docs: best-practices pass on CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Operational context for agents working in this repo. Start here, then read `CLAUDE.md` for deeper implementation context.
 
-**Last updated:** 2026-06-19
+**Last updated:** 2026-06-25
 
 ---
 
@@ -72,7 +72,7 @@ Canonical redirects:
 
 ---
 
-## Navigation And Shell
+## Navigation and Shell
 
 Promoted header items (from `src/constants/navlinks.tsx`):
 
@@ -439,7 +439,7 @@ For public fantasy updates, GitHub Actions is the source of truth.
 
 ---
 
-## Source Of Truth Docs
+## Source of Truth Docs
 
 - `README.md`
 - `AGENTS.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Deep implementation context for Claude Code and other agents working in this repo.
 
-**Last updated:** 2026-06-23
+**Last updated:** 2026-06-25
 
 ---
 


### PR DESCRIPTION
## Summary

A best-practices review of the agent context files (`CLAUDE.md`, `AGENTS.md`, `AGENT.md`).

The headline finding is that these files are already in good shape — they're focused, they delegate depth to subsystem docs, they carry a clear "when docs and code disagree, code wins" rule, and the load-bearing claims still match the codebase. I verified the highest-risk-of-rot claims against source:

- **Nav links** (`src/constants/navlinks.tsx`): 8 links, "Projects" → `/portfolio`, "Fantasy" → `/fantasy-football` — matches.
- **npm scripts** (`package.json`): command reference table matches the actual scripts.
- **Redirects** (`next.config.mjs`): `/projects`, `/work` → `/portfolio`; `/blog`, `/blog/:slug` → `/writing` — all present.

Because the content checked out, this change is deliberately small — only consistency/freshness polish, no substantive content rewrites.

## Changes

- Sync both `Last updated` stamps to `2026-06-25` (they had drifted to `2026-06-23` / `2026-06-19`).
- Fix Title Case conjunctions in two `AGENTS.md` headings (`Navigation And Shell` → `Navigation and Shell`, `Source Of Truth Docs` → `Source of Truth Docs`) to match the sentence-case style used elsewhere.

## Optional follow-up (not done here)

The one real best-practices tension is **length**: both files auto-load into context and total ~700 lines, with some intentional overlap (guardrails, route lists, doc maps) and several long reference lists in `AGENTS.md` (route lists, command table, automation surfaces) that duplicate dedicated docs like `docs/DATA_UPDATE_OPERATIONS.md` and `API.md`. Trimming those would cut token cost and maintenance surface, but it's a judgment call about your deliberate two-tier structure, so I left it for you to decide rather than gut maintained reference material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjJMqRcfekzqVje5spPkQJ)_