### PR TITLE
docs: update changelog + auto-log merged PRs

### DIFF
--- a/.github/workflows/changelog-on-merge.yml
+++ b/.github/workflows/changelog-on-merge.yml
@@ -1,0 +1,58 @@
+name: Update Changelog on Merge
+
+# Every merged pull request appends a dated bullet to CHANGELOG.md on main.
+# Snapshot-refresh bots push straight to main (no PR), so they never trigger
+# this. Add the `skip-changelog` label to a PR to opt out. The commit lands on
+# main directly with `[skip ci]`, and pushes made with GITHUB_TOKEN do not
+# start new workflow runs, so there is no trigger loop.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+concurrency:
+  group: changelog-on-merge
+  cancel-in-progress: false
+
+jobs:
+  update-changelog:
+    name: Append merged PR to CHANGELOG
+    if: >-
+      github.event.pull_request.merged == true &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Append changelog entry
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          DATE_UTC="$(date -u +'%Y-%m-%d')"
+          node scripts/append-changelog-entry.mjs "$PR_NUMBER" "$PR_TITLE" "$PR_URL" "$DATE_UTC"
+
+      - name: Commit and push
+        run: |
+          bash scripts/ci/commit-and-push-snapshot.sh \
+            "docs: log PR #${PR_NUMBER} in changelog [automated] [skip ci]" \
+            CHANGELOG.md
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this repository are documented here. Format: `YYYY-MM-DD`
 
 ---
 
+## 2026-07-02
+
+- Brought `CHANGELOG.md` current by backfilling every release from 2026-03-28 through 2026-06-24 that had been recorded only in the public `content/changelog` entries, and added a public changelog entry for the 2026-06-24 dashboard-polish and investments live-pricing work.
+- Added a `Update Changelog on Merge` GitHub Action (`.github/workflows/changelog-on-merge.yml`) that appends a dated bullet to `CHANGELOG.md` for every merged pull request, backed by `scripts/append-changelog-entry.mjs` (idempotent, groups bullets under a UTC date header) and the shared `scripts/ci/commit-and-push-snapshot.sh` push path. Snapshot bots push straight to main so they are never logged, and a `skip-changelog` PR label opts out.
+
+---
+
 ## 2026-06-24
 
 - Redesigned the `/ai-dev-tools` directory from a horizontally-scrolling table into a responsive row-card list (single column on mobile, three-up facts grid on wider screens) with a sort control (curated, GitHub stars, recently shipped, name), relative GitHub-stars bars, release-freshness dots, and lifecycle status badges, and fixed the placeholder GitHub quick-link to an open-source filter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,89 @@ All notable changes to this repository are documented here. Format: `YYYY-MM-DD`
 
 ---
 
