### PR TITLE
Add /arcade — a synthwave CRT reflex game in a deliberately off-brand style

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -10,7 +10,6 @@
 <url><loc>https://isaacavazquez.com/fintech-tools/interchange-iq</loc><lastmod>2026-04-02T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/now</loc><lastmod>2026-04-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/portfolio</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-<url><loc>https://isaacavazquez.com/portfolio/pulse-dashboards</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/recipe-finder</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/resume</loc><lastmod>2026-04-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
 <url><loc>https://isaacavazquez.com/travel</loc><lastmod>2026-05-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
@@ -138,6 +137,7 @@
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-contenders-9-morocco</loc><lastmod>2026-06-02T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-top-ten-contenders</loc><lastmod>2026-05-31T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/ai-dev-tools</loc><lastmod>2026-04-28T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/arcade</loc><lastmod>2026-06-25T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/bay-area-transit</loc><lastmod>2026-06-23T20:22:46.609Z</lastmod><changefreq>hourly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/decision-lab</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/earthquake-pulse</loc><lastmod>2026-06-23T20:22:58.940Z</lastmod><changefreq>hourly</changefreq><priority>0.6</priority></url>

--- a/src/app/arcade/ArcadeClient.tsx
+++ b/src/app/arcade/ArcadeClient.tsx
@@ -1,0 +1,438 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import styles from "./arcade.module.css";
+
+/*
+ * REACTOR — a self-contained reflex arcade game.
+ *
+ * This component intentionally avoids the site's editorial primitives and
+ * shared hooks. It is a standalone toy with its own state machine:
+ *   boot -> playing -> over -> (retry) playing
+ *
+ * Timing runs off requestAnimationFrame against a deadline so the countdown
+ * bar stays smooth and the difficulty can ramp every round. All visual motion
+ * is handled in CSS and gated behind prefers-reduced-motion.
+ */
+
+const GRID = 9;
+const START_WINDOW = 1250; // ms a target stays "hittable" on round 0
+const MIN_WINDOW = 460; // floor so late game stays fair
+const WINDOW_DECAY = 26; // ms shaved per round survived
+const START_LIVES = 3;
+const HISCORE_KEY = "arcade-reactor-hiscore-v1";
+
+const BOOT_LINES = [
+  "> PHOSPHOR ARCADE SYS v2.6",
+  "> loading reactor core ........ OK",
+  "> calibrating reflex matrix ... OK",
+  "> neon tubes ................... LIT",
+  "> ready player one.",
+];
+
+type Status = "boot" | "playing" | "over";
+type Feedback = { cell: number; type: "hit" | "miss" } | null;
+const COLORS = ["cyan", "magenta", "acid"] as const;
+
+function readHiScore(): number {
+  if (typeof window === "undefined") return 0;
+  const raw = window.localStorage.getItem(HISCORE_KEY);
+  const n = raw ? Number.parseInt(raw, 10) : 0;
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+export default function ArcadeClient() {
+  const [status, setStatus] = useState<Status>("boot");
+  const [bootText, setBootText] = useState("");
+  const [bootDone, setBootDone] = useState(false);
+
+  const [score, setScore] = useState(0);
+  const [combo, setCombo] = useState(1);
+  const [lives, setLives] = useState(START_LIVES);
+  const [hiScore, setHiScore] = useState(0);
+
+  const [liveCell, setLiveCell] = useState<number | null>(null);
+  const [decoyCell, setDecoyCell] = useState<number | null>(null);
+  const [liveColor, setLiveColor] = useState<(typeof COLORS)[number]>("cyan");
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const [timerPct, setTimerPct] = useState(100);
+
+  // Refs mirror state the rAF / timeout closures need without going stale.
+  const statusRef = useRef<Status>("boot");
+  const roundRef = useRef(0);
+  const scoreRef = useRef(0);
+  const comboRef = useRef(1);
+  const livesRef = useRef(START_LIVES);
+  const liveCellRef = useRef<number | null>(null);
+  const decoyCellRef = useRef<number | null>(null);
+  const deadlineRef = useRef(0);
+  const windowRef = useRef(START_WINDOW);
+  const rafRef = useRef<number | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Holds the latest spawnRound so endRound can schedule the next round
+  // without creating a declaration cycle between the round-control callbacks.
+  const spawnRoundRef = useRef<() => void>(() => {});
+
+  const clearTimers = useCallback(() => {
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+    rafRef.current = null;
+    timeoutRef.current = null;
+  }, []);
+
+  // ---- Boot typewriter ----
+  useEffect(() => {
+    const reduce =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    const full = BOOT_LINES.join("\n");
+
+    if (reduce) {
+      const id = setTimeout(() => {
+        setBootText(full);
+        setBootDone(true);
+      }, 0);
+      return () => clearTimeout(id);
+    }
+
+    let i = 0;
+    const id = setInterval(() => {
+      i += 1;
+      setBootText(full.slice(0, i));
+      if (i >= full.length) {
+        clearInterval(id);
+        setBootDone(true);
+      }
+    }, 18);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => () => clearTimers(), [clearTimers]);
+
+  const endRound = useCallback(
+    (next: "again" | "over") => {
+      clearTimers();
+      liveCellRef.current = null;
+      decoyCellRef.current = null;
+      setLiveCell(null);
+      setDecoyCell(null);
+
+      if (next === "over") {
+        // Commit the high score here (event-driven), not in an effect.
+        const finalScore = scoreRef.current;
+        const stored = readHiScore();
+        if (finalScore > stored) {
+          try {
+            window.localStorage.setItem(HISCORE_KEY, String(finalScore));
+          } catch {
+            /* storage may be unavailable — score just won't persist */
+          }
+        }
+        setHiScore(Math.max(stored, finalScore));
+        statusRef.current = "over";
+        setStatus("over");
+        return;
+      }
+      timeoutRef.current = setTimeout(() => {
+        roundRef.current += 1;
+        spawnRoundRef.current();
+      }, 260);
+    },
+    [clearTimers]
+  );
+
+  const handleHit = useCallback(
+    (cell: number) => {
+      clearTimers();
+      const gained = 10 * comboRef.current;
+      comboRef.current += 1;
+      scoreRef.current += gained;
+      setCombo(comboRef.current);
+      setScore((s) => s + gained);
+      setFeedback({ cell, type: "hit" });
+      endRound("again");
+    },
+    [clearTimers, endRound]
+  );
+
+  const handleMiss = useCallback(
+    (reason: "timeout" | "decoy") => {
+      clearTimers();
+      comboRef.current = 1;
+      setCombo(1);
+      const cell =
+        reason === "decoy" ? decoyCellRef.current : liveCellRef.current;
+      if (cell !== null) setFeedback({ cell, type: "miss" });
+
+      livesRef.current -= 1;
+      setLives(livesRef.current);
+      endRound(livesRef.current <= 0 ? "over" : "again");
+    },
+    [clearTimers, endRound]
+  );
+
+  const spawnRound = useCallback(() => {
+    if (statusRef.current !== "playing") return;
+    setFeedback(null);
+
+    const target = Math.floor(Math.random() * GRID);
+    // A decoy appears more often as rounds climb (cap ~55%).
+    const decoyChance = Math.min(0.55, 0.12 + roundRef.current * 0.03);
+    let decoy: number | null = null;
+    if (Math.random() < decoyChance) {
+      do {
+        decoy = Math.floor(Math.random() * GRID);
+      } while (decoy === target);
+    }
+
+    const window_ = Math.max(
+      MIN_WINDOW,
+      START_WINDOW - roundRef.current * WINDOW_DECAY
+    );
+    windowRef.current = window_;
+    deadlineRef.current = performance.now() + window_;
+
+    liveCellRef.current = target;
+    decoyCellRef.current = decoy;
+    setLiveCell(target);
+    setDecoyCell(decoy);
+    setLiveColor(COLORS[Math.floor(Math.random() * COLORS.length)]);
+    setTimerPct(100);
+
+    const tick = () => {
+      if (statusRef.current !== "playing") return;
+      const remaining = deadlineRef.current - performance.now();
+      const pct = Math.max(0, (remaining / windowRef.current) * 100);
+      setTimerPct(pct);
+      if (remaining <= 0) {
+        handleMiss("timeout");
+        return;
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+  }, [handleMiss]);
+
+  // Keep the ref pointed at the freshest spawnRound for endRound's scheduler.
+  useEffect(() => {
+    spawnRoundRef.current = spawnRound;
+  }, [spawnRound]);
+
+  const handleCellClick = useCallback(
+    (i: number) => {
+      if (statusRef.current !== "playing") return;
+      if (i === liveCellRef.current) {
+        handleHit(i);
+      } else if (i === decoyCellRef.current) {
+        handleMiss("decoy");
+      } else {
+        // Misfire on an empty cell only breaks the combo — no life lost.
+        comboRef.current = 1;
+        setCombo(1);
+      }
+    },
+    [handleHit, handleMiss]
+  );
+
+  const startGame = useCallback(() => {
+    clearTimers();
+    roundRef.current = 0;
+    scoreRef.current = 0;
+    comboRef.current = 1;
+    livesRef.current = START_LIVES;
+    setScore(0);
+    setCombo(1);
+    setLives(START_LIVES);
+    setFeedback(null);
+    statusRef.current = "playing";
+    setStatus("playing");
+    timeoutRef.current = setTimeout(spawnRound, 400);
+  }, [clearTimers, spawnRound]);
+
+  // Keyboard support: number keys 1-9 map left-to-right, top-to-bottom.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (statusRef.current !== "playing") return;
+      const n = Number.parseInt(e.key, 10);
+      if (n >= 1 && n <= 9) {
+        e.preventDefault();
+        handleCellClick(n - 1);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [handleCellClick]);
+
+  const isOverlay = status !== "playing";
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.shell}>
+        <div className={styles.topbar}>
+          <p className={styles.kicker}>ISAAC VAZQUEZ // SIDE-QUEST #07</p>
+          <p className={styles.coin}>● ● ● INSERT COIN</p>
+        </div>
+
+        <div className={styles.titleWrap}>
+          <h1 className={styles.title}>REACTOR</h1>
+          <p className={styles.tagline}>
+            A neon reflex cabinet bolted onto a buttoned-up portfolio. The rest
+            of this site is paper, ink, and serif restraint — this is{" "}
+            <b>none of that</b>. Light the live cell before it fades. Dodge the
+            dashed decoys. Keep the combo alive.
+          </p>
+        </div>
+
+        <section className={styles.cabinet} aria-label="Reactor game cabinet">
+          <div className={styles.hud}>
+            <div className={styles.stat}>
+              <span className={styles.statLabel}>SCORE</span>
+              <span className={`${styles.statValue} ${styles.score}`}>
+                {String(score).padStart(5, "0")}
+              </span>
+            </div>
+            <div className={styles.stat}>
+              <span className={styles.statLabel}>COMBO</span>
+              <span className={`${styles.statValue} ${styles.combo}`}>
+                x{combo}
+              </span>
+            </div>
+            <div className={styles.stat}>
+              <span className={styles.statLabel}>LIVES</span>
+              <span className={`${styles.statValue} ${styles.lives}`}>
+                {Array.from({ length: START_LIVES }, (_, i) => (
+                  <span key={i} className={i >= lives ? styles.spent : ""}>
+                    ♥
+                  </span>
+                ))}
+              </span>
+            </div>
+          </div>
+
+          <div className={styles.board} role="grid" aria-label="Reactor grid">
+            {Array.from({ length: GRID }, (_, i) => {
+              const live = i === liveCell;
+              const decoy = i === decoyCell;
+              const fb = feedback?.cell === i ? feedback.type : null;
+              const cls = [
+                styles.cell,
+                live ? `${styles.live} ${styles[liveColor]}` : "",
+                decoy ? styles.decoy : "",
+                fb === "hit" ? styles.hit : "",
+                fb === "miss" ? styles.miss : "",
+              ]
+                .filter(Boolean)
+                .join(" ");
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  className={cls}
+                  disabled={status !== "playing"}
+                  onPointerDown={() => handleCellClick(i)}
+                  aria-label={`Cell ${i + 1}${
+                    live ? ", target live" : decoy ? ", decoy" : ""
+                  }`}
+                >
+                  <span className={styles.index} aria-hidden="true">
+                    {i + 1}
+                  </span>
+                  {live ? "◎" : decoy ? "✕" : ""}
+                </button>
+              );
+            })}
+
+            {isOverlay && (
+              <div className={styles.overlay}>
+                {status === "boot" ? (
+                  <>
+                    <pre className={styles.boot}>
+                      {bootText}
+                      {!bootDone && <span className={styles.cursor} />}
+                    </pre>
+                    {bootDone && (
+                      <>
+                        <p className={styles.overlayTitle}>PRESS START</p>
+                        <button
+                          type="button"
+                          className={styles.btn}
+                          onClick={startGame}
+                        >
+                          ▶ START GAME
+                        </button>
+                      </>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <p className={`${styles.overlayTitle} ${styles.over}`}>
+                      GAME OVER
+                    </p>
+                    <p className={styles.overlayText}>
+                      You scored{" "}
+                      <strong style={{ color: "var(--ph-acid)" }}>
+                        {score}
+                      </strong>
+                      .{" "}
+                      {score >= hiScore && score > 0
+                        ? "New high score — the cabinet remembers."
+                        : `High score to beat: ${hiScore}.`}
+                    </p>
+                    <button
+                      type="button"
+                      className={styles.btn}
+                      onClick={startGame}
+                    >
+                      ↻ RETRY
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className={styles.timerTrack} aria-hidden="true">
+            <div
+              className={styles.timerFill}
+              style={{ width: `${status === "playing" ? timerPct : 0}%` }}
+            />
+          </div>
+        </section>
+
+        <div className={styles.legend}>
+          <div className={styles.legendItem}>
+            <span className={styles.legendTerm}>◎ LIVE CELL</span>
+            <p className={styles.legendDesc}>
+              The glowing tile. Hit it before the bar empties to bank points.
+            </p>
+          </div>
+          <div className={styles.legendItem}>
+            <span className={styles.legendTerm}>✕ DECOY</span>
+            <p className={styles.legendDesc}>
+              Dashed magenta trap. Tap one and you lose a life.
+            </p>
+          </div>
+          <div className={styles.legendItem}>
+            <span className={styles.legendTerm}>x COMBO</span>
+            <p className={styles.legendDesc}>
+              Each clean hit multiplies the next. A miss resets it to one.
+            </p>
+          </div>
+          <div className={styles.legendItem}>
+            <span className={styles.legendTerm}>⌨ KEYS 1–9</span>
+            <p className={styles.legendDesc}>
+              Play by mouse, touch, or the number keys laid out like the grid.
+            </p>
+          </div>
+        </div>
+
+        <p className={styles.backNote}>
+          Built as a one-off style experiment. Head back to the{" "}
+          <Link href="/">portfolio</Link> for the regularly scheduled paper and
+          ink, or browse the <Link href="/portfolio">project archive</Link>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/arcade/arcade.module.css
+++ b/src/app/arcade/arcade.module.css
@@ -1,0 +1,511 @@
+/*
+ * arcade.module.css
+ *
+ * A deliberately self-contained, synthwave CRT-arcade aesthetic — the polar
+ * opposite of the site's refined light "editorial" system. Every token below
+ * is locally scoped (no `--home-*` editorial tokens, no global hex leakage):
+ * this surface is intentionally NOT part of the editorial design system, so it
+ * defines and owns its own palette. Keep it that way.
+ *
+ * The look: deep-indigo void, neon magenta/cyan/acid accents, scanlines, a
+ * faint CRT flicker, chunky brutalist borders, and pixel/terminal type. All
+ * motion is gated behind `prefers-reduced-motion`.
+ */
+
+.root {
+  /* Scoped palette — never references editorial tokens on purpose. */
+  --ph-void: #06010f;
+  --ph-void-2: #11052b;
+  --ph-panel: rgba(20, 6, 48, 0.72);
+  --ph-line: rgba(124, 77, 255, 0.22);
+  --ph-cyan: #21e6ff;
+  --ph-magenta: #ff2e97;
+  --ph-acid: #d6ff3f;
+  --ph-amber: #ffb000;
+  --ph-green: #19f7a3;
+  --ph-text: #ece4ff;
+  --ph-text-dim: rgba(236, 228, 255, 0.62);
+  --ph-text-faint: rgba(236, 228, 255, 0.34);
+
+  position: relative;
+  isolation: isolate;
+  min-height: 100vh;
+  width: 100%;
+  overflow: hidden;
+  color: var(--ph-text);
+  font-family: var(--font-arcade-body, ui-monospace, monospace);
+  background:
+    radial-gradient(120% 90% at 50% -10%, var(--ph-void-2) 0%, var(--ph-void) 58%),
+    var(--ph-void);
+  padding: clamp(1.5rem, 4vw, 4rem) clamp(1rem, 4vw, 3rem) clamp(3rem, 6vw, 5rem);
+}
+
+/* Neon perspective grid floor + a few drifting "sun" bands. */
+.root::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  background-image:
+    linear-gradient(var(--ph-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--ph-line) 1px, transparent 1px);
+  background-size: 46px 46px;
+  -webkit-mask-image: linear-gradient(to bottom, transparent 38%, #000 100%);
+  mask-image: linear-gradient(to bottom, transparent 38%, #000 100%);
+  transform: perspective(40rem) rotateX(62deg) translateY(2rem) scale(1.6);
+  transform-origin: center bottom;
+  opacity: 0.85;
+}
+
+/* Scanlines + vignette + faint flicker, layered above the grid, below content. */
+.root::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0) 0px,
+      rgba(0, 0, 0, 0) 2px,
+      rgba(0, 0, 0, 0.28) 3px,
+      rgba(0, 0, 0, 0) 4px
+    ),
+    radial-gradient(140% 110% at 50% 30%, transparent 55%, rgba(2, 0, 8, 0.85) 100%);
+  animation: flicker 5.5s steps(60) infinite;
+}
+
+@keyframes flicker {
+  0%, 96%, 100% { opacity: 1; }
+  97% { opacity: 0.82; }
+  98% { opacity: 0.94; }
+  99% { opacity: 0.8; }
+}
+
+.shell {
+  position: relative;
+  z-index: 1;
+  max-width: 56rem;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 4vw, 2.75rem);
+}
+
+/* ---- Header / marquee ---- */
+
+.topbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem 1.5rem;
+  border-bottom: 2px solid var(--ph-line);
+  padding-bottom: 0.85rem;
+}
+
+.kicker {
+  font-family: var(--font-arcade-display, monospace);
+  font-size: clamp(0.5rem, 1.4vw, 0.7rem);
+  letter-spacing: 0.18em;
+  color: var(--ph-cyan);
+  text-shadow: 0 0 8px rgba(33, 230, 255, 0.65);
+  margin: 0;
+}
+
+.coin {
+  font-family: var(--font-arcade-display, monospace);
+  font-size: clamp(0.5rem, 1.4vw, 0.7rem);
+  letter-spacing: 0.16em;
+  color: var(--ph-acid);
+  text-shadow: 0 0 8px rgba(214, 255, 63, 0.55);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-arcade-display, monospace);
+  font-size: clamp(1.6rem, 8vw, 4.25rem);
+  line-height: 0.92;
+  margin: 0;
+  letter-spacing: 0.02em;
+  color: var(--ph-text);
+  text-shadow:
+    3px 0 var(--ph-magenta),
+    -3px 0 var(--ph-cyan),
+    0 0 18px rgba(255, 46, 151, 0.45);
+  animation: chromashift 4.5s ease-in-out infinite;
+}
+
+@keyframes chromashift {
+  0%, 100% { text-shadow: 3px 0 var(--ph-magenta), -3px 0 var(--ph-cyan), 0 0 18px rgba(255, 46, 151, 0.45); }
+  50% { text-shadow: -2px 0 var(--ph-magenta), 2px 0 var(--ph-cyan), 0 0 22px rgba(33, 230, 255, 0.5); }
+}
+
+.titleWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tagline {
+  font-size: clamp(0.85rem, 2.4vw, 1.1rem);
+  line-height: 1.5;
+  color: var(--ph-text-dim);
+  max-width: 38rem;
+  margin: 0;
+}
+
+.tagline b {
+  color: var(--ph-acid);
+  font-weight: 400;
+}
+
+/* ---- Cabinet / scoreboard ---- */
+
+.cabinet {
+  position: relative;
+  border: 2px solid var(--ph-magenta);
+  border-radius: 4px;
+  background: var(--ph-panel);
+  box-shadow:
+    0 0 0 1px rgba(255, 46, 151, 0.35),
+    0 0 32px rgba(255, 46, 151, 0.18),
+    inset 0 0 40px rgba(8, 2, 24, 0.6);
+  padding: clamp(1rem, 3vw, 1.75rem);
+  backdrop-filter: blur(2px);
+}
+
+.hud {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.stat {
+  border: 1px solid var(--ph-line);
+  border-radius: 3px;
+  padding: 0.6rem 0.75rem;
+  background: rgba(6, 1, 15, 0.55);
+  text-align: center;
+}
+
+.statLabel {
+  display: block;
+  font-family: var(--font-arcade-display, monospace);
+  font-size: clamp(0.42rem, 1.5vw, 0.58rem);
+  letter-spacing: 0.14em;
+  color: var(--ph-text-faint);
+  margin-bottom: 0.45rem;
+}
+
+.statValue {
+  display: block;
+  font-family: var(--font-arcade-display, monospace);
+  font-size: clamp(0.95rem, 4vw, 1.6rem);
+  color: var(--ph-cyan);
+  text-shadow: 0 0 10px rgba(33, 230, 255, 0.5);
+  font-variant-numeric: tabular-nums;
+}
+
+.statValue.score { color: var(--ph-acid); text-shadow: 0 0 10px rgba(214, 255, 63, 0.45); }
+.statValue.combo { color: var(--ph-magenta); text-shadow: 0 0 10px rgba(255, 46, 151, 0.5); }
+
+.lives {
+  letter-spacing: 0.1em;
+}
+
+.lives .spent { opacity: 0.22; }
+
+/* ---- The playfield ---- */
+
+.board {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: clamp(0.5rem, 2vw, 0.85rem);
+  aspect-ratio: 1 / 1;
+  width: 100%;
+  max-width: 30rem;
+  margin: 0 auto;
+}
+
+.cell {
+  position: relative;
+  min-height: 44px;
+  min-width: 44px;
+  border: 2px solid var(--ph-line);
+  border-radius: 4px;
+  background:
+    radial-gradient(circle at 50% 40%, rgba(124, 77, 255, 0.08), transparent 70%),
+    rgba(6, 1, 15, 0.6);
+  color: var(--ph-text-faint);
+  font-family: var(--font-arcade-display, monospace);
+  font-size: clamp(0.7rem, 3vw, 1.05rem);
+  cursor: pointer;
+  transition: transform 90ms ease, border-color 120ms ease, background-color 120ms ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.cell:disabled { cursor: default; }
+
+.cell .index {
+  position: absolute;
+  top: 4px;
+  left: 6px;
+  font-size: 0.5rem;
+  color: var(--ph-text-faint);
+}
+
+.cell:hover:not(:disabled) { border-color: rgba(124, 77, 255, 0.5); }
+
+/* A live target. Color is assigned per-spawn via a modifier class. */
+.cell.live {
+  color: var(--ph-void);
+  transform: scale(1.04);
+  animation: pulse 0.9s ease-in-out infinite;
+}
+
+.cell.cyan.live {
+  background: var(--ph-cyan);
+  border-color: var(--ph-cyan);
+  box-shadow: 0 0 24px rgba(33, 230, 255, 0.7), inset 0 0 12px rgba(255, 255, 255, 0.4);
+}
+.cell.magenta.live {
+  background: var(--ph-magenta);
+  border-color: var(--ph-magenta);
+  box-shadow: 0 0 24px rgba(255, 46, 151, 0.7), inset 0 0 12px rgba(255, 255, 255, 0.35);
+}
+.cell.acid.live {
+  background: var(--ph-acid);
+  border-color: var(--ph-acid);
+  box-shadow: 0 0 24px rgba(214, 255, 63, 0.7), inset 0 0 12px rgba(255, 255, 255, 0.4);
+}
+
+/* A decoy — do NOT hit these. */
+.cell.decoy {
+  background: rgba(255, 46, 151, 0.04);
+  border-color: rgba(255, 46, 151, 0.35);
+  border-style: dashed;
+  color: var(--ph-magenta);
+}
+
+.cell.hit {
+  animation: hitflash 280ms ease-out;
+}
+
+.cell.miss {
+  animation: missflash 280ms ease-out;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1.04); }
+  50% { transform: scale(1.12); }
+}
+
+@keyframes hitflash {
+  0% { background: #fff; transform: scale(1.18); }
+  100% { background: rgba(6, 1, 15, 0.6); transform: scale(1); }
+}
+
+@keyframes missflash {
+  0% { background: var(--ph-magenta); transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  75% { transform: translateX(5px); }
+  100% { background: rgba(6, 1, 15, 0.6); transform: translateX(0); }
+}
+
+/* Countdown bar under a live target */
+.timerTrack {
+  height: 6px;
+  border: 1px solid var(--ph-line);
+  border-radius: 3px;
+  overflow: hidden;
+  background: rgba(6, 1, 15, 0.6);
+  margin-top: 1rem;
+}
+
+.timerFill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--ph-acid), var(--ph-magenta));
+  transition: width 80ms linear;
+}
+
+/* ---- Overlay screens (boot / game over) ---- */
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.1rem;
+  text-align: center;
+  padding: 1.5rem;
+  background:
+    repeating-linear-gradient(to bottom, rgba(0,0,0,0) 0 2px, rgba(0,0,0,0.25) 3px, rgba(0,0,0,0) 4px),
+    rgba(6, 1, 15, 0.92);
+  border-radius: 4px;
+}
+
+.overlayTitle {
+  font-family: var(--font-arcade-display, monospace);
+  font-size: clamp(1.1rem, 5vw, 2rem);
+  margin: 0;
+  color: var(--ph-acid);
+  text-shadow: 0 0 14px rgba(214, 255, 63, 0.5);
+}
+
+.overlayTitle.over { color: var(--ph-magenta); text-shadow: 0 0 14px rgba(255, 46, 151, 0.55); }
+
+.overlayText {
+  font-size: clamp(0.8rem, 2.4vw, 1rem);
+  line-height: 1.6;
+  color: var(--ph-text-dim);
+  max-width: 26rem;
+  margin: 0;
+}
+
+.boot {
+  font-family: var(--font-arcade-body, monospace);
+  font-size: clamp(0.7rem, 2vw, 0.9rem);
+  color: var(--ph-green);
+  text-align: left;
+  line-height: 1.7;
+  text-shadow: 0 0 8px rgba(25, 247, 163, 0.4);
+  min-height: 7.5rem;
+}
+
+.cursor {
+  display: inline-block;
+  width: 0.6em;
+  height: 1.05em;
+  margin-left: 2px;
+  background: var(--ph-green);
+  vertical-align: text-bottom;
+  animation: blink 1s steps(2) infinite;
+}
+
+@keyframes blink { 50% { opacity: 0; } }
+
+/* ---- Buttons ---- */
+
+.btn {
+  font-family: var(--font-arcade-display, monospace);
+  font-size: clamp(0.62rem, 2vw, 0.82rem);
+  letter-spacing: 0.1em;
+  color: var(--ph-void);
+  background: var(--ph-acid);
+  border: 2px solid var(--ph-acid);
+  border-radius: 3px;
+  padding: 0.85rem 1.4rem;
+  min-height: 44px;
+  cursor: pointer;
+  box-shadow: 4px 4px 0 rgba(255, 46, 151, 0.9);
+  transition: transform 90ms ease, box-shadow 90ms ease;
+}
+
+.btn:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 6px 6px 0 rgba(255, 46, 151, 0.9);
+}
+
+.btn:active {
+  transform: translate(2px, 2px);
+  box-shadow: 1px 1px 0 rgba(255, 46, 151, 0.9);
+}
+
+.btn.ghost {
+  color: var(--ph-cyan);
+  background: transparent;
+  border-color: var(--ph-cyan);
+  box-shadow: 4px 4px 0 rgba(33, 230, 255, 0.4);
+}
+
+.btnRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  justify-content: center;
+}
+
+/* ---- How-to-play strip ---- */
+
+.legend {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 0.85rem;
+  margin-top: 0.5rem;
+}
+
+.legendItem {
+  border: 1px solid var(--ph-line);
+  border-left: 3px solid var(--ph-cyan);
+  border-radius: 3px;
+  padding: 0.7rem 0.9rem;
+  background: rgba(6, 1, 15, 0.45);
+}
+
+.legendItem:nth-child(2) { border-left-color: var(--ph-magenta); }
+.legendItem:nth-child(3) { border-left-color: var(--ph-acid); }
+.legendItem:nth-child(4) { border-left-color: var(--ph-green); }
+
+.legendTerm {
+  display: block;
+  font-family: var(--font-arcade-display, monospace);
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  color: var(--ph-text);
+  margin-bottom: 0.35rem;
+}
+
+.legendDesc {
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--ph-text-dim);
+  margin: 0;
+}
+
+/* ---- Footer note that bridges back to the editorial site ---- */
+
+.backNote {
+  text-align: center;
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: var(--ph-text-faint);
+}
+
+.backNote a {
+  color: var(--ph-cyan);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.backNote a:hover { color: var(--ph-acid); }
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .root::after { animation: none; }
+  .title { animation: none; text-shadow: 2px 0 var(--ph-magenta), -2px 0 var(--ph-cyan); }
+  .cell.live { animation: none; }
+  .cell.hit, .cell.miss { animation: none; }
+  .cursor { animation: none; }
+  .btn:hover { transform: none; }
+}

