### PR TITLE
fix: drop stale /portfolio/pulse-dashboards entry from sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -10,7 +10,6 @@
 <url><loc>https://isaacavazquez.com/fintech-tools/interchange-iq</loc><lastmod>2026-04-02T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/now</loc><lastmod>2026-04-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/portfolio</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-<url><loc>https://isaacavazquez.com/portfolio/pulse-dashboards</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/recipe-finder</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/resume</loc><lastmod>2026-04-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>1</priority></url>
 <url><loc>https://isaacavazquez.com/travel</loc><lastmod>2026-05-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>


### PR DESCRIPTION
## Summary

Removes a stale entry from `public/sitemap.xml`. The `/portfolio/pulse-dashboards` route was removed (see #256, "Pulse Dashboards removal"), but the committed sitemap was never regenerated, so it still listed that URL.

## Why

`src/lib/__tests__/sitemap-consistency.test.ts` asserts that the committed `public/sitemap.xml` matches the canonical route inventory from `getPublicSitemapEntries()`. Because the sitemap had one URL (`/portfolio/pulse-dashboards`) that the inventory no longer produces, the test fails — on **every** PR branched from current `main`, regardless of its own changes:

```
● public sitemap › matches the canonical route inventory
    + Received  + 1
    +   "/portfolio/pulse-dashboards",
```

## Fix

Delete the single stale `<url>` entry. The route inventory and the committed sitemap now agree, so the test passes. No other sitemap entries change.

## Verification

The failing test does a pure string comparison: it regex-extracts `<loc>` paths from the committed sitemap and compares them, sorted, to `getPublicSitemapEntries()`. The CI diff showed exactly one extra entry and nothing missing, so removing that one line makes the two lists identical. (Couldn't run the suite in this fresh container — no `node_modules` — but the change is deterministic given the CI diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mb1U19zoipQiKyXsqyU1kh)_