### PR TITLE
Add La Liga 2025-26 season article series

### DIFF
--- a/content/blog/la-liga-2025-26-arbeloa-madrid-midseason.mdx
+++ b/content/blog/la-liga-2025-26-arbeloa-madrid-midseason.mdx
@@ -1,0 +1,42 @@
+---
+title: "Midseason Check: Arbeloa Steadies Madrid, but the Title Gap Is the Wrong Thing to Watch Now"
+excerpt: "Real Madrid have stopped the slide under Arbeloa without closing the gap, which is roughly the realistic outcome. With the title race narrowing to a formality, the season is really being decided in the middle and the bottom of the table now."
+publishedAt: "2026-02-23"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "Real Madrid", "European Qualification", "Relegation"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Read the three races at once"
+  description: "La Liga Pulse separates the title fight, the European scramble, and the relegation battle so you can see where the season is actually being decided."
+  href: "/la-liga"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "La Liga Midseason 2025-26: Arbeloa's Madrid and the Races That Actually Matter Now"
+  description: "A midseason read on La Liga 2025-26. Real Madrid have steadied under Arbeloa without closing Barcelona's lead, so the season's real drama is now the European scramble and the relegation fight."
+  keywords: ["la liga midseason 2025-26", "arbeloa real madrid form", "la liga european qualification race", "la liga relegation battle 2026", "barcelona title lead"]
+---
+
+# Midseason Check: Arbeloa Steadies Madrid, but the Title Gap Is the Wrong Thing to Watch Now
+
+A month or so on from the managerial change, the honest read on Real Madrid is that Álvaro Arbeloa has done the achievable thing rather than the miraculous one. He has stopped the slide and gotten the team back toward the level the squad should produce, without meaningfully closing the gap to Barcelona at the top. I said when he was appointed that this was roughly the realistic version of a good outcome, because winning the title back was probably already a long shot with Barcelona clear and playing the way they were, and steadying the ship was the part actually within reach. That is more or less what has happened, and I think it counts as Arbeloa passing the first test even though it will not feel like it to anyone who expects Madrid to win everything.
+
+The reason I am not spending more words on the title race is that I think it has quietly become the least interesting of the three races in the league, and pretending otherwise would be writing about the game I wish were happening rather than the one that is. Barcelona have the lead, the more repeatable way of playing, and a full year of evidence that the level is real, and a chasing team that changed managers in January is not well positioned to overhaul that in the spring. It is not mathematically over, and I will happily eat my words if Madrid string together the run of their lives, but the base case is a Barcelona title and the drama is elsewhere.
+
+## The middle of the table is the real competition
+
+Where the season is genuinely alive is the fight for European places, which in La Liga is almost always the most crowded and most volatile part of the table, and this year is no exception. There is a cluster of clubs separated by a couple of points all chasing the same handful of continental spots, and the difference between finishing in the Champions League places and finishing in the Europa or Conference qualification is enormous in money and prestige and in what kind of players a club can attract over the summer. That is a race where a single result genuinely moves a club's whole next year, and it is being contested by more teams than the title ever is.
+
+What makes the European scramble hard to follow from the standings alone is that the meaning lives at the boundaries, not in the rank. A team sitting comfortably in eighth is in one of the least interesting positions in the league, closer to the top than the bottom and fighting for nothing in particular. The interesting rows are the ones sitting a point either side of a line that changes their season, and those lines move every weekend as the results come in. This is exactly the problem I built the dashboard to solve, because a flat table sorted by points hides which gaps carry pressure and which are just noise.
+
+## The bottom is where the format comes alive
+
+The relegation fight is the other race that is actually being decided right now, and it is the one I would tell someone to watch first if they only had time for one. The math down at the bottom is the math people feel, because a single result can swing a club from safe to in trouble, and the three promoted sides came up on very different footing even though the standings will flatten that into one line by May. I wrote in the preview that I expected the promoted teams to split rather than share a season, with one finding enough to stay up, one grinding through a fight that goes to the final weeks, and one struggling from the start, and the shape of the bottom of the table is starting to look like that is roughly how it is going.
+
+I do not want to name outcomes that have not happened yet, because a relegation fight in February is genuinely unsettled and the teams in the most danger now are not always the ones who go down. What I will say is that the survival math is going to run to the final weekends, the way it usually does, and that the clubs a few points above the line are under a kind of pressure that the comfortable mid-table clubs simply are not, regardless of how close together they look in the standings.
+
+## What I am actually tracking from here
+
+So the midseason picture is a title race that is probably settled, a European scramble that is wide open, and a relegation fight that will go to the wire. Arbeloa has done his job of restoring Madrid's floor, and the interesting questions from here are which cluster of clubs claims the continental places and which promoted side, if any, survives. Those are the races I will be following week by week on [La Liga Pulse](/la-liga), because they are where the season is actually being decided now that the top of the table has mostly made up its mind.

--- a/content/blog/la-liga-2025-26-barcelona-clinch-title.mdx
+++ b/content/blog/la-liga-2025-26-barcelona-clinch-title.mdx
@@ -1,0 +1,44 @@
+---
+title: "Barcelona Win It in the Clásico: A Second Straight Title, and No Doubt About It"
+excerpt: "Barcelona beat Real Madrid 2-0 at home through Rashford and Ferran Torres to clinch the title with three games to spare, their 29th and their second in a row under Flick. Winning it against the rival is the fitting end to the way they won it."
+publishedAt: "2026-05-11"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "El Clasico", "Barcelona", "Hansi Flick"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "See how the title was won"
+  description: "La Liga Pulse tracked the swing from a five-point deficit in October to the title with three games to spare, and now turns to the European and relegation races still live."
+  href: "/la-liga"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Barcelona Clinch La Liga 2025-26: 2-0 Clásico Win, 29th Title, Second in a Row"
+  description: "Barcelona beat Real Madrid 2-0 through Rashford and Ferran Torres to clinch the 2025-26 La Liga title with three games to spare, their 29th and a second straight under Hansi Flick. My analysis of a deserved title."
+  keywords: ["barcelona win la liga 2026", "barcelona 2-0 real madrid clasico may 2026", "barcelona 29th title", "hansi flick second title", "rashford ferran torres clasico"]
+---
+
+# Barcelona Win It in the Clásico: A Second Straight Title, and No Doubt About It
+
+Barcelona are champions again, and they did it in the most fitting way available, by beating Real Madrid 2-0 at home to clinch the title with three games still to play. Marcus Rashford and Ferran Torres got the goals, the second Clásico of the season went the opposite way to the first, and the practical effect is a 29th league title and a second in a row under Hansi Flick. There is a neatness to sealing it against the direct rival that I do not want to over-romanticize, but it is hard to script a cleaner ending to the way this particular season went.
+
+The reason this title feels settled rather than lucky is that it was settled a long time before the mathematics caught up. I have been writing all season that Barcelona were carried by something repeatable rather than by a run of good luck in tight games, and clinching with three games to spare is what that looks like at the finish. You do not win a league by early May with room to spare because you edged a series of close matches. You win it that early because you were consistently better than everyone else across the ordinary weekends, and the cushion is the accumulated receipt of all those Tuesday nights that did not make anyone's highlight reel.
+
+## The symmetry with the first Clásico
+
+I keep thinking about how this bookends the October Clásico. Back then Madrid won 2-1 at the Bernabéu, moved five points clear, and the season looked like it might belong to them. I wrote at the time that the result widened the gap without settling anything, because the two teams were closely matched and the title would be decided by consistency across the season rather than by the head-to-head. That turned out to be exactly right, just not in Madrid's favor. The head-to-head split one apiece across the two league games, and the title was decided by everything in between, which is the whole argument for not reading too much into any single Clásico.
+
+There is something clarifying about the two results canceling out. It removes the temptation to say Barcelona won the league because they beat Madrid, because they did not really, they won it 2-0 today and lost 2-1 in October, so the Clásicos were a wash. What decided the title was the two-month stretch in the autumn when Madrid won one of five and Barcelona kept winning, and the winter when the lead held, and the spring when nobody could reel them back in. Today was the confirmation, not the cause, and I think it is worth being precise about that because it is the difference between a title won by a rivalry and a title won by a level.
+
+## Rashford and the depth point
+
+The detail I want to sit with is that the goals came from Rashford and Ferran Torres rather than from the names you would have listed as the season's headline scorers. That is not a footnote. One of the quiet truths of a title-winning squad is that the difference between the champions and the chasers is often depth, the ability to get decisive contributions from across the group rather than from one or two players who have to be brilliant every week. Winning the deciding Clásico through those two is a small illustration of the larger thing that won the league, which is a team good enough all over the pitch that the pressure does not sit on any single player.
+
+That depth is also why I trusted them in August and again in December. A title that comes from a coherent way of playing, where the plan produces chances for whoever happens to be in the right place, is more repeatable than a title that comes from individual moments, because the plan keeps working when any given individual is tired or hurt or out of form. Today the plan produced goals for Rashford and Torres. On another day it produces them for someone else, and that is exactly the point.
+
+## What is left to play for
+
+The title is done, but the season is not, and I would not want the trophy to obscure that the races I have been pointing at all spring are still live. The European places and the relegation fight both run to the final weekends, and with the top of the table now formally decided, all the remaining tension sits down there. Barcelona will get their celebration, deservedly, and Madrid finish a distant but not disgraced second after the year they had, which given the managerial upheaval in January is a more respectable outcome than it might have been.
+
+For now, though, this is Barcelona's title, won early, won against the rival, and won the way they earned it all season. If you want to see the full arc, from the five-point deficit in October to the title with three games to spare, [La Liga Pulse](/la-liga) has tracked the swing the whole way, and it now turns to the two races that are still undecided.

