### PR TITLE
feat: three-readout live feed in the homepage hero

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -86,6 +86,194 @@
   --hp-rule-soft: color-mix(in srgb, var(--home-rule) 55%, transparent);
 }
 
+/* ---- Hero live-feed instrument (sits inside the dark hero plate) ---- */
+.feedPanel {
+  position: relative;
+  border-top: 3px solid var(--home-signal);
+  background: color-mix(in srgb, var(--hp-paper) 6%, var(--hp-ink));
+  color: var(--hp-paper);
+}
+.feedCap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid color-mix(in srgb, var(--hp-paper) 18%, transparent);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--hp-paper) 64%, transparent);
+}
+.feedCapLive {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  color: color-mix(in srgb, var(--hp-paper) 82%, transparent);
+}
+.feedDot {
+  position: relative;
+  width: 7px;
+  height: 7px;
+  flex-shrink: 0;
+  display: inline-block;
+}
+.feedDot > span {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--home-signal);
+  animation: feedBlip 1.9s ease-in-out infinite;
+}
+.feedDot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 1px solid var(--home-signal);
+  animation: feedRing 1.9s ease-out infinite;
+}
+.feedRd {
+  padding: 13px 16px;
+  border-bottom: 1px solid color-mix(in srgb, var(--hp-paper) 12%, transparent);
+}
+.feedRdHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.feedRdSrc {
+  color: color-mix(in srgb, var(--hp-paper) 68%, transparent);
+}
+.feedRdMeta {
+  font-variant-numeric: tabular-nums;
+  color: color-mix(in srgb, var(--hp-paper) 48%, transparent);
+}
+.feedUp {
+  color: var(--home-positive);
+}
+.feedDown {
+  color: var(--home-negative);
+}
+.feedRdFigure {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  margin-top: 8px;
+}
+.feedRdBig {
+  font-family: var(--font-mono);
+  font-size: 2rem;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--hp-paper);
+}
+.feedRdUnit {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--hp-paper) 44%, transparent);
+}
+.feedRdSub {
+  margin-top: 5px;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: color-mix(in srgb, var(--hp-paper) 66%, transparent);
+}
+.feedSpark {
+  display: block;
+  width: 100%;
+  height: 26px;
+  margin-top: 9px;
+}
+.feedBar {
+  fill: color-mix(in srgb, var(--hp-paper) 24%, transparent);
+}
+.feedBarLast {
+  fill: var(--home-signal);
+}
+.feedRdLine {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 6px;
+}
+.feedClock,
+.feedRdPrice {
+  font-family: var(--font-mono);
+  font-size: 1.2rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  color: var(--hp-paper);
+  flex-shrink: 0;
+}
+.feedRdName {
+  font-size: 0.76rem;
+  color: color-mix(in srgb, var(--hp-paper) 56%, transparent);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+}
+.feedNow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--hp-paper) 64%, transparent);
+  overflow: hidden;
+}
+.feedNowLead {
+  flex-shrink: 0;
+  color: color-mix(in srgb, var(--hp-paper) 82%, transparent);
+}
+.feedNowText {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: color-mix(in srgb, var(--hp-paper) 60%, transparent);
+}
+@keyframes feedBlip {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.38;
+  }
+}
+@keyframes feedRing {
+  0% {
+    transform: scale(1);
+    opacity: 0.5;
+  }
+  70%,
+  100% {
+    transform: scale(2.8);
+    opacity: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .feedDot > span,
+  .feedDot::after {
+    animation: none;
+  }
+}
+
 .plate::before {
   content: "";
   position: absolute;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,14 @@
+import { readFile } from "fs/promises";
+import path from "path";
 import { StructuredData } from "@/components/StructuredData";
 import { AIStructuredData } from "@/components/AIStructuredData";
-import {
-  HomeInstrument,
-  type QuakePulse,
-} from "@/components/home/HomeInstrument";
+import { HomeInstrument } from "@/components/home/HomeInstrument";
+import type {
+  HomeLiveFeedData,
+  HomeLiveFeedLaunch,
+  HomeLiveFeedMarket,
+  HomeLiveFeedQuake,
+} from "@/components/home/HomeLiveFeed";
 import {
   getHomepageFeaturedCaseStudies,
   getPortfolioProjects,
@@ -11,44 +16,110 @@ import {
 import { getAllBlogPostPreviews } from "@/lib/blog";
 import { getLiveToolGroups } from "@/constants/toolCategories";
 import { getEarthquakeSummary } from "@/lib/earthquakeSnapshot";
+import { getSpaceXSnapshotSummary } from "@/lib/spacexSnapshot";
 import { profile, profileSameAs } from "@/lib/profile";
 
 export { metadata } from "./metadata";
 
-const HOUR_MS = 3_600_000;
+// Relative "N min ago" style label for the live-feed readouts, computed at
+// render time from an ISO timestamp.
+function relativeAgo(iso: string): string {
+  const ms = Date.now() - Date.parse(iso);
+  if (Number.isNaN(ms) || ms < 0) return "just now";
+  const minutes = Math.round(ms / 60000);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} h ago`;
+  return `${Math.round(hours / 24)} d ago`;
+}
 
-/**
- * Bucket the earthquake snapshot's rolling 24h feed into hourly counts for
- * the hero's live-pulse sparkline. Fail-soft: an empty or malformed snapshot
- * yields an empty series and the hero simply hides the sparkline.
- */
-async function buildQuakePulse(): Promise<QuakePulse> {
+// The hero's live feed reads three production tools. Each readout fails soft to
+// null so a missing or malformed snapshot just drops that row rather than
+// breaking the hero.
+
+// Latest USGS quake plus a short recent-magnitude series for the bar spark.
+async function buildQuakeReadout(): Promise<HomeLiveFeedQuake | null> {
   try {
     const summary = await getEarthquakeSummary();
-    const endTs = Date.parse(summary.generatedAt);
-    const buckets = new Array<number>(24).fill(0);
-
-    if (!Number.isNaN(endTs)) {
-      for (const quake of summary.recent) {
-        const age = endTs - Date.parse(quake.time);
-        if (Number.isNaN(age) || age < 0 || age >= 24 * HOUR_MS) continue;
-        buckets[23 - Math.floor(age / HOUR_MS)] += 1;
-      }
-    }
-
-    // The caption count must describe the same events the line draws. The
-    // snapshot's `recent` list is capped, so it can hold fewer events than
-    // heroStats.total24h — quoting that larger number next to a line built
-    // from the capped feed would misrepresent the chart.
-    const windowTotal = buckets.reduce((sum, count) => sum + count, 0);
+    const latest = summary.recent[0];
+    if (!latest) return null;
+    // `recent` is newest-first; reverse the trailing window so the spark reads
+    // left-to-right chronologically with the latest quake as the final bar.
+    const recentMagnitudes = summary.recent
+      .slice(0, 12)
+      .map((quake) => quake.magnitude)
+      .reverse();
     return {
-      series: windowTotal > 0 ? buckets : [],
-      total24h: windowTotal,
-      asOf: Number.isNaN(endTs) ? null : summary.generatedAt,
+      magnitude: latest.magnitude,
+      depthKm: latest.depthKm,
+      place: latest.place,
+      agoLabel: relativeAgo(latest.time),
+      recentMagnitudes,
     };
   } catch {
-    return { series: [], total24h: 0, asOf: null };
+    return null;
   }
+}
+
+// Next SpaceX launch for the T-minus readout.
+function buildLaunchReadout(): HomeLiveFeedLaunch | null {
+  try {
+    const next = getSpaceXSnapshotSummary()?.nextLaunch;
+    if (!next) return null;
+    const vehicle =
+      [next.rocketName, next.launchpadName].filter(Boolean).join(" · ") || "SpaceX";
+    return {
+      mission: next.name,
+      vehicle,
+      dateUtc: next.dateUtc,
+      hasExactTime: next.hasExactTime,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// S&P 500 day move from the committed SPY snapshot (daily closes).
+async function buildMarketReadout(): Promise<HomeLiveFeedMarket | null> {
+  try {
+    const raw = await readFile(
+      path.join(process.cwd(), "public", "data", "investments", "SPY", "snapshot.json"),
+      "utf8",
+    );
+    const prices = (JSON.parse(raw) as { sections?: { price?: unknown } }).sections
+      ?.price;
+    if (!Array.isArray(prices) || prices.length < 2) return null;
+    const last = prices[prices.length - 1] as { close?: unknown };
+    const prev = prices[prices.length - 2] as { close?: unknown };
+    if (typeof last.close !== "number" || typeof prev.close !== "number") return null;
+    const delta = last.close - prev.close;
+    const changePct = prev.close !== 0 ? (delta / prev.close) * 100 : 0;
+    return {
+      symbol: "SPY",
+      name: "S&P 500 ETF",
+      price: last.close.toLocaleString("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }),
+      changePct,
+      delta: `${delta >= 0 ? "+" : ""}${delta.toFixed(2)}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function buildLiveFeed(): Promise<HomeLiveFeedData> {
+  const [quake, market] = await Promise.all([
+    buildQuakeReadout(),
+    buildMarketReadout(),
+  ]);
+  return {
+    quake,
+    launch: buildLaunchReadout(),
+    market,
+    sourceNote: "Committed snapshots across three production tools",
+  };
 }
 
 export default async function Home() {
@@ -72,7 +143,7 @@ export default async function Home() {
     essayCount: allPosts.length,
     liveToolCount: liveTools,
   };
-  const quakePulse = await buildQuakePulse();
+  const liveFeed = await buildLiveFeed();
 
   return (
     <>
@@ -81,7 +152,7 @@ export default async function Home() {
         recentPosts={allPosts}
         heroIndex={heroIndex}
         liveToolGroups={liveToolGroups}
-        quakePulse={quakePulse}
+        liveFeed={liveFeed}
       />
 
       <StructuredData type="ProfilePage" />

--- a/src/components/home/HomeInstrument.tsx
+++ b/src/components/home/HomeInstrument.tsx
@@ -10,19 +10,9 @@ import {
 import type { BlogPostPreview } from "@/lib/blog";
 import { publishedDateFormatter } from "@/lib/utils";
 import { ContactCta } from "@/components/ContactCta";
-import { InstrumentCounter } from "@/components/home/InstrumentCounter";
-import { PanelClock } from "@/components/home/PanelClock";
-import { NowLine } from "@/components/home/NowLine";
-import { ReadoutPanel } from "@/components/ui/ReadoutPanel";
+import { HomeLiveFeed } from "@/components/home/HomeLiveFeed";
+import type { HomeLiveFeedData } from "@/components/home/HomeLiveFeed";
 import styles from "@/app/page.module.css";
-
-export interface QuakePulse {
-  /** Hourly counts over the snapshot's last 24h window, oldest first. */
-  series: number[];
-  total24h: number;
-  /** ISO timestamp of the snapshot the series was derived from. */
-  asOf: string | null;
-}
 
 interface HomeInstrumentProps {
   featuredProjects: CaseStudyData[];
@@ -33,20 +23,8 @@ interface HomeInstrumentProps {
     liveToolCount: number;
   };
   liveToolGroups: LiveToolGroup[];
-  quakePulse: QuakePulse;
+  liveFeed: HomeLiveFeedData;
 }
-
-// Month-and-year stamp for the live index cap. Derived from the most recent
-// published post so the label tracks real content freshness, not wall clock.
-const updatedMonthFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  year: "numeric",
-});
-
-const asOfFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-});
 
 function ArrowRight({ size = 14 }: { size?: number }) {
   return (
@@ -68,14 +46,6 @@ function ArrowRight({ size = 14 }: { size?: number }) {
   );
 }
 
-function LiveDot() {
-  return (
-    <span className={styles.liveDot} aria-hidden="true">
-      <span />
-    </span>
-  );
-}
-
 function categoryLabelFor(slug: string): string {
   const id = classifyToolSlug(slug);
   return TOOL_CATEGORY_DEFS.find((def) => def.id === id)?.label ?? "Project";
@@ -85,59 +55,14 @@ function pad2(n: number): string {
   return String(n).padStart(2, "0");
 }
 
-/**
- * Map an hourly count series onto sparkline coordinates in a 300x72 viewBox
- * with a little padding so the stroke never clips.
- */
-const SPARK_W = 300;
-const SPARK_H = 72;
-const SPARK_PAD = 6;
-
-function sparklineCoords(series: number[]): Array<{ x: number; y: number }> {
-  const max = Math.max(...series, 1);
-  const step = SPARK_W / Math.max(series.length - 1, 1);
-  return series.map((count, index) => ({
-    x: Math.round(index * step * 100) / 100,
-    y:
-      Math.round(
-        (SPARK_H - SPARK_PAD - (count / max) * (SPARK_H - SPARK_PAD * 2)) * 100,
-      ) / 100,
-  }));
-}
-
-function sparklinePoints(series: number[]): string {
-  return sparklineCoords(series)
-    .map((point) => `${point.x},${point.y}`)
-    .join(" ");
-}
-
-function sparklineEnd(series: number[]): { x: number; y: number } {
-  const coords = sparklineCoords(series);
-  return coords[coords.length - 1] ?? { x: SPARK_W, y: SPARK_H / 2 };
-}
-
 export function HomeInstrument({
   featuredProjects,
   recentPosts,
   heroIndex,
   liveToolGroups,
-  quakePulse,
+  liveFeed,
 }: HomeInstrumentProps) {
   const writingRows = recentPosts.slice(0, 3);
-
-  // Most recent post timestamp drives the "Live index" freshness stamp.
-  const lastUpdatedTs = recentPosts.reduce((latest, post) => {
-    const ts = Date.parse(post.publishedAt);
-    return Number.isNaN(ts) ? latest : Math.max(latest, ts);
-  }, 0);
-  const indexStamp =
-    lastUpdatedTs > 0 ? updatedMonthFormatter.format(lastUpdatedTs) : null;
-
-  const showSparkline = quakePulse.series.length >= 6;
-  const quakeAsOf = quakePulse.asOf ? Date.parse(quakePulse.asOf) : NaN;
-  const quakeAsOfLabel = Number.isNaN(quakeAsOf)
-    ? null
-    : asOfFormatter.format(quakeAsOf);
 
   return (
     <div className={styles.page}>
@@ -183,91 +108,7 @@ export function HomeInstrument({
               </div>
             </div>
 
-            <ReadoutPanel
-              label={
-                <>
-                  <LiveDot />
-                  Live index
-                </>
-              }
-              stamp={
-                <>
-                  <PanelClock />
-                  {indexStamp ? (
-                    <span className={styles.capStamp}>· {indexStamp}</span>
-                  ) : null}
-                </>
-              }
-              rows={[
-                {
-                  label: "Projects shipped",
-                  value: <InstrumentCounter value={heroIndex.projectCount} />,
-                },
-                {
-                  label: "Tools in production",
-                  value: <InstrumentCounter value={heroIndex.liveToolCount} />,
-                },
-                {
-                  label: "Essays and notes",
-                  value: <InstrumentCounter value={heroIndex.essayCount} />,
-                },
-              ]}
-              footer={<NowLine />}
-            >
-              {showSparkline ? (
-                <div className={styles.spark}>
-                  <svg
-                    viewBox="0 0 300 72"
-                    preserveAspectRatio="none"
-                    role="img"
-                    aria-label={`Sparkline of ${quakePulse.total24h} recent earthquakes bucketed by hour`}
-                  >
-                    <line
-                      className={styles.sparkGrid}
-                      x1={SPARK_PAD}
-                      y1={SPARK_H / 2}
-                      x2={SPARK_W - SPARK_PAD}
-                      y2={SPARK_H / 2}
-                    />
-                    <polygon
-                      className={styles.sparkFill}
-                      fill="var(--hp-signal)"
-                      points={`${sparklinePoints(quakePulse.series)} 300,72 0,72`}
-                    />
-                    <polyline
-                      className={styles.sparkLine}
-                      fill="none"
-                      stroke="var(--hp-signal)"
-                      strokeWidth="2"
-                      strokeLinejoin="round"
-                      strokeLinecap="round"
-                      pathLength={100}
-                      points={sparklinePoints(quakePulse.series)}
-                    />
-                    <circle
-                      className={styles.sparkPing}
-                      cx={sparklineEnd(quakePulse.series).x}
-                      cy={sparklineEnd(quakePulse.series).y}
-                      r="3.5"
-                      fill="none"
-                      stroke="var(--hp-signal)"
-                      strokeWidth="1.5"
-                    />
-                    <circle
-                      className={styles.sparkDot}
-                      cx={sparklineEnd(quakePulse.series).x}
-                      cy={sparklineEnd(quakePulse.series).y}
-                      r="3.5"
-                      fill="var(--hp-signal)"
-                    />
-                  </svg>
-                  <span className={styles.sparkCap}>
-                    {quakePulse.total24h} recent quakes · by hour · USGS
-                    {quakeAsOfLabel ? ` · as of ${quakeAsOfLabel}` : ""}
-                  </span>
-                </div>
-              ) : null}
-            </ReadoutPanel>
+            <HomeLiveFeed data={liveFeed} />
           </div>
           </div>
         </div>

--- a/src/components/home/HomeLiveFeed.tsx
+++ b/src/components/home/HomeLiveFeed.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "@/app/page.module.css";
+import { PanelClock } from "@/components/home/PanelClock";
+
+export interface HomeLiveFeedQuake {
+  magnitude: number;
+  depthKm: number;
+  place: string;
+  agoLabel: string;
+  recentMagnitudes: number[];
+}
+
+export interface HomeLiveFeedLaunch {
+  mission: string;
+  vehicle: string;
+  /** ISO 8601 launch time (UTC). */
+  dateUtc: string;
+  /** Whether the schedule carries an exact T-0 (vs. a NET/TBD window). */
+  hasExactTime: boolean;
+}
+
+export interface HomeLiveFeedMarket {
+  /** Source ticker, e.g. "SPY". */
+  symbol: string;
+  /** Display label, e.g. "S&P 500 ETF". */
+  name: string;
+  price: string;
+  changePct: number;
+  delta: string;
+}
+
+export interface HomeLiveFeedData {
+  quake: HomeLiveFeedQuake | null;
+  launch: HomeLiveFeedLaunch | null;
+  market: HomeLiveFeedMarket | null;
+  /** One-line provenance note under the readouts. */
+  sourceNote: string;
+}
+
+// Seismograph-style bar spark of recent magnitudes; the latest bar is signal.
+function MagSpark({ data }: { data: number[] }) {
+  const W = 300;
+  const H = 26;
+  const gap = 3;
+  const n = data.length;
+  if (n === 0) return null;
+  const barWidth = (W - gap * (n - 1)) / n;
+  const max = Math.max(...data, 0.1);
+  return (
+    <svg
+      className={styles.feedSpark}
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      {data.map((value, index) => {
+        const barHeight = Math.max(2, (value / max) * H);
+        return (
+          <rect
+            key={index}
+            x={(index * (barWidth + gap)).toFixed(1)}
+            y={(H - barHeight).toFixed(1)}
+            width={barWidth.toFixed(1)}
+            height={barHeight.toFixed(1)}
+            className={index === n - 1 ? styles.feedBarLast : styles.feedBar}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+function formatCountdown(msRemaining: number): string {
+  const seconds = Math.max(0, Math.round(msRemaining / 1000));
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const days = Math.floor(seconds / 86400);
+  const hh = pad(Math.floor((seconds % 86400) / 3600));
+  const mm = pad(Math.floor((seconds % 3600) / 60));
+  const ss = pad(seconds % 60);
+  return days > 0 ? `${days}d ${hh}:${mm}:${ss}` : `${hh}:${mm}:${ss}`;
+}
+
+const dateLabelFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+});
+
+// Launch T-minus. The server and first client paint render the scheduled date
+// (deterministic, so no hydration mismatch); once mounted, the effect swaps in
+// a live countdown that ticks each second. A launch with no exact time (a
+// NET/TBD window) keeps the date rather than ticking a meaningless clock.
+function LaunchClock({ launch }: { launch: HomeLiveFeedLaunch }) {
+  const targetMs = Date.parse(launch.dateUtc);
+  const validTarget = launch.hasExactTime && !Number.isNaN(targetMs);
+  const [countdown, setCountdown] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!validTarget) return;
+    const tick = () => {
+      const remaining = targetMs - Date.now();
+      setCountdown("T− " + formatCountdown(Math.max(0, remaining)));
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [validTarget, targetMs]);
+
+  if (validTarget && countdown !== null) {
+    return (
+      <span className={styles.feedClock} suppressHydrationWarning>
+        {countdown}
+      </span>
+    );
+  }
+
+  const label = Number.isNaN(targetMs)
+    ? "Scheduled"
+    : `NET ${dateLabelFormatter.format(targetMs)}`;
+  return <span className={styles.feedClock}>{label}</span>;
+}
+
+/**
+ * The homepage hero's live-feed instrument. Real readouts from three production
+ * tools: the latest USGS quake with a magnitude bar spark, the next SpaceX
+ * launch with a ticking T-minus, and the S&P 500 ETF (SPY) day move. The clock
+ * and countdown tick client-side; everything else is server-computed data.
+ */
+export function HomeLiveFeed({ data }: { data: HomeLiveFeedData }) {
+  const { quake, launch, market } = data;
+  const marketUp = market ? market.changePct >= 0 : true;
+
+  return (
+    <div className={styles.feedPanel}>
+      <div className={styles.feedCap}>
+        <span className={styles.feedCapLive}>
+          <span className={styles.feedDot}>
+            <span />
+          </span>
+          Live feed
+        </span>
+        <PanelClock />
+      </div>
+
+      {quake ? (
+        <div className={styles.feedRd}>
+          <div className={styles.feedRdHead}>
+            <span className={styles.feedRdSrc}>Earthquake Pulse</span>
+            <span className={styles.feedRdMeta}>{quake.agoLabel}</span>
+          </div>
+          <div className={styles.feedRdFigure}>
+            <span className={styles.feedRdBig}>M {quake.magnitude.toFixed(1)}</span>
+            <span className={styles.feedRdUnit}>USGS · {quake.depthKm} km deep</span>
+          </div>
+          <div className={styles.feedRdSub}>{quake.place}</div>
+          <MagSpark data={quake.recentMagnitudes} />
+        </div>
+      ) : null}
+
+      {launch ? (
+        <div className={styles.feedRd}>
+          <div className={styles.feedRdHead}>
+            <span className={styles.feedRdSrc}>Next launch</span>
+            <span className={styles.feedRdMeta}>{launch.vehicle}</span>
+          </div>
+          <div className={styles.feedRdLine}>
+            <LaunchClock launch={launch} />
+            <span className={styles.feedRdName}>{launch.mission}</span>
+          </div>
+        </div>
+      ) : null}
+
+      {market ? (
+        <div className={styles.feedRd}>
+          <div className={styles.feedRdHead}>
+            <span className={styles.feedRdSrc}>Markets · {market.symbol}</span>
+            <span
+              className={`${styles.feedRdMeta} ${marketUp ? styles.feedUp : styles.feedDown}`}
+            >
+              {marketUp ? "▲" : "▼"} {Math.abs(market.changePct).toFixed(2)}%
+            </span>
+          </div>
+          <div className={styles.feedRdLine}>
+            <span className={styles.feedRdPrice}>{market.price}</span>
+            <span className={styles.feedRdName}>{market.delta} today</span>
+          </div>
+        </div>
+      ) : null}
+
+      <div className={styles.feedNow}>
+        <span className={styles.feedDot}>
+          <span />
+        </span>
+        <span className={styles.feedNowLead}>Feed ·</span>
+        <span className={styles.feedNowText}>{data.sourceNote}</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements the homepage hero from the Working Instrument design project (imported from the claude.ai design system).

**What changed.** The hero's right-hand panel goes from a stat readout (project/tool/essay counters + an earthquake sparkline) to a stacked three-readout live-feed instrument matching the kit:
- **Earthquake Pulse** — latest USGS quake magnitude with a seismograph bar spark
- **Next launch** — the next SpaceX launch with a ticking T-minus countdown
- **Markets · SPY** — the S&P 500 ETF day move

All under a live Pacific clock, with a source note footer.

**Data.** Real, from committed snapshots — `getEarthquakeSummary`, `getSpaceXSnapshotSummary().nextLaunch`, and the `SPY` snapshot. Each readout fails soft to a dropped row rather than breaking the hero. The countdown and clock tick client-side and are hydration-safe (the server renders the scheduled date; an effect swaps in the live countdown after mount).

**Styling.** The dark instrument panel is ported to sit inside your existing dark hero plate (I kept the current plate rather than flipping it to the kit's light bone plate — that fuller hero redesign is an optional follow-up). Removed the now-dead readout-panel and sparkline code.

Verified locally: eslint clean, tsc clean on touched files, homepage unit test passes, full `next build --webpack` succeeds.