+## 2026-06-24
+
+- Redesigned the `/ai-dev-tools` directory from a horizontally-scrolling table into a responsive row-card list (single column on mobile, three-up facts grid on wider screens) with a sort control (curated, GitHub stars, recently shipped, name), relative GitHub-stars bars, release-freshness dots, and lifecycle status badges, and fixed the placeholder GitHub quick-link to an open-source filter.
+- Surfaced a `Trending topics` leaderboard on the `/news-pulse` coverage view (keywords ranked across two or more outlets with a relative count bar and per-outlet coverage dots), replacing the hardcoded `Average reading time` placeholder stat with a real trending-topics count from the already-implemented topic extraction.
+- Restored investments live pricing and the `/api/investments/index` route in production by adding a canonical production-origin fallback (mirroring `seo.ts`) so the deployed Netlify function can reach its own committed public assets when `URL`/`SITE_URL`/`NEXT_PUBLIC_SITE_URL` are unset at runtime, and threaded the request origin through the Finnhub symbol-allowlist lookups used by the quotes, data, and stocks routes.
+- Made the investments allocation donut responsive and centered by switching the D3 SVG from fixed dimensions to a `viewBox` with a responsive box.
+- Synced the source-of-truth documentation set with the current codebase (fantasy-football surface overhaul, cross-surface browser stores, the shared snapshot commit-and-push helper, and a batch of stale-fact corrections).
+
+---
+
+## 2026-06-10
+
+- Filled out the investments research column with real position data only: a holdings card (shares, average cost, market value, total return, day P/L, allocation bar) drawn from the local portfolio, a price chart with a cost-basis reference line, a 50-day moving average, up/down volume coloring, and per-overlay toggle pills, plus restyled news cards with monogram thumbnails and mono timestamps.
+- Swapped the Formula 1 dashboard circuit-map images for a cleaner marker tile, trued the header, footer, projects, and writing pages against the V3 design system, and bumped the primary nav size to balance the header.
+- Published a dozen new writing pieces (a two-part horology history, a researched take on the AI mega-cap rally, a series on building with AI agents, and an early 2026 fantasy football look) and rewrote legacy post SEO descriptions in-voice.
+
+---
+
+## 2026-06-09
+
+- Launched three snapshot-driven dashboards: `/earthquake-pulse` (global USGS seismic activity, hourly refresh), `/bay-area-transit` (BART departures, service advisories, and elevator outages, every six hours), and `/tech-startup-tracker` (an editorially curated, unverified dataset with an on-page as-of disclosure).
+- Upgraded the `/travel` planner with itinerary stop time windows and overlap detection, day category color-coding, an itinerary progress bar, journal mood icons, and a fix for a localStorage bug that could corrupt or delete stored trips.
+- Ran a consolidation pass: moved off-system colors and micro-typography onto the editorial design tokens, unified card radius/shadows, fixed broken color-mix utilities, added dashboard loading states, lazy-loaded the MBA tracker dialogs and team crests, added screen-reader column associations across eight sports dashboards, removed nested landmarks on `/writing` and `/travel`, fixed keyboard access on the transit and startup dashboards, corrected the retirement planner success metric to count guaranteed income, fixed World Cup fixture date classification and the bare `/investments` URL-sync loop, and added unit coverage across several surfaces.
+
+---
+
+## 2026-06-08
+
+- Launched `/world-cup-2026` (World Cup Pulse), a snapshot-driven dashboard that works as a pre-kickoff tournament hub (format, venues, dates) and fills in groups, knockout bracket, schedule, and scorers from ESPN data refreshed every six hours, plus a ten-part contenders countdown series on `/writing`.
+- Added a retirement planner to the investments dashboard (`/investments#retirement`): allocation-derived return and volatility from dated capital-market assumptions, a seeded 1,000-trial Monte Carlo rendered as confidence bands with "N of 100 scenarios" framing, a two-phase accumulation/decumulation projection with coarse account-aware taxes, RMDs, Social Security claim mechanics, and withdrawal strategies, and a sensitivity panel computed off the critical path. Educational output only, with disclosed and editable assumptions.
+- Launched a fantasy Formula 1 lineup optimizer (`/fantasy-formula-1`) with versioned browser-local saved teams, added a tier-grouped position-column board view to `/fantasy-football/draft-tracker`, and gave the rankings page a list density toggle, sticky board header, and compact rows.
+- Rebuilt the `/food-map` on Leaflet as a multi-city, curator-driven surface, launching Miami, Atlanta, Copenhagen, and San Sebastián alongside Austin.
+
+---
+
+## 2026-05-31
+
+- Refreshed the about and portfolio surfaces, added a shared `HomeStatsPanel` feeding the homepage and writing archive, tightened player ID validation and snapshot handling across the sports modules, moved NBA player stats to a newer ESPN endpoint, and aligned UI copy with the writing voice.
+
+---
+
+## 2026-05-04
+
+- Launched the `/travel` planner (trips, day-by-day itineraries, per-trip journal) with all state persisted in localStorage and no backend or account.
+
+---
+
+## 2026-04-29
+
+- Shipped a nine-launch wave: `/nba`, `/mlb`, and `/nfl` dashboards (standings, fixtures, stat leaders from ESPN, the MLB Stats API, and NFLverse), `/github-trending-pulse`, `/frontier-models`, and personal tools `/food-map`, `/wine-cellar`, `/museum-log`, and `/recipe-finder`, each reading from a committed snapshot or curated dataset with no runtime API calls.
+
+---
+
+## 2026-04-26
+
+- Rolled out the V3 editorial design system across the homepage hero, the `/writing` archive layout, and a rebuilt three-column `/investments` dashboard that merges portfolio and research with a hero balance card, a dense key-metrics grid, and a numbers-first asset header.
+
+---
+
+## 2026-04-20
+
+- Refreshed the MBA internship tracker styling to match the editorial system, added compact company filters, expanded role sourcing across more career types, tightened job filtering, and gave the tracker a dedicated homepage feature slot.
+
+---
+
+## 2026-04-10
+
+- Launched the MBA internship notifications dashboard (`/mba-internship-notifications`) with role aggregation and per-company filters, email notifications via Resend, and a lightweight admin layer for curating the source list.
+
+---
+
+## 2026-04-05
+
+- Reorganized the older root-level SEO docs into an archive with `SEO.md` as the single source of truth, updated homepage content, refreshed test mocks to match new component boundaries, and tuned the homepage section width.
+
+---
+
+## 2026-03-28
+
+- Fixed SpaceX mission control (`/spacex-mission-control`) image caching that re-fetched mission art more than needed and a hydration mismatch that flickered the summary panel on first load.
+
+---
+
 ## 2026-03-21
 
 - Fixed a real fantasy football snapshot integrity bug where `overall` boards could drift from the matching positional boards because overall rankings were still sourced from stale checked-in overall files while positional boards were generated from current FantasyPros consensus data.

