### PR TITLE
Add 2026 Formula 1 race review articles (rounds 1-9)

### DIFF
--- a/content/blog/2026-australian-grand-prix-mercedes-new-era.mdx
+++ b/content/blog/2026-australian-grand-prix-mercedes-new-era.mdx
@@ -1,0 +1,35 @@
+---
+title: "The 2026 Rules Reset Opened With Mercedes in Complete Control"
+excerpt: "The new regulations were supposed to produce a runaway. Instead Melbourne gave us a real race, a Mercedes 1-2 from pole, and the early sense that Mercedes understood the new power unit better than anyone."
+publishedAt: "2026-03-08"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "Australian Grand Prix", "Mercedes", "George Russell", "2026 F1 Season", "Sports Analytics"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/2026-australian-grand-prix-mercedes-new-era/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The dashboard keeps the driver and constructor standings, the next Grand Prix, and race-by-race context in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Mercedes Control the 2026 Season Opener in Melbourne"
+  description: "George Russell led a Mercedes 1-2 at the 2026 Australian Grand Prix as F1's new-era rules debuted, and Mercedes look like the team that solved the reset."
+  keywords: ["2026 Australian Grand Prix", "F1 2026 rules", "Mercedes 1-2", "George Russell win", "2026 F1 season opener", "new F1 power unit"]
+---
+
+# The 2026 Rules Reset Opened With Mercedes in Complete Control
+
+The fear going into 2026 was that the biggest regulation change in a generation would hand one team a second a lap and turn the season into eleven months of processional racing while everyone else caught up. Melbourne mostly put that fear to rest, and it did something more specific than that too. It suggested that the team which understood the new package best is Mercedes, and that the rest of the grid is now the one doing the catching up.
+
+I should explain what actually changed, because it is the backdrop to the whole year. The 2026 cars run a power unit split roughly evenly between the internal combustion engine and the electric motor, with the MGU-H removed entirely and the electric side nearly tripled in output, all of it burning fully sustainable fuel. The cars are lighter, narrower, and shorter than last year's, and the old DRS flap is gone, replaced by active front and rear wings plus an electric override that a trailing driver gets when he is within a second of the car ahead. That is a lot of new variables arriving at once, and the honest truth before the weekend was that nobody outside the teams knew who had gotten it right.
+
+George Russell answered part of it by putting his Mercedes on pole and leading a 1-2, winning by 2.974 seconds from his teammate Kimi Antonelli, with Charles Leclerc third for Ferrari and Lewis Hamilton fourth. What I liked about the race is that it was actually a race. Russell and Leclerc traded the lead six times inside the first nine laps before strategy settled it, and the decisive call was a virtual safety car that both Mercedes used to pit while Ferrari left Leclerc out. That is what let Russell escape, and it is the kind of execution edge that tends to matter more across a season than raw pace does.
+
+The other side of the weekend was Red Bull, and it was not encouraging for them. Max Verstappen crashed in Q1 with what the team called a car fault, started twentieth, and carved back to sixth with the fastest lap of the race. You can read that as a brilliant recovery drive, which it was, or you can read it as a team that used to define these regulation resets now spending its opening weekend recovering from its own unreliability. I lean toward the second reading. When the sport rewrites the rules, the advantage goes to whoever prepared the new car best, and on the evidence of one Sunday that is clearly not Red Bull.
+
+A smaller thing worth filing away is that the grid's only genuine rookie, eighteen-year-old Arvid Lindblad at Racing Bulls, ran as high as third early and finished eighth, which made him one of the youngest points scorers the sport has had. In a year when the youngest drivers keep rewriting the record book, that is worth remembering.
+
+The pattern I would pull out of Melbourne is that the new formula did not flatten the racing the way people feared, but it did reward preparation, and Mercedes look the most prepared. Russell leads a championship for the first time in his career, the car is quick and reliable, and the team executed the one strategic decision that actually mattered. It is one race and one data point, so I would not overstate it, but the shape of the 2026 order showed up on the very first Sunday, and it has silver at the front. You can follow how the rest of it develops on my [Formula 1 dashboard](/formula-1).

