### PR TITLE
fix: normalize The Guardian news-pulse feed to its front page

### DIFF
--- a/src/lib/news-pulse-sources.ts
+++ b/src/lib/news-pulse-sources.ts
@@ -22,8 +22,11 @@ export const NEWS_FEEDS = [
   },
   {
     id: "guardian",
+    // Front-page feed, not the World section, so it's comparable to the other
+    // sources' homepage-level feeds (NYT HomePage, BBC top stories, NPR news)
+    // rather than skewing The Guardian's mix toward world news.
     name: "The Guardian",
-    url: "https://www.theguardian.com/world/rss",
+    url: "https://www.theguardian.com/international/rss",
     color: "#052962",
   },
   {


### PR DESCRIPTION
Audit backlog Wave 4 (finishes the news-pulse item). The Guardian used its World-section feed (`/world/rss`) while the other sources used homepage-level feeds, skewing its mix toward world news. Switched to the international front-page feed (`/international/rss`, verified live, 114 items, mixed sections) for apples-to-apples comparison. Verified locally: news-pulse tests pass.