--- a/content/changelog/2026-06-24-dashboard-polish-and-investments-pricing.mdx
+++ b/content/changelog/2026-06-24-dashboard-polish-and-investments-pricing.mdx
@@ -1,0 +1,17 @@
+---
+title: Dashboard polish and investments live pricing back online
+publishedAt: "2026-06-24"
+category: Update
+summary: The AI dev tools directory and the news pulse coverage view both got real UI passes, and live pricing on the investments dashboard is working in production again.
+tags:
+  - dashboards
+  - investments
+---
+
+A cleanup pass across a few surfaces that had rough edges:
+
+- **[AI dev tools](/ai-dev-tools) directory** — the horizontally-scrolling table is gone, replaced by a row-card list that reads as a single column on mobile and a three-up facts grid on wider screens. There's a sort control now (curated, GitHub stars, recently shipped, or name), and the data actually renders visually, with relative stars bars, release-freshness dots, and lifecycle status badges instead of a wall of cells.
+- **[News pulse](/news-pulse) trending topics** — the coverage view now shows a trending-topics leaderboard, ranking keywords that show up across two or more outlets with a count bar and per-outlet dots. The topic extraction was already there in the code, it just wasn't being rendered.
+- **Investments live pricing** — live prices and the index route were quietly dead in production because the deployed function couldn't find its own public assets when the usual origin environment variables weren't set at runtime. I added a canonical-origin fallback so it can always reach its committed data, and the allocation donut now scales and centers properly instead of sitting off to the side.
+
+The kind of pass that doesn't add features so much as make the existing ones behave.