--- a/content/blog/2026-austrian-grand-prix-russell-title-race.mdx
+++ b/content/blog/2026-austrian-grand-prix-russell-title-race.mdx
@@ -1,0 +1,33 @@
+---
+title: "Russell's Win in Austria Reopened a Title Race Everyone Had Closed"
+excerpt: "After Monaco the title looked settled. Then Russell won at the Red Bull Ring from a contested pole, his first win since Australia, cutting Antonelli's lead to forty and reopening a race everyone had already closed."
+publishedAt: "2026-06-28"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "Austrian Grand Prix", "George Russell", "Max Verstappen", "Mercedes", "2026 F1 Season"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/2026-austrian-grand-prix-russell-title-race/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The dashboard keeps the driver and constructor standings, the next Grand Prix, and race-by-race context in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Russell Wins the 2026 Austrian GP to Reopen the Title"
+  description: "George Russell won the 2026 Austrian Grand Prix from a contested pole, his first win since Australia, cutting Antonelli's championship lead to forty points."
+  keywords: ["2026 Austrian Grand Prix", "George Russell win", "Verstappen second", "yellow flag qualifying", "Mercedes title fight", "2026 F1 season"]
+---
+
+# Russell's Win in Austria Reopened a Title Race Everyone Had Closed
+
+By the end of Monaco the consensus had hardened into something close to a foregone conclusion. Antonelli was five wins from six, he had just produced a Grand Slam, and the championship was being treated as a formality with sixteen races still to run. Austria did not overturn that, exactly, but it did the useful work of reminding everyone that the gap was built partly on the other Mercedes failing, and that when Russell's car holds together he is right there. He won at the Red Bull Ring from pole, his first victory since [the season opener in Australia](/writing/2026-australian-grand-prix-mercedes-new-era), and it moved him back to second in the standings.
+
+The win came with a controversy attached, and it is worth walking through because it arguably decided the front row. In final qualifying Verstappen crashed at the second-to-last corner and brought out yellow flags. Antonelli, seeing what he believed were double-waved yellows, aborted his final lap, which dropped him to fourth. Russell lifted for what he read as a single yellow and kept going, and took pole. The stewards investigated whether Russell had slowed enough, decided he had, and let the pole stand. I can see the argument both ways, but the reality is that two drivers made opposite judgment calls about the same flags and it sorted their grid slots, which is a thin thread for a result to hang on.
+
+The race itself was the best Red Bull day of the year, and it still was not quite enough. Verstappen recovered from his qualifying crash to run second and closed to within a second of Russell in the middle stint, close enough that it looked like it might genuinely happen, before a late Red Bull pit stop left him too much to do and he came home 1.611 seconds back. Antonelli took third, salvaging a podium and the fastest lap from a compromised grid slot, which is the sort of damage limitation that wins championships. The top three covered by about two seconds made it the closest finish of the season.
+
+Ferrari, a week after [winning in Barcelona](/writing/2026-barcelona-catalunya-grand-prix-hamilton-ferrari), went backwards, Hamilton fifth and Leclerc eighth, which fits the pattern I keep noticing with them, that their form swings hard from weekend to weekend in a way the Mercedes form does not. The new Cadillac team had a miserable afternoon with both cars retiring on overheating brakes, a reminder that expanding the grid to eleven teams means some of them are going to spend this reset season simply trying to finish.
+
+What Austria did was shrink Antonelli's lead to forty and put Russell back into the conversation as the nearest challenger. I still think Antonelli is clearly the favorite, and the underlying pace has been his all year. But the margin is now the kind that a couple of bad weekends could erase, and Russell has shown that when his car survives he can beat his teammate on merit. The race everyone had closed after Monaco is, at minimum, open enough to be worth watching again, and that is healthier for the season than the procession we were being promised.

--- a/content/blog/2026-barcelona-catalunya-grand-prix-hamilton-ferrari.mdx
+++ b/content/blog/2026-barcelona-catalunya-grand-prix-hamilton-ferrari.mdx
@@ -1,0 +1,33 @@
+---
+title: "Hamilton Finally Won for Ferrari in Barcelona, but the Story Was How"
+excerpt: "Hamilton's first win for Ferrari was a genuinely historic afternoon, the oldest F1 winner since 1970 leading an all-British podium. But it came on a three-stop and a well-timed safety car, and Antonelli's late failure was the result that moved the title."
+publishedAt: "2026-06-14"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "Barcelona-Catalunya Grand Prix", "Lewis Hamilton", "Ferrari", "Kimi Antonelli", "2026 F1 Season"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/2026-barcelona-catalunya-grand-prix-hamilton-ferrari/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The dashboard keeps the driver and constructor standings, the next Grand Prix, and race-by-race context in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Hamilton's First Ferrari Win at the 2026 Barcelona GP"
+  description: "Lewis Hamilton took his maiden Ferrari win at the 2026 Barcelona Grand Prix as Antonelli's late failure, not a jump in Ferrari pace, tightened the title race."
+  keywords: ["2026 Barcelona-Catalunya Grand Prix", "Hamilton first Ferrari win", "oldest F1 winner", "Antonelli retirement", "all-British podium", "2026 F1 season"]
+---
+
+# Hamilton Finally Won for Ferrari in Barcelona, but the Story Was How
+
+Lewis Hamilton winning for Ferrari was supposed to be the moment the whole move made sense, and in the emotional register it was exactly that. His first win in red, his hundred and sixth in all, his first victory in six hundred and eighty-six days, and at forty-one the oldest man to win a Formula 1 race since Jack Brabham in 1970. If you care about the sport's history, Barcelona was a moving afternoon, and the sight of three British drivers on the podium, the first all-British top three since 1968, only added to it. I would just be careful about what the win actually tells us, because the how matters here and the how was strategy and circumstance more than a step in outright pace.
+
+Ferrari won this race on a three-stop, and the three-stop worked because a well-timed virtual safety car let Hamilton take one of those stops cheaply while the Mercedes ran a conventional two. That is a smart, aggressive call executed well, and Ferrari deserve the credit for it. But it is a different thing from having the fastest car. Russell had put his Mercedes on pole, his third of the year, narrowly ahead of Hamilton, and led comfortably until the strategies diverged. Hamilton beat him by nineteen and a half seconds in the end, a gap that looks dominant and mostly reflects the pit stop math rather than a sudden Ferrari advantage.
+
+The result that will actually move the championship is the one that did not finish. Antonelli was running second, having got ahead of Russell, and looked set for a routine podium when his Mercedes failed with three or four laps to go, an abrupt retirement from a race he was managing comfortably. It was the first time all year the car had let him down [rather than his teammate](/writing/2026-canadian-grand-prix-mercedes-civil-war), and it cut his championship lead from sixty-six points to forty-one in an afternoon. There was even a strange coda where he picked up a five-second track limits penalty despite having already retired, part of an officiating procedure the stewards themselves admitted had misfired.
+
+So the standings tightened without Antonelli doing anything wrong, which is the thing about reliability, it does not care about merit. Hamilton's win lifted him and reshuffled the order behind the leader, but Antonelli still holds a comfortable margin, and the drivers chasing him are chasing on scraps. Norris took third to remind everyone McLaren are still there, Verstappen was a distant fourth, and Ferrari left the weekend having finally turned a race into a win without having closed the underlying gap to Mercedes on pure speed.
+
+What I would take from Barcelona is that Ferrari's execution has caught up even where their car has not, and for Hamilton that is enough to produce the day he moved to Maranello for. It was a great story and a deserved one. It was also, if you strip the emotion out, a race Mercedes were quicker in and lost on strategy and a failure. Both of those things are true at once, and pretending the win was more than it was would do a disservice to how well Ferrari actually played a hand that was not the best one on the grid.