--- a/src/app/arcade/page.tsx
+++ b/src/app/arcade/page.tsx
@@ -1,0 +1,38 @@
+import { Metadata } from "next";
+import { Press_Start_2P, VT323 } from "next/font/google";
+import { constructMetadata } from "@/lib/seo";
+import ArcadeClient from "./ArcadeClient";
+
+// Characterful display/terminal faces, scoped to this route only. They are
+// wired to the local CSS-module variables (--font-arcade-*) and never touch
+// the site-wide font stack.
+const pressStart = Press_Start_2P({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-arcade-display",
+  display: "swap",
+  preload: false,
+});
+
+const vt323 = VT323({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-arcade-body",
+  display: "swap",
+  preload: false,
+});
+
+export const metadata: Metadata = constructMetadata({
+  title: "Reactor — Arcade",
+  description:
+    "Reactor: a neon synthwave reflex arcade game tucked inside Isaac Vazquez's portfolio. A deliberate style experiment — light the live cell, dodge the decoys, keep the combo alive.",
+  canonicalUrl: "https://isaacavazquez.com/arcade",
+});
+
+export default function ArcadePage() {
+  return (
+    <div className={`${pressStart.variable} ${vt323.variable}`}>
+      <ArcadeClient />
+    </div>
+  );
+}

