### PR TITLE
fix: remove stale pulse-dashboards entry from sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -10,7 +10,6 @@
 <url><loc>https://isaacavazquez.com/fintech-tools/interchange-iq</loc><lastmod>2026-04-02T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/now</loc><lastmod>2026-04-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/portfolio</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-<url><loc>https://isaacavazquez.com/portfolio/pulse-dashboards</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/recipe-finder</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/resume</loc><lastmod>2026-04-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
 <url><loc>https://isaacavazquez.com/travel</loc><lastmod>2026-05-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>


### PR DESCRIPTION
## What was failing

The `sitemap-consistency` unit test (`src/lib/__tests__/sitemap-consistency.test.ts`) was failing in CI. It asserts that the committed `public/sitemap.xml` exactly matches the canonical route inventory from `src/lib/sitemap.js` (`getPublicSitemapEntries()`).

The test diff showed a single extra entry in the committed sitemap:

```
+ "/portfolio/pulse-dashboards"
```

## Root cause

`/portfolio/pulse-dashboards` is now a **permanent redirect** to `/writing/building-the-pulse-dashboard-family` (see `next.config.mjs`) — it is no longer a standalone route. It was correctly removed from the canonical sitemap inventory in `src/lib/sitemap.js`, but the committed `public/sitemap.xml` (normally regenerated by `next-sitemap` at postbuild) still listed it.

## Fix

Removed the stale `<url>` entry for `/portfolio/pulse-dashboards` from `public/sitemap.xml`, matching what a fresh `next-sitemap` generation would produce. No other discrepancies existed between the committed sitemap and the canonical inventory.

## Verification

- `npx jest sitemap-consistency` → passes
- Full suite: **201 suites / 1034 tests passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S62aSxaEG7EbbA1qK76NQ4)_