--- a/scripts/append-changelog-entry.mjs
+++ b/scripts/append-changelog-entry.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Append a merged pull request to CHANGELOG.md, grouped under a UTC date header.
+ *
+ * Usage:
+ *   node scripts/append-changelog-entry.mjs <pr-number> <pr-title> <pr-url> <yyyy-mm-dd>
+ *
+ * Called by the "Update Changelog on Merge" workflow. Kept pure and dependency
+ * free so it can run in a bare Node step. The insertion is idempotent: if the
+ * PR is already referenced in the changelog, nothing changes.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const CHANGELOG_PATH = path.join(process.cwd(), "CHANGELOG.md");
+
+/**
+ * Turn a PR title into a changelog sentence. Strips a leading
+ * conventional-commit prefix (`fix:`, `feat(scope):`, `docs!:`), capitalizes,
+ * and drops trailing punctuation so we can append the link and a period.
+ */
+export function cleanTitle(rawTitle) {
+  let title = String(rawTitle ?? "").trim();
+  title = title.replace(/^[a-z]+(\([^)]*\))?!?:\s*/i, "");
+  title = title.replace(/[.\s]+$/, "").trim();
+  if (!title) return "Merged a pull request";
+  return title.charAt(0).toUpperCase() + title.slice(1);
+}
+
+/**
+ * Return the changelog text with a new bullet inserted for the given PR.
+ * If a section for `date` already leads the log, the bullet is appended to it;
+ * otherwise a fresh dated section is inserted at the top.
+ */
+export function buildUpdatedChangelog(content, { prNumber, title, url, date }) {
+  const linkRef = `[#${prNumber}](${url})`;
+  if (content.includes(linkRef)) {
+    return { content, changed: false };
+  }
+
+  const bullet = `- ${cleanTitle(title)} (${linkRef}).`;
+  const lines = content.split("\n");
+  const todayHeader = `## ${date}`;
+
+  const firstHeaderIdx = lines.findIndex((line) => /^## /.test(line));
+
+  if (firstHeaderIdx !== -1 && lines[firstHeaderIdx].trim() === todayHeader) {
+    // Append to today's existing section, before its closing `---` separator.
+    let sepIdx = lines.findIndex(
+      (line, i) => i > firstHeaderIdx && line.trim() === "---"
+    );
+    if (sepIdx === -1) sepIdx = lines.length;
+
+    let insertAt = sepIdx - 1;
+    while (insertAt > firstHeaderIdx && lines[insertAt].trim() === "") {
+      insertAt--;
+    }
+    lines.splice(insertAt + 1, 0, bullet);
+  } else {
+    // Start a new dated section ahead of the most recent one.
+    const anchor = firstHeaderIdx !== -1 ? firstHeaderIdx : lines.length;
+    lines.splice(anchor, 0, todayHeader, "", bullet, "", "---", "");
+  }
+
+  return { content: lines.join("\n"), changed: true };
+}
+
+function main() {
+  const [prNumber, title, url, date] = process.argv.slice(2);
+
+  if (!prNumber || !title || !url || !date) {
+    console.error(
+      "Usage: node scripts/append-changelog-entry.mjs <pr-number> <pr-title> <pr-url> <yyyy-mm-dd>"
+    );
+    process.exit(2);
+  }
+
+  const original = readFileSync(CHANGELOG_PATH, "utf8");
+  const { content, changed } = buildUpdatedChangelog(original, {
+    prNumber,
+    title,
+    url,
+    date,
+  });
+
+  if (!changed) {
+    console.log(`CHANGELOG.md already references PR #${prNumber}; nothing to do.`);
+    return;
+  }
+
+  writeFileSync(CHANGELOG_PATH, content);
+  console.log(`Added CHANGELOG.md entry for PR #${prNumber}.`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}


### PR DESCRIPTION
## Summary

The repo `CHANGELOG.md` had stalled at 2026-03-21 while the site's public changelog (`content/changelog/*.mdx`) kept moving through 2026-06-10, and neither surface recorded the 2026-06-24 work. This brings both current and adds automation so the changelog stays current on every merge going forward.

### Changelog brought up to date

- **`CHANGELOG.md`** — backfilled every date from 2026-03-28 through 2026-06-24 that was missing, mirroring the work already documented in the public changelog entries (SpaceX stability, SEO/homepage refresh, MBA tracker launch + refresh, V3 editorial redesign, the nine-launch dashboard wave, travel planner, about/portfolio refresh, and the June 8–10 fantasy/world-cup/retirement/food-map/pulse/investments wave), plus the 2026-06-24 batch (PRs #255–258). Entries match the file's existing terse `YYYY-MM-DD` bullet style.
- **`content/changelog/2026-06-24-dashboard-polish-and-investments-pricing.mdx`** — a new public entry covering the `/ai-dev-tools` directory redesign, the `/news-pulse` trending-topics leaderboard, and the restored investments live pricing plus allocation-donut fix. Frontmatter follows the `changelog.ts` schema and the writing voice.

### Auto-log merged PRs

- **`.github/workflows/changelog-on-merge.yml`** — a `Update Changelog on Merge` workflow that fires on `pull_request` `closed` + `merged == true` and appends a dated bullet to `CHANGELOG.md` on `main`. It reuses the shared `scripts/ci/commit-and-push-snapshot.sh` push path, commits with `[skip ci]` (and `GITHUB_TOKEN` pushes don't re-trigger CI, so there's no loop), and honors a `skip-changelog` label to opt a PR out. Snapshot-refresh bots push straight to main without a PR, so they're never logged.
- **`scripts/append-changelog-entry.mjs`** — the idempotent insert behind it: groups bullets under a UTC `## YYYY-MM-DD` header (appending to today's section if it already leads the log, otherwise starting a new one) and strips conventional-commit prefixes from the PR title.

## Testing

- `scripts/append-changelog-entry.mjs` was exercised against a copy of the real `CHANGELOG.md` for all three paths: new dated section, same-day append, and idempotent re-run (no duplicate). Separator structure verified.
- Workflow YAML validated; confirmed it introduces no inline `git push origin HEAD:main` and no banned action pins, so `snapshot-workflows.test.ts` stays green.
- The `src/lib/__tests__/changelog.test.ts` suite fully mocks `fs`, so the new public entry doesn't affect it.

Note: PR #273's own merge won't be auto-logged, since the workflow only exists on `main` after this merges — that's why the 2026-07-02 entry is included by hand. Every subsequent merged PR is logged automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VExuG6YQKcV1CFUjP4UvK