### PR TITLE
perf: cache fantasy snapshot reads and harden refresh workflows

### DIFF
--- a/.github/workflows/update-bay-area-transit.yml
+++ b/.github/workflows/update-bay-area-transit.yml
@@ -6,7 +6,9 @@ on:
   # without committing noisy minute-to-minute churn. BART's public API needs no
   # token.
   schedule:
-    - cron: "20 */6 * * *"
+    # Staggered off :20 so it doesn't race the hourly earthquake and 6h world-cup
+    # refreshes (which also push to main) over the same minute.
+    - cron: "35 */6 * * *"
   workflow_dispatch:
 
 # Don't stack a manual dispatch on top of a scheduled run.

--- a/.github/workflows/update-golf.yml
+++ b/.github/workflows/update-golf.yml
@@ -142,6 +142,14 @@ jobs:
 
       - name: Create job summary
         if: always()
+        # Pass step outputs through the environment rather than interpolating
+        # ${{ }} straight into the script. The tournament name comes from ESPN
+        # (untrusted), so direct interpolation under `contents: write` would be a
+        # shell-injection surface; as an env var the shell treats it as data.
+        env:
+          TOURNAMENT: ${{ steps.verify_quality.outputs.tournament }}
+          LEADERBOARD: ${{ steps.verify_quality.outputs.leaderboard }}
+          PLAYERS: ${{ steps.verify_quality.outputs.players }}
         run: |
           echo "## Golf Snapshot Refresh" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -149,10 +157,10 @@ jobs:
           echo "**Run Date:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_STEP_SUMMARY"
           echo "**Schedule:** Daily at 08:40 UTC" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ -n "${{ steps.verify_quality.outputs.leaderboard }}" ]; then
-            echo "**Tournament:** ${{ steps.verify_quality.outputs.tournament }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Leaderboard entries:** ${{ steps.verify_quality.outputs.leaderboard }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Player options:** ${{ steps.verify_quality.outputs.players }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$LEADERBOARD" ]; then
+            echo "**Tournament:** $TOURNAMENT" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Leaderboard entries:** $LEADERBOARD" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Player options:** $PLAYERS" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
           fi
           if [ "${{ steps.check_changes.outputs.changed }}" = "true" ]; then

--- a/.github/workflows/update-world-cup.yml
+++ b/.github/workflows/update-world-cup.yml
@@ -6,7 +6,9 @@ on:
   # current. ESPN's site API needs no token. Outside those months there is
   # nothing to refresh, so the schedule stays dormant.
   schedule:
-    - cron: "20 */6 * 6,7 *"
+    # Staggered off :20 so it doesn't race the hourly earthquake and 6h transit
+    # refreshes (which also push to main) over the same minute.
+    - cron: "50 */6 * 6,7 *"
   workflow_dispatch:
 
 # Don't stack a manual dispatch on top of a scheduled run.

--- a/src/app/api/stocks/__tests__/route.test.ts
+++ b/src/app/api/stocks/__tests__/route.test.ts
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "../route";
+
+describe("/api/stocks (retired)", () => {
+  it("returns 410 Gone with deprecation headers pointing to the successor route", () => {
+    const response = GET();
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("Deprecation")).toBe("true");
+    expect(response.headers.get("Sunset")).toBeTruthy();
+    expect(response.headers.get("Link")).toContain("/api/investments/quotes");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+});

--- a/src/app/api/stocks/route.ts
+++ b/src/app/api/stocks/route.ts
@@ -1,116 +1,31 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getAllowedSymbols, fetchFinnhubQuote } from "@/lib/finnhub";
-import { apiRateLimiter, rateLimitResponse } from "@/lib/rateLimit";
-import { logger } from "@/lib/logger";
+import { NextResponse } from "next/server";
 
 /**
- * Stock API Route
- * Fetches live stock data via Finnhub.
+ * Deprecated and retired: /api/stocks.
  *
- * Hardening:
- *  - Per-IP rate limit (30 req/min) backed by the in-process apiRateLimiter
- *  - Allowlist of curated symbols (public/data/investments/index.json)
- *  - Caps to 25 symbols per request
- *  - Caches successful responses 30s + 60s SWR; errors get no-store
- *
- * Query Parameters:
- * - symbols: comma-separated list of stock symbols (e.g., "AAPL,GOOGL,MSFT")
+ * This was an orphaned near-duplicate of /api/investments/quotes (same Finnhub
+ * allowlist and quote shape) with no first-party consumer, yet it still spent
+ * Finnhub quota. It now returns 410 Gone with Deprecation/Sunset headers so any
+ * lingering caller fails loudly and can migrate to /api/investments/quotes.
  */
 
