### PR TITLE
docs: web design & portfolio best-practices research

### DIFF
--- a/docs/web-design-research/CASE_STUDY_PLAYBOOK.md
+++ b/docs/web-design-research/CASE_STUDY_PLAYBOOK.md
@@ -1,0 +1,139 @@
+# Case Study Playbook
+
+**Last updated:** 2026-06-25
+**Companion to:** `PORTFOLIO_BEST_PRACTICES.md`, `WRITING_VOICE.md`, `src/constants/caseStudies.ts`
+
+How to write a project write-up that a skimmer keeps reading and a deep reader finds
+convincing. A case study tells **two intertwined stories**: the story of the *project*
+(what problem, whose, what solution, what impact) and the story of *you* (what you chose to
+do and why, how you worked within constraints).
+
+---
+
+## The non-negotiable: hook in the first 60 seconds
+
+Reviewers spend under a minute deciding whether to keep reading. So the top of every case
+study must front-load the payoff:
+
+1. **One-line outcome / problem** — the result or the problem solved, in plain language.
+2. **Context in a sentence** — who it was for and the constraint that made it hard.
+3. **Your role** — what *you* did (especially on team projects).
+
+Never open with "First I opened Figma…" or a wall of stack logos. Lead with *why this
+mattered and what changed.*
+
+---
+
+## Recommended structure
+
+A reliable arc — adapt the headings to the project, but keep the order:
+
+1. **Hook / outcome** — the result up front (see above).
+2. **Context & problem** — audience, goal, constraints. What made this non-trivial?
+3. **Your role & the approach** — what you owned; the method or process you chose and *why*.
+4. **Key decisions** — 2–4 real forks in the road. Show the trade-off and the reasoning, not
+   just the final answer. This is where *your* story lives.
+5. **The solution** — the built result, shown with a few high-signal visuals (not every
+   screenshot you ever made).
+6. **Impact** — measurable results if you have them; before/after if you don't (see below).
+7. **Reflection** — what you learned or would do differently. Short, honest, not filler.
+
+> Follow the actual process you used (design-thinking, build-measure-learn, whatever fits) —
+> a genuine method reads as more credible than a templated one.
+
+---
+
+## Show impact — the most powerful tool you have
+
+Before/after evidence is the single most persuasive element of a case study.
+
+- **Best:** real numbers. "Cut LCP from 4.1s to 1.8s," "increased completed flows 22%,"
+  "reduced manual data refresh from 2h to a scheduled job." Tie the number to the change.
+- **Good when you lack numbers:** before/after visuals with a sentence explaining what changed
+  and why it's better.
+- **Always:** connect the outcome to a decision *you* made, so the impact is attributable.
+
+If a project genuinely has no metrics, say what you'd measure now — that itself signals
+maturity.
+
+---
+
+## Length & scannability
+
+- **~800–1,500 words** plus relevant visuals is plenty for most projects. Depth over volume.
+- Write for the skimmer: meaningful headings, short paragraphs, bolded key takeaways,
+  pull-out results. A reader should get the gist from headings alone.
+- **Curate visuals:** include only the wireframes/screens/diagrams that advance the story.
+  Cut the rest — extra screenshots dilute, not strengthen.
+
+---
+
+## Common failure modes
+
+- **Tech-stack-first openings.** The stack is supporting detail, not the headline.
+- **Process theater.** Listing every ceremony you ran without showing a real decision.
+- **No "you" in it.** On team projects, ambiguity about your role reads as a red flag —
+  state it explicitly.
+- **Everything is a highlight.** If nothing was hard, nothing was impressive. Show at least
+  one real constraint and how you handled it.
+- **No outcome.** A case study that ends at "and then I shipped it" leaves the value unproven.
+
+---
+
+## Mapping to this site
+
+Project content is structured data in **`src/constants/caseStudies.ts`** and rendered by the
+`/portfolio` route (`src/app/portfolio/page.tsx` — *not* `ProjectsContent.tsx`). When adding
+or revising an entry:
+
+- **Card-level fields** (title, summary, stack) are the *hook* — make the title
+  outcome-oriented and the summary a one-line reason to click.
+- **Body content** should follow the structure above. Keep prose in `WRITING_VOICE.md` voice.
+- Link the live demo and the repository wherever both exist.
+- If the project is one of the curated/unverified data tools, preserve any `asOf` /
+  `verified: false` disclosure conventions described in `CLAUDE.md` and
+  `SNAPSHOT_DRIVEN_DASHBOARDS.md`.
+
+Confirm the exact field shape from the current `caseStudies.ts` before writing — the type is
+the contract, this playbook is the editorial intent.
+
+---
+
+## A one-screen template
+
+```
+# <Outcome-oriented title>
+
+> <One line: the result, or the problem solved.>
+
+**Context.** Who it was for and the constraint that made it hard.
+**My role.** What I owned.
+
+## The problem
+<Audience, goal, why it was non-trivial.>
+
+## Approach
+<The method I chose and why.>
+
+## Key decisions
+<2–4 real forks: the trade-off and my reasoning.>
+
+## The solution
+<The built result + a few high-signal visuals.>
+
+## Impact
+<Numbers if I have them; before/after if I don't.>
+
+## Reflection
+<One honest thing I learned or would change.>
+```
+
+---
+
+## Sources
+
+- [How to Write UX/UI Design Case Studies That Get You Hired — IxDF](https://ixdf.org/literature/article/how-to-write-great-case-studies-for-your-ux-design-portfolio)
+- [The Ultimate UX Case Study Template & Structure (2026) — UXfolio](https://blog.uxfol.io/ux-case-study-structure/)
+- [How to Write UX Case Studies That Land You a Job (2026) — UX Playbook](https://uxplaybook.org/articles/ux-case-study-minto-pyramid-structure-guide)
+- [How to Craft an Outstanding Case Study for Your UX Portfolio — CareerFoundry](https://careerfoundry.com/en/blog/ux-design/ux-case-study/)
+- [The 27 Best UX Portfolio Examples — UXfolio](https://blog.uxfol.io/ux-portfolio-examples/)

--- a/docs/web-design-research/PERFORMANCE_ACCESSIBILITY.md
+++ b/docs/web-design-research/PERFORMANCE_ACCESSIBILITY.md
@@ -1,0 +1,131 @@
+# Performance & Accessibility
+
+**Last updated:** 2026-06-25
+**Companion to:** `PERFORMANCE.md`, `ACCESSIBILITY_AUDIT.md`, `SEO.md`, `DESIGN_CHECKLIST.md`
+
+Speed and accessibility are 2026 baseline expectations, not polish. They also compound:
+faster, more stable pages rank better and convert better (sites passing all three Core Web
+Vitals see meaningfully lower bounce). This page sets the targets and the highest-leverage
+fixes; the existing `PERFORMANCE.md` and `ACCESSIBILITY_AUDIT.md` hold implementation status.
+
+---
+
+## Targets at a glance
+
+| Metric | Good | What it measures | Notes |
+| --- | --- | --- | --- |
+| **LCP** (Largest Contentful Paint) | < 2.5s | Loading — when the main content appears | Hardest CWV to pass; only ~62% of mobile pages hit it |
+| **INP** (Interaction to Next Paint) | < 200ms | Responsiveness across *all* interactions | Most-failed CWV in 2026 (~43% of sites miss it); replaced FID |
+| **CLS** (Cumulative Layout Shift) | < 0.1 | Visual stability — unexpected layout jumps | Fixable with explicit dimensions |
+| **Lighthouse** (all categories) | 90+ | Lab proxy across perf/a11y/best-practices/SEO | 90+ is Google's "good" bar |
+| **WCAG** | 2.2 AA | Accessibility conformance | The 2026 baseline expectation |
+
+---
+
+## LCP — the four highest-impact fixes
+
+LCP is usually the hero image or the largest hero text block. In priority order:
+
+1. **Preload the LCP image** and serve it in a modern format (AVIF/WebP) at the right size.
+   Use `next/image` with `priority` on the hero; don't lazy-load the LCP element.
+2. **Inline critical CSS** and keep render-blocking resources off the head.
+3. **Preload fonts with `font-display: swap`.** Prevents invisible text delaying paint.
+4. **Server-render the above-the-fold content** (App Router default — keep hero content in a
+   server component; don't hydrate the hero behind a client boundary that delays it).
+
+**This site:** Next.js 16 App Router gives SSR by default. The risk is regressions — a hero
+that becomes a client component, an un-prioritized hero image, or a heavy animation library
+in the critical path. Guard the hero specifically.
+
+---
+
+## INP — responsiveness (the 2026 problem child)
+
+INP measures *every* interaction, so it punishes main-thread blocking anywhere.
+
+- **Don't ship `transition-all`** on shared primitives (also a `STYLING.md` rule) — transition
+  specific properties so the compositor, not layout, does the work.
+- **Keep handlers light;** defer non-urgent work, break up long tasks, avoid synchronous
+  layout thrash in scroll/hover handlers.
+- **Respect `useReducedMotion()`** in Framer Motion — JS/rAF animation runs on the main
+  thread and can hurt INP even when CSS motion is reduced.
+- **Be wary of heavy client islands** (large D3 renders, big tables) on interaction-heavy
+  pages — virtualize or chunk where needed. The dashboards are the place to watch.
+
+---
+
+## CLS — visual stability
+
+CLS is the most mechanically fixable CWV: **reserve space for everything that loads late.**
+
+- Every `img`, `video`, `iframe`, chart container, and ad/embed slot needs **explicit
+  width/height** (or aspect-ratio). `next/image` enforces this — use it.
+- **`font-display: swap`** + matched fallback metrics to avoid reflow on web-font swap.
+- **Reserve space for async/dynamic content** (snapshot-driven dashboards, late data) so a
+  late fetch doesn't shove the layout. Render skeletons at final dimensions.
+- Never inject content above existing content after paint.
+
+---
+
+## Accessibility — WCAG 2.2 AA baseline
+
+2026 treats accessibility as reach, not compliance overhead. The essentials:
+
+- **Semantic HTML first.** One page-level `main` landmark per self-shell route (owned by
+  `ConditionalLayout` here); leaf sections use `section`/`div`, never a nested `main`. Exactly
+  one page-level `h1`. Headings nest in order.
+- **Keyboard operability.** Every interactive element reachable and operable by keyboard, in a
+  logical order. Test a full keyboard-only pass.
+- **Visible focus states.** Don't remove focus outlines — style them to match the editorial
+  system. (WCAG 2.2 adds focus-appearance and target-size criteria.)
+- **Contrast.** Meet AA contrast in *both* themes — use the editorial tokens and the semantic
+  status tokens (`--home-positive/-negative/-warning`); verify dark mode separately.
+- **Touch targets ≥ 44px** (WCAG 2.2 target-size; already a `STYLING.md` rule).
+- **`prefers-reduced-motion`** honored for every animated component — and remember the CSS
+  guard does **not** stop JS/Framer motion, so gate those in code with `useReducedMotion()`.
+- **Alt text** that conveys meaning; empty `alt=""` for purely decorative images.
+- **Forms** (contact, tools): real `<label>`s, programmatic error association, focus moved to
+  errors.
+- **Test with a screen reader and with keyboard only** — automated tools catch perhaps half.
+
+---
+
+## Where this intersects the snapshot-driven dashboards
+
+The dominant pattern here (15+ dashboards: snapshot → builder → action → API) is performance-
+and stability-friendly *if you keep the discipline*:
+
+- **No external calls at request time** — routes read committed snapshots. Preserve this; a
+  runtime fetch would wreck LCP and reliability.
+- **Render skeletons at final dimensions** so fail-soft/late data doesn't cause CLS.
+- **When adding a new data dashboard,** drop in its `error.tsx` (per `CLAUDE.md`) and confirm
+  the chart resolves token colors at render time (theme correctness) and reserves layout space
+  (CLS).
+
+---
+
+## Pre-ship perf/a11y checklist
+
+Run alongside `DESIGN_CHECKLIST.md`:
+
+- [ ] Hero is server-rendered; LCP image uses `next/image` + `priority`, modern format.
+- [ ] Fonts preloaded with `font-display: swap`.
+- [ ] All media and chart/embed containers have explicit dimensions (CLS).
+- [ ] No `transition-all` on shared primitives; handlers don't block the main thread (INP).
+- [ ] Every animation honors `useReducedMotion()` / `prefers-reduced-motion`.
+- [ ] One `main`, one `h1`, ordered headings; full keyboard pass works; focus visible.
+- [ ] AA contrast verified in **both** light and dark.
+- [ ] Touch targets ≥ 44px.
+- [ ] New dashboards: `error.tsx` present, skeleton at final dimensions, tokens resolved at
+      render time, no request-time external calls.
+- [ ] Lighthouse 90+ across categories on the changed route.
+
+---
+
+## Sources
+
+- [Core Web Vitals 2026: INP, LCP, CLS Optimization Guide — Senorit](https://senorit.de/en/blog/core-web-vitals-2026)
+- [Core Web Vitals Guide 2026 — W3era](https://www.w3era.com/blog/seo/core-web-vitals-guide/)
+- [The Most Important Core Web Vitals Metrics in 2026 — NitroPack](https://nitropack.io/blog/most-important-core-web-vitals-metrics/)
+- [Core Web Vitals 2026: INP, LCP & CLS — Digital Applied](https://www.digitalapplied.com/blog/core-web-vitals-2026-inp-lcp-cls-optimization-guide)
+- [Top Web Design Trends for 2026 (accessibility) — Figma](https://www.figma.com/resource-library/web-design-trends/)

--- a/docs/web-design-research/PORTFOLIO_BEST_PRACTICES.md
+++ b/docs/web-design-research/PORTFOLIO_BEST_PRACTICES.md
@@ -1,0 +1,159 @@
+# Portfolio Best Practices
+
+**Last updated:** 2026-06-25
+**Companion to:** `PAGES.md` (route behavior), `WRITING_VOICE.md` (copy), `CASE_STUDY_PLAYBOOK.md`
+
+Strategy and content guidance for the portfolio-first surfaces — homepage, about, portfolio,
+contact. The unifying principle: a portfolio's job is to make a busy person *trust your work
+fast*. Optimize for the 5–60 second skim, then reward the reader who goes deeper.
+
+---
+
+## The core mental model
+
+Hiring managers and clients skim. The field's consistent finding: a reviewer spends well
+under a minute deciding whether to keep reading. So the site must answer three questions
+**above the fold, without a scroll**:
+
+1. **Who is this?** (name + a one-line, specific identity)
+2. **Is this person credible?** (proof — recognizable work, results, or a strong sample)
+3. **What do I do next?** (one obvious action)
+
+Everything below the fold exists to deepen trust for the reader who chose to stay.
+
+---
+
+## Homepage & hero
+
+The hero is the first (and often only) impression. Best practice converges on **focus over
+density**.
+
+**Do:**
+
+- Lead with a **specific** identity line, not a generic title. "Builds data-driven products
+  in fintech and sports analytics" beats "Software Engineer." Specificity is credibility.
+- Make everything essential — headline, sub-line, primary visual, primary CTA — visible
+  *without scrolling*.
+- Ship **one** primary CTA. At most add one quiet secondary action that doesn't compete.
+  (See CTAs below.)
+- Let typography carry the hero (on-brand for this site's editorial system) rather than a
+  heavy stock image.
+
+**Don't:**
+
+- Bury the value proposition under a long intro paragraph.
+- Offer three or four equally-weighted buttons — competing CTAs reduce action.
+- Rely on a slow hero image or animation that delays first paint (the hero is almost always
+  the LCP element — see `PERFORMANCE_ACCESSIBILITY.md`).
+
+**This site:** the homepage uses the `compact` footer (no stacked closing CTA) and exposes
+exactly one page-level `h1` on portfolio-shell routes — keep that. Confirm current behavior
+from `src/app/page.tsx` and `ConditionalLayout.tsx`, not from memory.
+
+---
+
+## CTAs (calls to action)
+
+- **One primary action per view.** A focused CTA outperforms competing ones.
+- **Verb-first, concrete copy:** "See the work," "Read the case study," "Get in touch" —
+  not "Submit" or "Click here."
+- **First-person framing** ("Start my…") can increase ownership and conversion vs.
+  second-person, where it fits the voice. Keep it consistent with `WRITING_VOICE.md`.
+- **Visible contrast.** The CTA must stand out via the editorial accent
+  (`var(--home-acid)`), and meet contrast + 44px touch-target minimums.
+- **Place CTAs where intent peaks:** in the hero, at the end of each case study, and on the
+  about page after the credibility content — not only in the footer.
+
+---
+
+## About page
+
+The about page is where a skim turns into trust. It tells the *second* story — not just
+what you built, but who you are and how you work.
+
+- Open with a tight positioning statement, then earn it with specifics (domains, the kinds
+  of problems you solve, a thread that connects the work).
+- Show personality and a human element — 2026 design explicitly prizes the "more human" web —
+  but keep it in `WRITING_VOICE.md` voice.
+- Include a **photo** (people trust faces) and a clear path onward (to the work or to
+  contact). End with a CTA; don't dead-end.
+- Make credibility scannable: a short, honest list of domains/tools beats a sprawling skills
+  cloud.
+
+---
+
+## Project selection & presentation
+
+The single most repeated piece of portfolio advice in 2026:
+
+> **Three deep case studies beat eight shallow ones.** Include 3–6 of your *best* projects,
+> each demonstrating a *different* challenge or skill dimension.
+
+- **Curate ruthlessly.** Every weak project drags the average. Cut anything you wouldn't
+  defend in an interview.
+- **Show range deliberately.** Pick projects so that, together, they prove breadth — e.g. one
+  data/analytics build, one product/UX build, one systems/infra build.
+- **Each card must earn a click.** Card = outcome-oriented title + one-line problem/result +
+  the stack. The detail page does the depth (see `CASE_STUDY_PLAYBOOK.md`).
+- **Link both the live demo and the source** where they exist — proof beats description.
+- **Keep it current.** A portfolio is never static; remove outdated work and surface recent
+  wins. Stale projects quietly erode credibility.
+
+**This site:** project data lives in `src/constants/caseStudies.ts`, and `/portfolio` renders
+cards directly from the route page (`src/app/portfolio/page.tsx`) — `ProjectsContent.tsx`
+exists but is **not** the live path. Edit the data and the route page, and confirm behavior
+from the route, not old docs.
+
+---
+
+## Personal branding
+
+- **Consistency is the brand:** one custom domain, one name treatment, one color palette
+  (the editorial palette), one voice across every surface. Don't let dashboards drift into a
+  different visual language than the portfolio.
+- A **concise, specific bio** that reads the same (in spirit) across the homepage, about,
+  and any external profiles.
+- Authority content (writing, the analytics tools) reinforces the brand only if it's
+  visibly *yours* and consistent with the rest of the site — which is why the editorial
+  system spans every live route except `/admin`.
+
+---
+
+## Contact
+
+- Make contact *frictionless*: the fewer fields, the more messages. Ask only for what you'll
+  actually use.
+- Provide a non-form path too (email/social) for people who won't fill a form.
+- Set expectations ("I usually reply within…") to reduce hesitation.
+- **This site:** `/contact` uses the `compact` footer intentionally — avoid stacking a second
+  closing CTA beneath the contact content.
+
+---
+
+## A pre-ship portfolio checklist
+
+Run this *in addition to* `DESIGN_CHECKLIST.md` (the visual/a11y gate) whenever you touch a
+portfolio surface:
+
+- [ ] Above the fold answers who/credible/what-next without scrolling.
+- [ ] Exactly one primary CTA in the hero; secondary action (if any) is visibly quieter.
+- [ ] 3–6 projects, each showing a *distinct* skill; no filler.
+- [ ] Every project card has an outcome-oriented title and a reason to click.
+- [ ] Case studies lead with the result/problem, not the tech (see playbook).
+- [ ] Live demo + source linked wherever they exist.
+- [ ] About page has a face, a specific positioning statement, and an onward CTA.
+- [ ] No stale projects or dead "coming soon" entries.
+- [ ] Copy conforms to `WRITING_VOICE.md`.
+- [ ] Hero element doesn't block LCP; CTAs meet contrast + 44px targets.
+
+---
+
+## Sources
+
+- [How to Build a Web Developer Portfolio That Gets You Hired — Scrimba](https://scrimba.com/articles/how-to-build-a-web-developer-portfolio-that-gets-you-hired/)
+- [Developer Portfolio Guide 2026 — Hakia](https://hakia.com/skills/building-portfolio/)
+- [Website Hero Section Best Practices + Examples — Prismic](https://prismic.io/blog/website-hero-section)
+- [Hero Sections That Really Convert — Hype4 Academy](https://hype4.academy/articles/design/hero-sections-that-really-convert)
+- [The Best CTA Placement Strategies For 2026 — LandingPageFlow](https://www.landingpageflow.com/post/best-cta-placement-strategies-for-landing-pages)
+- [Website CTA Best Practices — Brand Llama](https://www.brandllama.com/website-cta-best-practices-quick-wins-for-better-conversions/)
+- [How to Build a Developer Portfolio Website in March 2026 — Learni](https://learni-group.com/en/blog/how-to-build-developer-portfolio-website-march-2026)

--- a/docs/web-design-research/README.md
+++ b/docs/web-design-research/README.md
@@ -1,0 +1,44 @@
+# Web Design & Portfolio Research
+
+**Last updated:** 2026-06-25
+
+A research-backed reference for the design and content decisions on this site. These
+notes synthesize current (2026) web-design and portfolio best practices and translate
+them into concrete, opinionated guidance for **this** portfolio — a portfolio-first
+Next.js site with secondary authority-building content.
+
+> These docs are *advisory research*, not normative spec. When they conflict with the
+> implemented system, the implemented system wins. The site-wide visual rules live in
+> `STYLING.md`; the single pre-merge gate is `DESIGN_CHECKLIST.md`; accessibility status
+> lives in `ACCESSIBILITY_AUDIT.md`. Use these research notes to decide *what* to build;
+> use those docs to decide *how* it must look and pass review.
+
+## The four documents
+
+| File | What it covers | Use it when |
+| --- | --- | --- |
+| [`WEB_DESIGN_TRENDS_2026.md`](./WEB_DESIGN_TRENDS_2026.md) | Current visual/UX direction — typography, layout, motion, dark mode, AI/ambient UI — filtered for what's worth adopting here | Considering a visual refresh or a new surface's look |
+| [`PORTFOLIO_BEST_PRACTICES.md`](./PORTFOLIO_BEST_PRACTICES.md) | Portfolio strategy — homepage/hero, about, project selection, CTAs, personal branding, what hiring managers actually scan | Editing the homepage, about, portfolio, or contact surfaces |
+| [`CASE_STUDY_PLAYBOOK.md`](./CASE_STUDY_PLAYBOOK.md) | How to write a project case study that converts — structure, storytelling, length, showing impact | Writing or revising entries in `src/constants/caseStudies.ts` |
+| [`PERFORMANCE_ACCESSIBILITY.md`](./PERFORMANCE_ACCESSIBILITY.md) | Core Web Vitals (LCP/INP/CLS) and WCAG 2.2 targets, with the highest-leverage fixes | Auditing speed/a11y, or shipping any new data dashboard |
+
+## How these connect to the existing docs
+
+- **Visual tokens & shell helpers** → `STYLING.md` (source of truth for color, type scale,
+  editorial shell). Research here never overrides a token rule.
+- **Pre-merge gate** → `DESIGN_CHECKLIST.md`. Every UI change still runs that checklist.
+- **Accessibility ground truth** → `ACCESSIBILITY_AUDIT.md`.
+- **SEO** → `SEO.md` (current reference; older root-level audits are historical).
+- **Copy/voice** → `WRITING_VOICE.md`. Any hero/about/case-study copy these docs suggest
+  must conform to the voice guide.
+
+## The five-second summary
+
+1. **Portfolio-first.** Lead with proof of work; everything else is supporting cast.
+2. **Three deep case studies beat eight shallow ones.** Each should show a different skill.
+3. **One clear hero, one primary CTA.** The visitor should know who you are and what to do
+   within five seconds, no scroll required.
+4. **Fast and accessible are table stakes,** not polish — LCP < 2.5s, INP < 200ms, CLS < 0.1,
+   WCAG 2.2 AA.
+5. **Personality through typography and editorial restraint,** not gimmicks. The site already
+   has a distinctive editorial system — lean into it rather than chasing trends.

--- a/docs/web-design-research/WEB_DESIGN_TRENDS_2026.md
+++ b/docs/web-design-research/WEB_DESIGN_TRENDS_2026.md
@@ -1,0 +1,122 @@
+# Web Design Trends 2026 — Filtered for This Site
+
+**Last updated:** 2026-06-25
+**Companion to:** `STYLING.md` (visual source of truth), `DESIGN_CHECKLIST.md` (pre-merge gate)
+
+Trends are inputs, not mandates. This page records the 2026 direction of the field and,
+for each trend, a verdict: **adopt**, **adapt**, or **skip** — based on whether it serves a
+portfolio-first site with a mature editorial system that already favors restraint.
+
+---
+
+## 1. Typography takes center stage
+
+The strongest 2026 signal: type *is* the design. Oversized headlines, variable fonts,
+playful scale shifts, and kinetic/animated type are anchoring hero sections in place of
+stock photography and heavy illustration. Type now sets tone and communicates personality.
+
+**Verdict: ADOPT (with restraint).** This aligns with the site's editorial identity.
+
+- Lean on the existing `--home-*` editorial scale and the `.home-kicker` / heading helpers
+  rather than inventing one-off sizes. No arbitrary `text-[Npx]` — use `text-3xs`/`text-2xs`
+  and the established scale (see `STYLING.md`).
+- Oversized, confident headlines are on-brand for the hero and section openers. Pair a large
+  display heading with a quiet, readable body to create hierarchy.
+- **Kinetic type:** acceptable only as a *subtle* entrance, and it must honor
+  `useReducedMotion()` (the global CSS guard does not stop JS/Framer-driven motion). No
+  perpetual looping text.
+
+## 2. Anti-grid / broken layouts and organic shapes
+
+After years of strict grids, 2026 softens: organic shapes, flowing lines, soft gradients,
+asymmetry, and "anti-grid" rhythm that introduces movement and personality.
+
+**Verdict: ADAPT — selectively.** A portfolio benefits from rhythm, but a *data-dashboard*
+site benefits from scannable grids. Reserve asymmetry for editorial/marketing surfaces
+(homepage, about, writing); keep dashboards, rankings, and tools on disciplined grids where
+density and comparison matter more than flair.
+
+## 3. Motion as a layer (micro-interactions, scroll-driven, ambient UI)
+
+Motion in 2026 is ambient and responsive — scroll-driven reveals, hover micro-interactions,
+and "living" backgrounds that react subtly to the user.
+
+**Verdict: ADAPT.** Tasteful micro-interactions improve perceived quality; ambient motion
+risks distraction and performance cost.
+
+- Every Framer Motion entrance must honor `useReducedMotion()`.
+- Shared portfolio-shell primitives must **not** use `transition-all` — transition specific
+  properties (a `STYLING.md` rule; also better for INP).
+- Keep animation off the critical render path — it should never delay LCP or block the main
+  thread enough to hurt INP (see `PERFORMANCE_ACCESSIBILITY.md`).
+
+## 4. Dark mode as a first-class mode
+
+Dark mode is expected, not optional, and 2026 designs treat it as a designed surface rather
+than an inverted afterthought.
+
+**Verdict: ALREADY DONE — protect it.** The site ships full light/dark via `next-themes`.
+
+- Never `color-mix(…, white)` for raised surfaces — it lightens in both themes and breaks
+  dark mode. Use `var(--home-paper-raised)` or mix toward `var(--home-elev-mix)`.
+- D3/SVG charts must resolve token colors at render time via `getComputedStyle`, never bake a
+  hex into a constant (see `PortfolioPerformanceChart`). This keeps charts correct in both
+  themes.
+
+## 5. High-contrast, accessible-by-default color
+
+2026 reframes accessibility as a *feature that expands reach*: high-contrast palettes,
+visible focus states, readable type, and semantic structure are now baseline expectations.
+
+**Verdict: ADOPT — it's table stakes.** Detail and targets live in
+`PERFORMANCE_ACCESSIBILITY.md` and `ACCESSIBILITY_AUDIT.md`. Use the semantic status tokens
+(`--home-positive/-negative/-warning`), never the legacy `--color-success/-error/-warning`
+aliases.
+
+## 6. AI-native touches (chatbots, AI project demos, AI-assisted layout)
+
+The field expects portfolios — especially developer portfolios — to *demonstrate* AI fluency:
+a real AI feature beyond an API wrapper (RAG, prompt engineering, a domain-specific tool),
+not necessarily a chatbot bolted onto the homepage.
+
+**Verdict: ADAPT — show, don't bolt on.** The strongest move is a *project* that proves AI
+capability, surfaced as a case study, rather than a generic site chatbot. Avoid novelty
+chatbots that add latency and accessibility burden for little signal.
+
+## 7. WebGPU / 3D / immersive demos
+
+Interactive 3D and WebGPU demos are a 2026 flex for developer portfolios.
+
+**Verdict: SKIP unless it's the actual work.** 3D for its own sake fights performance (LCP),
+accessibility, and the site's editorial restraint. Only include if a real project *is* a 3D
+or graphics piece — and then lazy-load it behind a poster image so it never blocks first paint.
+
+## 8. PWA / offline
+
+Progressive Web App patterns (installability, offline) appear on 2026 best-practice lists.
+
+**Verdict: SKIP for now.** Low payoff for a content/portfolio site; the browser-persisted
+tools already cover the "works without a backend" need via localStorage. Revisit only if a
+specific tool needs true offline.
+
+---
+
+## Net direction for this site
+
+The site's existing **editorial system is itself the trend-proof move**: confident
+typography, generous whitespace, restraint, real dark mode. The 2026 trends most worth
+adopting (bold type, tasteful motion, accessible-by-default color) *reinforce* that system.
+The trends most worth skipping (3D flexes, novelty AI chatbots, PWA) would dilute it. When a
+trend tempts you, ask: *does this make the work easier to read and trust, or just more
+decorated?* Adopt the former.
+
+---
+
+## Sources
+
+- [Top Web Design Trends for 2026 — Figma](https://www.figma.com/resource-library/web-design-trends/)
+- [Web Design Trends to Expect in 2026 — Elementor](https://elementor.com/blog/web-design-trends-2026/)
+- [Web design trends for 2026: kinetic type, broken grids — Envato](https://elements.envato.com/learn/web-design-trends)
+- [Web Design Trends 2026: AI, 3D, Ambient UI & Performance — Index.dev](https://www.index.dev/blog/web-design-trends)
+- [10 Website Design Trends 2026 — Lovable](https://lovable.dev/guides/website-design-trends-2026)
+- [How to Build a Developer Portfolio Website in March 2026 — Learni](https://learni-group.com/en/blog/how-to-build-developer-portfolio-website-march-2026)


### PR DESCRIPTION
## Summary

Adds a tailored, research-backed reference set under `docs/web-design-research/`. It synthesizes current (2026) web design and portfolio best practices and maps them directly onto **this** site — its editorial design system, snapshot-driven dashboard architecture, and existing docs (`STYLING.md`, `DESIGN_CHECKLIST.md`, `ACCESSIBILITY_AUDIT.md`, `WRITING_VOICE.md`).

These are advisory research notes, not normative spec — they explicitly defer to the implemented system and the existing pre-merge gate.

## What's included

| File | Focus |
| --- | --- |
| `README.md` | Index, five-second summary, and how the set connects to existing docs |
| `WEB_DESIGN_TRENDS_2026.md` | 2026 visual/UX trends with an **adopt / adapt / skip** verdict for each, given a portfolio-first editorial site |
| `PORTFOLIO_BEST_PRACTICES.md` | Hero/above-the-fold, about page, project curation, CTAs, personal branding, contact — plus a pre-ship checklist |
| `CASE_STUDY_PLAYBOOK.md` | Case-study structure, storytelling, showing impact, length — mapped to `src/constants/caseStudies.ts` and the `/portfolio` route |
| `PERFORMANCE_ACCESSIBILITY.md` | Core Web Vitals (LCP/INP/CLS) targets + highest-leverage fixes, and WCAG 2.2 AA essentials, tied to the snapshot-driven dashboards |

## Notes

- Docs-only change — no code, routes, or build behavior touched.
- Each doc cites its sources and cross-links the existing repo docs rather than duplicating them.
- Guidance is grounded in the repo's real structure (verified against `CLAUDE.md` conventions: editorial tokens, `ConditionalLayout` landmark ownership, `caseStudies.ts` as the live project source, snapshot-driven dashboard pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mb1U19zoipQiKyXsqyU1kh)_