--- a/content/blog/la-liga-2025-26-barcelona-retake-top.mdx
+++ b/content/blog/la-liga-2025-26-barcelona-retake-top.mdx
@@ -1,0 +1,44 @@
+---
+title: "Barcelona Are Top Again, and the Way It Happened Matters"
+excerpt: "Five points down after the Clásico, Barcelona end the calendar year four points clear because Real Madrid won just one of five while they kept winning. Their 2025 record is the kind of consistency that decides titles."
+publishedAt: "2025-12-22"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "Barcelona", "Real Madrid", "Hansi Flick"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "See the title race swing"
+  description: "La Liga Pulse shows how a five-point deficit became a four-point lead, and where the pressure sits now heading into the winter."
+  href: "/la-liga"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Barcelona Retake Top of La Liga: Why the December Swing Matters"
+  description: "Barcelona ended 2025 four points clear of Real Madrid after Madrid won just one of five league games. My analysis of the consistency behind Barcelona's title lead under Hansi Flick."
+  keywords: ["barcelona top of la liga december 2025", "real madrid drop points", "hansi flick barcelona 2025", "la liga title race winter", "barcelona 2025 record"]
+---
+
+# Barcelona Are Top Again, and the Way It Happened Matters
+
+Two months ago Barcelona lost the Clásico and fell five points behind Real Madrid, and I wrote at the time that a five-point gap was a real lead but not a decisive one because a chasing team that keeps winning can erase it in a few weeks. That is more or less exactly what happened. Barcelona end the calendar year four points clear at the top, which is a nine-point swing from where they stood in late October, and the swing came less from a single dramatic result than from the two teams handling the ordinary weekends very differently. Madrid won just one of their five league games in the run that mattered, and Barcelona kept winning theirs, and that is the whole story.
+
+I find this more instructive than the Clásico itself, because it is the kind of thing that actually decides leagues and the kind of thing that is easy to miss if you only tune in for the marquee games. The title is not usually won by beating your direct rival head-to-head. It is won by not dropping points against the teams in the middle of the table on a cold Tuesday when you are tired and the game is not on anyone's must-watch list. Barcelona did that better than Madrid over the last two months, and the four-point lead is the receipt.
+
+## The consistency number I keep looking at
+
+The stat that captures it for me is Barcelona's record across the whole of calendar 2025, which comes out to something like 31 wins, 3 draws, and 3 losses from 37 league matches, or 96 points from a possible 111. You can quibble with using a calendar year rather than a season as the unit, since it stitches together the end of one campaign and the start of another, but I actually think that makes it more useful, not less. It measures the team across a full year of the ordinary grind, through squad changes and fixture congestion and the mental reset of a summer, and it still comes out at a rate that wins almost any league almost every year. That is not a hot streak. That is a level.
+
+What I take from that number is that the thing carrying Barcelona is repeatable, and repeatable is the quality that survives the winter. This is Flick's second season, and the reason I trusted them as favorites in August was that the first title came from a coherent way of playing rather than from a run of luck in tight games, and coherence is exactly what shows up in a 96-from-111 year. When your points come from consistently controlling matches, you keep controlling matches. When they come from winning the close ones, you eventually stop, because the close ones are close for a reason.
+
+## What went wrong for Madrid
+
+I do not want to overstate Madrid's problems, because a team that spent months at the top and is four points back at the winter is not in crisis. But the shape of it is worth naming. I wrote in October that a fast start under a new manager rides on three tailwinds, the freshness of the players, the motivation of a new project, and the fact that opponents have not yet worked out what you want to do, and that none of the three last. Winning one of five is roughly what it looks like when those tailwinds turn. Opponents have had a full autumn to study Alonso's Madrid, the novelty has become the ordinary business of a season, and the results have gotten harder to come by exactly when the schedule got heavier.
+
+Whether that is a blip or a trend is the open question, and it is a genuinely open one. Madrid have the squad to string together a run that puts them right back on top, and there is a lot of season left for them to do it. But the pressure has clearly shifted. Two months ago Barcelona were chasing and had to take a few more risks, and now it is Madrid who have to chase, and chasing is how gaps grow as well as shrink.
+
+## The state of the race at the turn of the year
+
+So Barcelona go into the winter four clear, playing the more repeatable brand of football, with a full year of evidence that the level is real. I still would not call it settled, because four points is a bad month away from being nothing, and I have watched enough seasons turn in January and February to know that the winter is where the real separation happens. But if you asked me today who is more likely to be champion in May, I would say Barcelona without much hesitation, and I would say it because of the 96-from-111 rather than because of the Clásico.
+
+The next few weeks will tell us a lot. If you want to watch the gap move in real time rather than checking in at the Clásicos, [La Liga Pulse](/la-liga) lays the race out round by round, and the winter is when it stops being a formality and starts being a fight.

--- a/content/blog/la-liga-2025-26-final-day.mdx
+++ b/content/blog/la-liga-2025-26-final-day.mdx
@@ -1,0 +1,44 @@
+---
+title: "Final Day: Girona and Mallorca Fall, and Spain Fills Five Champions League Places"
+excerpt: "The last weekend sent Girona and Mallorca down to join Oviedo, settled the European places with Betis claiming a fifth Champions League spot for Spain, and did it all in the compressed, brutal way only a final day can. Here is how it landed."
+publishedAt: "2026-05-24"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "Relegation", "European Qualification", "Final Day"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "See the final table settle"
+  description: "La Liga Pulse tracked the relegation line and the European cutoff to the final whistle, where a single result decided multiple clubs' seasons at once."
+  href: "/la-liga"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "La Liga 2025-26 Final Day: Girona and Mallorca Relegated, Betis Take Fifth CL Spot"
+  description: "The final day of La Liga 2025-26 relegated Girona and Mallorca alongside Oviedo and settled the European places, with Betis claiming a fifth Champions League berth for Spain. My analysis of the closing weekend."
+  keywords: ["la liga final day 2025-26", "girona mallorca relegated 2026", "betis champions league fifth spot", "la liga european places 2026", "spain five champions league teams"]
+---
+
+# Final Day: Girona and Mallorca Fall, and Spain Fills Five Champions League Places
+
+The last weekend did what final days do, which is resolve several months of tension in the space of a single afternoon and do it without mercy. Girona and Mallorca are both relegated, joining Oviedo, who had gone down earlier with games to spare. Girona went into the day needing to win and knowing a good result would have saved Mallorca too, fell behind early, drew level through Arnau Martínez, and could not find the second goal that their season needed, so they went down after four years in the top flight. Mallorca, in one of those cruel final-day symmetries, actually won their own game and still could not survive, going down after five years up because the results elsewhere did not fall their way.
+
+I have written all season that the relegation math is the math people feel, and the final day is the purest version of that. There is no next weekend to fix it, no run of form left to find, just ninety minutes where a club's entire season, and often several clubs' seasons at once, hinge on results happening simultaneously across different stadiums. Mallorca winning and going down anyway is the detail that captures it, because it is the moment the sport stops being about what you did on the pitch in front of you and becomes about what happened somewhere you could not affect. That is brutal, and it is also exactly why the final day is compelling in a way a settled title never is.
+
+## The Mallorca case is the one that stings
+
+Of the three relegated clubs, Mallorca is the one whose season I find hardest to file away, because they had a genuine goalscoring threat all year and still could not stay up. When a team with a striker producing at the rate Mallorca's did across the season ends up relegated, it tells you the problem was never the attack, it was everything around it, the goals conceded and the points dropped in the games where the striker did not rescue them. A relegation with a prolific forward is a specific kind of failure, the kind where the highlight reel looks like a mid-table team and the table says otherwise, and it usually means the squad was carried by one player for as long as one player can carry a squad, which is not quite far enough.
+
+Girona's relegation is the more ordinary story, a club that overachieved to reach and briefly thrive at this level and then regressed toward its underlying resources, which is what usually happens to clubs that punch above their weight for a while. There is no shame in it and there is not much mystery in it either. The final day gave them a chance and they could not take it, and Arnau Martínez's equalizer being not quite enough is the kind of near miss that will sting for a summer but does not change the season-long picture, which is that they were in the fight because the fight had caught up with them.
+
+## Five Champions League places, and Betis take the last one
+
+At the other end of the table, the European places settled with Spain getting five clubs into the Champions League, and the fifth of those went to Betis. That extra place is not a normal feature of the league, it comes from the way European coefficients reward the countries whose clubs perform best on the continent, and Spain earning it meant fifth place in La Liga was worth a top-tier European berth rather than the Europa League consolation it would be in most years. For Betis that is a meaningful upgrade, because the difference between the Champions League and the Europa League is the difference I keep pointing at all season, the money and the recruiting pull that shapes what kind of club you get to be the following year.
+
+Below the Champions League cutoff, the Europa and Conference qualification filled out the way it usually does, as a scramble among the cluster of clubs that spent the spring a point or two apart, and it is worth noting that Rayo Vallecano's run to a European final gave the Spanish contingent an extra thread of continental relevance beyond the league placings themselves. The precise ordering of who ended up in which competition is less interesting to me than the fact that the middle of the table was, as it almost always is in La Liga, the most crowded and most volatile race in the country, more contested than the title and decided later than the drop.
+
+## What the final day confirmed
+
+So the season closes with three clubs down, five in the Champions League, and the usual final-day mixture of clubs celebrating and clubs devastated by results they did not control. I said in the preview that I expected the three promoted sides to split, and they did, though not cleanly, since two of the relegated clubs were established top-flight sides rather than newcomers, which is a reminder that survival is never guaranteed by tenure. The final day is the part of the season the standings hide the most all year and reveal all at once at the end, and this one revealed plenty.
+
+The full picture, from the title clinched two weeks ago to the last relegation confirmed today, is on [La Liga Pulse](/la-liga), and this is the weekend the three-race framing was built for, because it is the one where all three races finish at the same time.

