### PR TITLE
Give Formula 1 Pulse a racing-flavored visual identity

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -10,7 +10,6 @@
 <url><loc>https://isaacavazquez.com/fintech-tools/interchange-iq</loc><lastmod>2026-04-02T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/now</loc><lastmod>2026-04-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/portfolio</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-<url><loc>https://isaacavazquez.com/portfolio/pulse-dashboards</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/recipe-finder</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/resume</loc><lastmod>2026-04-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
 <url><loc>https://isaacavazquez.com/travel</loc><lastmod>2026-05-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>

--- a/src/app/formula-1/formula-1-client.tsx
+++ b/src/app/formula-1/formula-1-client.tsx
@@ -45,6 +45,7 @@ import {
   ChartBar,
   User,
 } from "@/components/ui/ServerIcons";
+import styles from "./formula-1.module.css";
 
 interface Formula1ClientProps {
   initialState: Formula1RouteState;
@@ -343,26 +344,16 @@ function CircuitMarker({ meeting }: { meeting: Formula1MeetingSummary }) {
 }
 
 /**
- * Five-light F1 start gantry. Purely decorative. The lights "arm" left to
- * right and the last one keeps a soft glow so the hero reads as a grid that is
- * about to go green.
+ * Five-light F1 start gantry. Purely decorative. The lights arm left to right,
+ * hold red, then go dark together — the real start procedure in miniature —
+ * looping on a timer. Honors `prefers-reduced-motion` (lights hold lit) via the
+ * CSS module.
  */
 function StartLights() {
   return (
-    <span className="inline-flex items-center gap-1.5" aria-hidden="true">
+    <span className={styles.gantry} aria-hidden="true">
       {[0, 1, 2, 3, 4].map((index) => (
-        <span
-          key={index}
-          className="h-2 w-2 rounded-full"
-          style={{
-            background:
-              "radial-gradient(circle at 30% 30%, #FF6A5A 0%, #E0271A 60%, #A50E04 100%)",
-            boxShadow:
-              index === 4
-                ? "0 0 8px 1px color-mix(in srgb, #E0271A 60%, transparent)"
-                : "0 0 4px color-mix(in srgb, #E0271A 35%, transparent)",
-          }}
-        />
+        <span key={index} className={styles.light} />
       ))}
     </span>
   );
@@ -1266,17 +1257,22 @@ export function Formula1Client({ initialState, snapshot }: Formula1ClientProps) 
   ];
 
   return (
-    <div className="home-page min-h-screen">
+    <div className={`home-page min-h-screen ${styles.f1}`}>
       <div className="home-shell home-section space-y-6 sm:space-y-8">
       <section
-        className="overflow-hidden rounded-[32px] border p-6 sm:p-8 lg:p-10"
+        className={`relative overflow-hidden rounded-[32px] border p-6 sm:p-8 lg:p-10 ${styles.carbon}`}
         style={{
-          borderColor: "color-mix(in srgb, var(--home-haze) 24%, var(--home-rule))",
+          borderColor: "color-mix(in srgb, var(--home-haze) 30%, var(--home-rule))",
           background:
-            "radial-gradient(circle at top right, color-mix(in srgb, var(--home-haze) 18%, transparent) 0%, transparent 38%), linear-gradient(140deg, color-mix(in srgb, var(--home-paper) 94%, var(--home-elev-mix)) 0%, color-mix(in srgb, var(--home-paper-alt) 88%, var(--home-elev-mix)) 100%)",
+            "radial-gradient(circle at top right, color-mix(in srgb, var(--home-haze) 22%, transparent) 0%, transparent 42%), linear-gradient(140deg, color-mix(in srgb, var(--home-paper) 94%, var(--home-elev-mix)) 0%, color-mix(in srgb, var(--home-paper-alt) 88%, var(--home-elev-mix)) 100%)",
           boxShadow: "var(--shadow-sm)",
         }}
       >
+        <span
+          className={styles.speedLines}
+          aria-hidden="true"
+          style={{ top: 0, right: 0, width: "42%", height: "60%" }}
+        />
         <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-start">
           <div>
             <p className="home-kicker mb-2">Formula 1 project</p>
@@ -1405,6 +1401,7 @@ export function Formula1Client({ initialState, snapshot }: Formula1ClientProps) 
             )}
           </aside>
         </div>