--- a/content/blog/2026-british-grand-prix-leclerc-silverstone.mdx
+++ b/content/blog/2026-british-grand-prix-leclerc-silverstone.mdx
@@ -1,0 +1,33 @@
+---
+title: "Leclerc Won a Chaotic British Grand Prix Silverstone Will Argue About for Years"
+excerpt: "Leclerc won a chaotic British Grand Prix he had spent most of fighting for fifth, after Antonelli's car failed from the lead and Verstappen crashed out. A software error denied Silverstone its finish, and the title race is suddenly tight."
+publishedAt: "2026-07-05"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "British Grand Prix", "Charles Leclerc", "Ferrari", "Kimi Antonelli", "2026 F1 Season"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/2026-british-grand-prix-leclerc-silverstone/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The dashboard keeps the driver and constructor standings, the next Grand Prix, and race-by-race context in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Leclerc Wins a Chaotic 2026 British Grand Prix"
+  description: "Charles Leclerc won a chaotic 2026 British Grand Prix after Antonelli's failure and a safety-car software error at Silverstone cut the title lead to 25 points."
+  keywords: ["2026 British Grand Prix", "Leclerc Silverstone win", "Antonelli failure", "safety car software error", "F1 title fight", "2026 F1 season"]
+---
+
+# Leclerc Won a Chaotic British Grand Prix Silverstone Will Argue About for Years
+
+The British Grand Prix is the one where almost everything that could go sideways did, where the driver who won it had spent most of the afternoon fighting for fifth, and where the biggest talking point was a message on the timing screens that turned out to be wrong. Charles Leclerc won at Silverstone, his ninth career victory, his first there, and the first British Grand Prix ever won by a driver from Monaco. He won it because the two cars in front of him hit trouble and because the race finished behind a safety car after a software error denied everyone the finish they were set up for. It was a strange, unsatisfying, genuinely dramatic afternoon, and it tightened the championship at exactly the point in the season where that starts to matter.
+
+Let me trace how Leclerc got there, because he did very little wrong and still needed a lot to go right. Antonelli had taken pole, his fifth of the year, and won the sprint on Saturday for his first sprint victory, so he arrived at Sunday as the clear favorite and led early. Then his left front wheel shield failed around lap forty-one, the car turned undrivable, he went off repeatedly, needed two extra stops, collected a track limits penalty on top of it all, and finished sixteenth with no points. That is a disaster for a championship leader, and it is the second time in three weekends that a Mercedes has broken while leading, after [his own retirement from second in Barcelona](/writing/2026-barcelona-catalunya-grand-prix-hamilton-ferrari).
+
+While that was unfolding, Verstappen crashed out of a podium position at Stowe with four laps to go, and his crash brought out the safety car that ended the race. Here is where it got contentious. The timing feed displayed a message indicating the safety car would come in, which implied a final-lap restart and a three-car shootout for the win between Leclerc, Russell, and Hamilton. It never happened. The safety car stayed out, the race finished behind it, and the FIA later said a software error had produced the incorrect message while insisting the regulations themselves had been applied correctly. A packed Silverstone crowd was denied a green-flag finish to a home race by a computer error, which is about as deflating as an ending gets.
+
+So Ferrari came away with a one-three, Leclerc winning and Hamilton third, split by Russell's Mercedes in second, and Leclerc's victory is worth holding two thoughts about at once. It was a real milestone, a first Silverstone win and a first for his country, and he took it by being in the right place when the chaos came, running a clean race while others broke and crashed. Both of those are true. A win you back into because the fast cars ahead of you fail is still a win, and over a long season the drivers who are there to collect when things go wrong are the ones who finish high in the standings.
+
+The championship picture at the midpoint is the part I find most interesting. Antonelli still leads, on a hundred and seventy-nine points, but his cushion over Russell is down to twenty-five, and Hamilton sits third another thirty-two back, so the top three are all genuinely live. Mercedes plainly have the best car, they lead the constructors' by seventy-eight, and they have won seven of the nine races. But they have also handed away two likely wins to their own unreliability in three weekends, and in a title fight this tight that is the difference between a procession and a contest. Nine races in, the season that was supposed to be settled by Monaco is instead set up for a real second half, and if you want to keep track of how it swings, that is exactly what I built [Formula 1 Pulse](/formula-1) to show.