--- a/content/blog/la-liga-2025-26-first-clasico.mdx
+++ b/content/blog/la-liga-2025-26-first-clasico.mdx
@@ -1,0 +1,36 @@
+---
+title: "The First Clásico: Madrid Win It, and the Lead Becomes Five"
+excerpt: "Real Madrid beat Barcelona 2-1 at the Bernabéu through Mbappé and a Bellingham winner, survived a chaotic VAR-heavy opening, and moved five points clear at the top. Here is what I think the game actually told us."
+publishedAt: "2025-10-27"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "El Clasico", "Real Madrid", "Barcelona"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+seo:
+  title: "El Clásico October 2025: Real Madrid 2-1 Barcelona, Lead Goes to Five"
+  description: "Real Madrid beat Barcelona 2-1 at the Bernabéu in the first Clásico of 2025-26 through Mbappé and Bellingham, moving five points clear. My analysis of what the result did and didn't decide."
+  keywords: ["el clasico october 2025", "real madrid 2-1 barcelona", "bellingham clasico winner", "mbappe clasico penalty", "la liga title race clasico"]
+---
+
+# The First Clásico: Madrid Win It, and the Lead Becomes Five
+
+Real Madrid beat Barcelona 2-1 at the Bernabéu yesterday, and the practical effect is that the lead at the top is now five points after ten rounds. Mbappé opened the scoring around the twenty-minute mark off a Bellingham assist, Fermín López equalized for Barcelona before the half hour was out, and Bellingham got the winner right before the interval, so the whole of the decisive action happened inside a frantic first half. The second half added a subplot when Mbappé missed a penalty, and the opening quarter of an hour had already been a mess of VAR interventions that took a penalty and a goal off the board for the hosts before the game settled into itself. It was the kind of Clásico that felt like three games stitched together.
+
+I want to resist the two easy reactions to a game like this, because both of them overstate what one match tells you. The first easy reaction is that Madrid have proven they are the better team and the title is theirs to lose. The second is that the game was so chaotic, with the VAR reversals and the missed penalty, that the result was basically a coin flip and does not mean much. I think the truth sits between those, and it is worth being specific about where.
+
+## What the result actually changes
+
+The concrete thing that changed is the number, and the number matters more than the performance in a race this tight. Five points with most of the season still to play is not a decisive lead, but it is a real one, because it means Barcelona now need to make up ground rather than simply hold their position. A draw would have left the gap where it was and kept the pressure evenly distributed. A Madrid win widens it and shifts the burden onto Barcelona to chase, and chasing changes how a team plays over the following months in ways that are easy to underrate. The trailing team has to take a few more risks, and risks are how gaps get bigger as well as smaller.
+
+What the result does not change is my read on how good these two teams are relative to each other, because the game was close enough and strange enough that I would not update much on it. Barcelona were in it, equalized, and were a Mbappé penalty away from a very different second half. Madrid took their chances at the right moments and defended the lead, which is exactly what a front-running team is supposed to do, but "took their chances and held on" is a description of a team executing under pressure, not proof of a talent gap. If anything, the game reinforced that these are two closely matched sides and the season is going to be decided by consistency across the ordinary weekends rather than by the head-to-head.
+
+## The Bellingham point
+
+The detail I keep returning to is Bellingham getting the assist and the winner in the same half, because it is a reminder of the thing that is hardest to model in a title race, which is that elite individuals decide close games in ways that do not show up in the underlying structure. You can build the better team and still lose the match to one player having twenty good minutes at the right time, and you can be the slightly worse team and win it the same way. Over a full season that noise mostly averages out and the better team tends to finish ahead, which is why I trust the table more in May than in October. In a single Clásico, though, the individual moment is the story, and yesterday it belonged to Bellingham.
+
+## Where this leaves the race
+
+So Madrid go five clear, and the honest summary is that they have done what a front-runner should do without settling anything. I had written before the game that the Clásico would tell us whether Madrid's fast start was closer to their real level or to a honeymoon, and I do not think we got a clean answer, because winning a chaotic one-goal game at home is consistent with both stories. What we did get is a wider gap, and a wider gap is its own kind of pressure that Barcelona now have to live with for the next few months.
+
+I still think this race runs to the spring, and I still think the interesting question is how each team looks in the winter when the fixtures pile up and the early-season freshness is gone. For now the lead is five, Barcelona are chasing, and the return Clásico in the spring suddenly has a lot more riding on it. If you want to see how quickly a five-point gap can move, [La Liga Pulse](/la-liga) tracks it round by round, and this is the part of the season where it starts to get interesting.

