### PR TITLE
fix: use Greenhouse first_published for MBA job posted dates

### DIFF
--- a/src/app/api/mba-jobs/__tests__/route.test.ts
+++ b/src/app/api/mba-jobs/__tests__/route.test.ts
@@ -140,6 +140,9 @@ describe("GET /api/mba-jobs", () => {
                 title: "PM Intern",
                 location: { name: "San Francisco, CA" },
                 absolute_url: "https://example.com/jobs/1001",
+                // first_published (posted) predates updated_at (a later edit);
+                // postedAt should track the earlier first_published.
+                first_published: "2026-03-01T10:00:00.000Z",
                 updated_at: "2026-04-14T16:00:00.000Z",
                 departments: [{ name: "Product" }],
                 content: "<p>MBA summer internship for product leaders.</p>",
@@ -232,6 +235,8 @@ describe("GET /api/mba-jobs", () => {
           title: "PM Intern",
           roleType: "internship",
           roleFamilies: ["product"],
+          // Prefers first_published over the later updated_at (2026-04-14).
+          postedAt: "2026-03-01T10:00:00.000Z",
         }),
         expect.objectContaining({
           title: "Strategic Finance Associate",

--- a/src/app/api/mba-jobs/route.ts
+++ b/src/app/api/mba-jobs/route.ts
@@ -169,6 +169,10 @@ interface GHJob {
   title: string;
   location: { name: string };
   absolute_url: string;
+  // `first_published` is when the posting first went live; `updated_at` moves on
+  // any later edit, so it overstates recency. Prefer first_published for the
+  // posted date and fall back to updated_at only when it's absent.
+  first_published?: string;
   updated_at: string;
   departments: { name: string }[];
   content?: string;
@@ -194,7 +198,7 @@ async function fetchGreenhouse(company: GreenhouseMBACompany): Promise<MBAJob[]>
       location: job.location?.name ?? "Remote",
       department: job.departments?.[0]?.name ?? "General",
       applyUrl: job.absolute_url,
-      postedAt: job.updated_at,
+      postedAt: job.first_published ?? job.updated_at,
       snippet,
       roleType: match.roleType,
       roleFamilies: match.roleFamilies,


### PR DESCRIPTION
Audit backlog Wave 4. The MBA Greenhouse fetcher mapped `postedAt` from `updated_at`, which moves on any later edit and overstates recency. It now prefers `first_published` (the true posting date, verified present in the board API) and falls back to `updated_at` only when absent. New test asserts the preference (fails on the old mapping). Verified locally: 20/20 MBA tests pass, tsc clean.