--- a/content/blog/2026-canadian-grand-prix-mercedes-civil-war.mdx
+++ b/content/blog/2026-canadian-grand-prix-mercedes-civil-war.mdx
@@ -1,0 +1,33 @@
+---
+title: "Canada Turned the Title Race Into a Mercedes Civil War"
+excerpt: "Antonelli won a fourth straight race, but Montreal was really about Mercedes. A hard sprint clash between the teammates and a battery failure that killed Russell's race turned the title fight into a civil war."
+publishedAt: "2026-05-24"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "Canadian Grand Prix", "Kimi Antonelli", "George Russell", "Mercedes", "2026 F1 Season"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/2026-canadian-grand-prix-mercedes-civil-war/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The dashboard keeps the driver and constructor standings, the next Grand Prix, and race-by-race context in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "The 2026 Canadian GP and Mercedes' Title Civil War"
+  description: "Antonelli won the 2026 Canadian Grand Prix for a fourth straight win as a sprint clash and Russell's battery failure turned the Mercedes title fight tense."
+  keywords: ["2026 Canadian Grand Prix", "Antonelli fourth win", "Russell battery failure", "Mercedes teammates", "Montreal 2026", "F1 title fight"]
+---
+
+# Canada Turned the Title Race Into a Mercedes Civil War
+
+Montreal is where this stopped being a story about a fast young driver and became a story about two teammates who clearly do not enjoy racing each other. Antonelli won again, his fourth in a row, which no driver in the history of the sport had done with the first four wins of a career. But the win is not what I remember from the weekend. What I remember is the sprint, where Russell shut the door on Antonelli hard enough, twice, that Antonelli was on the radio demanding a penalty, and the Grand Prix, where Russell led on merit and then had his car die under him.
+
+Take the sprint first, because it set the tone. Russell won it, but he won it by closing the door on his teammate at the second corner and again at the final chicane, running Antonelli across the grass and letting Norris through to second in the process. Antonelli's radio was furious, something to the effect of it being very naughty, and Toto Wolff's response was to tell him to concentrate on the driving rather than the moaning. No penalty was issued, which I think was the right call, but the exchange made public what had been implied for a month, which is that the two Mercedes drivers are now in a real fight and the team is going to have to manage it.
+
+The Grand Prix was crueler. Russell qualified on pole, led, and was racing Antonelli wheel to wheel when his car simply stopped around lap thirty, a battery failure the team later confirmed, an outright engine kill that left him to throw his headrest into the grass and walk away. He said afterward that it felt like somebody did not want him to fight for the championship, which is the kind of thing you say when you have led on merit twice in a row and scored nothing for it. Antonelli inherited the lead and took the win, with Hamilton passing Verstappen late for second, his best result since joining Ferrari, and Verstappen third.
+
+So Antonelli now leads by forty-three points, and the shape of how he got there is worth being honest about. He has been the fastest driver [most weekends](/writing/2026-miami-grand-prix-mclaren-mercedes), but the size of the lead is partly Russell's reliability falling apart at exactly the wrong moments. That is still Antonelli's advantage to bank, because points are points and the standings do not care why. But it changes the character of the title race. This is not a young driver running away from a beaten teammate. It is two closely matched drivers in the same car, and one of them keeps having the car break while he is in front.
+
+The phrase that kept coming to mind in Montreal is that the title is Antonelli's to lose, and I mean it in both directions. He is far enough ahead that only he can really give it away. And the reason he is that far ahead is not that Russell has been slower, it is that Russell has been unlucky, which is not a thing you can count on continuing. Mercedes have a civil war on their hands, and for now the reliability is picking a side.