+        <span className={`${styles.finishLine} ${styles.checkers}`} aria-hidden="true" />
       </section>
 
       <HomeStatsPanel

--- a/src/app/formula-1/formula-1.module.css
+++ b/src/app/formula-1/formula-1.module.css
@@ -1,0 +1,165 @@
+/*
+ * Formula 1 Pulse — route-scoped racing theme.
+ *
+ * The dashboard is built on the editorial `--home-*` system. This module does
+ * NOT re-declare that palette; it aliases it and layers a thin racing identity
+ * on top: the signature F1 red as the local accent, a checkered-flag band, a
+ * carbon-fibre weave, and an arming start-light sequence. Everything degrades
+ * to the editorial look in `prefers-reduced-motion` and supports light/dark.
+ */
+
+.f1 {
+  /* Racing accent — the iconic Formula 1 red. We remap the local meaning of
+     --home-haze (the editorial brand-blue) to red so every accent the
+     dashboard already paints with haze — view toggles, leaderboard bars,
+     season progress "next" marker, links, upcoming-weekend tones — turns red
+     in one place instead of touching dozens of inline styles. */
+  --f1-red: #E10600;
+  --f1-red-bright: #FF2D1A;
+  --f1-carbon: #15161A;
+  --f1-checker: color-mix(in srgb, var(--home-ink) 82%, transparent);
+
+  --home-haze: var(--f1-red);
+}
+
+:global(.dark) .f1 {
+  --f1-red: #FF2D1A;
+  --f1-red-bright: #FF5341;
+  --f1-carbon: #0B0C0E;
+  --f1-checker: color-mix(in srgb, var(--home-ink) 70%, transparent);
+
+  --home-haze: var(--f1-red);
+}
+
+/* Carbon-fibre weave — a fine twill pattern kept low-contrast so it reads as
+   texture, not noise. Sits behind the hero copy. */
+.carbon {
+  position: relative;
+  isolation: isolate;
+}
+
+.carbon::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  opacity: 0.5;
+  background-image:
+    repeating-linear-gradient(
+      45deg,
+      color-mix(in srgb, var(--f1-carbon) 9%, transparent) 0,
+      color-mix(in srgb, var(--f1-carbon) 9%, transparent) 1px,
+      transparent 1px,
+      transparent 5px
+    ),
+    repeating-linear-gradient(
+      -45deg,
+      color-mix(in srgb, var(--f1-carbon) 9%, transparent) 0,
+      color-mix(in srgb, var(--f1-carbon) 9%, transparent) 1px,
+      transparent 1px,
+      transparent 5px
+    );
+  background-size: 7px 7px;
+  pointer-events: none;
+}
+
+:global(.dark) .carbon::before {
+  opacity: 0.7;
+}
+
+/* Checkered-flag band — a two-row finish-line checkerboard. Used as a thin
+   accent strip rather than a full fill. */
+.checkers {
+  background-image:
+    repeating-conic-gradient(
+      var(--f1-checker) 0% 25%,
+      transparent 0% 50%
+    );
+  background-size: 14px 14px;
+  background-position: 0 0;
+}
+
+/* The hero's bottom finish-line: a checker strip that fades in from the left so
+   it reads as a flag being waved across the panel. */
+.finishLine {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 12px;
+  opacity: 0.85;
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 18%, #000 100%);
+  mask-image: linear-gradient(90deg, transparent, #000 18%, #000 100%);
+  pointer-events: none;
+}
+
+/* Diagonal speed slashes echoing a livery's leading edge. Decorative, anchored
+   to a corner of the hero. */
+.speedLines {
+  position: absolute;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    115deg,
+    color-mix(in srgb, var(--f1-red) 55%, transparent) 0,
+    color-mix(in srgb, var(--f1-red) 55%, transparent) 3px,
+    transparent 3px,
+    transparent 10px
+  );
+  -webkit-mask-image: radial-gradient(circle at 100% 0%, #000, transparent 70%);
+  mask-image: radial-gradient(circle at 100% 0%, #000, transparent 70%);
+}
+
+/* ---- Start-light gantry ---------------------------------------------------
+   Five lights arm left-to-right, hold, then the whole row "goes dark" (lights
+   out) before the loop restarts — the real F1 start procedure in miniature. */
+
+.gantry {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.45rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--f1-carbon) 90%, transparent);
+  border: 1px solid color-mix(in srgb, var(--home-ink) 30%, transparent);
+}
+
+.light {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, #2a0604 70%, var(--f1-carbon));
+  box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.6);
+  animation: f1-light-cycle 5s linear infinite;
+}
+
+.light:nth-child(1) { animation-delay: 0s; }
+.light:nth-child(2) { animation-delay: 0.6s; }
+.light:nth-child(3) { animation-delay: 1.2s; }
+.light:nth-child(4) { animation-delay: 1.8s; }
+.light:nth-child(5) { animation-delay: 2.4s; }
+
+@keyframes f1-light-cycle {
+  /* arm */
+  0%, 4% {
+    background: color-mix(in srgb, #2a0604 70%, var(--f1-carbon));
+    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.6);
+  }
+  8%, 60% {
+    background: radial-gradient(circle at 30% 30%, var(--f1-red-bright) 0%, var(--f1-red) 55%, #7a0500 100%);
+    box-shadow: 0 0 7px 1px color-mix(in srgb, var(--f1-red) 70%, transparent);
+  }
+  /* lights out — go dark together */
+  64%, 100% {
+    background: color-mix(in srgb, #2a0604 70%, var(--f1-carbon));
+    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.6);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .light {
+    animation: none;
+    background: radial-gradient(circle at 30% 30%, var(--f1-red-bright) 0%, var(--f1-red) 55%, #7a0500 100%);
+    box-shadow: 0 0 5px color-mix(in srgb, var(--f1-red) 50%, transparent);
+  }
+}


### PR DESCRIPTION
## What

Restyles the `/formula-1` (Formula 1 Pulse) dashboard so it reads as Formula 1 rather than the site's generic editorial blue accent — without breaking the editorial design system, light/dark support, or reduced-motion guarantees.

## Changes

- **New route-scoped theme module** (`formula-1.module.css`):
  - Remaps the local accent to the **iconic F1 red** (with light/dark variants). Because the dashboard already paints accents through `--home-haze`, this single remap repaints view toggles, leaderboard bars, season-progress markers, the countdown, links, and upcoming-weekend tones in one place — no need to touch dozens of inline styles.
  - **Carbon-fibre weave** behind the hero copy (subtle twill texture).
  - **Diagonal speed slashes** raking off the hero's top-right corner.
  - **Checkered finish-line strip** along the hero's bottom edge.
- **Animated start-light gantry**: the five lights now arm left-to-right, hold red, then go *lights out* together on a loop — the real F1 start procedure in miniature. Falls back to a static lit row under `prefers-reduced-motion`.

## Guardrails respected

- Aliases the global editorial tokens (`--home-*`) rather than re-declaring the palette; no `color-mix(…, white)`.
- Light/dark both verified via screenshots; reduced-motion fallback included.
- Dashboard structure, copy, and routing are untouched.
- `npx jest src/app/formula-1` → 10/10 pass.

## Verification

Ran the dev server and captured light + dark screenshots plus a hero close-up; the red accent, speed slashes, carbon texture, finish-line checkers, and start-light gantry all render correctly in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaWzEgifA9Qgnkahk5fuia

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaWzEgifA9Qgnkahk5fuia)_