--- a/content/blog/la-liga-2025-26-joan-garcia-zamora.mdx
+++ b/content/blog/la-liga-2025-26-joan-garcia-zamora.mdx
@@ -1,0 +1,38 @@
+---
+title: "Joan García's Zamora Is the Award That Explains the Title"
+excerpt: "Barcelona's new goalkeeper won the Zamora for the league's best goals-conceded ratio in his first season at the club, conceding about 0.7 a game. The scoring chart went to Madrid, but the award that tracks title-winning is this one."
+publishedAt: "2026-05-26"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "Zamora Trophy", "Goalkeepers", "Barcelona"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+seo:
+  title: "Joan García Wins the Zamora Trophy: The Award That Tracks Title-Winning"
+  description: "Barcelona goalkeeper Joan García won the 2025-26 Zamora Trophy for the best goals-conceded ratio in his first season at the club. Why the goalkeeping award tracks titles more closely than the golden boot."
+  keywords: ["joan garcia zamora trophy", "la liga best goalkeeper 2025-26", "barcelona goalkeeper zamora", "goals conceded ratio la liga", "zamora trophy 2026"]
+---
+
+# Joan García's Zamora Is the Award That Explains the Title
+
+Joan García has won the Zamora Trophy for the best goals-conceded ratio in La Liga, in his first season as Barcelona's goalkeeper, playing around thirty games and conceding at a rate of roughly 0.7 goals per match. The Zamora goes to the keeper who lets in the fewest per game over a full season, subject to a minutes threshold, and by that measure García was the best in the country in a debut campaign at a new club. I wrote yesterday that the golden boot tells you almost nothing about which team won the league. This is the award that tells you a great deal, and I think the contrast is the most useful thing about putting the two next to each other.
+
+The Pichichi went to a player on the runner-up. The Zamora went to the champion's goalkeeper. That is not a coincidence, it is close to a rule, because conceding fewer goals than everyone else is far more tightly connected to winning leagues than scoring more than everyone else is. Titles are built on the games you do not lose as much as the games you win, and a defense that concedes at 0.7 a game turns a lot of matches that might have been draws into wins and a lot that might have been losses into draws. The points that come from not conceding are quieter than the ones that come from scoring, but there are more of them and they are more reliable, and over a season they are what separates a champion from a chaser.
+
+## Why the goalkeeping award tracks titles
+
+The reason the Zamora correlates with success more than the Pichichi is the same depth argument I have been making all season, just from the defensive end. A great goalkeeping season is never only about the goalkeeper. The goals-conceded ratio is a team statistic wearing an individual's name, because it reflects the whole defensive structure, the shape of the side, the discipline of the press, and the quality of the players in front of the keeper, as much as it reflects the saves themselves. When a goalkeeper wins the Zamora, what you are usually looking at is evidence that the entire team defended well, and a team that defends well is most of the way to a title before it scores a goal.
+
+That is why I read García's award as an explanation of Barcelona's season rather than a separate accolade tacked onto it. The story of the title, the one I have been telling since December, is that Barcelona won because of something repeatable rather than because of a run of luck in tight games, and a league-best defensive record is exactly what repeatable looks like from the back. You do not concede at 0.7 a game by getting lucky. You do it by being organized every single week, which is the same organization that produced the four-point winter lead and the title clinched with three games to spare. The Zamora and the trophy are two views of one thing.
+
+## The debut-season detail
+
+The part that impresses me most is that this was García's first season at the club, because settling in as a new goalkeeper at a side with title expectations is harder than an established keeper making it look routine. A goalkeeper is the one position where the team's trust has to be nearly total for the whole structure to function, and earning that trust while also adapting to new defenders, a new system, and the specific pressure of the shirt, all in one season, and then posting the best conceding ratio in the league, is a genuinely difficult thing to pull off. It is easy to focus on the attacking signings when a team wins a title, but the defensive spine is usually where the quieter, more important work happens, and this is a case of it happening at the most demanding position on the pitch.
+
+There is also a nice symmetry with how the deciding Clásico was won, through squad players rather than headline names, because both point at the same underlying truth about this Barcelona team. The strength was distributed. The goals came from across the group, the clean sheets came from a coherent defensive structure anchored by a new goalkeeper, and no single individual had to be brilliant every week for the team to keep winning. That is the profile of a champion, and it is why they were champions with room to spare.
+
+## The two awards, read together
+
+If you only looked at the golden boot this year, you would think the season belonged to the runner-up, because the top two scorers played for a team that lost the title and a team that got relegated. If you look at the Zamora instead, you see the champion's goalkeeper at the top of the list, and the season snaps into focus. That is the case for paying more attention to the defensive award than the attacking one when you are trying to understand who actually won, and this season is about as clean an illustration of it as you could ask for.
+
+The [scoring chart told one story](/writing/la-liga-2025-26-mbappe-pichichi) and the standings told another, and the Zamora is the award that sits on the standings' side of that divide. Joan García's season is the one that explains the title, even if it will get a fraction of the attention the golden boot does.