--- a/content/blog/2026-chinese-grand-prix-antonelli-first-win.mdx
+++ b/content/blog/2026-chinese-grand-prix-antonelli-first-win.mdx
@@ -1,0 +1,33 @@
+---
+title: "Kimi Antonelli's First Win Was the Real Story in Shanghai, Not McLaren's Meltdown"
+excerpt: "Both McLarens failed to start and that got the headlines, but the story in Shanghai was a nineteen-year-old taking his maiden win, the youngest pole in F1 history, and the first Grand Prix win by an Italian since 2006."
+publishedAt: "2026-03-15"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "Chinese Grand Prix", "Kimi Antonelli", "Mercedes", "2026 F1 Season", "Sports Analytics"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/2026-chinese-grand-prix-antonelli-first-win/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The dashboard keeps the driver and constructor standings, the next Grand Prix, and race-by-race context in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Antonelli's First F1 Win at the 2026 Chinese Grand Prix"
+  description: "Kimi Antonelli won the 2026 Chinese Grand Prix for his maiden victory and F1's youngest-ever pole, while a McLaren double DNS overshadowed the Mercedes 1-2."
+  keywords: ["2026 Chinese Grand Prix", "Kimi Antonelli first win", "youngest F1 pole", "McLaren DNS", "Mercedes 1-2", "2026 F1 season"]
+---
+
+# Kimi Antonelli's First Win Was the Real Story in Shanghai, Not McLaren's Meltdown
+
+The headline out of Shanghai wrote itself, and it was the wrong headline. Both McLaren cars failed to start the Grand Prix, a double non-start with power unit electrical faults, and for a team a lot of people picked to fight for the title, watching the race from the garage is a genuine disaster. But the story that will still matter in December is the one that happened at the front, where a nineteen-year-old put the car on pole, broke a record that had stood since 2008, and won going away.
+
+Kimi Antonelli qualified fastest for the Grand Prix, a little over two tenths clear of his teammate, and in doing so became the youngest driver ever to take pole in Formula 1, beating the mark Sebastian Vettel set at Monza. It helped that Russell hit a problem in final qualifying, briefly stuck in first gear, but the lap was still the quickest anyone managed. On Sunday Antonelli lost the lead off the line to a fast-starting Hamilton, took it straight back, and controlled the race to the flag for a second Mercedes 1-2 in two rounds, after [the one Russell led in Melbourne](/writing/2026-australian-grand-prix-mercedes-new-era). That gave him his maiden win, made him the second-youngest Grand Prix winner in history behind only Verstappen, and made him the first Italian to win a Formula 1 race since Giancarlo Fisichella in Malaysia in 2006.
+
+I want to be careful about how much to load onto a single win, because Saturday had shown the other side of him. In the sprint he dropped back at the start and picked up a ten-second penalty for running into Isack Hadjar at the second corner, and Hadjar was angry enough afterward that he reportedly refused the apology. Nineteen-year-olds make nineteen-year-old mistakes. But the pole is the part I keep coming back to, because a win can be circumstantial and a pole cannot. Being the single fastest driver over one lap, in a car your very accomplished teammate is also driving, is about as clean a signal of raw pace as the sport produces.
+
+The subplot underneath all of this is that the fight for the championship might be inside the Mercedes garage. Russell leads Antonelli by four points after two rounds, which is nothing, and the momentum plainly sits with the younger driver. Hamilton, for his part, took third for his first podium in Ferrari red, which is the emotional beat of the weekend, though it is worth noticing he finished it a place behind his own teammate and that Ferrari still look a step off Mercedes on execution. Red Bull's weekend, meanwhile, ended with Verstappen retiring in the closing laps with an ERS coolant failure, a second straight round defined for them by the car breaking rather than the driver delivering.
+
+So everyone spent the weekend talking about who broke, and there was plenty of it, from McLaren's double non-start, to Verstappen's retirement, to hydraulic failures further down the order. I would spend it talking about who is nineteen and already the fastest man in the field. The reliability stories will even out as the teams sort the new package. A driver this quick this young does not.

