### PR TITLE
ci: auto-append merged PRs to the changelog

### DIFF
--- a/.github/workflows/changelog-on-merge.yml
+++ b/.github/workflows/changelog-on-merge.yml
@@ -1,0 +1,58 @@
+name: Update Changelog on Merge
+
+# Every merged pull request appends a dated bullet to CHANGELOG.md on main.
+# Snapshot-refresh bots push straight to main (no PR), so they never trigger
+# this. Add the `skip-changelog` label to a PR to opt out. The commit lands on
+# main directly with `[skip ci]`, and pushes made with GITHUB_TOKEN do not
+# start new workflow runs, so there is no trigger loop.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+concurrency:
+  group: changelog-on-merge
+  cancel-in-progress: false
+
+jobs:
+  update-changelog:
+    name: Append merged PR to CHANGELOG
+    if: >-
+      github.event.pull_request.merged == true &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Append changelog entry
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          DATE_UTC="$(date -u +'%Y-%m-%d')"
+          node scripts/append-changelog-entry.mjs "$PR_NUMBER" "$PR_TITLE" "$PR_URL" "$DATE_UTC"
+
+      - name: Commit and push
+        run: |
+          bash scripts/ci/commit-and-push-snapshot.sh \
+            "docs: log PR #${PR_NUMBER} in changelog [automated] [skip ci]" \
+            CHANGELOG.md
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/__tests__/append-changelog-entry.test.ts
+++ b/scripts/__tests__/append-changelog-entry.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ */
+import { cleanTitle, buildUpdatedChangelog } from "../append-changelog-entry.mjs";
+
+const HEADER = "# Changelog\n\nAll notable changes to this repository are documented here.\n\n---\n";
+
+describe("cleanTitle", () => {
+  it("strips a conventional-commit prefix and capitalizes", () => {
+    expect(cleanTitle("feat: add earthquake dashboard")).toBe(
+      "Add earthquake dashboard"
+    );
+  });
+
+  it("strips a scoped, breaking prefix", () => {
+    expect(cleanTitle("fix(api)!: guard the allowlist origin")).toBe(
+      "Guard the allowlist origin"
+    );
+  });
+
+  it("leaves a title with no prefix intact (but capitalizes)", () => {
+    expect(cleanTitle("update the resume")).toBe("Update the resume");
+  });
+
+  it("drops trailing punctuation and whitespace", () => {
+    expect(cleanTitle("docs: tidy the readme.  ")).toBe("Tidy the readme");
+  });
+
+  it("falls back for empty or nullish input", () => {
+    expect(cleanTitle("")).toBe("Merged a pull request");
+    expect(cleanTitle(undefined)).toBe("Merged a pull request");
+    expect(cleanTitle("chore:")).toBe("Merged a pull request");
+  });
+});
+
+describe("buildUpdatedChangelog", () => {
+  const pr = {
+    prNumber: "275",
+    title: "chore: align site prose with writing voice",
+    url: "https://github.com/IsaacAVazquez/Website/pull/275",
+    date: "2026-07-05",
+  };
+
+  it("is idempotent when the PR link is already present", () => {
+    const existing = `${HEADER}\n## 2026-07-05\n\n- Earlier work ([#275](${pr.url})).\n\n---\n`;
+    const { content, changed } = buildUpdatedChangelog(existing, pr);
+    expect(changed).toBe(false);
+    expect(content).toBe(existing);
+  });
+
+  it("starts a new dated section when today's is not the lead", () => {
+    const existing = `${HEADER}\n## 2026-07-02\n\n- Older entry.\n\n---\n`;
+    const { content, changed } = buildUpdatedChangelog(existing, pr);
+    expect(changed).toBe(true);
+    // new section for today is inserted ahead of the 2026-07-02 section
+    expect(content.indexOf("## 2026-07-05")).toBeLessThan(
+      content.indexOf("## 2026-07-02")
+    );
+    expect(content).toContain(
+      `- Align site prose with writing voice ([#275](${pr.url})).`
+    );
+  });
+
+  it("appends to today's section when it already leads the log", () => {
+    const existing = `${HEADER}\n## 2026-07-05\n\n- First merge of the day ([#274](https://example.com/274)).\n\n---\n`;
+    const { content, changed } = buildUpdatedChangelog(existing, pr);
+    expect(changed).toBe(true);
+    // only one 2026-07-05 header (appended, not duplicated)
+    expect(content.match(/## 2026-07-05/g)).toHaveLength(1);
+    // the new bullet lands inside that section, before its closing separator
+    const section = content.slice(content.indexOf("## 2026-07-05"));
+    const newBullet = `- Align site prose with writing voice ([#275](${pr.url})).`;
+    expect(section).toContain(newBullet);
+    expect(section.indexOf(newBullet)).toBeLessThan(section.indexOf("---"));
+    expect(section.indexOf("#274")).toBeLessThan(section.indexOf("#275"));
+  });
+});

--- a/scripts/append-changelog-entry.mjs
+++ b/scripts/append-changelog-entry.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Append a merged pull request to CHANGELOG.md, grouped under a UTC date header.
+ *
+ * Usage:
+ *   node scripts/append-changelog-entry.mjs <pr-number> <pr-title> <pr-url> <yyyy-mm-dd>
+ *
+ * Called by the "Update Changelog on Merge" workflow. Kept pure and dependency
+ * free so it can run in a bare Node step. The insertion is idempotent: if the
+ * PR is already referenced in the changelog, nothing changes.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const CHANGELOG_PATH = path.join(process.cwd(), "CHANGELOG.md");
+
+/**
+ * Turn a PR title into a changelog sentence. Strips a leading
+ * conventional-commit prefix (`fix:`, `feat(scope):`, `docs!:`), capitalizes,
+ * and drops trailing punctuation so we can append the link and a period.
+ */
+export function cleanTitle(rawTitle) {
+  let title = String(rawTitle ?? "").trim();
+  title = title.replace(/^[a-z]+(\([^)]*\))?!?:\s*/i, "");
+  title = title.replace(/[.\s]+$/, "").trim();
+  if (!title) return "Merged a pull request";
+  return title.charAt(0).toUpperCase() + title.slice(1);
+}
+
+/**
+ * Return the changelog text with a new bullet inserted for the given PR.
+ * If a section for `date` already leads the log, the bullet is appended to it;
+ * otherwise a fresh dated section is inserted at the top.
+ */
+export function buildUpdatedChangelog(content, { prNumber, title, url, date }) {
+  const linkRef = `[#${prNumber}](${url})`;
+  if (content.includes(linkRef)) {
+    return { content, changed: false };
+  }
+
+  const bullet = `- ${cleanTitle(title)} (${linkRef}).`;
+  const lines = content.split("\n");
+  const todayHeader = `## ${date}`;
+
+  const firstHeaderIdx = lines.findIndex((line) => /^## /.test(line));
+
+  if (firstHeaderIdx !== -1 && lines[firstHeaderIdx].trim() === todayHeader) {
+    // Append to today's existing section, before its closing `---` separator.
+    let sepIdx = lines.findIndex(
+      (line, i) => i > firstHeaderIdx && line.trim() === "---"
+    );
+    if (sepIdx === -1) sepIdx = lines.length;
+
+    let insertAt = sepIdx - 1;
+    while (insertAt > firstHeaderIdx && lines[insertAt].trim() === "") {
+      insertAt--;
+    }
+    lines.splice(insertAt + 1, 0, bullet);
+  } else {
+    // Start a new dated section ahead of the most recent one.
+    const anchor = firstHeaderIdx !== -1 ? firstHeaderIdx : lines.length;
+    lines.splice(anchor, 0, todayHeader, "", bullet, "", "---", "");
+  }
+
+  return { content: lines.join("\n"), changed: true };
+}
+
+function main() {
+  const [prNumber, title, url, date] = process.argv.slice(2);
+
+  if (!prNumber || !title || !url || !date) {
+    console.error(
+      "Usage: node scripts/append-changelog-entry.mjs <pr-number> <pr-title> <pr-url> <yyyy-mm-dd>"
+    );
+    process.exit(2);
+  }
+
+  const original = readFileSync(CHANGELOG_PATH, "utf8");
+  const { content, changed } = buildUpdatedChangelog(original, {
+    prNumber,
+    title,
+    url,
+    date,
+  });
+
+  if (!changed) {
+    console.log(`CHANGELOG.md already references PR #${prNumber}; nothing to do.`);
+    return;
+  }
+
+  writeFileSync(CHANGELOG_PATH, content);
+  console.log(`Added CHANGELOG.md entry for PR #${prNumber}.`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}


### PR DESCRIPTION
## What

Adopts changelog-on-merge automation: a GitHub Action that appends a dated bullet to `CHANGELOG.md` for every merged PR, backed by a small idempotent Node script, plus unit tests.

This is the salvaged infrastructure from the stale `claude/update-changelog-release-notes` branch (112 commits behind main). I took **only** the two infra files — main's `CHANGELOG.md` is already current back to 2026-03-28, so that branch's 90-line backfill would have duplicated existing entries.

## Files

- `scripts/append-changelog-entry.mjs` — pure, dependency-free, idempotent insert. Groups bullets under a UTC `## YYYY-MM-DD` header (appends to today's section if it already leads the log, otherwise starts a new one), strips conventional-commit prefixes from the PR title, and no-ops if the PR is already referenced.
- `.github/workflows/changelog-on-merge.yml` — fires on `pull_request` closed+merged to `main`, honors a `skip-changelog` opt-out label, commits with `[skip ci]` via the shared `scripts/ci/commit-and-push-snapshot.sh`. Pushes use `GITHUB_TOKEN` so they don't retrigger CI (no loop). Snapshot bots push straight to main without a PR, so they're never logged. Action versions (`checkout@v7`, `setup-node@v6`) match the repo's other 19 workflows.
- `scripts/__tests__/append-changelog-entry.test.ts` — covers `cleanTitle` (prefix stripping, capitalization, fallbacks) and `buildUpdatedChangelog` (new-section vs same-day append, idempotency). 8 tests, plus a manual end-to-end smoke test of the CLI entrypoint.

## Design note / limitation

This automates the **internal** `CHANGELOG.md` only. It does **not** touch the public `content/changelog/*.mdx` entries rendered at `/changelog`, which still need to be written by hand. The two surfaces can drift; if that matters, a follow-up could target the public changelog instead.

Tradeoff to be aware of: this adds one `[automated] [skip ci]` commit to `main` per merged PR (including dependabot PRs, unless labeled `skip-changelog`).