### PR TITLE
Add World Cup 2026 group-stage coverage articles

### DIFF
--- a/content/blog/world-cup-2026-groups-a-b-c-decided.mdx
+++ b/content/blog/world-cup-2026-groups-a-b-c-decided.mdx
@@ -1,0 +1,49 @@
+---
+title: "World Cup 2026 Group Stage: The First Three Groups Are Settled"
+excerpt: "Groups A, B and C are done, and they gave us a flawless Mexico, a Switzerland side that grew into the tournament, and a Brazil-Morocco finish that looked less like an upset and more like a preview. Here is who went through, who went home, and what it tells me."
+publishedAt: "2026-06-25"
+category: "Sports Analytics"
+tags: ["World Cup", "World Cup 2026", "Group Stage", "Mexico", "Brazil", "Morocco", "Switzerland", "Sports Analytics"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/world-cup-2026-groups-a-b-c-decided/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open World Cup Pulse"
+  description: "Every group table, the new 32-team bracket, and the full schedule update in one place as results land."
+  href: "/world-cup-2026"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "World Cup 2026 Groups A, B and C: Final Tables and Who Qualified"
+  description: "A recap of the first three completed groups at the 2026 World Cup. Mexico's flawless Group A, Switzerland and Canada from Group B, and Brazil over Morocco in Group C, with who advanced and what it means."
+  keywords: ["World Cup 2026 Group A", "World Cup 2026 Group B", "World Cup 2026 Group C", "Mexico World Cup 2026", "Brazil Morocco World Cup", "World Cup 2026 group standings"]
+---
+
+# World Cup 2026 Group Stage: The First Three Groups Are Settled
+
+The first three groups of this World Cup have played out their full three rounds, and before the rest of the field finishes I want to write down what I actually saw rather than what I expected going in. Groups A, B and C were always going to close out first because of how the schedule front-loaded the host openers, and now that the tables are final they tell a cleaner story than the half-played groups still to come. You can see all twelve tables side by side on my [World Cup dashboard](/world-cup-2026), but these three are the ones with verdicts attached, so they are the ones worth sitting with.
+
+## Group A: Mexico looked like a host should
+
+Mexico did the thing a host nation dreams about and almost never pulls off, which is win all three group games without conceding a single goal. Three played, three won, six scored, none allowed. They opened by handling [South Africa](/world-cup-2026?team=south-africa) two-nil, edged [South Korea](/world-cup-2026?team=south-korea) by a single goal in the tight one, and then closed the group with a three-nil win over [Czechia](/world-cup-2026?team=czechia) that was as comfortable as the scoreline suggests. I went into this tournament treating Mexico as a quarterfinal-ceiling team at best, and nothing here changes my ceiling on them, but the floor looks a lot higher than I gave them credit for. A back line that does not concede across three games buys you a long way into a knockout bracket, especially with the crowd and the altitude on your side at the [Azteca](/world-cup-2026).
+
+The second qualifying spot went to South Africa, and it went to them in the least glamorous way possible. They lost to Mexico, drew Czechia, and then beat South Korea one-nil on the final day to climb above the Koreans on the head-to-head and the goal column. Four points and a minus-one goal difference is not the profile of a team anyone fears, but it is enough, and in a 48-team tournament enough is the whole point. South Korea go out on three points after beating Czechia early and then losing their last two, which is the cruelty of these groups: you can win a game and still pack your bags. Czechia were the clear weak link, one point and six goals conceded, and they never recovered from leaking that three-nil to Mexico.
+
+## Group B: Switzerland grew into it, Canada survived at home
+
+Switzerland are the kind of team I always underrate and always regret underrating. They opened with a flat one-all draw against [Qatar](/world-cup-2026?team=qatar) that had me ready to write them off, then they turned around and put four past [Bosnia and Herzegovina](/world-cup-2026?team=bosnia-herzegovina) and beat the host [Canada](/world-cup-2026?team=canada) two-one to take the group on seven points. That is the Swiss pattern in a sentence. They start slow, they tidy up, and by the end of a group they are the most organized side in it. Seven points and a plus-four difference from a group that looked like a coin flip on paper is a real result.
+
+Canada is the more interesting story to me because of what the table hides. They finished second on four points, but they have the best goal difference in the entire group at plus-five, built mostly on a six-nil demolition of Qatar that was the most lopsided result of these first three groups. The problem is that big wins and big losses both count once, and a two-one loss to Switzerland on the final day is what dropped them out of first. Second place at a home World Cup is a perfectly good outcome, and the way they advanced over Bosnia is worth understanding because it is the format doing exactly what it was designed to do. Canada and Bosnia both finished on four points, they drew their head-to-head one-all, and so it came down to goal difference, where Canada's plus-five buried Bosnia's minus-one. Bosnia beat Qatar three-one on the last day and still went home. Qatar finished bottom with ten goals conceded, which is the harsh edge of the expanded field showing up early.
+
+## Group C: Brazil over Morocco, and it felt like a preview
+
+This was the group I had circled, and it delivered. Brazil and Morocco both finished on seven points, both unbeaten, and the only thing separating them was a goal difference of plus-six against plus-three. Brazil took top spot, but the part I keep coming back to is that they did not beat Morocco. The two of them drew one-all on the opening day, and from there it was a race to see who could be more ruthless against [Scotland](/world-cup-2026?team=scotland) and [Haiti](/world-cup-2026?team=haiti). Brazil were, just barely, closing the group with a three-nil win over Scotland that secured the seeding.
+
+I had Morocco in my top ten contenders before the tournament, and two matchdays into the knockout math I feel good about that call. Beating Scotland one-nil and then putting four past Haiti is exactly the businesslike scoring you want from a team that fancies a deep run, and drawing the best side in the group rather than losing to them is the kind of result that travels. [Brazil](/world-cup-2026?team=brazil) topping the group keeps them on the seeded side of the bracket, which matters, but if these two end up on a collision course later in this tournament I will not be calling it an upset. Scotland go out on three points after beating Haiti and then losing to the two heavyweights, and Haiti finish pointless with eight conceded, which is roughly where the gap between this group's top and bottom always looked likely to land.
+
+## What the first three tell me about the rest
+
+The thing I am taking from these groups is that the favorites who were supposed to win their groups mostly did, and they did it without drama, which is a quietly important signal in a format this new. Mexico, Switzerland and Brazil all topped out, and the second spots went to the teams with either the better goal difference or the better final day rather than to any genuine shock. That is the boring outcome, and boring outcomes from the strong teams are usually the sign of a tournament where the seeding is going to hold up better than the expanded bracket made people fear.
+
+The other thing is that the best-third-placed math is going to be unforgiving. South Korea went out on three points, Bosnia went out on four, and both of those totals will look like they should have been enough by the time the rest of the groups settle. They will not be, because the eight best third-placed teams are going to need at least four points and a respectable goal difference to sneak in, and a couple of the groups still in progress are going to produce thirds that clear that bar comfortably. If you want to follow that race as the other nine groups finish, the [group view on the dashboard](/world-cup-2026?view=groups) is where I am watching it. For now, three groups down, nine to go, and the teams I expected to advance are the ones advancing.

--- a/content/blog/world-cup-2026-groups-d-e-f-final-round.mdx
+++ b/content/blog/world-cup-2026-groups-d-e-f-final-round.mdx
@@ -1,0 +1,47 @@
+---
+title: "World Cup 2026: Groups D, E and F Going Into the Final Round"
+excerpt: "The USA group is the cleanest American story of the tournament so far, Germany are scoring for fun, and Group F has set up a straight shootout between the Netherlands and Japan. Here is where these three stand with one match left."
+publishedAt: "2026-06-25"
+category: "Sports Analytics"
+tags: ["World Cup", "World Cup 2026", "Group Stage", "United States", "Germany", "Netherlands", "Japan", "Sports Analytics"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/world-cup-2026-groups-d-e-f-final-round/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open World Cup Pulse"
+  description: "Track the live group tables and the qualification math as the final round of matches lands."
+  href: "/world-cup-2026"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "World Cup 2026 Groups D, E and F: Standings and Final-Round Scenarios"
+  description: "Where Groups D, E and F stand with one match left at the 2026 World Cup. The USA cruising in Group D, Germany dominant in Group E, and a Netherlands-Japan finish in Group F."
+  keywords: ["World Cup 2026 Group D", "World Cup 2026 Group E", "World Cup 2026 Group F", "USA World Cup 2026", "Germany World Cup 2026", "Netherlands Japan World Cup"]
+---
+
+# World Cup 2026: Groups D, E and F Going Into the Final Round
+
+Groups D, E and F have each played two rounds and have one to go, and unlike the three groups that already closed out, these are the ones where the final day actually decides something. I want to capture where they stand before the last matches scramble the tables, because the scenarios are clean right now and they will not stay that way for long. If you want the live versions, the [group view on my dashboard](/world-cup-2026?view=groups) updates as results land, but here is how I read all three heading into the decisive round.
+
+## Group D: the cleanest American story so far
+
+This is the home group I care about most, and the [United States](/world-cup-2026?team=united-states) have made it simple. Two games, two wins, six scored and one conceded. They opened by beating [Paraguay](/world-cup-2026?team=paraguay) four-one, which is the kind of statement scoreline that settles a host nation's nerves early, and then they ground out a two-nil win over [Australia](/world-cup-2026?team=australia) that was more about control than flair. Six points with a plus-five difference means the United States are through, and a point against [Türkiye](/world-cup-2026?team=turkiye) in the final game locks up first place. I came into this tournament worried the American group-stage ceiling was a draw-and-pray situation, and instead they have looked like the most comfortable host of the three. That matters for the bracket, because topping the group keeps them away from the bigger seeds in the round of thirty-two.
+
+The race underneath them is the good part. Australia and Paraguay both sit on three points, and they happen to play each other on the final day, which turns their game into a straight knockout for second place. Australia beat Türkiye two-nil and lost to the USA, Paraguay lost to the USA and then beat Türkiye one-nil, so the two of them arrive level and settle it head-to-head. A draw favors Australia on the slightly better goal difference, which means Paraguay essentially have to win. Türkiye are the casualty here, pointless and yet to score across two games, and barring a result against an American side that only needs a point, they are going home. It is a tidy little group, one team cruising and three others fighting over the math, which is exactly what the format was supposed to produce.
+
+## Group E: Germany are scoring like they mean it
+
+Germany are the most fun team to watch in these three groups right now, and it is not close. They opened by putting seven past [Curaçao](/world-cup-2026?team=curacao), which is the single biggest scoreline of the tournament so far, and then beat [Ivory Coast](/world-cup-2026?team=ivory-coast) two-one in a genuine contest. Six points, nine goals scored, a plus-seven difference, and a forward line that looks like it has finally been let off the leash. Germany are through, and their final game against [Ecuador](/world-cup-2026?team=ecuador) is about seeding rather than survival. I had Germany a notch below the very top tier of contenders coming in, mostly on doubts about whether they could turn possession into goals, and two games in they have answered that question loudly enough that I am reconsidering.
+
+The second spot is where Group E gets interesting. Ivory Coast sit on three points after beating Ecuador one-nil and then losing a competitive game to Germany, and they close against Curaçao, which on paper is the softest remaining fixture in the group. Win that and they are very likely through. Ecuador are the team in trouble, one point from a goalless draw with Curaçao and a loss to Ivory Coast, and they now have to go and get a result against a Germany side that has scored nine in two games. That is a brutal final assignment. Curaçao deserve a mention regardless of where they finish, because they are the smallest nation by population ever to reach a World Cup, and even sitting on a single point with a heavy goal difference, just being the team that other groups have to game-plan around is its own kind of history.
+
+## Group F: a Netherlands and Japan shootout
+
+Group F has set up the cleanest final-day drama of the three. The [Netherlands](/world-cup-2026?team=netherlands) and [Japan](/world-cup-2026?team=japan) are both on four points, both with a plus-four goal difference, and the only thing separating them is that the Dutch have scored seven to Japan's six. They drew each other two-all on the opening day, which is the result that has them locked together now, and then they each won their second game in style. The Netherlands beat [Sweden](/world-cup-2026?team=sweden) five-one and Japan beat [Tunisia](/world-cup-2026?team=tunisia) four-nil. The wrinkle is that they do not play each other again, so the group is going to be decided by who does more damage in their final fixtures, the Netherlands against Tunisia and Japan against Sweden, played at the same time.
+
+That simultaneity is what makes Sweden dangerous. They sit on three points after beating Tunisia five-one and then getting beaten by the same scoreline by the Netherlands, and they close against Japan in a game they have to win to have any chance of stealing second. If Sweden beat Japan and the Netherlands handle Tunisia, the Dutch top the group and Japan are suddenly sweating the best-third math. I do not love Japan's position as much as the points total suggests, because their fate is partly in Sweden's hands rather than entirely their own. Tunisia are out, pointless with nine conceded, and their job now is spoiler. Of the three groups here, this is the one I would actually clear my schedule for, because two teams genuinely deserve to go through and the format is going to make them earn the seeding the hard way.
+
+## How I am reading the third-place picture
+
+The thread running through all three of these groups is the best-third-placed race, and it is going to be tighter than people expect. Australia or Paraguay will produce a third on three points that is almost certainly going home. Ecuador or Curaçao will produce a third that is clearly eliminated. But Group F could spit out a third-placed team on four points with a positive goal difference if Sweden win, and that is the kind of profile that sneaks into the round of thirty-two while better-sounding teams from weaker groups miss out. That is the whole tension of the expanded format, where a fourth point and a couple of goals can be the difference between a flight home and a knockout game. I am tracking the cross-group comparison on the [dashboard's group view](/world-cup-2026?view=groups) as the rest of the field finishes, because the order these last matches land in is going to swing who survives.

--- a/content/blog/world-cup-2026-groups-g-h-i-final-round.mdx
+++ b/content/blog/world-cup-2026-groups-g-h-i-final-round.mdx
@@ -1,0 +1,47 @@
+---
+title: "World Cup 2026: Groups G, H and I Going Into the Final Round"
+excerpt: "Belgium are stuck on two draws in the most wide-open group at the tournament, Spain are one game from topping a sneaky-tough Group H, and France and Norway have turned Group I into a heavyweight playoff while Senegal pack their bags."
+publishedAt: "2026-06-25"
+category: "Sports Analytics"
+tags: ["World Cup", "World Cup 2026", "Group Stage", "Belgium", "Spain", "France", "Norway", "Senegal", "Sports Analytics"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/world-cup-2026-groups-g-h-i-final-round/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open World Cup Pulse"
+  description: "Follow the group tables and the final-round scenarios as the results come in."
+  href: "/world-cup-2026"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "World Cup 2026 Groups G, H and I: Standings and Final-Round Scenarios"
+  description: "Where Groups G, H and I stand with one match left at the 2026 World Cup. Belgium stuck in a wide-open Group G, Spain leading Group H, and France versus Norway to top Group I."
+  keywords: ["World Cup 2026 Group G", "World Cup 2026 Group H", "World Cup 2026 Group I", "Belgium World Cup 2026", "Spain World Cup 2026", "France Norway World Cup"]
+---
+
+# World Cup 2026: Groups G, H and I Going Into the Final Round
+
+These three groups are two rounds deep with one to play, and they are where my pre-tournament reads are being tested hardest. One of my top-ten contenders is in real trouble, another is cruising about as expected, and the third group has produced a genuine heavyweight playoff that I did not see coming in quite this shape. Here is where Groups G, H and I stand before the final round rearranges them, with the live tables on the [dashboard](/world-cup-2026?view=groups) if you want to follow along.
+
+## Group G: the most open group at the tournament, and Belgium are the problem
+
+I ranked [Belgium](/world-cup-2026?team=belgium) tenth in my contenders countdown, and two games in I am regretting nothing about the doubts and everything about the placement. They have drawn both games, one-all with [Egypt](/world-cup-2026?team=egypt) and nil-nil with [Iran](/world-cup-2026?team=iran), and they have scored exactly one goal. Two points, and a forward line that has gone quiet at the worst possible time. That is the floor of the range I worried about with this team, an aging core that controls games without finishing them, and it has left them needing to beat [New Zealand](/world-cup-2026?team=new-zealand) on the final day to be sure of going through.
+
+The reason this is the most open group in the tournament is that nobody has separated. Egypt lead on four points after drawing Belgium and beating New Zealand three-one, and they control their own fate against Iran. Iran sit on two points from two draws, New Zealand have a single point, and every team in the group can still finish second, and a couple can still win it. Egypt are the side I trust most here precisely because they have already shown they can win a game, which is more than Belgium or Iran can say. New Zealand drew Iran two-all and have been competitive in a way that makes them a live spoiler rather than a free three points. If Belgium are going to justify a top-ten ranking, the time to start is now, because right now they look like a team that bows out early and leaves me looking generous.
+
+## Group H: Spain in control, Cape Verde refusing to leave
+
+This is Spain's group, and I had [Spain](/world-cup-2026?team=spain) as my number one team in the whole tournament, so I have been watching it closely. They lead on four points, and the headline is a four-nil dismantling of [Saudi Arabia](/world-cup-2026?team=saudi-arabia) that looked exactly like the class-of-the-field performance I expected. The asterisk is the game before it, a goalless draw with [Cape Verde](/world-cup-2026?team=cape-verde) that is the reason Spain are on four points instead of six. I am not panicking about it, because not conceding while you wait for the finishing to click is a fine way to navigate a group, but it is a reminder that the knockout fragility I flagged with Spain can show up as a flat ninety minutes against a team they should beat.
+
+The final-day fixture is the one everyone circled, Spain against [Uruguay](/world-cup-2026?team=uruguay), and it decides the group. Uruguay have two points from two draws, one-all with Saudi Arabia and two-all with Cape Verde, which is an underwhelming return for a team I rated as a real second seed, and they now have to get a result against Spain to be sure of advancing. The surprise package is Cape Verde, also on two points, having drawn Spain and Uruguay and proven they belong on this stage. They close against Saudi Arabia in a game that could send them through if the Spain-Uruguay result breaks their way. Spain need a point to top the group and are very likely through regardless, but the second spot is a genuine three-way tangle between Uruguay, Cape Verde and the goal-difference math, and I would not bet the house on the team that was supposed to take it.
+
+## Group I: France and Norway turned this into a playoff
+
+Group I has produced the cleanest heavyweight finish on the board. [France](/world-cup-2026?team=france) and [Norway](/world-cup-2026?team=norway) have both won both of their games, France with six points and a plus-five difference, Norway with six points and a plus-four. They are both already through, and they play each other on the final day in what is now a straight playoff for first place, with nothing but seeding on the line and a lot of pride attached. France beat [Senegal](/world-cup-2026?team=senegal) three-one and [Iraq](/world-cup-2026?team=iraq) three-nil, Norway beat Iraq four-one and edged Senegal three-two, so both of them have been scoring freely. I had France a hair behind Spain at the very top of my rankings, and this is the kind of group performance that keeps them there. Topping it matters, because the reward is the friendlier seeded path, and against a Norway side built around one of the best strikers alive, France will want that top spot rather than the runner-up's road.
+
+The story underneath the two qualifiers is the one I keep coming back to, because Senegal are out. I had Senegal as a dark horse I could not quite fit into my top ten, a team with the athletes and the recent pedigree to bother anyone, and they have lost both games and scored their way to nothing. Two losses, no points, and a final dead-rubber against Iraq that cannot save them. That is the brutal reading of the expanded format from the other direction. The bracket got bigger and easier to reach, and a team good enough to be a dark horse still managed to draw into a group with two of the best sides in the tournament and pay the full price for it. Iraq are also out, pointless with seven conceded, which was the likelier outcome from the start. France and Norway go through as expected, and the only real question left is which of them takes the top seed into the knockouts.
+
+## The third-place math is getting clearer
+
+What these three groups are doing to the best-third-placed race is tightening it from the top. Group G is going to produce a third-placed team with a real shot at qualifying, because the points are so evenly spread that whoever finishes third could land on four points. Group H could do the same if Cape Verde or Uruguay slips to third with a positive or even goal difference. Group I, by contrast, has no usable third at all, because France and Norway took all the points and Senegal and Iraq took none. That unevenness is exactly why the cross-group comparison is so hard to eyeball, and why I keep the [group view](/world-cup-2026?view=groups) open as the results land. A four-point third from Group G or H is going to knock out a team that finished second somewhere else on goal difference, and that is the kind of outcome that only this format produces.

--- a/content/blog/world-cup-2026-groups-j-k-l-final-round.mdx
+++ b/content/blog/world-cup-2026-groups-j-k-l-final-round.mdx
@@ -1,0 +1,47 @@
+---
+title: "World Cup 2026: Groups J, K and L Going Into the Final Round"
+excerpt: "Argentina are defending their title without breaking a sweat, Colombia and Portugal have set up a final-day decider, and England are level with Ghana while Croatia fight to stay alive. Here is where the last three groups stand with one match to play."
+publishedAt: "2026-06-25"
+category: "Sports Analytics"
+tags: ["World Cup", "World Cup 2026", "Group Stage", "Argentina", "Portugal", "Colombia", "England", "Croatia", "Sports Analytics"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/world-cup-2026-groups-j-k-l-final-round/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open World Cup Pulse"
+  description: "See the final group tables and the new 32-team bracket fill in as the group stage closes out."
+  href: "/world-cup-2026"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "World Cup 2026 Groups J, K and L: Standings and Final-Round Scenarios"
+  description: "Where Groups J, K and L stand with one match left at the 2026 World Cup. Argentina cruising in Group J, Colombia and Portugal to decide Group K, and England, Ghana and Croatia in Group L."
+  keywords: ["World Cup 2026 Group J", "World Cup 2026 Group K", "World Cup 2026 Group L", "Argentina World Cup 2026", "Portugal Colombia World Cup", "England World Cup 2026"]
+---
+
+# World Cup 2026: Groups J, K and L Going Into the Final Round
+
+These are the last three groups to finish, two rounds in with one to play, and they close out the group stage with a defending champion in cruise control, a marquee decider between two genuine contenders, and a group where England are being made to work harder than the seeding suggested. Here is where Groups J, K and L stand before the final round, with the live tables sitting on the [dashboard](/world-cup-2026?view=groups) if you want to watch the math move.
+
+## Group J: Argentina are doing exactly what champions do
+
+[Argentina](/world-cup-2026?team=argentina) are defending the title, and through two games they have made it look like the least stressful job at the tournament. Two wins, five goals scored, none conceded, a three-nil over [Algeria](/world-cup-2026?team=algeria) and a two-nil over [Austria](/world-cup-2026?team=austria). Six points, a plus-five difference, two clean sheets, and the air of a team that knows exactly what it is doing and feels no need to rush. They are through, and their final game against [Jordan](/world-cup-2026?team=jordan) is about nothing more than rhythm and rotation. I had Argentina just outside my very top tier coming in, partly on questions about whether the champion core still had the legs, and the early answer is that they do not need to run when they are this organized. Not conceding across two games is the quiet tell that they are built for a deep run again.
+
+The second spot is a clean final-day shootout. Austria and Algeria both sit on three points, and they play each other in the last round, so the math could not be simpler. Austria beat Jordan three-one and lost to Argentina, Algeria lost to Argentina and beat Jordan two-one, and now the winner of their head-to-head takes second place outright. A draw drags goal difference and the best-third math into it, but the clean version is that one of them goes through and one of them goes home based on ninety minutes against each other. Jordan are out, pointless across two games, and their final assignment is the unenviable one of facing a champion with nothing to lose. This is the format at its most legible, one team cruising and two others handed a winner-takes-the-spot finale.
+
+## Group K: Colombia and Portugal, and Ronaldo's team found its level
+
+Group K has set up the kind of final-day game I will rearrange my evening for. [Colombia](/world-cup-2026?team=colombia) lead on six points after beating [Uzbekistan](/world-cup-2026?team=uzbekistan) three-one and [Congo DR](/world-cup-2026?team=congo-dr) one-nil, and they are already through. [Portugal](/world-cup-2026?team=portugal) sit second on four points, and the way they got there is the story. They opened with a flat one-all draw against Congo DR that had people questioning whether this was finally the tournament where the veteran core ran out of road, and then they answered with a five-nil demolition of Uzbekistan that was the most emphatic response available. I ranked Portugal sixth in my contenders countdown, and that bounce-back is exactly the resilience that ranking was betting on.
+
+The two of them play each other on the final day to decide the group, and both are essentially safe, so it becomes a fight over the top seed and the friendlier knockout path. Colombia have the points lead, Portugal have the better goal difference at plus-five, and a Portugal win flips the group. I love this as a measuring-stick game for both, because Colombia have quietly been one of the more convincing teams nobody is talking about, and Portugal need a marquee result to confirm the five-nil was the real them rather than the one-all. Underneath them, Congo DR are alive on a single point and close against Uzbekistan in a game they probably have to win to chase a best-third spot. Uzbekistan, at their first World Cup, are out, pointless with eight conceded, having run into the buzzsaw of Portugal's response game.
+
+## Group L: England made to work, Croatia on the brink
+
+This is the group where the seeding is being tested. [England](/world-cup-2026?team=england) lead on four points, but they have not had the comfortable ride a top seed expects. They beat [Croatia](/world-cup-2026?team=croatia) four-two in a genuinely open opener, and then they were held to a goalless draw by [Ghana](/world-cup-2026?team=ghana) that has tightened the whole group. Four points and a plus-two difference is fine, and England are very likely through, but the nil-nil with Ghana is the kind of result that keeps a manager honest. They close against [Panama](/world-cup-2026?team=panama), and a win locks up the group.
+
+The reason England cannot fully relax is that Ghana are right alongside them on four points. Ghana beat Panama one-nil and held England, and they have the best defensive record in the group, having conceded just once. They close against Croatia in what is effectively a knockout game for a qualifying spot. Croatia are the team I am watching most here, because they have been the great tournament overachievers of the last two World Cups and now they are on the brink. Three points from a loss to England and a one-nil win over Panama, and they have to beat Ghana to go through. A draw likely sends Ghana through on the better goal difference and sends Croatia home, which would be a genuinely jarring early exit for a side that has made a habit of going deep. Panama are out, pointless, but they have made both of their losses competitive enough to be a nuisance in the final round.
+
+## Closing the book on the group stage
+
+When these three groups finish, the full field for the round of thirty-two is set, and the picture they paint is consistent with everything the first nine groups showed. The favorites are mostly topping their groups, the second spots are being decided by head-to-head finales rather than chaos, and the best-third-placed race is going to come down to which fourth point lands where. Group J will likely produce a third on three points that is going home. Group K could produce a Congo DR third on four points that sneaks in. Group L is so tight that its third-placed team could finish on four points with a positive goal difference and still sweat the cross-group comparison. That is the whole drama of the expanded format compressed into the final day, and it is why I keep the [group view](/world-cup-2026?view=groups) and the filling-in [knockout bracket](/world-cup-2026?view=knockout) open side by side. The group stage is almost done, the seeds have mostly held, and now the part of the tournament that actually rewards being the best team is about to begin.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -10,7 +10,6 @@
 <url><loc>https://isaacavazquez.com/fintech-tools/interchange-iq</loc><lastmod>2026-04-02T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/now</loc><lastmod>2026-04-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/portfolio</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-<url><loc>https://isaacavazquez.com/portfolio/pulse-dashboards</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/recipe-finder</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/resume</loc><lastmod>2026-04-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
 <url><loc>https://isaacavazquez.com/travel</loc><lastmod>2026-05-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
@@ -136,6 +135,10 @@
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-contenders-7-germany</loc><lastmod>2026-06-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-contenders-8-netherlands</loc><lastmod>2026-06-03T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-contenders-9-morocco</loc><lastmod>2026-06-02T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/world-cup-2026-groups-a-b-c-decided</loc><lastmod>2026-06-25T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/world-cup-2026-groups-d-e-f-final-round</loc><lastmod>2026-06-25T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/world-cup-2026-groups-g-h-i-final-round</loc><lastmod>2026-06-25T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/world-cup-2026-groups-j-k-l-final-round</loc><lastmod>2026-06-25T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-top-ten-contenders</loc><lastmod>2026-05-31T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/ai-dev-tools</loc><lastmod>2026-04-28T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/bay-area-transit</loc><lastmod>2026-06-23T20:22:46.609Z</lastmod><changefreq>hourly</changefreq><priority>0.6</priority></url>


### PR DESCRIPTION
## What

Four new writing posts covering the 2026 World Cup group stage in Isaac's editorial voice, dated `2026-06-25` to match the current state of the tournament ("up to this point").

- `world-cup-2026-groups-a-b-c-decided.mdx` — recap of the three groups that have finished all three rounds (Mexico's flawless Group A, Switzerland/Canada from Group B, Brazil over Morocco in Group C).
- `world-cup-2026-groups-d-e-f-final-round.mdx` — final-round state of play (USA cruising, Germany dominant, a Netherlands–Japan shootout in F).
- `world-cup-2026-groups-g-h-i-final-round.mdx` — Belgium struggling in a wide-open Group G, Spain leading H, France vs Norway to top I as Senegal go out.
- `world-cup-2026-groups-j-k-l-final-round.mdx` — Argentina serene in J, Colombia–Portugal decider in K, England level with Ghana while Croatia fight to survive in L.

## Grounding

All standings, scorelines, records, goal differences, and qualification scenarios are drawn from the committed `src/data/worldCupSnapshot.ts` (generated `2026-06-25`). Groups A–C have completed all three matchdays; Groups D–L have one match left, so they are written as "going into the final round" without inventing results that haven't been played. No scorer data was present in the snapshot, so no individual goalscorers are named.

## Conventions

- Follow `WRITING_VOICE.md`: first person, opinion-forward, flowing prose, no em dashes or colon-as-connector, no bullet-list-with-bold-labels, no generic conclusion sections.
- Match the existing World Cup series frontmatter (`category: Sports Analytics`, `archiveBucket: Sports & Fantasy`, opengraph-image cover fallback, `cta` to `/world-cup-2026`).
- Deep-link to the World Cup Pulse dashboard via `?team=` and `?view=` params validated against `world-cup-state.ts`.

Required frontmatter fields validated for all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmSzPvc8zmzCh5xYPPpPk4)_