--- a/content/blog/2026-japanese-grand-prix-antonelli-title-lead.mdx
+++ b/content/blog/2026-japanese-grand-prix-antonelli-title-lead.mdx
@@ -1,0 +1,33 @@
+---
+title: "Antonelli Took the Title Lead in Japan and Flipped the Order at Mercedes"
+excerpt: "Antonelli won again at Suzuka and took over the championship as the youngest points leader in F1 history. The safety car helped, but the real story is that he has moved ahead of Russell inside Mercedes."
+publishedAt: "2026-03-29"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "Japanese Grand Prix", "Kimi Antonelli", "Mercedes", "Championship", "2026 F1 Season"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/2026-japanese-grand-prix-antonelli-title-lead/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The dashboard keeps the driver and constructor standings, the next Grand Prix, and race-by-race context in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Antonelli Leads the Title After the 2026 Japanese GP"
+  description: "Kimi Antonelli won the 2026 Japanese Grand Prix at Suzuka to become F1's youngest-ever championship leader, moving ahead of George Russell inside Mercedes."
+  keywords: ["2026 Japanese Grand Prix", "Antonelli championship lead", "youngest F1 title leader", "Suzuka 2026", "Mercedes title fight", "2026 F1 season"]
+---
+
+# Antonelli Took the Title Lead in Japan and Flipped the Order at Mercedes
+
+The convenient way to dismiss Antonelli's win at Suzuka is to point at the safety car. He was sixth off the line after too much wheelspin, the race turned on a caution period that happened to fall when it helped him most, and if you want to call the whole thing timing and luck, the raw sequence of events lets you. I do not think the dismissal holds. Winning two races in a row, and doing it by climbing past the established number one in your own team, is not something a safety car does for you.
+
+Here is what happened. Antonelli qualified on pole again, three tenths clear of Russell, on a weekend where Verstappen was knocked out in Q2 and lined up eleventh, ending a four-year run of consecutive Suzuka poles that had been one of the most dependable facts in the sport. Off the start Antonelli bogged down to sixth and Russell slid to fourth. Antonelli had worked back to fourth by lap ten when Oliver Bearman crashed heavily, a shunt reported at around fifty G, and the safety car came out on lap twenty-two. Antonelli pitted under it, jumped the drivers who had already stopped, and led the restart to the flag. Oscar Piastri took second, more than thirteen seconds back, for his first finish of the season and McLaren's first podium of the year, with Leclerc third.
+
+The number that matters is the championship. Antonelli now leads it, seventy-two points to Russell's sixty-three, which makes him the youngest driver ever to lead a Formula 1 title race and the first teenager to do it. But the age record is not really the point. The point is the hierarchy. Three rounds ago Russell was unambiguously the lead driver at Mercedes, the experienced hand who had earned that status, and Antonelli was the promising kid in his second season, fresh off [his maiden win the week before in Shanghai](/writing/2026-chinese-grand-prix-antonelli-first-win). Now the kid is ahead of him in the same machinery, and it does not look like an accident of one caution period. It looks like the faster driver moving to the front, which is usually what these things turn out to be.
+
+The other thing Suzuka clarified is McLaren. A week after both cars failed to start in China, Piastri put one on the podium and Norris ran fifth, and Piastri's very first classified finish of the year was a second place. That tells me the car has real pace whenever it actually runs, and that the early McLaren story is reliability rather than speed, which is a much more fixable problem to have. Verstappen recovering from eleventh to eighth at the track he has owned for years, meanwhile, is the clearest marker yet of how far the new-era order has shifted away from Red Bull.
+
+Three races into the biggest rules change in decades, Mercedes have won all three, and the most compelling championship in the sport is the one between their own two drivers. I did not expect to be writing that in March, and I think it is going to define the year.

--- a/content/blog/2026-miami-grand-prix-mclaren-mercedes.mdx
+++ b/content/blog/2026-miami-grand-prix-mclaren-mercedes.mdx
@@ -1,0 +1,33 @@
+---
+title: "Miami Proved McLaren Is Chasing Mercedes, and Still a Step Behind"
+excerpt: "McLaren took sprint pole and won the sprint, and everyone decided they were back. Then Antonelli won the Grand Prix from his third straight pole, and Miami quietly confirmed McLaren are the only team chasing Mercedes, and still a step behind."
+publishedAt: "2026-05-03"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "Miami Grand Prix", "Kimi Antonelli", "McLaren", "Lando Norris", "2026 F1 Season"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/2026-miami-grand-prix-mclaren-mercedes/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The dashboard keeps the driver and constructor standings, the next Grand Prix, and race-by-race context in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Antonelli Wins the 2026 Miami GP as McLaren Closes In"
+  description: "Kimi Antonelli won the 2026 Miami Grand Prix from his third straight pole as McLaren took second and third. Why the closest challenger is still a step behind."
+  keywords: ["2026 Miami Grand Prix", "Antonelli third win", "McLaren sprint pole", "Lando Norris", "Mercedes 2026", "F1 Miami sprint"]
+---
+
+# Miami Proved McLaren Is Chasing Mercedes, and Still a Step Behind
+
+After the sprint on Saturday, a lot of people decided McLaren were back. Lando Norris took the first non-Mercedes pole of the season, led the sprint from lights to flag, and put both cars in front. It was the sort of result that generates a narrative, and the narrative was that the title fight had a third team in it again. I think Miami actually showed something more precise and less exciting for McLaren, which is that they are the only team capable of chasing Mercedes, and that chasing is not the same as catching.
+
+The Grand Prix went the way most of this season has gone. Antonelli took pole, his third in a row to open his career, which is company only Ayrton Senna and Michael Schumacher keep. He converted it into his third win, holding off Norris by 3.264 seconds with Piastri third for a McLaren double podium, and in doing so became the first driver in the sport's history to win each of his first three Grands Prix from pole. So the upgraded McLaren was quick enough to sit within three and a bit seconds of the Mercedes for a full race and never actually get past it. That is real progress from a team that failed to start in China, and it is also a three-second gap.
+
+The detail I would point to is that Antonelli won this one from the front rather than through circumstance. There was no safety car handing him track position [the way Suzuka did](/writing/2026-japanese-grand-prix-antonelli-title-lead). He qualified fastest, led, and managed the tyres and the override deployment to keep Norris just out of range for the whole race. When a nineteen-year-old wins the messy ones and then wins the clean ones, you stop looking for the asterisk.
+
+Everyone else had a harder day. Charles Leclerc finished sixth on the road and then took a twenty-second penalty that dropped him to eighth and cost Ferrari real points, part of a weekend where the stewards were busy from Saturday onward, when Gabriel Bortoleto's Audi was disqualified from the sprint over an engine intake breach. Verstappen qualified second, which was Red Bull's best Saturday of the year, and finished fifth, which tells you the race pace still is not there. And Russell, who has now watched his teammate beat him pole for pole, damaged his front wing and salvaged fourth, sliding further behind Antonelli in a fight that increasingly looks one-directional.
+
+What Miami confirmed for me is that the 2026 grid has settled into a clear shape earlier than these reset years usually do. Mercedes are in front, McLaren are the closest and getting closer, Ferrari are quick in patches and losing points to their own mistakes, and Red Bull are somewhere in the midfield of a category they used to own. Antonelli leads the championship by twenty over Russell, and the run of poles says the gap is about pace and not luck. McLaren will win races this year, probably soon. On the evidence of Miami they are still racing for second.