--- a/content/blog/la-liga-2025-26-mbappe-pichichi.mdx
+++ b/content/blog/la-liga-2025-26-mbappe-pichichi.mdx
@@ -1,0 +1,38 @@
+---
+title: "Mbappé's Second Pichichi Is a Study in How Little Golden Boots Say About Teams"
+excerpt: "Kylian Mbappé wins the Pichichi again with 25 goals in a season his team lost the title and sacked its manager, while the runner-up scored 23 for a relegated side. The scoring chart and the standings tell almost unrelated stories."
+publishedAt: "2026-05-25"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "Pichichi", "Kylian Mbappe", "Awards"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+seo:
+  title: "Mbappé Wins the Pichichi Again: Why Golden Boots Say Little About Team Success"
+  description: "Kylian Mbappé won the 2025-26 Pichichi with 25 goals despite Real Madrid losing the title, while runner-up Vedat Muriqi scored 23 for a relegated Mallorca. My analysis of the gap between scoring charts and standings."
+  keywords: ["mbappe pichichi 2025-26", "la liga top scorer 2026", "vedat muriqi goals mallorca", "golden boot team success", "mbappe 25 goals la liga"]
+---
+
+# Mbappé's Second Pichichi Is a Study in How Little Golden Boots Say About Teams
+
+Kylian Mbappé has won the Pichichi for the second season in a row, finishing as La Liga's top scorer with 25 goals in 31 matches. It is a genuinely elite achievement, back-to-back scoring titles in a league this strong, and it puts him in company with the small group of forwards who have dominated the Spanish scoring charts across multiple years. What makes it worth writing about rather than just noting is the context around it, because Mbappé won the individual prize in a season where his team lost the title, lost a cup final to the champions, and sacked the manager who started the year winning almost everything. The golden boot and the trophy cabinet point in almost opposite directions.
+
+I find this useful precisely because it is such a clean example of something I believe generally, which is that individual scoring numbers tell you far less about team success than people intuitively assume. There is a strong pull toward reading the top of the scoring chart as a proxy for the best team or the best attack, and it just is not one. Mbappé scored 25 for the runner-up. The player who finished second in the race, Vedat Muriqi, scored 23 for Mallorca, who were relegated on the final day. The two most prolific forwards in the country played for a team that lost the league and a team that lost its place in the league, which is about as direct a refutation of the goals-equal-success intuition as a single season can offer.
+
+## Why the best scorer is often not on the best team
+
+The reason for this is not a coincidence of one season, it is structural. A great striker on a merely good team often scores more than a great striker on a great team, because the great team distributes its goals across more players and does not need any single forward to carry the load. When the whole side is creating chances for whoever is in the right position, no individual runs up the huge personal tally, and the goals get spread around, which is a feature of a deep team rather than a bug. The champions this year won the deciding game through two players who were not their headline scorers, and that is the same phenomenon viewed from the other side. Depth suppresses individual totals even as it produces team success.
+
+So a player can lead the league in goals for one of two very different reasons. Either he is on a dominant team and is so good that he outscores everyone anyway, which is rare, or he is the focal point of a team that leans on him because it does not have the surrounding quality to share the burden, which is common. Mbappé is closer to the first case and Muriqi is squarely the second, a forward whose personal output was heroic and whose team went down around him. Both stories end with a lot of goals and neither ends with a league title, and the scoring chart cannot distinguish between them, which is the whole point.
+
+## The Muriqi line is the one I will remember
+
+Of the two, it is Muriqi's 23 for a relegated side that I will remember longer, because it is the more poignant statistic in the league this year. Scoring at that rate and still going down is the specific tragedy I wrote about on the final day, the failure that looks like success on the highlight reel and reads as relegation in the table. It also underlines why I would never evaluate a forward on goals alone. Muriqi did his job at an exceptional level and it was not close to enough, because a striker cannot defend the goals his team concedes or win the points his team drops in the games he does not personally rescue. His season is a monument to the limits of what one player can do.
+
+Mbappé's season is the inverse limit, a reminder that being the best individual attacker in the country does not entitle you to the collective prize, because the collective prize is won by the better team and the better team is not always the one with the top scorer. He was also named his club's player of the season, which is fair, and none of this diminishes what he did. It just refuses to let the golden boot stand in for a story it does not actually tell.
+
+## What the award is good for
+
+I do not want to be dismissive of the Pichichi, because scoring 25 goals against La Liga defenses is hard and rare and worth honoring on its own terms. The award is a genuine measure of individual finishing and availability and quality, and Mbappé is a genuinely great player having a genuinely great scoring season. What it is not is a measure of the season's best team, or even the season's best attack in the sense that matters, which is the attack that produces titles. For that you have to look at the standings, and the standings this year told a completely different story from the scoring chart, which is exactly why I think both are worth reading and neither should be mistaken for the other.
+
+The team story of the season is [Barcelona's second straight title](/writing/la-liga-2025-26-barcelona-clinch-title), won by a squad deep enough that no single player had to lead the scoring chart to lead the league. The individual story is Mbappé's, and the two barely intersect, which is the most interesting thing about both.

--- a/content/blog/la-liga-2025-26-oviedo-relegated.mdx
+++ b/content/blog/la-liga-2025-26-oviedo-relegated.mdx
@@ -1,0 +1,38 @@
+---
+title: "Oviedo Go Down First: The Brutal Half of the Promotion Story"
+excerpt: "Real Oviedo are relegated with three games to spare, back down after a single season in the top flight. I wrote in August that promotion earns you a place in the division, not the depth to survive it, and this is what that looks like up close."
+publishedAt: "2026-05-12"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "Relegation", "Real Oviedo", "Promotion"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+seo:
+  title: "Real Oviedo Relegated From La Liga After One Season: The Depth Gap Up Close"
+  description: "Real Oviedo are the first team relegated from La Liga 2025-26, back down after a single season up. My analysis of why the gap between the Segunda and La Liga is mostly a gap in squad depth."
+  keywords: ["real oviedo relegated 2026", "la liga first team relegated 2025-26", "oviedo one season la liga", "promoted teams relegation la liga", "segunda division la liga gap"]
+---
+
+# Oviedo Go Down First: The Brutal Half of the Promotion Story
+
+Real Oviedo are the first team relegated from La Liga this season, confirmed with three games still to play once Girona took a point that put survival mathematically out of reach. Oviedo finish their stay in the top flight on around 29 points, roughly seven behind the team in nineteenth and eight behind the team in eighteenth, which is the kind of margin that tells you this was not a near miss decided by a bad weekend. It was a season where the gap was visible for a long time before the arithmetic made it official. After a single year back among the elite, following a long time away, Oviedo go down.
+
+I wrote about Oviedo specifically in the preview, because their return was the story I found easiest to romanticize and knew would be brutal to live through. This is the brutal half. Promotion is a genuine achievement and a genuine joy, and I do not want to be glib about a club and a city getting a season they had waited a very long time for. But promotion earns you a place in the division. It does not earn you the squad that survives the division, and the difference between those two things is the whole of what just happened to Oviedo.
+
+## The gap is mostly a depth gap
+
+The thing I keep saying about the jump from the Segunda to La Liga is that it is mostly a gap in depth rather than a gap in the starting eleven. A promoted side can often field a first choice team that competes, and on their best day with everyone fit they can beat almost anyone, which is what makes the early-season upsets happen and what makes people believe survival is coming. The problem is that a season is not played by the best eleven on their best day. It is played across nearly forty games by whoever is available when three players are hurt and two are suspended and the fixtures are stacked three to a week, and that is where the promoted club runs out of road. The bench is where La Liga is survived, and the bench is exactly what promotion does not buy you.
+
+That is why the margin matters more than the moment of relegation. Going down with three games to spare, seven or eight points adrift, is the signature of the depth gap rather than of bad luck. A team that loses a relegation fight on the final day to a single result can tell itself a story about fine margins, and often that story is true. A team that is mathematically down with three to play has been ground out over months by the accumulation of games it did not have the players to win, and there is less comfort available in that, even if there is also less to second-guess.
+
+## Why I still think promotion is worth it
+
+None of this is an argument against the ambition of getting promoted, and I want to be clear about that because the depth-gap point can read as fatalism. A season in La Liga, even one that ends in relegation, is worth an enormous amount to a club, in revenue, in exposure, in the experience the younger players bank, and in the simple fact of the games themselves against the best teams in the country. Oviedo got that season. The romance was real even though the survival was not, and I do not think the two cancel out. The brutal half of the story does not erase the good half. It is just the part that the preview knew was coming and the part that is hard to watch when it arrives.
+
+The harder question for a club in this position is what they do next, because the danger after relegation is a slow drift rather than an immediate bounce back. The clubs that come straight back up tend to be the ones that hold their core together and treat the top-flight season as an investment rather than a one-off, and the clubs that fall away are the ones that let the squad scatter and have to rebuild the promotion from scratch. Which of those Oviedo becomes is a story for next season, and it is a more consequential story than this relegation, even though it will get a fraction of the attention.
+
+## The rest of the fight
+
+Oviedo going down first does not end the relegation drama, it just resolves one of the three questions at the bottom. The other two spots are still being contested, and unlike Oviedo's slow slide, those look likely to run to the final weekend, which is the version of a relegation fight that keeps you watching. I said in the preview that I expected the promoted sides to split rather than share a season, with one struggling from the start, and Oviedo is the one that struggled from the start. Whether the survival math claims anyone else, and who, is the part still to be decided.
+
+For now, this is the first confirmed drop of the season, and it is the half of the promotion story that nobody puts on the poster. You can follow the two spots still up for grabs on [La Liga Pulse](/la-liga), where the relegation line is its own tracker precisely because the math down there is the math people feel.

--- a/content/blog/la-liga-2025-26-real-madrid-flying-start.mdx
+++ b/content/blog/la-liga-2025-26-real-madrid-flying-start.mdx
@@ -1,0 +1,40 @@
+---
+title: "Real Madrid's Flying Start and the Question It Doesn't Answer Yet"
+excerpt: "Xabi Alonso's Madrid have opened the season about as well as a new manager can, winning almost everything and leading the table into the first Clásico. I think the start is real. I am less sure it tells us who wins the league."
+publishedAt: "2025-10-20"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "Real Madrid", "Xabi Alonso", "Barcelona"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Track the title race live"
+  description: "La Liga Pulse reads the standings as three races at once, so you can see whether Madrid's lead is real or one bad weekend from reopening."
+  href: "/la-liga"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Real Madrid's Fast Start Under Xabi Alonso: What It Does and Doesn't Prove"
+  description: "Xabi Alonso's Real Madrid opened 2025-26 winning almost everything and leading La Liga into the first Clásico. My take on why the start is real but not yet decisive."
+  keywords: ["real madrid xabi alonso start", "la liga 2025-26 table october", "real madrid barcelona title race", "mbappe la liga scorer 2025-26"]
+---
+
+# Real Madrid's Flying Start and the Question It Doesn't Answer Yet
+
+Real Madrid have opened the season about as well as a new manager could reasonably hope, winning nearly everything in front of them across all competitions and sitting top of La Liga going into the first Clásico next weekend. Xabi Alonso took the August manager of the month award for a perfect start, and the results have kept coming since. I want to be clear that I think this is real and not a mirage, because the way they are winning looks like a team that has bought into a plan, not a team getting lucky in tight games. But I also think a flying start is the single most over-read signal in a long season, and the honest thing is to separate what it proves from what it does not.
+
+What it proves is that the transition worked faster than transitions usually do. Handing a squad this good to a new coach is the kind of move that can cost you the autumn while everyone learns the patterns, and Madrid have skipped that phase almost entirely. Alonso clearly had a specific idea of how he wanted the team to play and the players clearly absorbed it quickly, which is not a small thing and reflects well on both the coach and the group. Mbappé is scoring, the results are stacking up, and the early schedule has been navigated without the dropped points that usually pepper a manager's first months. That is a genuine achievement, and I would not wave it away.
+
+## Why the start doesn't settle the season
+
+Here is the part I keep coming back to. A talented squad under a sharp new coach almost always starts well, because the players are fresh, the motivation of a new project is at its peak, and opponents have not yet worked out what the team wants to do. None of those three advantages last. The freshness fades as the fixture list compresses into the winter, the novelty of the project becomes the ordinary business of a season, and opponents study you and start taking away your first option. What a fast start cannot tell you is how the team plays once all three of those tailwinds turn into headwinds, and you only find that out when something finally goes wrong and you watch how the group responds.
+
+That is not a criticism of Madrid so much as a limit on what October can tell us. The league is not won by the team that is best in the first ten weeks. It is won by the team that is still executing its plan in February when players are tired and hurt and the results have gotten harder to come by, and there is no way to observe that quality in advance. I have seen enough seasons where the autumn pacesetter faded to treat a lead in October as information about the present rather than a prediction of May. It matters, because points are points and a cushion is a cushion, but it is not the same as knowing who wins.
+
+## Barcelona are right there, which is the point
+
+The reason the start does not settle anything is that Barcelona are close behind and look like the same coherent team that won last season. When the defending champion is within touching distance and playing well, an early lead is a comfort, not a decision, because a single Clásico result can erase the gap or double it. That is exactly why next weekend matters more than a normal round. It is not that one game decides the title, because it does not, but that the Clásico is the first time this season we get to watch these two teams measure themselves directly rather than against the rest of the league.
+
+What I will be watching in that match is less the scoreline than the character of it. If Madrid win the way they have been winning, controlling the game and taking their chances, that tells me the start is closer to their real level than to a honeymoon. If Barcelona expose something, or if Madrid win but in a way that looks fortunate, that tells me the autumn form was flattering and the season is wider open than the table suggests. Either way the table lies a little right now, because it shows a Madrid lead without showing how fragile or solid that lead actually is.
+
+If you want to see the gap in context rather than as a single number, [La Liga Pulse](/la-liga) lays the title race out so you can tell whether the lead is real or one weekend from reopening, which is the entire question at this point in the season. Come back after the Clásico and we will know a little more than we do now.

--- a/content/blog/la-liga-2025-26-season-preview.mdx
+++ b/content/blog/la-liga-2025-26-season-preview.mdx
@@ -1,0 +1,44 @@
+---
+title: "What I'm Watching in La Liga 2025-26 Before a Ball Is Kicked"
+excerpt: "Barcelona are the defending champions, Real Madrid have handed the rebuild to Xabi Alonso, and three promoted sides arrive with very different odds. Here is what I think actually decides the season, and how I plan to track it."
+publishedAt: "2025-08-15"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "Barcelona", "Real Madrid", "Season Preview"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Open La Liga Pulse"
+  description: "I built a dashboard that reads the season as three races at once, the title fight, European qualification, and relegation, with the scoring leaders alongside."
+  href: "/la-liga"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "La Liga 2025-26 Season Preview: What Actually Decides the Title"
+  description: "My preview of the 2025-26 La Liga season. Barcelona defend under Flick, Real Madrid reset under Xabi Alonso, and the promoted sides Levante, Elche, and Real Oviedo face very different survival odds."
+  keywords: ["la liga 2025-26 preview", "barcelona real madrid title race", "xabi alonso real madrid", "la liga promoted teams", "real oviedo la liga"]
+---
+
+# What I'm Watching in La Liga 2025-26 Before a Ball Is Kicked
+
+The season starts this weekend, and I want to write down what I think matters before the results start rewriting my memory of what I expected. That is the honest reason to do a preview at all. It is not to predict the table, because nobody can, but to make my assumptions explicit enough that I can check them against reality later and see where my read of the league was wrong.
+
+The one thing I feel confident about is that Barcelona start as the team to beat, and I think that is the correct read rather than just deference to the defending champion. Hansi Flick's first season worked because the structure worked, not because a couple of players had career years, and structure tends to carry over in a way that hot form does not. When a title comes from a coherent way of playing rather than from a run of good luck in tight games, the base case for the next season is that the same thing mostly keeps happening. So my starting assumption is that Barcelona are the favorite, and the interesting question is who pushes them and how close it gets.
+
+## The Madrid reset is the real story
+
+The story I am most curious about is Real Madrid, because they have done the thing that is genuinely hard to evaluate in advance, which is change the manager at a club where the squad is already full of talent. Xabi Alonso arrives with a strong reputation and a clear idea of how he wants to play, and he inherits a group that includes Kylian Mbappé coming off a Pichichi season, so the raw material is not the problem. The problem, if there is one, is that a new manager needs the results to arrive before the identity is fully installed, and Madrid is not a club that grants much patience.
+
+What I will be watching is the gap between how good Madrid look early and how good they still look once the fixture list gets heavy. A talented squad under a sharp new coach almost always starts well, because the players are fresh and motivated and the opponents have not yet worked out the patterns. The test is not August. The test is whether the early form is the real level or whether it is the honeymoon, and you usually cannot tell the difference until something goes wrong and you see how the group responds. I do not have a strong prediction here, which is exactly why it is the thing I most want to track.
+
+## Three promoted sides, three different seasons
+
+The bottom of the table is where I think the preview is most useful, because the three promoted teams are not arriving on equal footing and the standings will flatten that difference into a single relegation line. Levante, Elche, and Real Oviedo all came up, and they will all be described the same way in previews, as newly promoted and likely to struggle, but I do not think their seasons are actually the same shape.
+
+Oviedo is the one I keep thinking about, because a return to the top flight after that long away is the kind of story that is easy to romanticize and brutal to live through. Promotion earns you a place in the division. It does not earn you the squad depth that survives a division, and the gap between the Segunda and La Liga is mostly a gap in the players you can bring off the bench when the starters tire or get hurt. I would not be surprised if the promoted sides split, with one finding enough to stay up comfortably, one grinding through a survival fight that goes to the final weeks, and one struggling from the start. Which team ends up in which slot is the part I cannot call, and it is the part that makes the bottom of the table worth watching every week rather than only at the end.
+
+## Why I built a screen for this
+
+The reason I care about the framing rather than just the results is that a league table hides most of what is actually happening. Twenty rows sorted by points tells you the order and almost nothing about the pressure, and the pressure is the whole point. The title race at the top, the scramble for European places in the middle, and the relegation fight at the bottom are three separate competitions sharing one set of standings, and I wanted a way to read them as three things instead of one list. That is why I built [La Liga Pulse](/la-liga), and I wrote up the [product thinking behind it](/writing/building-a-la-liga-dashboard) separately if you want the longer version.
+
+My plan for this season is to track it week by week rather than only show up for the Clásicos, because the season is decided in the ordinary weekends as much as the marquee ones. If Barcelona are as good as I think, the interesting drama moves down the table, to the European places and the drop, and those are the races I would tell you to watch even in a year where the title looks settled early. Ask me in May how much of this I got right.

--- a/content/blog/la-liga-2025-26-season-verdict.mdx
+++ b/content/blog/la-liga-2025-26-season-verdict.mdx
@@ -1,0 +1,48 @@
+---
+title: "La Liga 2025-26, the Season in One Idea: Repeatable Beats Spectacular"
+excerpt: "Barcelona won a second straight title with room to spare, Real Madrid's spectacular start turned into a January sacking, and the awards split neatly between the two. Looking back, the whole season was an argument for consistency over fireworks."
+publishedAt: "2026-05-27"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "Season Review", "Barcelona", "Real Madrid"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Revisit the whole season"
+  description: "La Liga Pulse tracked all three races from August to the final whistle. It is the fastest way to see how the season actually unfolded rather than how it is remembered."
+  href: "/la-liga"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "La Liga 2025-26 Season Review: Why Repeatable Beat Spectacular"
+  description: "My season review of La Liga 2025-26. Barcelona's second straight title, Real Madrid's fast start and January collapse, and the awards all point to one lesson, that consistency beats fireworks over a full season."
+  keywords: ["la liga 2025-26 season review", "barcelona second title flick", "real madrid alonso season", "la liga awards 2026", "la liga season verdict"]
+---
+
+# La Liga 2025-26, the Season in One Idea: Repeatable Beats Spectacular
+
+The season is over, and looking back across all of it, from the preview I wrote before a ball was kicked to the final relegation confirmed last weekend, I think it told one story more clearly than any La Liga season I can remember. The story is that repeatable beats spectacular over a full year, almost every time, and this season made that case from the top of the table to the bottom and in the individual awards as well. Barcelona were the repeatable team and they won with room to spare. Real Madrid were the spectacular one, and spectacular got a manager sacked in January.
+
+I want to lay out how the pieces fit, because the pattern is cleaner in hindsight than it felt at any single point during the year, and the whole reason I write these as they happen is to be able to check the pattern against what I actually thought at the time rather than against a tidied-up memory.
+
+## The title was won in the ordinary weekends
+
+Barcelona's second straight title under Flick was not won in the Clásicos, which split one apiece, and it was not won by any single dramatic result. It was won in the two-month autumn stretch when Real Madrid took one of five and Barcelona kept winning theirs, in the winter when the four-point lead held, and in the spring when nobody could reel them back. They [clinched it with three games to spare](/writing/la-liga-2025-26-barcelona-clinch-title), and clinching that early is the signature of a team that was consistently better across the whole calendar rather than one that edged a run of close games. I trusted them as favorites in August because their first title came from a coherent way of playing rather than from luck, and coherence is exactly what carried them again.
+
+## The fast start was a credit line, not a foundation
+
+Real Madrid are the other half of the lesson, and the more instructive half. They started the season winning almost everything under Xabi Alonso, led by five points after the October Clásico, and looked for a while like the story of the year. I wrote at the time that a fast start under a new manager rides on tailwinds that never last, the freshness of the players, the novelty of the project, and opponents not yet having worked you out, and when those faded the team fell apart fast enough that [Alonso was gone by January](/writing/la-liga-2025-26-supercopa-alonso-sacked) after 233 days. Álvaro Arbeloa steadied them to a respectable second, which given the upheaval is a better outcome than it might have been, but the season is a permanent reminder that spectacular early form is a credit line a club will call in the moment results turn.
+
+## The depth gap decided the bottom
+
+At the other end, the relegation of Oviedo, Girona, and Mallorca made the same argument in a different register. Oviedo went down first, [back to the second tier after a single season up](/writing/la-liga-2025-26-oviedo-relegated), because promotion earns you a place in the division but not the depth to survive it, and the bench is where a La Liga season is actually survived. Mallorca went down on the final day despite having one of the most prolific forwards in the country, which is the clearest possible proof that individual brilliance does not add up to a repeatable team. A striker cannot defend the goals conceded or win the points dropped in the games he does not personally rescue, and 23 goals were not enough to keep a side up.
+
+## The awards split exactly along the divide
+
+The individual prizes closed the argument. The [Pichichi went to Mbappé](/writing/la-liga-2025-26-mbappe-pichichi), the best individual scorer, on the runner-up, with the second-place finisher scoring 23 for a relegated club, so the top of the scoring chart belonged to teams that lost the title and lost their place in the league. The [Zamora went to Joan García](/writing/la-liga-2025-26-joan-garcia-zamora), the champion's goalkeeper, because conceding fewer goals than everyone else is far more tightly connected to winning than scoring more than everyone else is. The golden boot is the spectacular award and it went to the spectacular team. The goalkeeping award is the repeatable one and it went to the champion. You could hardly design a cleaner illustration.
+
+## The pattern I would pull out of this
+
+The thread running through the whole season is that the things which win over forty games are not the things which win a highlight reel. Barcelona won because they were organized every week, deep enough that no single player had to carry them, and consistent enough to clinch early. Real Madrid lost the title, and a manager, because a spectacular start could not be sustained once the tailwinds turned. The promoted clubs went down because a competitive best eleven is not the same as a squad that survives a season. And the awards split precisely between the spectacular and the repeatable, with the trophy sitting on the repeatable side. If I take one thing from this year into the next, it is to trust the boring, consistent version of quality over the exciting, streaky one, because the season is long enough that the boring version almost always wins.
+
+I tracked all of it, week by week, on [La Liga Pulse](/la-liga), and going back through the season there is the fastest way to see how it actually unfolded rather than how it will be remembered. I will run the same series next season, starting with a preview before a ball is kicked, and we will find out whether the lesson holds again.

--- a/content/blog/la-liga-2025-26-supercopa-alonso-sacked.mdx
+++ b/content/blog/la-liga-2025-26-supercopa-alonso-sacked.mdx
@@ -1,0 +1,38 @@
+---
+title: "233 Days: Xabi Alonso Is Out, and the Fast Start Was the Whole Case For Him"
+excerpt: "Barcelona beat Real Madrid 3-2 in the Supercopa final in Jeddah, and a day later Alonso was gone, replaced by Álvaro Arbeloa from the reserves. A manager who started 13 of 14 lost his job in January. That tells you something about the club."
+publishedAt: "2026-01-13"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "Real Madrid", "Xabi Alonso", "Supercopa"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+seo:
+  title: "Xabi Alonso Sacked After 233 Days: The Supercopa Loss and the Madrid Reset"
+  description: "Real Madrid lost the Supercopa final 3-2 to Barcelona and sacked Xabi Alonso a day later, promoting Álvaro Arbeloa. My analysis of how a manager who started 13 of 14 lost his job in January."
+  keywords: ["xabi alonso sacked real madrid", "arbeloa real madrid coach", "supercopa 2026 barcelona real madrid", "real madrid manager change 2026", "la liga title race january"]
+---
+
+# 233 Days: Xabi Alonso Is Out, and the Fast Start Was the Whole Case For Him
+
+Real Madrid lost the Supercopa de España final 3-2 to Barcelona in Jeddah on Sunday, and by Monday Xabi Alonso was no longer the manager. The club framed it as a mutual parting, some of the reporting framed it as a sacking, and the practical distinction between those does not matter much. What matters is that a coach who started this season with something like 13 wins in his first 14 games across all competitions, who took the August manager of the month award, and who had Madrid five points clear of Barcelona in late October, was out of a job in the middle of January after 233 days. Álvaro Arbeloa, who had been coaching the reserves, has been promoted to replace him.
+
+I have been writing about Madrid's season as a question about whether the fast start was real, and this is the answer, though not the one I expected. The answer is that at a club like Real Madrid it does not fully matter whether the start was real, because the start bought Alonso time rather than security, and once the results turned the time ran out fast. That is the thing I keep turning over. The 13-of-14 was not a foundation. It was a credit line, and the club called it in the moment the season stopped going his way.
+
+## Why the fast start couldn't save him
+
+I wrote back in October that a talented squad under a sharp new coach almost always starts well, because the players are fresh, the project is new, and opponents have not worked out the patterns yet, and that none of those three advantages last. When they faded, Madrid went from five points clear to four points behind, winning one of five in the stretch that swung the title race. The Supercopa final was the last straw rather than the whole story, but losing a final to the direct rival is the kind of visible, on-the-day defeat that crystallizes a decision a club has already been circling.
+
+What makes the sacking a real statement rather than a routine one is that Alonso is not a manager with a thin reputation who lucked into a good autumn. He arrived as one of the more respected young coaches in Europe, installed a clear identity faster than almost anyone could have, and still lost the room's confidence, or the board's, inside a single half-season. If that can happen to him after that start, it tells you the tolerance for a downturn at this club is close to zero, and that the early results were being read not as proof of a good hire but as the minimum expected of a good squad. The credit was never as large as 13-of-14 made it look.
+
+## The Arbeloa gamble
+
+Promoting Arbeloa from the reserves is an interesting choice, and I mean interesting in the sense that I genuinely cannot call how it goes. Bringing in an inside candidate who knows the club and the younger players is a bet on continuity and cultural fit rather than on a proven top-level track record, because there is not one yet. A former player who spent seven years and made well over two hundred appearances at the club is not a random appointment, and there is a real logic to handing a talented but wobbling squad to someone who understands the environment and can steady it without a long adaptation period. But it is a gamble, and the club is making it in the middle of a title race that is currently slipping away, which is the hardest possible moment to hand a first big job to a rookie manager.
+
+The thing I will be watching is not whether Arbeloa can win the title back, because I think that is probably already a long shot with Barcelona four clear and playing the way they are. It is whether he can stop the slide and get Madrid back to the level the squad should produce, because that is the achievable version of a good outcome from here. A second-place finish that steadies the ship and sets up next season is a very different result from a spring where the season keeps unraveling, and the difference between those is mostly about whether the new manager can restore the floor.
+
+## What this does to the race
+
+For the title race, the immediate effect is that the chasing team just changed managers in January, which almost never helps you catch anyone in the short term. A managerial change buys medium-term hope at the cost of near-term disruption, because the players have to absorb a new voice and new instructions on the fly while the leader keeps accumulating points. Barcelona were already the favorite before this. They are more clearly the favorite now, not because they did anything this week but because their rival just added instability to a deficit.
+
+So the story of Madrid's season has become the story of a fast start that turned out to be a credit line, called in after 233 days. Whether Arbeloa turns it into something is the subplot worth following for the rest of the spring, and I will be tracking how the race actually settles on [La Liga Pulse](/la-liga) as it goes.

--- a/content/blog/la-liga-2025-26-title-race-run-in.mdx
+++ b/content/blog/la-liga-2025-26-title-race-run-in.mdx
@@ -1,0 +1,44 @@
+---
+title: "The Run-In: Read the Bottom of the Table Before the Top"
+excerpt: "With the title all but decided, the last stretch of the season is really two races, the scramble for European places and the fight to stay up. This is the part of the year the standings hide the most, and the part I most want a dashboard for."
+publishedAt: "2026-04-06"
+category: "Sports Analytics"
+tags: ["La Liga", "Football", "Soccer", "Sports Analytics", "European Qualification", "Relegation", "Barcelona"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Open La Liga Pulse"
+  description: "The dashboard reads the run-in as three races at once, so the European cutoff and the relegation line are as legible as the title at the top."
+  href: "/la-liga"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "La Liga 2025-26 Run-In: The European and Relegation Races Decide It Now"
+  description: "With Barcelona's title all but decided, the La Liga 2025-26 run-in comes down to the European qualification scramble and the relegation fight. Why the bottom of the table is the part worth watching."
+  keywords: ["la liga run-in 2025-26", "la liga relegation fight april 2026", "la liga european places race", "champions league qualification la liga", "la liga title clinch barcelona"]
+---
+
+# The Run-In: Read the Bottom of the Table Before the Top
+
+We are into the final stretch now, and the title race has arrived at the place I thought it would back in December, which is close to decided. Barcelona have carried the lead through the winter and into the spring, and while the arithmetic still leaves a narrow path for someone to catch them, I do not think anyone realistically will. That is not a knock on the run-in. It is the opposite. A settled title at the top is exactly when the rest of the table gets interesting, because all the pressure that would normally concentrate on the championship redistributes downward to the European places and the drop, and those are races with far more teams involved and far less certainty.
+
+If you only have time to watch one part of the league over the next few weekends, I would tell you to read the bottom of the table before the top. That is a slightly counterintuitive thing to say when there is a title being won, but the title is being won slowly and legibly, whereas the relegation fight is being decided fast and the outcomes genuinely change from one result to the next. The clubs sitting a couple of points either side of the drop line are living a completely different season from the ones a few rows above them, even though the standings make them look like neighbors.
+
+## Why the standings hide the run-in
+
+The problem with a normal league table in April is that it flattens three different competitions onto a single axis. Twenty rows sorted by points tells you the order and almost nothing about where the pressure lives, and the pressure is the whole point of the run-in. The gap between fifth and sixth might decide whether a club plays Champions League football and gets the money and the recruiting pull that comes with it, and that gap can be one point, while the ten-point gap between eighth and eighteenth is not a race at all. Rank does not tell you which gaps matter. You have to supply that context yourself every time you look, and by this stage of the season I got tired of doing that arithmetic by hand, which is the honest origin of the dashboard.
+
+The European scramble is the most crowded part of it. There is a cluster of clubs separated by a couple of points chasing the same handful of continental spots, and the difference between the Champions League places and the Europa or Conference qualification is enormous, not just this year but for what it lets a club do over the summer. A place in the top competition changes which players you can sign and which ones you can keep, so a single April result can echo through a club's next several seasons. That is a lot riding on games that will not lead any highlight show, and it is exactly the kind of stakes that a flat table renders invisible.
+
+## The relegation math is the math people feel
+
+The drop is where the format comes alive, and it is where I would point a newcomer first. The math down there is the math people actually feel, because a single result can move a club from safe to in trouble in ninety minutes, and the teams involved are fighting for something more fundamental than a trophy or a European place. I wrote in the preview that I expected the three promoted sides to split rather than share a season, with one staying up, one grinding through a fight to the final weekends, and one struggling throughout, and the run-in is where that prediction gets settled one way or the other.
+
+I am deliberately not going to name who goes down, because a relegation fight with a handful of games left is genuinely unsettled and the clubs in the most danger today are not always the ones who end up relegated. Survival math has a way of running to the final whistle of the final weekend, and teams that look doomed in early April sometimes find a run, while teams that look safe sometimes freeze. What I can say is that the line is going to move every weekend from here, and that watching it move is more compelling than watching a title get formally confirmed.
+
+## What I am watching to the finish
+
+So the run-in, for me, is two races rather than one. It is the European scramble in the middle, where a point decides which competition a club plays in and therefore what kind of club it gets to be next year, and it is the relegation fight at the bottom, where the stakes are existence in the division. The title at the top is the headline, and Barcelona will get their moment, but the headline is not where the drama is.
+
+I built [La Liga Pulse](/la-liga) precisely for this stretch of the season, so that the European cutoff and the relegation line are as legible as the title, and I wrote up the [thinking behind it](/writing/building-a-la-liga-dashboard) if you want the longer version. The fastest way to understand why I built it is to open it now, in the run-in, and look at the bottom of the table before you look at the top.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -189,4 +189,17 @@
 <url><loc>https://isaacavazquez.com/writing/2026-japanese-grand-prix-antonelli-title-lead</loc><lastmod>2026-03-29T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/writing/2026-miami-grand-prix-mclaren-mercedes</loc><lastmod>2026-05-03T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/writing/2026-monaco-grand-prix-antonelli-grand-slam</loc><lastmod>2026-06-07T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-arbeloa-madrid-midseason</loc><lastmod>2026-02-23T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-barcelona-clinch-title</loc><lastmod>2026-05-11T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-barcelona-retake-top</loc><lastmod>2025-12-22T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-final-day</loc><lastmod>2026-05-24T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-first-clasico</loc><lastmod>2025-10-27T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-joan-garcia-zamora</loc><lastmod>2026-05-26T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-mbappe-pichichi</loc><lastmod>2026-05-25T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-oviedo-relegated</loc><lastmod>2026-05-12T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-real-madrid-flying-start</loc><lastmod>2025-10-20T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-season-preview</loc><lastmod>2025-08-15T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-season-verdict</loc><lastmod>2026-05-27T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-supercopa-alonso-sacked</loc><lastmod>2026-01-13T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/la-liga-2025-26-title-race-run-in</loc><lastmod>2026-04-06T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 </urlset>


### PR DESCRIPTION
## What this adds

A curated, backdated La Liga 2025-26 series under `content/blog`, thirteen articles that cover the season week by week at its key inflection points, plus dedicated pieces for the major events and the individual awards. Each article is dated to when the events actually happened, written in the site's editorial voice (`WRITING_VOICE.md`), and cross-linked to the others and to the La Liga Pulse dashboard at `/la-liga`. They land in the existing `Sports & Fantasy` archive bucket under the `Sports Analytics` category, alongside the existing `building-a-la-liga-dashboard` post.

Because the site auto-discovers posts from `content/blog`, renders them as plain markdown via remark, and generates a per-slug OpenGraph image, no code changes were needed. All the dates are in the past, so the posts publish immediately.

## The season, and the articles

The series follows one storyline the season kept making, that a repeatable level beats a spectacular one over a full year. Real Madrid started fast under new manager Xabi Alonso and led after the October Clásico, then faded, lost the Supercopa final, and sacked Alonso in January before Arbeloa steadied them to second. Barcelona carried a consistent level through the winter and clinched a second straight title in the return Clásico with three games to spare. The awards split along the same line, with Mbappé's Pichichi going to the runner-up and Joan García's Zamora going to the champion's goalkeeper.

In chronological order:

| Date | Slug | Focus |
| --- | --- | --- |
| 2025-08-15 | `la-liga-2025-26-season-preview` | Season preview: Barça defend, Madrid reset, the promoted three |
| 2025-10-20 | `la-liga-2025-26-real-madrid-flying-start` | Madrid's fast start under Alonso |
| 2025-10-27 | `la-liga-2025-26-first-clasico` | First Clásico, Madrid win 2-1, go five clear |
| 2025-12-22 | `la-liga-2025-26-barcelona-retake-top` | Barça retake top by year-end |
| 2026-01-13 | `la-liga-2025-26-supercopa-alonso-sacked` | Supercopa loss, Alonso sacked, Arbeloa in |
| 2026-02-23 | `la-liga-2025-26-arbeloa-madrid-midseason` | Midseason reset, the races that matter now |
| 2026-04-06 | `la-liga-2025-26-title-race-run-in` | The three-race run-in |
| 2026-05-11 | `la-liga-2025-26-barcelona-clinch-title` | Barça clinch a second straight title |
| 2026-05-12 | `la-liga-2025-26-oviedo-relegated` | Oviedo relegated first |
| 2026-05-24 | `la-liga-2025-26-final-day` | Final-day relegation and European places |
| 2026-05-25 | `la-liga-2025-26-mbappe-pichichi` | Mbappé's second Pichichi |
| 2026-05-26 | `la-liga-2025-26-joan-garcia-zamora` | Joan García's Zamora |
| 2026-05-27 | `la-liga-2025-26-season-verdict` | Season verdict |

## How facts were sourced

The web archive of Wikipedia and the major football sites was unreachable from this environment, so the season facts were triangulated across multiple web searches (final table, both Clásicos, the managerial change, relegation, and awards). The articles anchor on the well-confirmed spine of the season and stay general where the sources were thin rather than inventing scorelines, in keeping with the writing voice. Worth a read-through for factual accuracy before merging, particularly the finer details in the awards and final-day pieces.

## Verification

- All 13 files pass the same required-frontmatter check the loader enforces (`title`, `excerpt`, `category`, `publishedAt`), use the valid `Sports & Fantasy` archive bucket, and include a leading H1.
- No em dashes, no colon-as-connector headers, no "Conclusion" / "Next Steps" / "About the Author" sections, no bold-label bullet lists.
- All internal `/writing/*` cross-links resolve to posts that exist (the new ones plus `building-a-la-liga-dashboard`).
- Word counts run 812 to 945, in line with the site's other sports articles.
- A full `next build` was not run because `node_modules` is not installed in this environment; the content is plain remark-compatible markdown and requires no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHvWVBeoECKBGk5iZoS9Aj)_