### PR TITLE
docs: refresh README routes and build notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Portfolio, writing, fantasy football analytics, investment research, and standalone data tools built on Next.js 16.
 
 **Live:** [isaacavazquez.com](https://isaacavazquez.com)
-**Last updated:** 2026-06-10
+**Last updated:** 2026-07-07
 
 ---
 
@@ -62,6 +62,7 @@ The site is portfolio-first. `Writing` is live and promoted in the global header
 | `/tech-startup-tracker` | Curated startup funding tracker |
 | `/writing` | Writing index |
 | `/writing/[slug]` | Article page |
+| `/writing/topics/[topic]` | Writing topic index |
 | `/march-madness-2026` | Seasonal bracket analysis |
 | `/fantasy-football/*` | Fantasy football tools |
 | `/ai-dev-tools` | AI development tools directory |
@@ -80,7 +81,9 @@ The site is portfolio-first. `Writing` is live and promoted in the global header
 | `/museum-log` | Museum visit log |
 | `/travel` | Browser-persisted travel planner |
 | `/now` | Current focus / status page |
-| `/changelog` | Site changelog |
+| `/changelog` | Running log of what's shipped |
+| `/release-notes` | Release notes, grouped by month |
+| `/arcade` | Reactor, a neon reflex arcade game (style experiment) |
 | `/resume` | Resume |
 | `/contact` | Contact page |
 | `/accessibility` | Accessibility statement |
@@ -134,7 +137,7 @@ npm run update:spacex
 npm run update:spacex-images
 ```
 
-`prebuild` runs a league-only football snapshot refresh automatically; `postbuild` runs `next-sitemap`.
+`prebuild` runs a league-only football snapshot refresh automatically; `postbuild` runs `next-sitemap` and `scripts/patch-nft-sharp.mjs`.
 
 ---
 


### PR DESCRIPTION
Brings the README back in sync with the current codebase. Since the last README refresh a few routes shipped that weren't reflected in the route table, and the build note was slightly stale.

## What changed

- Added `/writing/topics/[topic]`, `/release-notes`, and `/arcade` to the Main Routes table. `/arcade` is the Reactor reflex game (a style experiment), and `/release-notes` sits alongside the existing `/changelog`.
- Clarified the `/changelog` description to match its own page copy ("running log of what's shipped").
- Corrected the postbuild note so it lists both steps that actually run: `next-sitemap` and `scripts/patch-nft-sharp.mjs`.
- Bumped the last-updated date to 2026-07-07.

## Verification

Routes cross-checked against `src/app/**/page.tsx`; the postbuild note checked against the `scripts` block in `package.json`. The stack table (Next.js 16, React 19, Tailwind v4, NextAuth v4) still matches the pinned dependency versions, so it was left as-is. Docs-only change with no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UmNQJi7RyBmx21twiWGZA

---
_Generated by [Claude Code](https://claude.ai/code/session_016UmNQJi7RyBmx21twiWGZA)_