--- a/src/components/ConditionalLayout.tsx
+++ b/src/components/ConditionalLayout.tsx
@@ -50,6 +50,7 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
     "/about",
     "/accessibility",
     "/ai-dev-tools",
+    "/arcade",
     "/bay-area-transit",
     "/changelog",
     "/contact",

--- a/src/lib/sitemap.js
+++ b/src/lib/sitemap.js
@@ -8,6 +8,7 @@ const STATIC_ROUTE_LASTMOD = {
   "/about": "2026-04-13",
   "/accessibility": "2025-02-05",
   "/ai-dev-tools": "2026-04-28",
+  "/arcade": "2026-06-25",
   "/contact": "2026-03-16",
   "/resume": "2026-04-13",
   "/portfolio": "2026-04-04",
@@ -87,6 +88,8 @@ const CHANGEFREQ_BY_ROUTE = {
   "/writing": "weekly",
   "/now": "monthly",
   "/changelog": "weekly",
+  // Standalone style-experiment page
+  "/arcade": "monthly",
   // Fantasy football — weekly FantasyPros + ADP refresh
   "/fantasy-football": "weekly",
   "/fantasy-football/draft-tracker": "weekly",


### PR DESCRIPTION
## What this is

A new standalone project at **`/arcade`** — a playable reflex arcade game called **REACTOR** — built as a deliberate style experiment in an aesthetic that is the polar opposite of the rest of the site.

The site is a refined, light **editorial** system (paper, ink, serif, muted restraint). This route is **none of that**: a dark synthwave void, neon magenta/cyan/acid palette, a perspective neon grid floor, scanlines + faint CRT flicker, a chromatic-aberration glitch title, chunky brutalist borders, and pixel/terminal type. The contrast is visible in the same viewport — the editorial header sits directly above the neon cabinet.

## It's a real game, not just a styled page

- 3×3 grid where a **live cell** lights up and must be hit before a shrinking timer bar empties
- **Decoys** (dashed magenta traps) cost a life if you tap them
- **Combo** multiplier that grows per clean hit and resets on a miss
- 3 lives, **difficulty ramps** each round (the hit window shrinks to a floor)
- Plays by **mouse, touch, or number keys 1–9** laid out like the grid
- **localStorage high score**, CRT boot sequence, and game-over/retry flow

## How it stays a good citizen of the codebase

- All styling lives in a **route-scoped CSS module** that defines its own palette — it does **not** use or pollute the `--home-*` editorial tokens (this surface is intentionally outside the editorial design system).
- Characterful fonts (**Press Start 2P** + **VT323**) are loaded via `next/font` **scoped to this route only**, so they never touch the global font stack.
- All motion (flicker, pulse, glitch, typewriter) is gated behind **`prefers-reduced-motion`**.
- 44px minimum touch targets; `/arcade` registered as a self-shell route so it renders full-bleed under the single page-level `main` landmark.

## Files

- `src/app/arcade/page.tsx` — route, metadata, scoped display/terminal fonts
- `src/app/arcade/ArcadeClient.tsx` — rAF-driven game state machine
- `src/app/arcade/arcade.module.css` — scoped synthwave/CRT theme
- `src/components/ConditionalLayout.tsx` — register `/arcade` as a self-shell route

## Verification

- `tsc --noEmit` clean
- `eslint` clean on the new/changed files (resolved a callback dependency cycle and the `set-state-in-effect` rule)
- `next build --webpack` succeeds; `/arcade` prerenders as a static route
- Headless Chromium smoke test: page loads, boot → start works, scoring/combo/lives update on play, **no console errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtB2jBcJ2zWWAugm6ECLjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtB2jBcJ2zWWAugm6ECLjp)_