--- a/content/blog/2026-monaco-grand-prix-antonelli-grand-slam.mdx
+++ b/content/blog/2026-monaco-grand-prix-antonelli-grand-slam.mdx
@@ -1,0 +1,33 @@
+---
+title: "Antonelli's Monaco Grand Slam, and the Podium That Went to Court"
+excerpt: "Antonelli led every lap for a Monaco Grand Slam and became the youngest winner in the race's history, his fifth straight victory. Behind him, a chaotic race and a third place that ended up being argued in court."
+publishedAt: "2026-06-07"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "Monaco Grand Prix", "Kimi Antonelli", "Grand Slam", "Pierre Gasly", "2026 F1 Season"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/2026-monaco-grand-prix-antonelli-grand-slam/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The dashboard keeps the driver and constructor standings, the next Grand Prix, and race-by-race context in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Antonelli's Grand Slam at the 2026 Monaco Grand Prix"
+  description: "Antonelli led every lap for a Grand Slam at the 2026 Monaco Grand Prix and became its youngest winner, while a penalty saga left third place contested."
+  keywords: ["2026 Monaco Grand Prix", "Antonelli Grand Slam", "youngest Monaco winner", "Gasly penalty", "F1 right of review", "2026 F1 season"]
+---
+
+# Antonelli's Monaco Grand Slam, and the Podium That Went to Court
+
+Monaco produced the single most complete drive of the season and one of the messiest results, and the fact that both of those sentences describe the same afternoon tells you something about where Formula 1 is right now. Antonelli led every lap from pole, set the fastest lap, and won, which is a Grand Slam, the rarest clean sweep in the sport. He did it at nineteen, on the hardest track on the calendar, in a race that was red-flagged partway through when the surface broke up. And then the stewards spent the following week deciding who actually finished third.
+
+Start with the drive, because it earns its own paragraph. Antonelli took pole by forty-three thousandths of a second over Verstappen, the first Italian on pole at Monaco since Jarno Trulli in 2004, and around a circuit where overtaking barely exists he never gave the lead up. The Grand Slam made him the youngest Monaco winner in history, breaking a record Hamilton had held since 2008, and the youngest driver ever to win while leading every lap and setting the fastest one, breaking a mark Verstappen set in 2021. It was his [fifth win in a row](/writing/2026-canadian-grand-prix-mercedes-civil-war). Whatever doubts existed in March about whether the pace was real are gone. This is the best driver in the field having his best weekend on the circuit that punishes mistakes hardest.
+
+The race behind him was chaos. Verstappen stalled from the front row and retired on the opening lap with a power unit failure, which removed the one car that might have pressured Antonelli. Leclerc crashed out of third at his home race, a day after crashing in qualifying, a brutal weekend for him. There were seven retirements in all, the track surface failed badly enough to force a thirty-seven-minute red flag and a second standing start, and Russell had another weekend to forget, picking up a pit lane speeding penalty, botching how he served it, taking a drive-through, and finishing out of the points for the second race running. Hamilton came home second, his second straight runner-up, which quietly moved him past Russell to second in the championship.
+
+Then there is the matter of third place, which is genuinely unresolved as I write this. Pierre Gasly crossed the line third for Alpine, a terrific result, and was then handed two five-second penalties for pit lane speeding that dropped him behind Isack Hadjar, which would have been Hadjar's first career podium. Alpine went back with the timing data and argued the pit lane distance used to calculate Gasly's speed was simply wrong, the stewards agreed and rescinded the penalties, and now McLaren and Red Bull have appealed that reversal to the sport's court. So the third step of a Monaco podium is, at the moment, being litigated.
+
+I find the officiating saga more frustrating than interesting, and I think it points at a real problem. When the measurement a penalty rests on turns out to be inaccurate, and it takes a formal review to establish that, and then rival teams appeal the correction, the sport is spending its credibility on process rather than racing. A result like this should be settled on Sunday evening and not in a hearing room two weeks later. None of it touches Antonelli, who won cleanly and enormously. But the contrast between the best drive of the year and a podium nobody can confirm is a strange note to leave Monaco on, and the strangeness is entirely self-inflicted.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -166,4 +166,13 @@
 <url><loc>https://isaacavazquez.com/spacex-mission-control</loc><lastmod>2026-04-01T00:00:00.000Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/tech-startup-tracker</loc><lastmod>2026-06-09T16:39:05.583Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/world-cup-2026</loc><lastmod>2026-07-02T19:57:28.676Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/2026-australian-grand-prix-mercedes-new-era</loc><lastmod>2026-03-08T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/2026-austrian-grand-prix-russell-title-race</loc><lastmod>2026-06-28T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/2026-barcelona-catalunya-grand-prix-hamilton-ferrari</loc><lastmod>2026-06-14T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/2026-british-grand-prix-leclerc-silverstone</loc><lastmod>2026-07-05T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/2026-canadian-grand-prix-mercedes-civil-war</loc><lastmod>2026-05-24T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/2026-chinese-grand-prix-antonelli-first-win</loc><lastmod>2026-03-15T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/2026-japanese-grand-prix-antonelli-title-lead</loc><lastmod>2026-03-29T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/2026-miami-grand-prix-mclaren-mercedes</loc><lastmod>2026-05-03T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/2026-monaco-grand-prix-antonelli-grand-slam</loc><lastmod>2026-06-07T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 </urlset>