-const MAX_SYMBOLS_PER_REQUEST = 25;
-const SUCCESS_CACHE_HEADERS = {
-  "Cache-Control": "public, max-age=30, stale-while-revalidate=60",
-};
-const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
+// 2026-07-06 (a Monday) — the date this route was retired.
+const SUNSET_DATE = "Mon, 06 Jul 2026 00:00:00 GMT";
 
-function getClientIp(request: NextRequest): string {
-  const forwarded = request.headers.get("x-forwarded-for");
-  const realIp = request.headers.get("x-real-ip");
-  return forwarded?.split(",")[0]?.trim() || realIp || "unknown";
-}
-
-export async function GET(request: NextRequest) {
-  const clientIp = getClientIp(request);
-  const rate = apiRateLimiter.check(`stocks:${clientIp}`);
-  if (!rate.success) {
-    return rateLimitResponse(rate);
-  }
-
-  try {
-    const searchParams = request.nextUrl.searchParams;
-    const symbols = searchParams.get("symbols");
-
-    if (!symbols) {
-      return NextResponse.json(
-        { error: "Symbols parameter is required" },
-        { status: 400, headers: NO_STORE_HEADERS }
-      );
-    }
-
-    const symbolArray = symbols
-      .split(",")
-      .map((s) => s.trim().toUpperCase())
-      .filter(Boolean);
-
-    if (symbolArray.length > MAX_SYMBOLS_PER_REQUEST) {
-      return NextResponse.json(
-        {
-          error: `Too many symbols. Limit is ${MAX_SYMBOLS_PER_REQUEST} per request.`,
-        },
-        { status: 400, headers: NO_STORE_HEADERS }
-      );
-    }
-
-    const allowlist = await getAllowedSymbols({
-      assetOrigin: request.nextUrl.origin,
-    });
-    const validSymbols = symbolArray.filter((s) => allowlist.has(s));
-    const invalidSymbols = symbolArray.filter((s) => !allowlist.has(s));
-
-    const invalidQuotes = invalidSymbols.map((s) => ({
-      symbol: s,
-      price: 0,
-      change: 0,
-      changePercent: 0,
-      dayHigh: 0,
-      dayLow: 0,
-      open: 0,
-      previousClose: 0,
-      volume: 0,
-      marketCap: 0,
-      name: s,
-      error: `Invalid symbol: ${s}`,
-    }));
-
-    if (validSymbols.length === 0) {
-      return NextResponse.json(
-        {
-          quotes: invalidQuotes,
-          rateLimited: false,
-          allFailed: false,
-          timestamp: new Date().toISOString(),
-        },
-        { headers: SUCCESS_CACHE_HEADERS }
-      );
-    }
-
-    const validQuotes = await Promise.all(validSymbols.map(fetchFinnhubQuote));
-    const allFailed = validQuotes.length > 0 && validQuotes.every((q) => q.error);
-
-    return NextResponse.json(
-      {
-        quotes: [...validQuotes, ...invalidQuotes],
-        rateLimited: false,
-        allFailed,
-        timestamp: new Date().toISOString(),
+export function GET(): NextResponse {
+  return NextResponse.json(
+    {
+      error: "Gone",
+      message: "/api/stocks has been retired. Use /api/investments/quotes instead.",
+    },
+    {
+      status: 410,
+      headers: {
+        Deprecation: "true",
+        Sunset: SUNSET_DATE,
+        Link: '</api/investments/quotes>; rel="successor-version"',
+        "Cache-Control": "no-store",
       },
-      { headers: SUCCESS_CACHE_HEADERS }
-    );
-  } catch (error) {
-    logger.error("Stock API error", error);
-    return NextResponse.json(
-      { error: "Failed to fetch stock data" },
-      { status: 500, headers: NO_STORE_HEADERS }
-    );
-  }
+    }
+  );
 }

--- a/src/lib/__tests__/fantasySnapshotServer.test.ts
+++ b/src/lib/__tests__/fantasySnapshotServer.test.ts
@@ -5,9 +5,21 @@ import {
   FANTASY_SNAPSHOT_SCHEMA_VERSION,
   getFantasyPlayersForPosition,
 } from "@/lib/fantasy";
-import { loadFantasySnapshot } from "@/lib/fantasySnapshotServer";
+import {
+  loadFantasySnapshot,
+  resetFantasySnapshotCache,
+} from "@/lib/fantasySnapshotServer";
 
 describe("fantasySnapshotServer", () => {
+  it("serves the parsed snapshot from cache within the TTL", async () => {
+    resetFantasySnapshotCache();
+    const first = await loadFantasySnapshot("ppr");
+    const second = await loadFantasySnapshot("ppr");
+    // A cache hit returns the same object; without the cache each call parses
+    // the ~700KB file afresh and would return a different reference.
+    expect(second).toBe(first);
+  });
+
   it("loads published snapshots from disk with sourced overall metadata", async () => {
     const scoringFormats = {
       ppr: "PPR",

--- a/src/lib/fantasySnapshotServer.ts
+++ b/src/lib/fantasySnapshotServer.ts
@@ -2,12 +2,36 @@ import { readFile } from "fs/promises";
 import path from "path";
 import { FantasyRouteScoring, FantasySnapshot, normalizeFantasySnapshot } from "@/lib/fantasy";
 
+// The published boards are static committed JSON (~700KB combined) that only
+// change on deploy, yet /api/fantasy-data re-read and re-parsed the file on every
+// request. Cache the normalized snapshot per scoring format with the same 5-minute
+// TTL the investments server uses (src/lib/investmentsData.ts), so bursts of
+// requests reuse one parse instead of hitting the disk each time.
+const SNAPSHOT_TTL_MS = 5 * 60 * 1000;
+
+const snapshotCache = new Map<
+  FantasyRouteScoring,
+  { data: FantasySnapshot; expiresAt: number }
+>();
+
 function getFantasySnapshotPath(scoring: FantasyRouteScoring): string {
   return path.join(process.cwd(), "public", "data", "fantasy", `${scoring}.json`);
 }
 
 export async function loadFantasySnapshot(scoring: FantasyRouteScoring): Promise<FantasySnapshot> {
+  const cached = snapshotCache.get(scoring);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.data;
+  }
+
   const snapshotPath = getFantasySnapshotPath(scoring);
   const fileContents = await readFile(snapshotPath, "utf8");
-  return normalizeFantasySnapshot(JSON.parse(fileContents), scoring);
+  const data = normalizeFantasySnapshot(JSON.parse(fileContents), scoring);
+  snapshotCache.set(scoring, { data, expiresAt: Date.now() + SNAPSHOT_TTL_MS });
+  return data;
+}
+
+/** Test-only: clears the in-memory snapshot cache so cache behavior is testable. */
+export function resetFantasySnapshotCache(): void {
+  snapshotCache.clear();
 }


### PR DESCRIPTION
Self-contained runtime and CI hardening from the data-source audit backlog (Wave 3/4).

- **#21 Cache `/api/fantasy-data`**: `loadFantasySnapshot` now caches the normalized board per scoring with a 5-minute TTL (mirroring `investmentsData.ts`) instead of re-reading and re-parsing the ~700KB JSON on every request.
- **#23 Retire `/api/stocks`**: an orphaned near-duplicate of `/api/investments/quotes` with no first-party consumer that still spent Finnhub quota. Now returns 410 Gone with Deprecation/Sunset/Link headers.
- **#30 Stagger colliding crons**: bay-area-transit → `:35`, world-cup → `:50`, so they stop racing the hourly earthquake refresh at `:20` over pushes to main.
- **#29 Golf workflow injection**: the untrusted ESPN tournament name is now passed to the job-summary step via the environment instead of `${{ }}` interpolation into a `run:` script under `contents: write`.

Tests added for the cache (reference identity) and the 410 stub. CI verifies (local jest is unavailable this session).