### PR TITLE
fix: open the SpaceX mission drawer before asserting its detail panel

### DIFF
--- a/e2e/product-surfaces.spec.ts
+++ b/e2e/product-surfaces.spec.ts
@@ -88,12 +88,17 @@ test.describe("Product surfaces", () => {
     );
     await expect(page.getByTestId("mission-hero")).toBeVisible();
     await expect(page.getByTestId("mission-board")).toBeVisible();
-    await expect(page.getByTestId("mission-detail-panel")).toBeVisible();
     await expect(page.getByRole("tab", { name: /^Past$/i })).toHaveAttribute(
       "aria-selected",
       "true"
     );
     await expectNoHorizontalOverflow(page);
+
+    // The mission detail panel is a drawer that opens when a mission is
+    // selected (the page is a launch board, not an always-open detail view),
+    // so select the first mission card and confirm the drawer renders.
+    await page.locator('[data-testid^="mission-card-"]').first().click();
+    await expect(page.getByTestId("mission-detail-panel")).toBeVisible();
   });
 
   test("fintech tools accept calculator and ledger input", async ({ page }) => {


### PR DESCRIPTION
## Problem

The E2E test `e2e/product-surfaces.spec.ts:73` ("polling and SpaceX tools load deep-linked operational views") has been failing on `main`'s `test.yml` for many commits (E2E chromium shard 3), independent of any recent feature work. It asserts `getByTestId("mission-detail-panel")` is visible right after loading `/spacex-mission-control?status=past`, but that panel never appears in that state.

## Root cause

Mission control was rebuilt as a launch board (`feat: mission control rebuilt as the launch board`). The detail panel is now a drawer that opens only when a mission is selected: `MissionDrawer` sets `const isOpen = Boolean(launchId)` and renders `data-testid="mission-detail-panel"` only while open. On a bare `?status=past` deep link there is no `launch` param, so no mission is selected, the drawer stays closed, and the panel is correctly absent. The client-side unit tests were updated to this behavior and even assert the panel is null when no launch is selected ("No launch is selected in this test, so the overlay drawer isn't mounted"). This E2E test was not updated, so it asserts a surface that the redesign made drawer-only.

The page is behaving correctly. The test was stale.

## Fix

After confirming the hero, board, and Past tab, the test now selects the first mission card (`data-testid^="mission-card-"`) to open the drawer, then asserts the detail panel is visible. This matches the real interaction and avoids hardcoding a launch id, so it stays robust to snapshot data refreshes.

## Verification

I couldn't run Playwright locally (`@playwright/test` isn't installed in this environment), so CI on this PR runs the real E2E. The change is a one-liner interaction plus the assertion; the click calls `onSelect` → sets `routeState.launch` → `MissionDrawer` opens → the panel renders, and Playwright auto-waits for both the card and the panel.