### PR DESCRIPTION
## What this adds

Nine first-person race review articles under `content/blog`, one for each completed 2026 Grand Prix through the British GP. They read as opinionated season commentary in the site's writing voice rather than wire-service recaps, and they chain backward through the season so a reader can follow the title fight round by round.

| Round | Article | Published | Angle |
| --- | --- | --- | --- |
| 1 | Australian GP | 2026-03-08 | Mercedes look like the team that solved the new-era rules |
| 2 | Chinese GP | 2026-03-15 | Antonelli's maiden win and youngest-ever pole, not McLaren's double DNS, is the story |
| 3 | Japanese GP | 2026-03-29 | Antonelli takes the title lead and flips the Mercedes hierarchy |
| 4 | Miami GP | 2026-05-03 | McLaren are the only challenger, and still a step behind |
| 5 | Canadian GP | 2026-05-24 | Reliability turns the title race into a Mercedes civil war |
| 6 | Monaco GP | 2026-06-07 | A record-setting Grand Slam, and a podium that went to appeal |
| 7 | Barcelona-Catalunya GP | 2026-06-14 | Hamilton's first Ferrari win came on strategy, not raw pace |
| 8 | Austrian GP | 2026-06-28 | Russell reopens a title everyone had already closed |
| 9 | British GP | 2026-07-05 | Leclerc wins the chaos as the midseason picture tightens |

## Editorial and structural choices

- Each post follows `WRITING_VOICE.md`: first person, opinion-forward, flowing prose, no em dashes, no colon connectors, no bold-label bullets, no generic conclusion sections.
- Filed under the `Sports & Fantasy` archive bucket with a `Formula 1` category, matching how the existing F1 dashboard and fantasy-optimizer posts are grouped. Each carries a CTA to the `/formula-1` (Formula 1 Pulse) dashboard and links back to the prior race in the series.
- `publishedAt` is set to each race weekend so the articles backfill the archive in chronological order, the same pattern the dated commentary posts use.
- SEO titles and meta descriptions are kept within the search-title (60) and meta-description (160) limits, and cover images resolve to the existing per-slug dynamic OpenGraph route.

## On the data

The 2026 results, poles, sprint outcomes, penalties, and standings were researched and cross-checked across multiple public outlets before writing, since direct fetches to primary result pages were blocked in this environment. Driver and constructor point totals reconcile against each other after the British GP (Antonelli 179, Russell 154, Hamilton 147; Mercedes 333, Ferrari 255). The one genuinely unresolved real-world detail, the Monaco third-place appeal, is written as contested rather than settled.

## Verification

- `blog-taxonomy`, `blog-seo-content`, and `blog` unit suites pass with the new posts included.
- Writing page, per-slug page, OpenGraph image, RSS, and search route suites pass.
- All nine bodies render cleanly through the real `remark` + `remark-gfm` + `remark-html` pipeline, and every internal `/writing/` cross-link resolves to a slug in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACzcRBTSK3C3utpRz5kcyD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACzcRBTSK3C3utpRz5kcyD)_