### PR TITLE
Add scorepool: exact-score prediction pool CLI

### DIFF
--- a/tools/score-pool/.gitignore
+++ b/tools/score-pool/.gitignore
@@ -1,0 +1,18 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+build/
+dist/
+
+# Local working files the tool writes (state, snapshots, structured output)
+state.json
+*.snapshot.json
+out.json
+
+# Personal config/fixtures (the *.example.* files are committed; your own aren't)
+scorepool.toml
+/fixtures.csv
+/fixtures.json

--- a/tools/score-pool/README.md
+++ b/tools/score-pool/README.md
@@ -1,0 +1,231 @@
+# scorepool
+
+A command-line assistant for exact-score prediction pools. I built it to do the
+whole matchday job I used to run in my head: pull the odds, convert them to fair
+probabilities, build a distribution over scorelines, and then pick the score that
+earns the most expected points under my pool's rules, adjusted for where I sit on
+the leaderboard. It cares far more about getting the decision logic right than
+about looking fancy, and it tries to stay honest about how much it actually knows.
+
+The core insight it automates is the one that kept costing or saving me points at
+the World Cup. In a pool that scores the 90-minute result, a draw pick collects
+the result-and-goal-difference tier on *every* draw, not only on the exact score,
+so a 1-1 can be worth more in expected points than backing the favourite outright
+even when the favourite is more likely to win the game. And a game that finishes
+level after 90 but is won on penalties still scores as a draw, which is why a lot
+of favourite-to-win picks banked zero while the draw picks kept scoring.
+
+## Installing
+
+It needs Python 3.11+ and numpy and scipy. From this directory:
+
+```bash
+pip install -r requirements.txt
+# or, to get the `scorepool` command on your path:
+pip install -e .
+```
+
+`requests` is optional and only used for live odds. Everything works without it
+if you enter odds by hand or from a CSV.
+
+## Quickstart
+
+```bash
+python -m scorepool init                 # writes scorepool.toml + fixtures.csv
+# edit scorepool.toml: set your scoring rules and your standing
+python -m scorepool recommend --fixtures fixtures.csv
+```
+
+That prints a pick sheet (one row per match), a copyable submission table, a list
+of things to revisit before each game locks, and a short honesty note. To try it
+immediately against the shipped examples:
+
+```bash
+python -m scorepool --config config.example.toml recommend --fixtures fixtures.example.csv
+```
+
+## How it works
+
+The pipeline is four stages, and each one is a swappable piece so the same logic
+can point at a different sport or a different pool whose markets and rules don't
+match.
+
+**De-vigging.** Whatever odds format comes in (decimal, American, or fractional)
+is converted to implied probabilities, and then the bookmaker's margin is removed
+so the probabilities across a market sum to one. Proportional de-vigging is the
+transparent default; Shin's method, which corrects some favourite-longshot bias,
+and a plain additive method are available too. None of these is the one true
+answer, they are different assumptions about where the margin sits, so the tool
+reports which one it used rather than pretending otherwise.
+
+**The scoreline model.** From the de-vigged three-way prices, the over/under
+total, and both-teams-to-score when it is there, the tool fits a goals model whose
+implied market quantities match what the book is pricing. The default is a
+bivariate Poisson, which adds a shared component that lifts the draw mass the way
+real football does; independent Poisson and Dixon-Coles are also available. The
+key point is that the model is *fit* to the market, so the win, draw, and win
+masses line up with the de-vigged moneyline and the implied total lines up with
+the over/under, which anchors the scoreline probabilities to what the market is
+actually saying instead of pulling them from nowhere. Every fit reports its
+residuals so you can see how well it matched. Where I have flagged tournament
+context in a match's notes, that shades the distribution toward fewer goals and
+more draws, modestly, and the shading is always disclosed on the sheet.
+
+**The expected-points optimizer.** For every candidate scoreline the tool sums
+over the full distribution, weighting each possible actual result by the points
+that candidate would earn under my scoring rules, and ranks them. This is where
+the 1-1-beats-the-favourite effect falls out of the arithmetic rather than out of
+intuition. Alongside expected points it computes each pick's variance and its
+floor, meaning the chance of a goal-difference-or-better hit, because the
+leaderboard layer needs both. Under 90-minute scoring the optimizer treats a game
+that ends level after 90 as a draw even when the favourite advances on penalties.
+
+**The leaderboard tilt.** Expected points on its own is the right answer only when
+I am not managing a lead. So on top of it the tool models what the field is likely
+to submit, which in practice is the chalk, and then works out a single risk tilt
+from the gap to the people I am racing, the games remaining, and the pool size. A
+one-point lead with two games left and a ten-point lead with ten games left land
+in very different places because the swing the standings can still take scales with
+the square root of the games remaining. When I am protecting a lead the tilt
+favours low-variance picks that move with the field, since I win by not diverging
+from whoever is chasing me and letting the shared games cancel out, even when that
+means we both score zero on a game that goes to penalties. When I am behind it
+favours the differentiators the field will be off, and it surfaces the best
+high-quality contrarian, meaning a pick with real expected points that decorrelates
+from the chalk, rather than a random long shot. The sheet shows the plain
+expected-points pick, the tilted pick, a safer higher-floor alternative, and the
+differentiator, so you can see the trade instead of just being handed a label.
+
+## The pick sheet
+
+One row per match:
+
+| Column | What it holds |
+| --- | --- |
+| Match | the fixture |
+| Pick | the recommended exact score, after the standings tilt |
+| Conf | high, medium, or low, deliberately conservative |
+| xEP | the optimizer's expected points for that pick |
+| Safer alt | the higher-floor, lower-variance version |
+| Differentiator | the best contrarian pick for catching up |
+| Why | a short plain-language reason |
+
+Underneath it prints a clean submission table with only the match and score to
+paste into the pool, and a before-lock list of unconfirmed lineups, open injury
+questions, and standings that are close enough to shift the picture, each with the
+lock time and the timestamp on the odds it used.
+
+## Configuration
+
+Config is TOML. Run `init` for a fully commented starter, or see
+`config.example.toml`. The keys that matter most:
+
+| Key | Meaning |
+| --- | --- |
+| `scoring.exact` / `result_and_goal_difference` / `result_only` | points for the three tiers (default 5 / 3 / 2) |
+| `scoring.result_basis` | `regulation` scores the 90-minute result, `final` scores after extra time |
+| `standing.my_points` | my current total |
+| `standing.points_above` / `points_below` | the nearest competitor on each side (omit if I lead or trail the field) |
+| `standing.pool_size` | number of players |
+| `standing.games_remaining` | games still to be scored, which scales how much a lead is worth protecting |
+| `standing.risk` | `auto` derives protect/chase from the gaps, or force `protect` / `chase` / `neutral` |
+| `model.type` | `bivariate_poisson`, `independent_poisson`, or `dixon_coles` |
+| `model.devig` | `proportional`, `shin`, or `additive` |
+| `model.field_model` | how the field is modelled: `modal_scoreline`, `ep_optimal`, or `favorite_margin` |
+| `odds.source` | `manual`, `csv`, or `the_odds_api` |
+
+Most standing fields can also be overridden per run with flags like
+`--my-points`, `--above`, `--below`, `--pool`, `--games`, and `--risk`, which is
+handy for what-ifs without editing the file.
+
+## Fixtures and odds
+
+The match list, with the context and notes I attach, always comes from a fixtures
+file, and an odds source fills in the prices. This keeps the injuries, likely
+lineups, and tournament situation I note independent of where the odds come from.
+
+A CSV is the simplest input. One row per match, with columns for the teams, the
+kickoff, the three-way prices, the over/under, both-teams-to-score, optional
+opening lines for movement, an `odds_format` of decimal, american, or fractional,
+a `context` field, and a free-text `note`. See `fixtures.example.csv`. A JSON
+fixtures file is also supported and handles correct-score markets and opening
+lines more cleanly.
+
+The `context` field takes any of these flags, separated by semicolons, and they
+either shade the model or are surfaced next to the pick: `dead_rubber`,
+`draw_suits_both`, `heavy_rotation_home`, `heavy_rotation_away`, `low_scoring`,
+`high_scoring`, `must_win_home`, `must_win_away`, `lineup_unconfirmed`,
+`injury_question`.
+
+For live odds, set `odds.source = "the_odds_api"` and put your key in the
+environment variable named by `odds.api_key_env` (default `ODDS_API_KEY`). The API
+enriches the fixtures and keeps any hand-entered odds as a fallback for matches it
+doesn't cover, and it time-stamps everything so you always know how stale the
+numbers are. `scorepool fetch` pulls a snapshot to JSON without computing picks.
+
+## Re-running through the tournament
+
+Because I run this the same way all tournament, it keeps state so I can re-run as
+results come in, odds move, and team news breaks.
+
+```bash
+# save the planned picks
+python -m scorepool recommend --fixtures fixtures.csv --save state.json
+
+# enter a result (this one went to penalties after a 1-1)
+python -m scorepool result --state state.json --match ESP-GER --score 1-1 --final 2-1 --decided-by penalties
+
+# if I submitted something other than the recommendation
+python -m scorepool submit --state state.json --match ESP-GER --score 2-1
+
+# see the running total against the pool's rules, and my edge over the chalk
+python -m scorepool standings --state state.json
+```
+
+The running total scores each settled game under the pool's rules, including the
+90-minute-versus-final distinction, and tracks how my picks did versus just
+following the field.
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `recommend` | build and print the pick sheet, optionally `--save` and `--json` |
+| `fetch` | pull live odds and snapshot them to JSON |
+| `explain` | deep-dive one or more matches with the full candidate table |
+| `submit` | record the score I actually submitted |
+| `result` | enter a finished result and update the running total |
+| `standings` | show the running total and my edge over the chalk |
+| `init` | scaffold a commented config and a starter fixtures file |
+
+## Extending it
+
+The odds source, the scoreline model, the de-vig method, the field model, and the
+scoring rules are all separate, swappable pieces, because the whole value is that
+the domain logic stays the same while those change underneath it. To point it at
+another sport or pool, adjust the scoring in config, retune the context-shading
+factors, and if the markets differ, add an odds source under `scorepool/odds/` or
+a model under `scorepool/probability/scoreline.py` behind the existing interfaces.
+
+## Honesty
+
+This is for prediction pools and my own analysis, so it tries not to present the
+model as sharper than it is. The scoreline distribution is only as good as the
+prices it is fit to and the assumptions behind the goals model, the leaderboard
+tilt is a Gaussian approximation of how the standings can move rather than a full
+simulation of the field, and the context shading is a set of deliberately modest
+heuristics. The confidence labels are conservative on purpose, and genuine coin
+flips are marked down rather than up. The point is better decisions on the close
+calls, not false confidence.
+
+## Tests
+
+```bash
+pip install pytest
+python -m pytest
+```
+
+The suite pins down the parts that have to be right: the scoring tiers including
+the draw goal-difference subtlety and the penalties-count-as-a-draw rule, the
+de-vig math, the model reproducing the market it was fit to, the expected-points
+arithmetic on a hand-computable distribution, and the protect-versus-chase tilt.

--- a/tools/score-pool/config.example.toml
+++ b/tools/score-pool/config.example.toml
@@ -1,0 +1,76 @@
+# scorepool configuration
+# The pool rules and my standing drive every pick, so this is the first thing the
+# tool reads. Every value has a default; override only what your pool needs.
+
+[scoring]
+# Points for a submitted score against the actual result. The three tiers are
+# exact > right-winner-and-goal-difference > right-outcome-only. Defaults match a
+# 5 / 3 / 2 World Cup pool, but set them to whatever your pool pays.
+exact = 5
+result_and_goal_difference = 3
+result_only = 2
+# "regulation" scores the 90-minute result, so a 1-1 won on penalties counts as a
+# 1-1 draw. "final" scores the after-extra-time result. In the knockout rounds
+# this one line changes which picks are worth submitting.
+result_basis = "regulation"
+
+[standing]
+# Where I sit. Leave points_above out if I lead the pool; leave points_below out
+# if I am last. games_remaining counts the games still to be scored, including the
+# ones being analysed now; it scales how much a lead is worth protecting.
+my_points = 42
+points_above = 45      # nearest competitor ahead of me (omit if I lead)
+points_below = 41      # nearest competitor behind me (omit if I am last)
+pool_size = 30
+games_remaining = 6
+# "auto" derives protect/chase from the gaps; force it with "protect", "chase",
+# or "neutral".
+risk = "auto"
+
+[model]
+# Scoreline model: bivariate_poisson (default, lifts draws), independent_poisson,
+# or dixon_coles. De-vig method: proportional (default), shin, or additive.
+type = "bivariate_poisson"
+max_goals = 10
+devig = "proportional"
+# How the field is modelled for the leaderboard math: modal_scoreline (the single
+# most likely score, the usual chalk), ep_optimal (a sharper field), or
+# favorite_margin.
+field_model = "modal_scoreline"
+
+[model.context_shading]
+# Modest, configurable nudges applied when a match carries a context flag. Context
+# shades the distribution toward fewer goals and more draws; it does not overrule
+# the market. Factors < 1 lower the expected total; draw boosts add to the draw
+# probability before the model is fit.
+dead_rubber_total_factor = 0.90
+dead_rubber_draw_boost = 0.04
+draw_suits_both_total_factor = 0.92
+draw_suits_both_draw_boost = 0.06
+heavy_rotation_total_factor = 0.95
+low_scoring_total_factor = 0.88
+high_scoring_total_factor = 1.12
+must_win_total_factor = 1.05
+must_win_draw_penalty = 0.03
+
+[strategy]
+# variance_price is how many expected points I will trade for one unit of
+# differential standard deviation when protecting or chasing. Higher means the
+# standings tilt overrides raw expected points more aggressively.
+variance_price = 0.5
+safer_variance_penalty = 0.5
+differentiator_ep_tolerance = 1.5
+reach_quantile = 1.0
+pool_chase_scale = 0.08
+
+[odds]
+# manual/csv read odds straight from the fixtures file. the_odds_api pulls live
+# odds and merges them onto the fixtures, keeping any hand-entered odds as a
+# fallback for matches the API doesn't cover. The key is read from the named
+# environment variable, never stored here.
+source = "manual"           # the_odds_api | manual | csv
+api_key_env = "ODDS_API_KEY"
+sport_key = "soccer_fifa_world_cup"
+regions = "us,uk,eu"
+markets = "h2h,totals,btts"
+# bookmaker = "pinnacle"    # pin one book; otherwise prices are the median

--- a/tools/score-pool/fixtures.example.csv
+++ b/tools/score-pool/fixtures.example.csv
@@ -1,0 +1,5 @@
+match_id,home,away,commence_time,odds_format,home_odds,draw_odds,away_odds,ou_line,over_odds,under_odds,btts_yes,btts_no,home_odds_open,draw_odds_open,away_odds_open,correct_score,context,note,lineup_unconfirmed,injury_question
+ESP-GER,Spain,Germany,2026-07-08T19:00:00Z,decimal,2.55,3.20,2.95,2.5,2.05,1.80,1.95,1.85,,,,1-0:7.5;0-0:9.0;1-1:8.0;2-1:9.0,draw_suits_both,"Knockout tie: level after 90 goes to extra time and penalties, but the pool scores the 90-minute result. Both sides may be content to take it deep.",true,false
+BRA-KOR,Brazil,South Korea,2026-07-09T15:00:00Z,decimal,1.40,4.80,8.00,2.5,1.75,2.05,2.10,1.70,,,,,"",Clear favourite; Brazil expected to control.,false,false
+FRA-POL,France,Poland,2026-07-09T19:00:00Z,american,-140,260,380,2.5,-105,-115,100,-120,,,,,dead_rubber;heavy_rotation_home,"France already through as group winners and likely to rotate heavily; Poland need the win.",true,true
+ARG-NED,Argentina,Netherlands,2026-07-10T19:00:00Z,decimal,2.30,3.10,3.30,2.5,1.95,1.90,1.90,1.90,2.60,3.20,2.90,,"",Argentina has shortened since the line opened.,false,false

--- a/tools/score-pool/fixtures.example.json
+++ b/tools/score-pool/fixtures.example.json
@@ -1,0 +1,41 @@
+{
+  "matches": [
+    {
+      "match_id": "ESP-GER",
+      "home": "Spain",
+      "away": "Germany",
+      "commence_time": "2026-07-08T19:00:00Z",
+      "odds": {
+        "format": "decimal",
+        "bookmaker": "pinnacle",
+        "three_way": { "home": 2.55, "draw": 3.20, "away": 2.95 },
+        "over_under": { "line": 2.5, "over": 2.05, "under": 1.80 },
+        "btts": { "yes": 1.95, "no": 1.85 },
+        "correct_score": { "1-0": 7.5, "0-0": 9.0, "1-1": 8.0, "2-1": 9.0, "0-1": 8.0 },
+        "three_way_open": { "home": 2.70, "draw": 3.25, "away": 2.80 }
+      },
+      "context": {
+        "draw_suits_both": true,
+        "lineup_unconfirmed": true,
+        "note": "Knockout tie: level after 90 goes to extra time and penalties, but the pool scores the 90-minute result. Both sides may be content to take it deep."
+      }
+    },
+    {
+      "match_id": "ARG-NED",
+      "home": "Argentina",
+      "away": "Netherlands",
+      "commence_time": "2026-07-10T19:00:00Z",
+      "odds": {
+        "format": "decimal",
+        "three_way": { "home": 2.30, "draw": 3.10, "away": 3.30 },
+        "over_under": { "line": 2.5, "over": 1.95, "under": 1.90 },
+        "btts": { "yes": 1.90, "no": 1.90 },
+        "three_way_open": { "home": 2.60, "draw": 3.20, "away": 2.90 },
+        "over_under_open": { "line": 2.5, "over": 2.00, "under": 1.85 }
+      },
+      "context": {
+        "note": "Argentina has shortened since the line opened."
+      }
+    }
+  ]
+}

--- a/tools/score-pool/pyproject.toml
+++ b/tools/score-pool/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "scorepool"
+version = "0.1.0"
+description = "Exact-score prediction pool assistant: de-vig odds, model scorelines, optimise expected points, and tilt for the leaderboard."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "numpy>=1.24",
+    "scipy>=1.10",
+]
+
+[project.optional-dependencies]
+# Live odds fetching; the tool works without it via manual/CSV/JSON odds.
+api = ["requests>=2.28"]
+dev = ["pytest>=7.4"]
+
+[project.scripts]
+scorepool = "scorepool.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["scorepool*"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/tools/score-pool/requirements.txt
+++ b/tools/score-pool/requirements.txt
@@ -1,0 +1,10 @@
+# Core: the probability engine and optimizer.
+numpy>=1.24
+scipy>=1.10
+
+# Optional: only needed to pull live odds from The Odds API. The tool works
+# without it using hand-entered / CSV / JSON odds.
+requests>=2.28
+
+# Optional: running the test suite.
+pytest>=7.4

--- a/tools/score-pool/scorepool/__init__.py
+++ b/tools/score-pool/scorepool/__init__.py
@@ -1,0 +1,36 @@
+"""scorepool -- an exact-score prediction pool assistant.
+
+The pipeline, in one line: odds -> de-vigged market -> fitted scoreline
+distribution -> expected-points optimiser -> leaderboard tilt -> pick sheet.
+
+Every stage is a small, swappable piece so the same decision logic can point at a
+different sport or a different pool whose markets and rules don't match.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from .config import AppConfig, load_config  # noqa: E402
+from .engine import MatchAnalysis, analyze_all, analyze_match  # noqa: E402
+from .models import (  # noqa: E402
+    ActualResult,
+    Match,
+    MatchContext,
+    ScoringRules,
+    Standing,
+)
+
+__all__ = [
+    "__version__",
+    "AppConfig",
+    "load_config",
+    "analyze_all",
+    "analyze_match",
+    "MatchAnalysis",
+    "Match",
+    "MatchContext",
+    "ScoringRules",
+    "Standing",
+    "ActualResult",
+]

--- a/tools/score-pool/scorepool/__main__.py
+++ b/tools/score-pool/scorepool/__main__.py
@@ -1,0 +1,6 @@
+"""Enable ``python -m scorepool ...``."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/score-pool/scorepool/cli.py
+++ b/tools/score-pool/scorepool/cli.py
@@ -1,0 +1,457 @@
+"""Command-line interface.
+
+Subcommands:
+  recommend   load odds, build picks, print the pick sheet + submission table
+  fetch       pull live odds from the API and write a timestamped fixtures snapshot
+  explain     deep-dive one or more matches (full candidate table)
+  submit      record the score I actually submitted for a match
+  result      enter a finished result and update the running total
+  standings   show my running total versus the pool
+  init        scaffold an example config and fixtures file
+
+Config supplies the scoring rules, my standing, model, and odds source; most
+standing fields can be overridden with flags for quick what-ifs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import List, Optional
+
+from . import __version__
+from .config import AppConfig, load_config
+from .engine import analyze_all
+from .models import ActualResult, Match, MatchContext
+from .odds.manual import load_fixtures
+from .output.picksheet import render_full_report, render_match_detail
+from .state import (
+    load_state,
+    parse_score,
+    record_result,
+    render_standings,
+    save_state,
+    scoring_to_dict,
+    set_submitted,
+    upsert_pick,
+)
+
+
+def _resolve_config_path(path: Optional[str]) -> Optional[str]:
+    if path:
+        return path
+    for candidate in ("scorepool.toml", "config.toml"):
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def _apply_standing_overrides(cfg: AppConfig, args) -> None:
+    st = cfg.standing
+    if getattr(args, "my_points", None) is not None:
+        st.my_points = args.my_points
+    if getattr(args, "above", None) is not None:
+        st.points_above = args.above
+    if getattr(args, "below", None) is not None:
+        st.points_below = args.below
+    if getattr(args, "pool", None) is not None:
+        st.pool_size = args.pool
+    if getattr(args, "games", None) is not None:
+        st.games_remaining = args.games
+    if getattr(args, "risk", None):
+        st.risk = args.risk
+    if getattr(args, "model", None):
+        cfg.model.type = args.model
+    if getattr(args, "devig", None):
+        cfg.model.devig = args.devig
+
+
+def _load_matches(cfg: AppConfig, fixtures: Optional[str]) -> tuple[List[Match], List[str]]:
+    """Return (matches, warnings). Applies the configured odds source."""
+    warnings: List[str] = []
+    matches = load_fixtures(fixtures) if fixtures else []
+
+    if cfg.odds.source == "the_odds_api":
+        from .odds.the_odds_api import (
+            OddsAPIError,
+            enrich_with_api,
+            event_to_odds,
+            fetch_events,
+        )
+
+        try:
+            if matches:
+                unmatched = enrich_with_api(matches, cfg.odds)
+                if unmatched:
+                    warnings.append(
+                        "no API odds for (using any manual odds instead): "
+                        + ", ".join(unmatched)
+                    )
+            else:
+                events = fetch_events(cfg.odds)
+                for ev in events:
+                    odds = event_to_odds(ev, cfg.odds)
+                    if odds is None:
+                        continue
+                    matches.append(
+                        Match(
+                            match_id=f"{ev.get('home_team')}-{ev.get('away_team')}",
+                            home=ev.get("home_team", "?"),
+                            away=ev.get("away_team", "?"),
+                            commence_time=ev.get("commence_time"),
+                            odds=odds,
+                            context=MatchContext(),
+                        )
+                    )
+        except OddsAPIError as exc:
+            warnings.append(f"odds API unavailable ({exc}); falling back to fixtures odds")
+
+    if not matches:
+        warnings.append(
+            "no matches loaded -- supply --fixtures, or configure the_odds_api with a key"
+        )
+    return matches, warnings
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+def cmd_recommend(args) -> int:
+    cfg = load_config(_resolve_config_path(args.config))
+    _apply_standing_overrides(cfg, args)
+    matches, warnings = _load_matches(cfg, args.fixtures)
+    for w in warnings:
+        print(f"[warn] {w}", file=sys.stderr)
+    if not matches:
+        return 2
+
+    if args.match:
+        wanted = set(args.match)
+        matches = [m for m in matches if m.match_id in wanted or m.label in wanted]
+
+    analyses = analyze_all(matches, cfg)
+
+    print(render_full_report(analyses, cfg))
+
+    if args.detail:
+        print("\nMATCH DETAIL")
+        print("=" * 72)
+        for a in analyses:
+            print()
+            print(render_match_detail(a, cfg))
+
+    if args.save:
+        state = load_state(args.save)
+        state["scoring"] = scoring_to_dict(cfg.scoring)
+        for a in analyses:
+            if a.ok and a.selection is not None:
+                upsert_pick(
+                    state,
+                    a.match.match_id,
+                    a.match.label,
+                    a.selection.featured.score,
+                    a.selection.field_pick,
+                    a.match.commence_time,
+                    a.fetched_at,
+                    a.confidence,
+                )
+        save_state(args.save, state)
+        print(f"\n[saved planned picks to {args.save}]", file=sys.stderr)
+
+    if args.json:
+        _dump_json(analyses, args.json)
+        print(f"[wrote structured output to {args.json}]", file=sys.stderr)
+
+    return 0
+
+
+def cmd_fetch(args) -> int:
+    cfg = load_config(_resolve_config_path(args.config))
+    cfg.odds.source = "the_odds_api"
+    matches, warnings = _load_matches(cfg, args.fixtures)
+    for w in warnings:
+        print(f"[warn] {w}", file=sys.stderr)
+    if not matches:
+        return 2
+
+    snapshot = [_match_to_json(m) for m in matches]
+    with open(args.out, "w", encoding="utf-8") as fh:
+        json.dump({"matches": snapshot}, fh, indent=2)
+    print(f"wrote {len(snapshot)} matches with live odds to {args.out}")
+    return 0
+
+
+def cmd_explain(args) -> int:
+    cfg = load_config(_resolve_config_path(args.config))
+    _apply_standing_overrides(cfg, args)
+    matches, warnings = _load_matches(cfg, args.fixtures)
+    for w in warnings:
+        print(f"[warn] {w}", file=sys.stderr)
+    if not matches:
+        print("no matches loaded", file=sys.stderr)
+        return 2
+    # Analyse the whole slate so the tilt reflects every remaining game, then show
+    # detail only for the requested matches.
+    analyses = analyze_all(matches, cfg)
+    if args.match:
+        wanted = set(args.match)
+        analyses = [a for a in analyses if a.match.match_id in wanted or a.match.label in wanted]
+    if not analyses:
+        print("no matching matches", file=sys.stderr)
+        return 2
+    for a in analyses:
+        print(render_match_detail(a, cfg))
+        print()
+    return 0
+
+
+def cmd_submit(args) -> int:
+    state = load_state(args.state)
+    set_submitted(state, args.match, parse_score(args.score))
+    save_state(args.state, state)
+    print(f"recorded submitted pick {args.score} for {args.match}")
+    return 0
+
+
+def cmd_result(args) -> int:
+    cfg = load_config(_resolve_config_path(args.config))
+    state = load_state(args.state)
+    reg = parse_score(args.score)
+    final = parse_score(args.final) if args.final else None
+    actual = ActualResult(
+        home_reg=reg[0],
+        away_reg=reg[1],
+        home_final=final[0] if final else None,
+        away_final=final[1] if final else None,
+        decided_by=args.decided_by,
+    )
+    try:
+        rec = record_result(state, args.match, actual, cfg.scoring)
+    except KeyError as exc:
+        print(f"[error] {exc}", file=sys.stderr)
+        return 2
+    save_state(args.state, state)
+    print(
+        f"{rec['label']}: result {args.score}"
+        + (f" (final {args.final}, {args.decided_by})" if final else "")
+        + f" -> my pick {rec.get('submitted_override') or rec['pick']} scored "
+        f"{rec['points_mine']:g}"
+    )
+    print()
+    print(render_standings(state, cfg.scoring))
+    return 0
+
+
+def cmd_standings(args) -> int:
+    cfg = load_config(_resolve_config_path(args.config))
+    state = load_state(args.state)
+    print(render_standings(state, cfg.scoring))
+    return 0
+
+
+def cmd_init(args) -> int:
+    from .scaffold import CONFIG_TEMPLATE, FIXTURES_TEMPLATE
+
+    wrote = []
+    for name, content in (
+        ("scorepool.toml", CONFIG_TEMPLATE),
+        ("fixtures.csv", FIXTURES_TEMPLATE),
+    ):
+        path = os.path.join(args.dir, name)
+        if os.path.exists(path) and not args.force:
+            print(f"[skip] {path} exists (use --force to overwrite)")
+            continue
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        wrote.append(path)
+    for p in wrote:
+        print(f"wrote {p}")
+    if wrote:
+        print("\nEdit scorepool.toml (scoring + standing), then run:")
+        print("  python -m scorepool recommend --fixtures fixtures.csv")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# JSON serialisation of results
+# ---------------------------------------------------------------------------
+
+
+def _match_to_json(m: Match) -> dict:
+    o = m.odds
+    odds = None
+    if o:
+        odds = {"format": "decimal", "fetched_at": o.fetched_at, "bookmaker": o.bookmaker}
+        if o.three_way:
+            odds["three_way"] = {
+                "home": o.three_way.home,
+                "draw": o.three_way.draw,
+                "away": o.three_way.away,
+            }
+        if o.over_under:
+            odds["over_under"] = {
+                "line": o.over_under.line,
+                "over": o.over_under.over,
+                "under": o.over_under.under,
+            }
+        if o.btts:
+            odds["btts"] = {"yes": o.btts.yes, "no": o.btts.no}
+    ctx = m.context
+    context = {"note": ctx.note} if ctx.note else {}
+    for flag in (
+        "dead_rubber",
+        "draw_suits_both",
+        "heavy_rotation_home",
+        "heavy_rotation_away",
+        "low_scoring",
+        "high_scoring",
+        "must_win_home",
+        "must_win_away",
+        "lineup_unconfirmed",
+        "injury_question",
+    ):
+        if getattr(ctx, flag):
+            context[flag] = True
+    return {
+        "match_id": m.match_id,
+        "home": m.home,
+        "away": m.away,
+        "commence_time": m.commence_time,
+        "odds": odds,
+        "context": context,
+    }
+
+
+def _dump_json(analyses, path: str) -> None:
+    out = []
+    for a in analyses:
+        if not a.ok or a.selection is None:
+            out.append({"match": a.match.label, "ok": False, "reason": a.reason})
+            continue
+        sel = a.selection
+        out.append(
+            {
+                "match": a.match.label,
+                "match_id": a.match.match_id,
+                "ok": True,
+                "pick": f"{sel.featured.score[0]}-{sel.featured.score[1]}",
+                "expected_points": round(sel.featured.ep, 3),
+                "confidence": a.confidence,
+                "safer_alternative": f"{sel.safer.score[0]}-{sel.safer.score[1]}",
+                "differentiator": (
+                    f"{sel.differentiator.score[0]}-{sel.differentiator.score[1]}"
+                    if sel.differentiator
+                    else None
+                ),
+                "field_pick": f"{sel.field_pick[0]}-{sel.field_pick[1]}",
+                "posture": sel.tilt.mode,
+                "tilt": round(sel.tilt.tau, 3),
+                "p_protect": sel.p_protect,
+                "p_catch": sel.p_catch,
+                "devigged": {
+                    "home": a.dist.p_home(),
+                    "draw": a.dist.p_draw(),
+                    "away": a.dist.p_away(),
+                },
+                "expected_goals": a.dist.expected_total(),
+                "fit_rms": a.dist.fit_quality(),
+                "why": a.why,
+                "odds_fetched_at": a.fetched_at,
+                "lock_time": a.match.commence_time,
+                "revisit": a.revisit,
+            }
+        )
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(out, fh, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def _add_standing_flags(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--my-points", type=float, help="override my points total")
+    p.add_argument("--above", type=float, help="points of the nearest competitor ahead")
+    p.add_argument("--below", type=float, help="points of the nearest competitor behind")
+    p.add_argument("--pool", type=int, help="pool size")
+    p.add_argument("--games", type=int, help="games remaining (incl. these)")
+    p.add_argument(
+        "--risk", choices=["auto", "protect", "chase", "neutral"], help="override risk posture"
+    )
+    p.add_argument("--model", help="override scoreline model")
+    p.add_argument("--devig", help="override de-vig method")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="scorepool",
+        description="Exact-score prediction pool assistant: de-vig odds, build a "
+        "scoreline distribution, optimise expected points, and tilt for the leaderboard.",
+    )
+    parser.add_argument("--version", action="version", version=f"scorepool {__version__}")
+    parser.add_argument("--config", help="path to config TOML (default: scorepool.toml)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("recommend", help="build and print the pick sheet")
+    p.add_argument("--fixtures", help="fixtures CSV or JSON")
+    p.add_argument("--save", help="persist planned picks to this state JSON")
+    p.add_argument("--json", help="also write structured picks to this path")
+    p.add_argument("--detail", action="store_true", help="print per-match candidate tables")
+    p.add_argument("--match", action="append", help="limit to match id/label (repeatable)")
+    _add_standing_flags(p)
+    p.set_defaults(func=cmd_recommend)
+
+    p = sub.add_parser("fetch", help="pull live odds and snapshot to JSON")
+    p.add_argument("--fixtures", help="fixtures file for the match list + context")
+    p.add_argument("--out", default="fixtures.snapshot.json", help="output JSON path")
+    p.set_defaults(func=cmd_fetch)
+
+    p = sub.add_parser("explain", help="deep-dive one or more matches")
+    p.add_argument("--fixtures", help="fixtures CSV or JSON")
+    p.add_argument("--match", action="append", help="match id/label (repeatable)")
+    _add_standing_flags(p)
+    p.set_defaults(func=cmd_explain)
+
+    p = sub.add_parser("submit", help="record the score I actually submitted")
+    p.add_argument("--state", required=True)
+    p.add_argument("--match", required=True, help="match id")
+    p.add_argument("--score", required=True, help="submitted score, e.g. 1-1")
+    p.set_defaults(func=cmd_submit)
+
+    p = sub.add_parser("result", help="enter a finished result and update totals")
+    p.add_argument("--state", required=True)
+    p.add_argument("--match", required=True, help="match id")
+    p.add_argument("--score", required=True, help="90-minute score, e.g. 1-1")
+    p.add_argument("--final", help="score after extra time, e.g. 2-1")
+    p.add_argument(
+        "--decided-by",
+        choices=["regulation", "extra_time", "penalties"],
+        default="regulation",
+    )
+    p.set_defaults(func=cmd_result)
+
+    p = sub.add_parser("standings", help="show the running total")
+    p.add_argument("--state", required=True)
+    p.set_defaults(func=cmd_standings)
+
+    p = sub.add_parser("init", help="scaffold an example config and fixtures")
+    p.add_argument("--dir", default=".", help="directory to write into")
+    p.add_argument("--force", action="store_true", help="overwrite existing files")
+    p.set_defaults(func=cmd_init)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/score-pool/scorepool/config.py
+++ b/tools/score-pool/scorepool/config.py
@@ -1,0 +1,156 @@
+"""Configuration: scoring rules, my standing, model choices, and odds source.
+
+The pool rules and my standing drive everything else, so this is the first thing
+the tool reads. Config is TOML (read with the stdlib ``tomllib``); every value
+has a sensible default so a minimal file still works.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+from .models import ScoringRules, Standing
+
+
+@dataclass
+class ContextShading:
+    """How much each tournament-context flag nudges the market targets before the
+    scoreline model is fit. These are deliberately modest heuristics -- context
+    shades the distribution, it does not overrule the market -- and every value
+    is configurable so a different sport or pool can retune them."""
+
+    dead_rubber_total_factor: float = 0.90
+    dead_rubber_draw_boost: float = 0.04
+    draw_suits_both_total_factor: float = 0.92
+    draw_suits_both_draw_boost: float = 0.06
+    heavy_rotation_total_factor: float = 0.95  # applied per rotating side
+    low_scoring_total_factor: float = 0.88
+    high_scoring_total_factor: float = 1.12
+    must_win_total_factor: float = 1.05  # a must-win side pushes the game open
+    must_win_draw_penalty: float = 0.03
+
+
+@dataclass
+class ModelConfig:
+    type: str = "bivariate_poisson"  # independent_poisson | bivariate_poisson | dixon_coles
+    max_goals: int = 10
+    devig: str = "proportional"  # proportional | shin | additive
+    field_model: str = "modal_scoreline"  # modal_scoreline | ep_optimal | favorite_margin
+    shading: ContextShading = field(default_factory=ContextShading)
+
+
+@dataclass
+class StrategyConfig:
+    """Knobs for the leaderboard tilt. ``variance_price`` is how many expected
+    points I am willing to trade for one unit of differential standard deviation
+    when protecting or chasing -- the price of the expected-points-vs-variance
+    trade. The rest tune how the gap and pool size map onto that trade."""
+
+    variance_price: float = 0.5  # expected points traded per unit differential std
+    safer_variance_penalty: float = 0.5  # own-variance penalty defining the higher-floor pick
+    differentiator_ep_tolerance: float = 1.5  # most EP a featured/differentiator pick may give up
+    reach_quantile: float = 1.0  # SDs of reachable swing used to gauge precariousness
+    pool_chase_scale: float = 0.08  # how much a larger pool raises chase pressure
+
+
+@dataclass
+class OddsConfig:
+    source: str = "manual"  # the_odds_api | manual | csv
+    api_key_env: str = "ODDS_API_KEY"
+    sport_key: str = "soccer_fifa_world_cup"
+    regions: str = "us,uk,eu"
+    markets: str = "h2h,totals,btts"
+    bookmaker: Optional[str] = None  # prefer one book; else consensus median
+
+    @property
+    def api_key(self) -> Optional[str]:
+        return os.environ.get(self.api_key_env)
+
+
+@dataclass
+class AppConfig:
+    scoring: ScoringRules = field(default_factory=ScoringRules)
+    standing: Standing = field(default_factory=Standing)
+    model: ModelConfig = field(default_factory=ModelConfig)
+    odds: OddsConfig = field(default_factory=OddsConfig)
+    strategy: StrategyConfig = field(default_factory=StrategyConfig)
+
+
+def _as_float(d: Dict[str, Any], key: str, default):
+    v = d.get(key, default)
+    return None if v is None else float(v)
+
+
+def _as_int(d: Dict[str, Any], key: str, default):
+    v = d.get(key, default)
+    return None if v is None else int(v)
+
+
+def load_config(path: Optional[str]) -> AppConfig:
+    """Load config from a TOML file. A missing path yields all-defaults so the
+    tool is usable before any config exists."""
+    raw: Dict[str, Any] = {}
+    if path:
+        with open(path, "rb") as fh:
+            raw = tomllib.load(fh)
+    return config_from_dict(raw)
+
+
+def config_from_dict(raw: Dict[str, Any]) -> AppConfig:
+    sc = raw.get("scoring", {})
+    scoring = ScoringRules(
+        exact=float(sc.get("exact", 5.0)),
+        result_and_goal_difference=float(sc.get("result_and_goal_difference", 3.0)),
+        result_only=float(sc.get("result_only", 2.0)),
+        result_basis=str(sc.get("result_basis", "regulation")),
+    )
+    scoring.validate()
+
+    st = raw.get("standing", {})
+    standing = Standing(
+        my_points=float(st.get("my_points", 0.0)),
+        points_above=_as_float(st, "points_above", None),
+        points_below=_as_float(st, "points_below", None),
+        pool_size=int(st.get("pool_size", 20)),
+        games_remaining=_as_int(st, "games_remaining", None),
+        risk=str(st.get("risk", "auto")),
+    )
+
+    md = raw.get("model", {})
+    shading_raw = md.get("context_shading", {})
+    shading = ContextShading(
+        **{k: float(v) for k, v in shading_raw.items() if k in ContextShading().__dict__}
+    )
+    model = ModelConfig(
+        type=str(md.get("type", "bivariate_poisson")),
+        max_goals=int(md.get("max_goals", 10)),
+        devig=str(md.get("devig", "proportional")),
+        field_model=str(md.get("field_model", "modal_scoreline")),
+        shading=shading,
+    )
+
+    od = raw.get("odds", {})
+    odds = OddsConfig(
+        source=str(od.get("source", "manual")),
+        api_key_env=str(od.get("api_key_env", "ODDS_API_KEY")),
+        sport_key=str(od.get("sport_key", "soccer_fifa_world_cup")),
+        regions=str(od.get("regions", "us,uk,eu")),
+        markets=str(od.get("markets", "h2h,totals,btts")),
+        bookmaker=od.get("bookmaker") or None,
+    )
+
+    stcfg = raw.get("strategy", {})
+    strategy = StrategyConfig(
+        **{k: float(v) for k, v in stcfg.items() if k in StrategyConfig().__dict__}
+    )
+
+    return AppConfig(
+        scoring=scoring, standing=standing, model=model, odds=odds, strategy=strategy
+    )

--- a/tools/score-pool/scorepool/engine.py
+++ b/tools/score-pool/scorepool/engine.py
@@ -1,0 +1,278 @@
+"""Per-match assembly: odds -> targets -> distribution -> optimizer -> leaderboard.
+
+This wires the swappable pieces together and produces the ``MatchAnalysis`` the
+output layer renders. Two things are deliberately global to the slate rather than
+per match: the risk tilt (protect vs chase) and the typical per-game swing that
+feeds the standings model, because my stance depends on my standing and the
+schedule, not on any one game. Everything it does stays honest about what it
+knows: it discloses when context shaded the model, when a market was missing, and
+how well the distribution actually matched the market.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from .config import AppConfig
+from .leaderboard import field as field_mod
+from .leaderboard.strategy import PickSelection, Tilt, derive_tilt, select_picks
+from .models import Match
+from .optimizer.expected_points import Candidate, rank_candidates
+from .probability import market as market_mod
+from .probability.scoreline import MarketTargets, ScoreDistribution, get_model
+
+
+@dataclass
+class MatchAnalysis:
+    match: Match
+    ok: bool
+    reason: str = ""  # why analysis was not possible, when ok is False
+    dist: Optional[ScoreDistribution] = None
+    targets: Optional[MarketTargets] = None
+    shaded: bool = False
+    candidates: List[Candidate] = field(default_factory=list)
+    selection: Optional[PickSelection] = None
+    confidence: str = "n/a"
+    why: str = ""
+    line_move: Optional[dict] = None
+    revisit: List[str] = field(default_factory=list)
+
+    @property
+    def fetched_at(self) -> Optional[str]:
+        return self.match.odds.fetched_at if self.match.odds else None
+
+
+_CONTEXT_FLAG_LABELS = [
+    "dead_rubber",
+    "draw_suits_both",
+    "low_scoring",
+    "high_scoring",
+    "heavy_rotation_home",
+    "heavy_rotation_away",
+    "must_win_home",
+    "must_win_away",
+]
+
+
+def _active_context_flags(match: Match) -> List[str]:
+    return [f for f in _CONTEXT_FLAG_LABELS if getattr(match.context, f)]
+
+
+def compute_confidence(
+    dist: ScoreDistribution, cands: List[Candidate], targets: MarketTargets
+) -> str:
+    """A deliberately conservative high/medium/low read. It rewards a clear
+    expected-points winner, a high floor, a decisive market, and good calibration,
+    and it marks genuine coin flips down rather than up -- the point is honest
+    uncertainty, not false confidence."""
+    top = cands[0]
+    clarity = top.ep - (cands[1].ep if len(cands) > 1 else 0.0)
+    peak = max(dist.p_home(), dist.p_draw(), dist.p_away())
+    fitq = dist.fit_quality()
+
+    score = 0.0
+    score += min(clarity / 0.8, 1.0)  # clear EP winner: up to +1.0
+    score += min(top.floor / 0.5, 1.0) * 0.6  # high meaningful floor: up to +0.6
+    score += 0.4 if targets.p_over is not None else 0.0  # more markets, more anchored
+    score += max(min((peak - 0.34) / 0.3, 1.0), -1.0) * 0.5  # decisive vs coin-flip
+    score -= min(fitq / 0.05, 1.0) * 0.6  # poor calibration drags it down
+
+    if score >= 1.6:
+        return "high"
+    if score >= 0.9:
+        return "medium"
+    return "low"
+
+
+def _line_move_phrase(match: Match, line_move: dict) -> Optional[str]:
+    """Describe the biggest fair-probability move since the open, in team terms."""
+    biggest_key, biggest_val = max(line_move.items(), key=lambda kv: abs(kv[1]))
+    if abs(biggest_val) < 0.035:
+        return None
+    who = {"home": match.home, "away": match.away, "draw": "the draw"}[biggest_key]
+    # A rising outcome probability means that price has shortened.
+    if biggest_key == "draw":
+        moved = "shortened" if biggest_val > 0 else "drifted out"
+        return f"The draw has {moved} since the open ({biggest_val:+.0%})."
+    moved = "shortened" if biggest_val > 0 else "drifted out"
+    return f"{who} has {moved} since the open ({biggest_val:+.0%})."
+
+
+def build_why(
+    match: Match,
+    dist: ScoreDistribution,
+    sel: PickSelection,
+    line_move: Optional[dict],
+) -> str:
+    ph, pd, pa = dist.p_home(), dist.p_draw(), dist.p_away()
+    total = dist.expected_total()
+    raw = sel.raw_best
+    feat = sel.featured
+    field = f"{sel.field_pick[0]}-{sel.field_pick[1]}"
+    bits: List[str] = []
+
+    # Describe the plain expected-points winner first, honestly.
+    if raw.score[0] == raw.score[1]:
+        bits.append(
+            f"Raw expected points favour the draw {raw.label} at {raw.ep:.2f}, because a "
+            f"draw pick banks the result-and-goal-difference tier on every draw "
+            f"({pd:.0%} de-vigged), not just the exact score."
+        )
+    else:
+        home_side = raw.score[0] > raw.score[1]
+        name = match.home if home_side else match.away
+        p = ph if home_side else pa
+        bits.append(
+            f"Raw expected points favour {raw.label} at {raw.ep:.2f}, with {name} at {p:.0%}."
+        )
+
+    # Then, if the standings tilt moved the pick, say so and name the trade.
+    if feat.score != raw.score:
+        give = raw.ep - feat.ep
+        if sel.tilt.mode == "chase":
+            bits.append(
+                f"Chasing, the pick moves to {feat.label} ({feat.ep:.2f} xEP, about "
+                f"{give:.2f} less) to decorrelate from the field's {field}."
+            )
+        elif sel.tilt.mode == "protect":
+            bits.append(
+                f"Protecting, the pick moves to {feat.label} ({feat.ep:.2f} xEP) to move "
+                f"with the field and cut variance."
+            )
+        else:
+            bits.append(f"The pick is {feat.label} at {feat.ep:.2f} xEP.")
+
+    if total < 2.3:
+        bits.append(f"The market points to a low-scoring game, about {total:.1f} goals.")
+    elif total > 3.1:
+        bits.append(f"The market points to an open game, about {total:.1f} goals.")
+
+    mode = sel.tilt.mode
+    if mode == "protect" and sel.p_protect is not None:
+        bits.append(
+            f"Protecting the lead, this pick holds about {sel.p_protect:.0%} to stay "
+            f"ahead of the chaser, versus about {sel.p_protect_mirror:.0%} from mirroring "
+            f"the chalk, so it leans low-variance."
+        )
+    elif mode == "chase" and sel.p_catch is not None:
+        bits.append(
+            f"Chasing, with variance the lever now, this gives about {sel.p_catch:.0%} to "
+            f"catch the leader against about {sel.p_catch_mirror:.0%} from copying the field."
+        )
+
+    if line_move:
+        phrase = _line_move_phrase(match, line_move)
+        if phrase:
+            bits.append(phrase)
+
+    flags = _active_context_flags(match)
+    if flags:
+        bits.append(
+            "Context factored in was " + ", ".join(f.replace("_", " ") for f in flags) + "."
+        )
+
+    if match.context.note:
+        bits.append(match.context.note.strip())
+
+    return " ".join(bits)
+
+
+# ---------------------------------------------------------------------------
+# Two-pass analysis: build every match's model, then apply one slate-wide tilt
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MatchModel:
+    targets: MarketTargets
+    shaded: bool
+    dist: ScoreDistribution
+    cands: List[Candidate]
+    field_pick: tuple
+    sigma0: float
+
+
+def _build_model(match: Match, cfg: AppConfig) -> Optional[_MatchModel]:
+    if match.odds is None or match.odds.three_way is None:
+        return None
+    targets = market_mod.targets_from_odds(
+        match.odds, method=cfg.model.devig, max_goals=cfg.model.max_goals
+    )
+    shaded = bool(_active_context_flags(match))
+    if shaded:
+        targets = market_mod.apply_context_shading(targets, match.context, cfg.model.shading)
+
+    dist = get_model(cfg.model.type).fit(targets)
+    cands = rank_candidates(dist, cfg.scoring, candidate_max=min(6, cfg.model.max_goals))
+    field_pick = field_mod.field_pick(dist, cfg.scoring, cfg.model.field_model)
+    sigma0 = field_mod.typical_game_swing(dist, cfg.scoring, field_pick)
+    return _MatchModel(targets, shaded, dist, cands, field_pick, sigma0)
+
+
+def _finish(
+    match: Match,
+    model: _MatchModel,
+    tilt: Tilt,
+    cfg: AppConfig,
+    sigma0_global: float,
+    games_remaining: int,
+) -> MatchAnalysis:
+    selection = select_picks(
+        model.cands,
+        model.dist,
+        cfg.scoring,
+        model.field_pick,
+        cfg.standing,
+        tilt,
+        sigma0_global,
+        games_remaining,
+        cfg.strategy,
+    )
+    line_move = market_mod.line_movement(match.odds, cfg.model.devig)
+    confidence = compute_confidence(model.dist, model.cands, model.targets)
+    why = build_why(match, model.dist, selection, line_move)
+    return MatchAnalysis(
+        match=match,
+        ok=True,
+        dist=model.dist,
+        targets=model.targets,
+        shaded=model.shaded,
+        candidates=model.cands,
+        selection=selection,
+        confidence=confidence,
+        why=why,
+        line_move=line_move,
+        revisit=match.context.revisit_reasons(),
+    )
+
+
+def analyze_all(matches: List[Match], cfg: AppConfig) -> List[MatchAnalysis]:
+    games_remaining = cfg.standing.games_remaining or max(len(matches), 1)
+
+    models: Dict[int, Optional[_MatchModel]] = {}
+    for i, m in enumerate(matches):
+        models[i] = _build_model(m, cfg)
+
+    swings = [mm.sigma0 for mm in models.values() if mm is not None]
+    sigma0_global = float(statistics.median(swings)) if swings else 1.5
+    tilt = derive_tilt(cfg.standing, sigma0_global, games_remaining, cfg.strategy)
+
+    analyses: List[MatchAnalysis] = []
+    for i, m in enumerate(matches):
+        mm = models[i]
+        if mm is None:
+            analyses.append(
+                MatchAnalysis(
+                    match=m, ok=False, reason="no three-way (home/draw/away) odds supplied"
+                )
+            )
+        else:
+            analyses.append(_finish(m, mm, tilt, cfg, sigma0_global, games_remaining))
+    return analyses
+
+
+def analyze_match(match: Match, cfg: AppConfig) -> MatchAnalysis:
+    """Analyse a single match as a one-match slate (tilt derived from it alone)."""
+    return analyze_all([match], cfg)[0]

--- a/tools/score-pool/scorepool/leaderboard/__init__.py
+++ b/tools/score-pool/scorepool/leaderboard/__init__.py
@@ -1,0 +1,1 @@
+"""Leaderboard layer: model the field, then tilt the pick for my standing."""

--- a/tools/score-pool/scorepool/leaderboard/field.py
+++ b/tools/score-pool/scorepool/leaderboard/field.py
@@ -1,0 +1,90 @@
+"""Model what the rest of the field is likely to submit.
+
+A pick is not only a bet on a game; it is a move in the standings that only pays
+off relative to what everyone else does. To reason about that we need a model of
+the field's submission for each game. In practice the field piles onto the
+favourites and the chalk, so the default model is the single most likely
+scoreline. Two alternatives are offered: the expected-points-optimal pick (a
+sharper field) and the favourite's most likely winning margin.
+
+From the field's pick we derive, for any candidate of mine, the distribution of
+the point *differential* between me and that competitor on the game -- its mean
+and variance -- which is what the strategy layer needs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+
+from ..models import Score, ScoringRules
+from ..optimizer.expected_points import (
+    _outcome_and_gd,
+    modal_scoreline,
+    points_grid,
+    rank_candidates,
+)
+from ..probability.scoreline import ScoreDistribution
+
+
+def field_pick(dist: ScoreDistribution, rules: ScoringRules, model: str = "modal_scoreline") -> Score:
+    """The scoreline a typical opponent is expected to submit."""
+    if model == "modal_scoreline":
+        return modal_scoreline(dist)
+    if model == "ep_optimal":
+        return rank_candidates(dist, rules)[0].score
+    if model == "favorite_margin":
+        return _favorite_margin_pick(dist)
+    raise ValueError(f"unknown field model {model!r}")
+
+
+def _favorite_margin_pick(dist: ScoreDistribution) -> Score:
+    """Most likely scoreline *within the favoured outcome*. Captures the casual
+    player who backs the favourite to win by a plausible margin even when the
+    single most likely scoreline is a draw."""
+    grid = dist.grid
+    n = grid.shape[0] - 1
+    out, _ = _outcome_and_gd(n)
+    masses = {1: dist.p_home(), 0: dist.p_draw(), -1: dist.p_away()}
+    fav = max(masses, key=masses.get)
+    mask = out == fav
+    masked = np.where(mask, grid, -1.0)
+    idx = np.unravel_index(np.argmax(masked), grid.shape)
+    return (int(idx[0]), int(idx[1]))
+
+
+@dataclass
+class Differential:
+    """Mean and standard deviation of (my points - a competitor's points) on a
+    single game, for a given pick of mine against a fixed competitor pick."""
+
+    mean: float
+    std: float
+
+
+def differential_stats(
+    my_pick: Score, competitor_pick: Score, dist: ScoreDistribution, rules: ScoringRules
+) -> Differential:
+    n = dist.grid.shape[0] - 1
+    out, gd = _outcome_and_gd(n)
+    mine = points_grid(my_pick, rules, n, out, gd)
+    theirs = points_grid(competitor_pick, rules, n, out, gd)
+    delta = mine - theirs
+    mean = float((dist.grid * delta).sum())
+    ex2 = float((dist.grid * delta * delta).sum())
+    var = max(ex2 - mean * mean, 0.0)
+    return Differential(mean=mean, std=float(np.sqrt(var)))
+
+
+def typical_game_swing(dist: ScoreDistribution, rules: ScoringRules, field: Score) -> float:
+    """A rough per-game standard deviation of the differential the field could run
+    up against me, used as the stand-in for the *other* remaining games in the
+    Gaussian standings model. Estimated as the spread of differentials across
+    plausible picks I might make, so it scales with how live the game is."""
+    from ..optimizer.expected_points import rank_candidates
+
+    cands = rank_candidates(dist, rules, candidate_max=4)[:8]
+    stds = [differential_stats(c.score, field, dist, rules).std for c in cands]
+    return float(np.median(stds)) if stds else 1.0

--- a/tools/score-pool/scorepool/leaderboard/strategy.py
+++ b/tools/score-pool/scorepool/leaderboard/strategy.py
@@ -1,0 +1,216 @@
+"""The leaderboard layer: turn a standing into a pick.
+
+Expected points on its own is the right answer only when I am not managing a
+lead. This module adds the standings tilt on top. The core idea is that a pick's
+value is not just its expected points but its effect on where I finish relative
+to the people I am racing, and that effect depends on the gap and how many games
+are left.
+
+Two mechanisms:
+
+  1. A single risk tilt ``tau`` in [-1, +1] derived from the gaps, the games
+     remaining, and the pool size. tau < 0 means protect (favour low-variance
+     picks that move with the field); tau > 0 means chase (favour differentiators
+     the field will be off); tau near 0 means just maximise expected points. A
+     one-point lead with two games left and a ten-point lead with ten games left
+     land in very different places because the reachable swing scales with the
+     square root of the games remaining.
+
+  2. Candidates are ranked by expected points traded against the variance of the
+     differential versus the field: U(pick) = EP + variance_price * tau * sd.
+     When protecting, variance is penalised; when chasing, it is rewarded, which
+     is what pushes the recommendation toward the high-quality contrarian spots
+     (good expected points *and* decorrelated from the chalk) rather than a random
+     long shot.
+
+We also report the honest Gaussian probabilities -- of protecting the lead and of
+catching the leader -- so the trade is visible as numbers, not a label.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from scipy.stats import norm
+
+from ..config import StrategyConfig
+from ..models import Score, ScoringRules, Standing
+from ..optimizer.expected_points import Candidate
+from ..probability.scoreline import ScoreDistribution
+from .field import Differential, differential_stats
+
+
+def _clamp(x: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, x))
+
+
+@dataclass
+class Tilt:
+    tau: float
+    mode: str  # "protect" | "chase" | "neutral"
+    protect_pressure: float
+    chase_pressure: float
+    reachable: float
+    rationale: str
+
+
+@dataclass
+class PickSelection:
+    featured: Candidate
+    safer: Candidate
+    differentiator: Optional[Candidate]
+    raw_best: Candidate  # the plain expected-points winner, before any tilt
+    field_pick: Score
+    tilt: Tilt
+    diffs: Dict[Score, Differential] = field(default_factory=dict)
+    p_protect: Optional[float] = None  # P(stay ahead of chaser) with featured pick
+    p_catch: Optional[float] = None  # P(overtake leader) with featured pick
+    p_protect_mirror: Optional[float] = None  # baseline if I just copy the chalk
+    p_catch_mirror: Optional[float] = None
+
+
+def _reachable(sigma0: float, games_remaining: int, quantile: float) -> float:
+    return quantile * sigma0 * math.sqrt(max(games_remaining, 1))
+
+
+def derive_tilt(
+    standing: Standing, sigma0: float, games_remaining: int, cfg: StrategyConfig
+) -> Tilt:
+    """Map my standing to a risk tilt in [-1, +1]."""
+    if standing.risk in ("protect", "chase", "neutral"):
+        tau = {"protect": -1.0, "chase": 1.0, "neutral": 0.0}[standing.risk]
+        return Tilt(
+            tau=tau,
+            mode=standing.risk,
+            protect_pressure=1.0 if tau < 0 else 0.0,
+            chase_pressure=1.0 if tau > 0 else 0.0,
+            reachable=_reachable(sigma0, games_remaining, cfg.reach_quantile),
+            rationale=f"risk posture forced to '{standing.risk}' in config",
+        )
+
+    reachable = _reachable(sigma0, games_remaining, cfg.reach_quantile)
+    gb, ga = standing.gap_below, standing.gap_above
+
+    protect_pressure = 0.0
+    if gb is not None and reachable > 0:
+        protect_pressure = _clamp(1.0 - gb / reachable, 0.0, 1.0)
+
+    chase_pressure = 0.0
+    if ga is not None and reachable > 0:
+        chase_pressure = _clamp(ga / reachable, 0.0, 1.0)
+        # A bigger pool raises the bar for winning outright, so lean a little more
+        # into differentiation.
+        pool_bump = 1.0 + cfg.pool_chase_scale * math.log2(max(standing.pool_size / 8.0, 1.0))
+        chase_pressure = _clamp(chase_pressure * pool_bump, 0.0, 1.0)
+
+    tau = _clamp(chase_pressure - protect_pressure, -1.0, 1.0)
+    mode = "chase" if tau > 0.15 else "protect" if tau < -0.15 else "neutral"
+
+    parts = []
+    if gb is not None:
+        parts.append(f"cushion {gb:g} over the chaser")
+    else:
+        parts.append("leading the pool")
+    if ga is not None:
+        parts.append(f"{ga:g} behind the leader")
+    else:
+        parts.append("no one ahead")
+    parts.append(
+        f"reachable swing ~{reachable:.1f} pts over {games_remaining} game(s)"
+    )
+    rationale = "; ".join(parts)
+
+    return Tilt(
+        tau=tau,
+        mode=mode,
+        protect_pressure=protect_pressure,
+        chase_pressure=chase_pressure,
+        reachable=reachable,
+        rationale=rationale,
+    )
+
+
+def _gaussian_ahead(gap_signed: float, mu: float, sigma_game: float, sigma0: float, games_remaining: int) -> float:
+    """P(final margin over the competitor > 0), Gaussian-approximating the sum of
+    per-game differentials. ``gap_signed`` is my current lead over them (negative
+    if I trail); ``mu``/``sigma_game`` are this game's differential; the other
+    games contribute mean 0 and variance sigma0^2 each."""
+    var_total = sigma_game ** 2 + max(games_remaining - 1, 0) * sigma0 ** 2
+    sd = math.sqrt(max(var_total, 1e-9))
+    return float(norm.cdf((gap_signed + mu) / sd))
+
+
+def select_picks(
+    cands: list[Candidate],
+    dist: ScoreDistribution,
+    rules: ScoringRules,
+    field_pick: Score,
+    standing: Standing,
+    tilt: Tilt,
+    sigma0: float,
+    games_remaining: int,
+    cfg: StrategyConfig,
+) -> PickSelection:
+    """Choose the featured pick, the safer alternative, and the differentiator,
+    given the field's likely submission, my standing, and the slate-wide tilt.
+
+    The tilt is derived once for the whole slate (see ``derive_tilt``) because my
+    protect-vs-chase stance is a property of my standing and the schedule, not of
+    any single game. What varies per game is the differential variance -- the lever
+    the tilt acts on."""
+    lam = cfg.variance_price
+    diffs = {c.score: differential_stats(c.score, field_pick, dist, rules) for c in cands}
+    best_ep = max(c.ep for c in cands)
+    raw_best = max(cands, key=lambda c: c.ep)
+    cap = cfg.differentiator_ep_tolerance
+
+    # Three points on one expected-points-versus-variance frontier:
+    #
+    #   safer        higher-floor pick: maximise EP penalised by the pick's OWN
+    #                points variance, so it trades upside for a reliable score.
+    #   featured     the standings-tilted pick: EP plus the tilt times the variance
+    #                of the differential against the field. Capped so it never gives
+    #                up more than `cap` expected points -- a high-quality pick, not a
+    #                wild swing.
+    #   differentiator  the best catch-up pick: the chase end of the frontier, among
+    #                picks that diverge from the chalk and keep real expected points.
+    safer = max(cands, key=lambda c: c.ep - cfg.safer_variance_penalty * c.std)
+
+    eligible = [c for c in cands if c.ep >= best_ep - cap]
+    featured = max(eligible, key=lambda c: c.ep + lam * tilt.tau * diffs[c.score].std)
+
+    diff_pool = [c for c in eligible if diffs[c.score].std > 1e-9 and c.score != field_pick]
+    differentiator = (
+        max(diff_pool, key=lambda c: c.ep + lam * diffs[c.score].std) if diff_pool else None
+    )
+
+    sel = PickSelection(
+        featured=featured,
+        safer=safer,
+        differentiator=differentiator,
+        raw_best=raw_best,
+        field_pick=field_pick,
+        tilt=tilt,
+        diffs=diffs,
+    )
+
+    # Honest standings probabilities for the featured pick, plus the mirror baseline.
+    fdiff = diffs[featured.score]
+    if standing.gap_below is not None:
+        sel.p_protect = _gaussian_ahead(
+            standing.gap_below, fdiff.mean, fdiff.std, sigma0, games_remaining
+        )
+        sel.p_protect_mirror = _gaussian_ahead(
+            standing.gap_below, 0.0, 0.0, sigma0, games_remaining
+        )
+    if standing.gap_above is not None:
+        sel.p_catch = _gaussian_ahead(
+            -standing.gap_above, fdiff.mean, fdiff.std, sigma0, games_remaining
+        )
+        sel.p_catch_mirror = _gaussian_ahead(
+            -standing.gap_above, 0.0, 0.0, sigma0, games_remaining
+        )
+
+    return sel

--- a/tools/score-pool/scorepool/models.py
+++ b/tools/score-pool/scorepool/models.py
@@ -1,0 +1,231 @@
+"""Core data model for the score-prediction-pool tool.
+
+Everything downstream (probability engine, optimizer, leaderboard, output) speaks
+in terms of these small, framework-free dataclasses so the odds source, the
+scoreline model, the scoring rules, and the leaderboard logic all stay swappable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+# A scoreline is always (home_goals, away_goals).
+Score = Tuple[int, int]
+
+
+def sign(x: float) -> int:
+    """Return -1, 0, or +1. Used everywhere to reduce a scoreline to an outcome."""
+    return (x > 0) - (x < 0)
+
+
+# ---------------------------------------------------------------------------
+# Scoring rules
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScoringRules:
+    """How a pool pays out a submitted scoreline against an actual result.
+
+    The three tiers are mutually exclusive and strictly ranked:
+
+      exact                      -> the submitted score is exactly right
+      result_and_goal_difference -> right winner (or draw) AND right goal margin
+      result_only                -> right winner (or draw) but wrong margin
+
+    Note the asymmetry that makes draws valuable: for a draw pick the goal
+    difference is always 0, so any actual draw automatically clears the middle
+    tier. A draw pick therefore never lands on ``result_only`` -- it scores
+    ``exact`` on the nailed draw and ``result_and_goal_difference`` on every
+    other draw, and nothing otherwise.
+
+    ``result_basis`` decides which score is scored:
+      "regulation" -> the 90-minute score (a 1-1 won on penalties scores as 1-1)
+      "final"      -> the score after extra time
+    """
+
+    exact: float = 5.0
+    result_and_goal_difference: float = 3.0
+    result_only: float = 2.0
+    result_basis: str = "regulation"  # "regulation" | "final"
+
+    def score(self, pick: Score, actual: Score) -> float:
+        """Points a ``pick`` earns against a fully-decided ``actual`` scoreline."""
+        ph, pa = pick
+        ah, aa = actual
+        if ph == ah and pa == aa:
+            return self.exact
+        if sign(ph - pa) != sign(ah - aa):
+            return 0.0  # wrong outcome (this also rules out a draw-vs-decisive mix)
+        if (ph - pa) == (ah - aa):
+            return self.result_and_goal_difference
+        return self.result_only
+
+    def validate(self) -> None:
+        if self.result_basis not in ("regulation", "final"):
+            raise ValueError(
+                f"result_basis must be 'regulation' or 'final', got {self.result_basis!r}"
+            )
+        # A sane pool pays exact >= result_and_gd >= result_only, but we don't
+        # enforce it -- a pool is free to pay however it likes, and the optimizer
+        # simply follows the numbers.
+
+
+# ---------------------------------------------------------------------------
+# Standing / leaderboard position
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Standing:
+    """Where I sit in the pool. Drives the protect-vs-chase tilt."""
+
+    my_points: float = 0.0
+    points_above: Optional[float] = None  # nearest competitor ahead (None if I lead)
+    points_below: Optional[float] = None  # nearest competitor behind (None if last)
+    pool_size: int = 20
+    games_remaining: Optional[int] = None  # incl. the ones being analysed now
+    risk: str = "auto"  # "auto" | "protect" | "chase" | "neutral"
+
+    @property
+    def gap_above(self) -> Optional[float]:
+        """How far I trail the nearest competitor ahead (>=0), or None if I lead."""
+        if self.points_above is None:
+            return None
+        return self.points_above - self.my_points
+
+    @property
+    def gap_below(self) -> Optional[float]:
+        """My cushion over the nearest competitor behind (>=0), or None if last."""
+        if self.points_below is None:
+            return None
+        return self.my_points - self.points_below
+
+
+# ---------------------------------------------------------------------------
+# Match context (the things odds don't capture)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MatchContext:
+    """Qualitative context that either shades the model or is surfaced next to the
+    pick. The boolean flags nudge the scoreline distribution; the free-text and
+    revisit fields are surfaced verbatim so odds-invisible information stays in
+    front of me at decision time."""
+
+    # Distribution-shading flags
+    dead_rubber: bool = False
+    draw_suits_both: bool = False
+    heavy_rotation_home: bool = False
+    heavy_rotation_away: bool = False
+    low_scoring: bool = False
+    high_scoring: bool = False
+    must_win_home: bool = False
+    must_win_away: bool = False
+
+    # Surfaced-but-not-modelled
+    note: str = ""  # free text: injuries, likely lineup, tournament situation
+    lineup_unconfirmed: bool = False
+    injury_question: bool = False
+
+    def revisit_reasons(self) -> list[str]:
+        reasons = []
+        if self.lineup_unconfirmed:
+            reasons.append("lineups unconfirmed")
+        if self.injury_question:
+            reasons.append("open injury/suspension question")
+        return reasons
+
+
+# ---------------------------------------------------------------------------
+# Odds
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ThreeWay:
+    """Home / draw / away prices as decimal odds (90-minute market)."""
+
+    home: float
+    draw: float
+    away: float
+
+
+@dataclass
+class OverUnder:
+    line: float  # e.g. 2.5
+    over: float  # decimal odds
+    under: float
+
+
+@dataclass
+class BTTS:
+    yes: float  # decimal odds both teams to score
+    no: float
+
+
+@dataclass
+class MarketOdds:
+    """A snapshot of the markets for one match, plus provenance.
+
+    Prices are stored as decimal odds regardless of the format they arrived in,
+    so the rest of the system never has to think about American/fractional.
+    """
+
+    three_way: Optional[ThreeWay] = None
+    over_under: Optional[OverUnder] = None
+    btts: Optional[BTTS] = None
+    correct_score: Optional[Dict[Score, float]] = None  # scoreline -> decimal odds
+
+    # Opening lines, if supplied, so we can report line movement.
+    three_way_open: Optional[ThreeWay] = None
+    over_under_open: Optional[OverUnder] = None
+
+    fetched_at: Optional[str] = None  # ISO-8601 timestamp of when these were pulled
+    bookmaker: Optional[str] = None  # source book, or "median"/"consensus"
+    source: Optional[str] = None  # "the_odds_api" | "manual" | "csv"
+
+
+@dataclass
+class Match:
+    match_id: str
+    home: str
+    away: str
+    commence_time: Optional[str] = None  # ISO-8601 kickoff / lock time
+    odds: Optional[MarketOdds] = None
+    context: MatchContext = field(default_factory=MatchContext)
+
+    @property
+    def label(self) -> str:
+        return f"{self.home} vs {self.away}"
+
+
+# ---------------------------------------------------------------------------
+# Actual results (for re-running and keeping a running total)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ActualResult:
+    """A finished match. We always keep the 90-minute score; the after-ET score
+    and how it was decided are optional so a penalties game can be scored either
+    way depending on the pool's ``result_basis``."""
+
+    home_reg: int  # goals at 90 minutes
+    away_reg: int
+    home_final: Optional[int] = None  # after extra time (None => same as reg)
+    away_final: Optional[int] = None
+    decided_by: str = "regulation"  # "regulation" | "extra_time" | "penalties"
+
+    def scoring_score(self, basis: str) -> Score:
+        """Reduce to the score that actually counts under the pool's rules.
+
+        Under "regulation" this is always the 90-minute score, so a 1-1 that was
+        won on penalties counts as a 1-1 draw. Under "final" it is the after-ET
+        score when there was extra time.
+        """
+        if basis == "final" and self.home_final is not None and self.away_final is not None:
+            return (self.home_final, self.away_final)
+        return (self.home_reg, self.away_reg)

--- a/tools/score-pool/scorepool/odds/__init__.py
+++ b/tools/score-pool/scorepool/odds/__init__.py
@@ -1,0 +1,1 @@
+"""Odds sources: the fixtures/manual loader and the live API client."""

--- a/tools/score-pool/scorepool/odds/base.py
+++ b/tools/score-pool/scorepool/odds/base.py
@@ -1,0 +1,25 @@
+"""The odds-source contract.
+
+A match list (with my per-match context and notes) always comes from a fixtures
+file. An odds source then fills in prices. This keeps the context I attach --
+injuries, likely lineups, tournament situation -- independent of where the odds
+come from, so switching between the API and hand-entered odds never loses it.
+
+Concrete sources:
+  scorepool.odds.manual        load fixtures + hand/CSV/JSON odds
+  scorepool.odds.the_odds_api  enrich fixtures with live odds from The Odds API
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List
+
+from ..models import Match
+
+
+class OddsSource(ABC):
+    @abstractmethod
+    def load(self) -> List[Match]:
+        """Return the matches with whatever odds this source can supply."""
+        raise NotImplementedError

--- a/tools/score-pool/scorepool/odds/manual.py
+++ b/tools/score-pool/scorepool/odds/manual.py
@@ -1,0 +1,233 @@
+"""Load matches, context, and hand-entered / CSV / JSON odds from a fixtures file.
+
+This is the always-present input and the fallback for any match the odds API
+doesn't cover. Two formats are supported, picked by file extension:
+
+  .csv   one row per match, flat columns (see fixtures.example.csv)
+  .json  a list of match objects with a nested ``odds`` block (richer: supports
+         correct-score markets and opening lines cleanly)
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from ..models import (
+    BTTS,
+    Match,
+    MatchContext,
+    MarketOdds,
+    OverUnder,
+    Score,
+    ThreeWay,
+)
+from ..probability.devig import to_decimal
+
+_CONTEXT_FLAGS = {
+    "dead_rubber",
+    "draw_suits_both",
+    "heavy_rotation_home",
+    "heavy_rotation_away",
+    "low_scoring",
+    "high_scoring",
+    "must_win_home",
+    "must_win_away",
+    "lineup_unconfirmed",
+    "injury_question",
+}
+_CONTEXT_ALIASES = {
+    "rotation_home": "heavy_rotation_home",
+    "rotation_away": "heavy_rotation_away",
+    "deadrubber": "dead_rubber",
+    "mutual_draw": "draw_suits_both",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _f(v) -> Optional[float]:
+    if v is None or v == "":
+        return None
+    return float(v)
+
+
+def _b(v) -> bool:
+    return str(v).strip().lower() in ("1", "true", "yes", "y", "t")
+
+
+def parse_context_tokens(tokens: str) -> Dict[str, bool]:
+    out: Dict[str, bool] = {}
+    for raw in tokens.replace(";", ",").replace("|", ",").split(","):
+        tok = raw.strip().lower()
+        if not tok:
+            continue
+        tok = _CONTEXT_ALIASES.get(tok, tok)
+        if tok in _CONTEXT_FLAGS:
+            out[tok] = True
+    return out
+
+
+def _context_from_dict(d: Dict[str, Any]) -> MatchContext:
+    ctx = MatchContext()
+    for flag in _CONTEXT_FLAGS:
+        if flag in d:
+            setattr(ctx, flag, _b(d[flag]))
+    if "note" in d and d["note"]:
+        ctx.note = str(d["note"])
+    return ctx
+
+
+def _parse_correct_score(raw) -> Optional[Dict[Score, float]]:
+    """Accept either a dict {"1-0": 7.5} or a string "1-0:7.5;1-1:8.0"."""
+    if not raw:
+        return None
+    items = {}
+    if isinstance(raw, dict):
+        pairs = raw.items()
+    else:
+        pairs = (chunk.split(":") for chunk in str(raw).replace(";", ",").split(",") if chunk.strip())
+    for k, v in pairs:
+        h, a = str(k).split("-")
+        items[(int(h), int(a))] = float(v)
+    return items or None
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+def _match_from_csv_row(row: Dict[str, str]) -> Match:
+    fmt = (row.get("odds_format") or "decimal").strip() or "decimal"
+
+    def dec(key: str) -> Optional[float]:
+        v = _f(row.get(key))
+        return None if v is None else to_decimal(v, fmt)
+
+    three_way = None
+    if dec("home_odds") and dec("draw_odds") and dec("away_odds"):
+        three_way = ThreeWay(dec("home_odds"), dec("draw_odds"), dec("away_odds"))
+
+    three_way_open = None
+    if dec("home_odds_open") and dec("draw_odds_open") and dec("away_odds_open"):
+        three_way_open = ThreeWay(
+            dec("home_odds_open"), dec("draw_odds_open"), dec("away_odds_open")
+        )
+
+    over_under = None
+    if _f(row.get("ou_line")) is not None and dec("over_odds") and dec("under_odds"):
+        over_under = OverUnder(_f(row["ou_line"]), dec("over_odds"), dec("under_odds"))
+
+    btts = None
+    if dec("btts_yes") and dec("btts_no"):
+        btts = BTTS(dec("btts_yes"), dec("btts_no"))
+
+    odds = None
+    if three_way or over_under or btts:
+        odds = MarketOdds(
+            three_way=three_way,
+            over_under=over_under,
+            btts=btts,
+            correct_score=_parse_correct_score(row.get("correct_score")),
+            three_way_open=three_way_open,
+            fetched_at=(row.get("fetched_at") or "").strip() or _now_iso(),
+            bookmaker=(row.get("bookmaker") or "").strip() or None,
+            source="csv",
+        )
+
+    ctx = _context_from_dict(
+        {**parse_context_tokens(row.get("context", "")),
+         "note": row.get("note", ""),
+         "lineup_unconfirmed": row.get("lineup_unconfirmed", ""),
+         "injury_question": row.get("injury_question", "")}
+    )
+    home, away = row["home"].strip(), row["away"].strip()
+    return Match(
+        match_id=(row.get("match_id") or f"{home}-{away}").strip(),
+        home=home,
+        away=away,
+        commence_time=(row.get("commence_time") or "").strip() or None,
+        odds=odds,
+        context=ctx,
+    )
+
+
+def load_csv(path: str) -> List[Match]:
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        return [_match_from_csv_row(row) for row in reader if row.get("home")]
+
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+
+
+def _match_from_json(obj: Dict[str, Any]) -> Match:
+    o = obj.get("odds") or {}
+    fmt = (o.get("format") or "decimal")
+
+    def three(key: str) -> Optional[ThreeWay]:
+        tw = o.get(key)
+        if not tw:
+            return None
+        return ThreeWay(to_decimal(tw["home"], fmt), to_decimal(tw["draw"], fmt), to_decimal(tw["away"], fmt))
+
+    def ou(key: str) -> Optional[OverUnder]:
+        d = o.get(key)
+        if not d:
+            return None
+        return OverUnder(float(d["line"]), to_decimal(d["over"], fmt), to_decimal(d["under"], fmt))
+
+    btts = None
+    if o.get("btts"):
+        btts = BTTS(to_decimal(o["btts"]["yes"], fmt), to_decimal(o["btts"]["no"], fmt))
+
+    cs = _parse_correct_score(o.get("correct_score"))
+    if cs:
+        cs = {k: to_decimal(v, fmt) for k, v in cs.items()}
+
+    odds = None
+    if o:
+        odds = MarketOdds(
+            three_way=three("three_way"),
+            over_under=ou("over_under"),
+            btts=btts,
+            correct_score=cs,
+            three_way_open=three("three_way_open"),
+            over_under_open=ou("over_under_open"),
+            fetched_at=o.get("fetched_at") or _now_iso(),
+            bookmaker=o.get("bookmaker"),
+            source="json",
+        )
+
+    ctx = _context_from_dict(obj.get("context", {}))
+    home, away = obj["home"], obj["away"]
+    return Match(
+        match_id=obj.get("match_id") or f"{home}-{away}",
+        home=home,
+        away=away,
+        commence_time=obj.get("commence_time"),
+        odds=odds,
+        context=ctx,
+    )
+
+
+def load_json(path: str) -> List[Match]:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    if isinstance(data, dict):
+        data = data.get("matches", [])
+    return [_match_from_json(obj) for obj in data]
+
+
+def load_fixtures(path: str) -> List[Match]:
+    """Load a fixtures file, dispatching on extension."""
+    if path.lower().endswith(".json"):
+        return load_json(path)
+    return load_csv(path)

--- a/tools/score-pool/scorepool/odds/the_odds_api.py
+++ b/tools/score-pool/scorepool/odds/the_odds_api.py
@@ -1,0 +1,177 @@
+"""The Odds API client (https://the-odds-api.com).
+
+Fetches live odds and merges them onto a fixtures list, matching by team name.
+The API key is read from an environment variable (never hard-coded). Anything the
+API doesn't cover keeps whatever hand-entered odds the fixture already had, so
+the API is a convenience layer over the manual path, not a hard dependency --
+``requests`` is imported lazily so the rest of the tool works without it.
+
+Prices across books are combined by median (robust to one book being off), or a
+single book can be pinned in config. Everything is time-stamped so I always know
+how stale the numbers are.
+"""
+
+from __future__ import annotations
+
+import statistics
+import unicodedata
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from ..config import OddsConfig
+from ..models import BTTS, Match, MarketOdds, OverUnder, ThreeWay
+
+API_ROOT = "https://api.the-odds-api.com/v4"
+
+
+class OddsAPIError(RuntimeError):
+    pass
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _norm(name: str) -> str:
+    s = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()
+    return "".join(ch for ch in s.lower() if ch.isalnum())
+
+
+def fetch_events(cfg: OddsConfig, timeout: float = 20.0) -> List[Dict[str, Any]]:
+    """Pull raw events for the configured sport. Raises OddsAPIError on failure."""
+    key = cfg.api_key
+    if not key:
+        raise OddsAPIError(
+            f"no API key: set the {cfg.api_key_env} environment variable, or use a "
+            f"manual/CSV odds source"
+        )
+    try:
+        import requests  # lazy: only needed on the API path
+    except ImportError as exc:  # pragma: no cover
+        raise OddsAPIError("the 'requests' package is required for the odds API") from exc
+
+    url = f"{API_ROOT}/sports/{cfg.sport_key}/odds"
+    params = {
+        "apiKey": key,
+        "regions": cfg.regions,
+        "markets": cfg.markets,
+        "oddsFormat": "decimal",
+    }
+    try:
+        resp = requests.get(url, params=params, timeout=timeout)
+    except Exception as exc:  # network error
+        raise OddsAPIError(f"request to The Odds API failed: {exc}") from exc
+    if resp.status_code != 200:
+        raise OddsAPIError(
+            f"The Odds API returned {resp.status_code}: {resp.text[:200]}"
+        )
+    return resp.json()
+
+
+def _collect_prices(event: Dict[str, Any], only_book: Optional[str]):
+    """Gather prices per market across bookmakers into lists we can median."""
+    home_team = event.get("home_team", "")
+    away_team = event.get("away_team", "")
+    h2h = {"home": [], "draw": [], "away": []}
+    totals: Dict[float, Dict[str, list]] = {}
+    btts = {"yes": [], "no": []}
+
+    for book in event.get("bookmakers", []):
+        if only_book and book.get("key") != only_book and book.get("title") != only_book:
+            continue
+        for market in book.get("markets", []):
+            mkey = market.get("key")
+            outs = market.get("outcomes", [])
+            if mkey in ("h2h", "h2h_3_way"):
+                for o in outs:
+                    name, price = o.get("name"), o.get("price")
+                    if name == "Draw":
+                        h2h["draw"].append(price)
+                    elif name == home_team:
+                        h2h["home"].append(price)
+                    elif name == away_team:
+                        h2h["away"].append(price)
+            elif mkey == "totals":
+                for o in outs:
+                    point = o.get("point")
+                    if point is None:
+                        continue
+                    slot = totals.setdefault(float(point), {"over": [], "under": []})
+                    if o.get("name") == "Over":
+                        slot["over"].append(o.get("price"))
+                    elif o.get("name") == "Under":
+                        slot["under"].append(o.get("price"))
+            elif mkey in ("btts", "both_teams_to_score"):
+                for o in outs:
+                    if o.get("name") in ("Yes",):
+                        btts["yes"].append(o.get("price"))
+                    elif o.get("name") in ("No",):
+                        btts["no"].append(o.get("price"))
+    return h2h, totals, btts
+
+
+def _median(xs) -> Optional[float]:
+    xs = [x for x in xs if x]
+    return float(statistics.median(xs)) if xs else None
+
+
+def event_to_odds(event: Dict[str, Any], cfg: OddsConfig) -> Optional[MarketOdds]:
+    h2h, totals, btts = _collect_prices(event, cfg.bookmaker)
+
+    three_way = None
+    if h2h["home"] and h2h["draw"] and h2h["away"]:
+        three_way = ThreeWay(_median(h2h["home"]), _median(h2h["draw"]), _median(h2h["away"]))
+
+    over_under = None
+    if totals:
+        # Prefer the line with the most quotes; tie-break to the one nearest 2.5.
+        line = sorted(
+            totals,
+            key=lambda p: (len(totals[p]["over"]) + len(totals[p]["under"]), -abs(p - 2.5)),
+        )[-1]
+        o, u = _median(totals[line]["over"]), _median(totals[line]["under"])
+        if o and u:
+            over_under = OverUnder(line, o, u)
+
+    btts_odds = None
+    if btts["yes"] and btts["no"]:
+        btts_odds = BTTS(_median(btts["yes"]), _median(btts["no"]))
+
+    if not (three_way or over_under or btts_odds):
+        return None
+
+    return MarketOdds(
+        three_way=three_way,
+        over_under=over_under,
+        btts=btts_odds,
+        fetched_at=_now_iso(),
+        bookmaker=cfg.bookmaker or "median",
+        source="the_odds_api",
+    )
+
+
+def enrich_with_api(matches: List[Match], cfg: OddsConfig) -> List[str]:
+    """Fill in each match's odds from the API where a matching event exists.
+
+    Matches keep any hand-entered odds as a fallback. Returns the list of match
+    labels that were *not* found in the API feed, so the caller can report which
+    ones are running on manual odds.
+    """
+    events = fetch_events(cfg)
+    index = {}
+    for ev in events:
+        index[(_norm(ev.get("home_team", "")), _norm(ev.get("away_team", "")))] = ev
+
+    unmatched = []
+    for m in matches:
+        ev = index.get((_norm(m.home), _norm(m.away)))
+        if ev is None:  # try swapped home/away just in case
+            ev = index.get((_norm(m.away), _norm(m.home)))
+        odds = event_to_odds(ev, cfg) if ev else None
+        if odds is not None:
+            if ev.get("commence_time") and not m.commence_time:
+                m.commence_time = ev["commence_time"]
+            m.odds = odds
+        elif m.odds is None:
+            unmatched.append(m.label)
+    return unmatched

--- a/tools/score-pool/scorepool/optimizer/__init__.py
+++ b/tools/score-pool/scorepool/optimizer/__init__.py
@@ -1,0 +1,5 @@
+"""Expected-points optimiser over the scoreline distribution."""
+
+from .expected_points import Candidate, evaluate_pick, rank_candidates
+
+__all__ = ["Candidate", "evaluate_pick", "rank_candidates"]

--- a/tools/score-pool/scorepool/optimizer/expected_points.py
+++ b/tools/score-pool/scorepool/optimizer/expected_points.py
@@ -1,0 +1,171 @@
+"""The expected-points optimizer.
+
+For every candidate scoreline we sum over the full scoreline distribution,
+weighting each possible actual result by the points that candidate would earn
+under the pool's rules, and rank the candidates by expected points. This is the
+calculation that surfaces why a 1-1 often beats picking the favourite outright:
+a draw pick banks the result-and-goal-difference tier on *every* draw, not only
+on the exact 1-1, so its expected points can clear a narrow favourite even when
+the favourite is more likely to win the game.
+
+Alongside expected points we compute the variance and the floor of each pick,
+because the leaderboard layer trades expected points against variance and needs
+both.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+
+from ..models import Score, ScoringRules
+from ..probability.scoreline import ScoreDistribution
+
+
+@dataclass
+class Candidate:
+    """One candidate scoreline, fully evaluated against the distribution."""
+
+    score: Score
+    ep: float  # expected points under the pool's rules
+    variance: float  # variance of points earned
+    std: float
+    floor: float  # P(a goal-difference-or-better hit): the reliable, meaningful score
+    hit_any: float  # P(any points at all, including the outcome-only tier)
+    prob: float  # model probability of this exact scoreline occurring
+    p_exact: float  # P(actual == this pick)
+    p_result_gd: float  # P(same outcome & goal difference, not exact)
+    p_result_only: float  # P(same outcome, different goal difference)
+
+    @property
+    def label(self) -> str:
+        return f"{self.score[0]}-{self.score[1]}"
+
+
+def _outcome_and_gd(n: int):
+    """Precompute, for an (n+1)x(n+1) grid, the outcome sign and goal difference
+    of every cell. Cached-free but cheap."""
+    h = np.arange(n + 1)[:, None]
+    a = np.arange(n + 1)[None, :]
+    gd = h - a
+    out = np.sign(gd)
+    return out, gd
+
+
+def points_grid(pick: Score, rules: ScoringRules, n: int, out=None, gd=None) -> np.ndarray:
+    """Points this pick earns against every possible actual scoreline, as an
+    (n+1)x(n+1) array. Used by the leaderboard layer to build the distribution of
+    my-points-minus-a-competitor's-points for a game."""
+    if out is None or gd is None:
+        out, gd = _outcome_and_gd(n)
+    ph, pa = pick
+    p_out = np.sign(ph - pa)
+    p_gd = ph - pa
+    same_outcome = out == p_out
+    pts = np.zeros((n + 1, n + 1))
+    pts[same_outcome & (gd != p_gd)] = rules.result_only
+    pts[same_outcome & (gd == p_gd)] = rules.result_and_goal_difference
+    if ph <= n and pa <= n:
+        pts[ph, pa] = rules.exact
+    return pts
+
+
+def evaluate_pick(
+    pick: Score, grid: np.ndarray, rules: ScoringRules, out=None, gd=None
+) -> Candidate:
+    """Evaluate a single candidate scoreline against the actual-result grid."""
+    n = grid.shape[0] - 1
+    if out is None or gd is None:
+        out, gd = _outcome_and_gd(n)
+    ph, pa = pick
+    p_out = np.sign(ph - pa)
+    p_gd = ph - pa
+
+    same_outcome = out == p_out
+    same_gd = gd == p_gd
+
+    exact_mask = np.zeros_like(grid, dtype=bool)
+    if ph <= n and pa <= n:
+        exact_mask[ph, pa] = True
+
+    m_exact = grid[exact_mask].sum()
+    m_result_gd = grid[same_outcome & same_gd].sum() - m_exact
+    m_result_only = grid[same_outcome & ~same_gd].sum()
+
+    m_exact = float(max(m_exact, 0.0))
+    m_result_gd = float(max(m_result_gd, 0.0))
+    m_result_only = float(max(m_result_only, 0.0))
+
+    ep = (
+        rules.exact * m_exact
+        + rules.result_and_goal_difference * m_result_gd
+        + rules.result_only * m_result_only
+    )
+    ex2 = (
+        rules.exact ** 2 * m_exact
+        + rules.result_and_goal_difference ** 2 * m_result_gd
+        + rules.result_only ** 2 * m_result_only
+    )
+    variance = max(ex2 - ep * ep, 0.0)
+
+    # Floor is the chance of a *meaningful* hit -- exact or right goal difference,
+    # the tiers that reward actually reading the game. It deliberately excludes the
+    # outcome-only tier, because otherwise a lopsided winning scoreline like 6-0
+    # would look "safe" purely from banking 2 points on every win. hit_any keeps
+    # the P(any points) number for reference. Both respect a pool that zeroes a tier.
+    floor = 0.0
+    if rules.exact > 0:
+        floor += m_exact
+    if rules.result_and_goal_difference > 0:
+        floor += m_result_gd
+    hit_any = floor + (m_result_only if rules.result_only > 0 else 0.0)
+
+    return Candidate(
+        score=(ph, pa),
+        ep=float(ep),
+        variance=float(variance),
+        std=float(np.sqrt(variance)),
+        floor=float(floor),
+        hit_any=float(hit_any),
+        prob=float(grid[ph, pa]) if (ph <= n and pa <= n) else 0.0,
+        p_exact=m_exact,
+        p_result_gd=m_result_gd,
+        p_result_only=m_result_only,
+    )
+
+
+def rank_candidates(
+    dist: ScoreDistribution, rules: ScoringRules, candidate_max: int = 6
+) -> List[Candidate]:
+    """Evaluate every candidate scoreline (up to ``candidate_max`` goals a side)
+    against the full distribution and return them sorted by expected points."""
+    grid = dist.grid
+    n = grid.shape[0] - 1
+    cmax = min(candidate_max, n)
+    out, gd = _outcome_and_gd(n)
+
+    cands = [
+        evaluate_pick((ch, ca), grid, rules, out, gd)
+        for ch in range(cmax + 1)
+        for ca in range(cmax + 1)
+    ]
+    cands.sort(key=lambda c: c.ep, reverse=True)
+    return cands
+
+
+def modal_scoreline(dist: ScoreDistribution) -> Score:
+    """The single most likely exact scoreline -- the naive 'chalk' pick."""
+    idx = np.unravel_index(np.argmax(dist.grid), dist.grid.shape)
+    return (int(idx[0]), int(idx[1]))
+
+
+def safest_pick(cands: List[Candidate], ep_tolerance: float = 0.6) -> Candidate:
+    """Highest-floor pick among those within ``ep_tolerance`` points of the best
+    expected-points pick: the higher-floor version of the recommendation."""
+    if not cands:
+        raise ValueError("no candidates")
+    best_ep = cands[0].ep
+    pool = [c for c in cands if c.ep >= best_ep - ep_tolerance]
+    return max(pool, key=lambda c: (c.floor, c.ep))

--- a/tools/score-pool/scorepool/output/__init__.py
+++ b/tools/score-pool/scorepool/output/__init__.py
@@ -1,0 +1,1 @@
+"""Rendering: pick sheet, submission table, revisit list, running total."""

--- a/tools/score-pool/scorepool/output/picksheet.py
+++ b/tools/score-pool/scorepool/output/picksheet.py
@@ -1,0 +1,223 @@
+"""Plain, readable output: the pick sheet, the copyable submission table, and the
+before-lock revisit list.
+
+No table library -- a small wrapping renderer keeps it dependency-light and gives
+full control over the layout, including a Why column that wraps cleanly.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import List, Optional
+
+from ..config import AppConfig
+from ..engine import MatchAnalysis
+
+
+def render_table(headers: List[str], rows: List[List[str]], widths: List[int]) -> str:
+    """Render a grid table, wrapping each cell to at most its column width."""
+    all_rows = [headers] + rows
+    colw = [
+        min(widths[i], max(len(str(r[i])) for r in all_rows)) for i in range(len(headers))
+    ]
+
+    def wrap(cell: str, w: int) -> List[str]:
+        lines: List[str] = []
+        for para in str(cell).split("\n"):
+            lines.extend(textwrap.wrap(para, w) or [""])
+        return lines or [""]
+
+    def render_row(cells: List[str]) -> str:
+        wrapped = [wrap(c, colw[i]) for i, c in enumerate(cells)]
+        height = max(len(c) for c in wrapped)
+        out = []
+        for h in range(height):
+            parts = []
+            for i, col in enumerate(wrapped):
+                text = col[h] if h < len(col) else ""
+                parts.append(" " + text.ljust(colw[i]) + " ")
+            out.append("|" + "|".join(parts) + "|")
+        return "\n".join(out)
+
+    sep = "+" + "+".join("-" * (w + 2) for w in colw) + "+"
+    lines = [sep, render_row(headers), sep]
+    for r in rows:
+        lines.append(render_row(r))
+    lines.append(sep)
+    return "\n".join(lines)
+
+
+def _fmt_score(score) -> str:
+    return f"{score[0]}-{score[1]}"
+
+
+def _global_header(cfg: AppConfig, analyses: List[MatchAnalysis]) -> str:
+    s = cfg.scoring
+    st = cfg.standing
+    lines = [
+        "SCORE-PREDICTION POOL  --  PICK SHEET",
+        "=" * 72,
+        f"Scoring        : exact {s.exact:g} / result+GD {s.result_and_goal_difference:g} "
+        f"/ result {s.result_only:g}   (basis: {s.result_basis})",
+        f"Model          : {cfg.model.type}, de-vig {cfg.model.devig}, "
+        f"field = {cfg.model.field_model}",
+    ]
+    stand_bits = [f"my points {st.my_points:g}"]
+    if st.points_above is not None:
+        stand_bits.append(f"leader-side {st.points_above:g} (gap {st.gap_above:g})")
+    else:
+        stand_bits.append("no one ahead")
+    if st.points_below is not None:
+        stand_bits.append(f"chaser {st.points_below:g} (cushion {st.gap_below:g})")
+    else:
+        stand_bits.append("no one behind")
+    stand_bits.append(f"pool {st.pool_size}")
+    lines.append("Standing       : " + ", ".join(stand_bits))
+
+    # Posture comes from the first analysed match (it's a global tilt).
+    posture = None
+    for a in analyses:
+        if a.ok and a.selection is not None:
+            posture = a.selection.tilt
+            break
+    if posture is not None:
+        lines.append(
+            f"Posture        : {posture.mode.upper()} (tilt {posture.tau:+.2f}); {posture.rationale}"
+        )
+    return "\n".join(lines)
+
+
+def render_pick_sheet(analyses: List[MatchAnalysis], cfg: AppConfig) -> str:
+    headers = ["Match", "Pick", "Conf", "xEP", "Safer alt", "Differentiator", "Why"]
+    widths = [22, 5, 6, 6, 12, 14, 46]
+    rows: List[List[str]] = []
+    for a in analyses:
+        if not a.ok or a.selection is None:
+            continue
+        sel = a.selection
+        safer = f"{_fmt_score(sel.safer.score)} ({sel.safer.floor:.0%})"
+        if sel.differentiator is not None:
+            d = sel.differentiator
+            diff_cell = f"{_fmt_score(d.score)} ({d.ep:.1f}xEP)"
+        else:
+            diff_cell = "-- (chalk)"
+        rows.append(
+            [
+                a.match.label,
+                _fmt_score(sel.featured.score),
+                a.confidence.upper(),
+                f"{sel.featured.ep:.2f}",
+                safer,
+                diff_cell,
+                a.why,
+            ]
+        )
+    if not rows:
+        return "No matches had enough odds to produce a pick."
+    return render_table(headers, rows, widths)
+
+
+def render_submission(analyses: List[MatchAnalysis]) -> str:
+    """A clean two-column table with only match and score, easy to paste."""
+    headers = ["Match", "Score"]
+    rows = [
+        [a.match.label, _fmt_score(a.selection.featured.score)]
+        for a in analyses
+        if a.ok and a.selection is not None
+    ]
+    if not rows:
+        return ""
+    width = max(len(r[0]) for r in rows + [headers])
+    lines = ["SUBMISSION (copyable)", "-" * (width + 12)]
+    for r in rows:
+        lines.append(f"{r[0].ljust(width)}   {r[1]}")
+    return "\n".join(lines)
+
+
+def render_revisit(analyses: List[MatchAnalysis], cfg: AppConfig) -> str:
+    lines = ["BEFORE EACH GAME LOCKS", "-" * 40]
+    any_flag = False
+    for a in analyses:
+        reasons = list(a.revisit)
+        if not a.ok:
+            reasons.append(a.reason)
+        if not reasons:
+            continue
+        any_flag = True
+        lock = a.match.commence_time or "lock time unknown"
+        stamp = a.fetched_at or "no timestamp"
+        lines.append(f"- {a.match.label}")
+        lines.append(f"    {', '.join(reasons)}")
+        lines.append(f"    locks {lock}; odds pulled {stamp}")
+
+    # A standings caveat when the margin is thin enough to flip the picture.
+    st = cfg.standing
+    thin = False
+    if st.gap_below is not None and st.gap_below <= max(cfg.scoring.exact, 5):
+        thin = True
+    if st.gap_above is not None and st.gap_above <= max(cfg.scoring.exact, 5):
+        thin = True
+    if thin:
+        any_flag = True
+        lines.append("- Standings are close enough that a single result can change the tilt;")
+        lines.append("    re-run after other players' games settle.")
+
+    if not any_flag:
+        lines.append("- Nothing flagged. Still re-check lineups near kickoff.")
+    return "\n".join(lines)
+
+
+def render_disclaimer() -> str:
+    return (
+        "NOTE  These are model estimates anchored to the betting market, not "
+        "predictions.\n      The scoreline model is fit to the de-vigged prices, "
+        "so it is only as good as\n      those prices and the assumptions behind "
+        "it. Treat the numbers as a decision\n      aid for close calls, not as "
+        "certainty. Confidence labels are conservative on\n      purpose."
+    )
+
+
+def render_full_report(analyses: List[MatchAnalysis], cfg: AppConfig) -> str:
+    blocks = [
+        _global_header(cfg, analyses),
+        "",
+        render_pick_sheet(analyses, cfg),
+        "",
+        render_submission(analyses),
+        "",
+        render_revisit(analyses, cfg),
+        "",
+        render_disclaimer(),
+    ]
+    return "\n".join(b for b in blocks if b is not None)
+
+
+def render_match_detail(a: MatchAnalysis, cfg: AppConfig, top_n: int = 8) -> str:
+    """A deep look at one match: the top candidate scorelines with their expected
+    points, floor, and how likely the exact score is."""
+    if not a.ok or a.selection is None:
+        return f"{a.match.label}: {a.reason}"
+    lines = [f"{a.match.label}  ({a.confidence.upper()} confidence)"]
+    d = a.dist
+    lines.append(
+        f"  de-vigged  home {d.p_home():.0%} / draw {d.p_draw():.0%} / away {d.p_away():.0%}"
+        f"   expected goals {d.expected_total():.2f}   fit rms {d.fit_quality():.4f}"
+    )
+    lines.append(f"  model params: {d.params}")
+    lines.append(f"  field is modelled on {_fmt_score(a.selection.field_pick)}")
+    headers = ["Scoreline", "xEP", "P(this exact)", "Floor", "diff sd vs field"]
+    rows = []
+    for c in a.candidates[:top_n]:
+        diff = a.selection.diffs.get(c.score)
+        rows.append(
+            [
+                _fmt_score(c.score),
+                f"{c.ep:.3f}",
+                f"{c.prob:.1%}",
+                f"{c.floor:.1%}",
+                f"{diff.std:.2f}" if diff else "-",
+            ]
+        )
+    lines.append(render_table(headers, rows, [10, 8, 14, 8, 16]))
+    lines.append(f"  why: {a.why}")
+    return "\n".join(lines)

--- a/tools/score-pool/scorepool/probability/__init__.py
+++ b/tools/score-pool/scorepool/probability/__init__.py
@@ -1,0 +1,1 @@
+"""Probability engine: de-vigging and market-anchored scoreline models."""

--- a/tools/score-pool/scorepool/probability/devig.py
+++ b/tools/score-pool/scorepool/probability/devig.py
@@ -1,0 +1,141 @@
+"""Odds conversion and vig removal.
+
+Two jobs:
+  1. Turn whatever odds format arrives (decimal, American, fractional) into
+     decimal odds, then into raw implied probabilities.
+  2. Strip the bookmaker's margin (the "vig" / "overround") so the probabilities
+     across a market's outcomes sum to 1 and can be treated as fair.
+
+Three de-vig methods are provided. Proportional is the transparent default;
+Shin's method corrects for favourite-longshot bias and is a reasonable upgrade
+for three-way markets; additive is included for completeness. None of them is
+"true" -- they are different assumptions about where the margin sits, so the
+tool reports which one it used rather than pretending there is one right answer.
+"""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+# ---------------------------------------------------------------------------
+# Format conversion
+# ---------------------------------------------------------------------------
+
+
+def to_decimal(price, fmt: str = "decimal") -> float:
+    """Convert a single price to decimal odds.
+
+    decimal:    already decimal (e.g. 2.50)
+    american:   +150 -> 2.50, -200 -> 1.50
+    fractional: "3/2" -> 2.50
+    """
+    fmt = fmt.lower()
+    if fmt == "decimal":
+        d = float(price)
+    elif fmt == "american":
+        p = float(price)
+        if p == 0:
+            raise ValueError("American odds cannot be 0")
+        d = 1.0 + (p / 100.0 if p > 0 else 100.0 / abs(p))
+    elif fmt == "fractional":
+        num, den = str(price).split("/")
+        d = 1.0 + float(num) / float(den)
+    else:
+        raise ValueError(f"unknown odds format {fmt!r}")
+    if d <= 1.0:
+        raise ValueError(f"decimal odds must be > 1.0, got {d} (from {price!r} as {fmt})")
+    return d
+
+
+def implied_prob(decimal_odds: float) -> float:
+    """Raw implied probability of a single decimal price (still carries vig)."""
+    return 1.0 / decimal_odds
+
+
+def overround(decimals: Sequence[float]) -> float:
+    """Sum of implied probabilities minus 1: the bookmaker's margin on a market."""
+    return sum(1.0 / d for d in decimals) - 1.0
+
+
+# ---------------------------------------------------------------------------
+# De-vig methods
+# ---------------------------------------------------------------------------
+
+
+def devig_proportional(decimals: Sequence[float]) -> List[float]:
+    """Scale raw implied probabilities so they sum to 1 (a.k.a. multiplicative /
+    normalisation). Assumes the margin is spread proportionally across outcomes."""
+    q = [1.0 / d for d in decimals]
+    s = sum(q)
+    return [x / s for x in q]
+
+
+def devig_additive(decimals: Sequence[float]) -> List[float]:
+    """Subtract an equal share of the overround from each outcome. Assumes the
+    margin is spread as a flat amount, which tilts probability toward longshots
+    relative to proportional. Clamped to stay non-negative and renormalised."""
+    q = [1.0 / d for d in decimals]
+    n = len(q)
+    excess = sum(q) - 1.0
+    p = [max(qi - excess / n, 0.0) for qi in q]
+    s = sum(p)
+    return [x / s for x in p] if s > 0 else devig_proportional(decimals)
+
+
+def devig_shin(decimals: Sequence[float], max_iter: int = 100, tol: float = 1e-12) -> List[float]:
+    """Shin's (1992) method. Models the margin as protection against a proportion
+    ``z`` of insider money and backs out fair probabilities, which corrects some
+    favourite-longshot bias. Solved for ``z`` by bisection so it works for any
+    number of outcomes. Falls back to proportional if the market has no margin."""
+    q = [1.0 / d for d in decimals]
+    booksum = sum(q)
+    if booksum <= 1.0 + 1e-9:
+        return devig_proportional(decimals)
+
+    def probs_for(z: float) -> List[float]:
+        # p_i = (sqrt(z^2 + 4(1-z) q_i^2 / booksum) - z) / (2(1-z))
+        out = []
+        for qi in q:
+            root = (z * z + 4.0 * (1.0 - z) * qi * qi / booksum) ** 0.5
+            out.append((root - z) / (2.0 * (1.0 - z)))
+        return out
+
+    lo, hi = 0.0, 0.99  # z in [0, 1)
+    for _ in range(max_iter):
+        mid = 0.5 * (lo + hi)
+        s = sum(probs_for(mid))
+        # sum(probs) decreases as z increases; find z with sum == 1
+        if s > 1.0:
+            lo = mid
+        else:
+            hi = mid
+        if abs(s - 1.0) < tol:
+            break
+    p = probs_for(0.5 * (lo + hi))
+    s = sum(p)
+    return [x / s for x in p]  # tiny renormalisation for safety
+
+
+_METHODS = {
+    "proportional": devig_proportional,
+    "additive": devig_additive,
+    "shin": devig_shin,
+}
+
+
+def devig(decimals: Sequence[float], method: str = "proportional") -> List[float]:
+    """De-vig a market's decimal prices with the named method."""
+    try:
+        fn = _METHODS[method]
+    except KeyError:
+        raise ValueError(
+            f"unknown devig method {method!r}; choose from {sorted(_METHODS)}"
+        )
+    return fn(decimals)
+
+
+def devig_two_way(over: float, under: float, method: str = "proportional") -> float:
+    """Return the fair probability of the first outcome of a two-way market
+    (over/under, BTTS yes/no) after removing vig."""
+    p_over, _ = devig([over, under], method)
+    return p_over

--- a/tools/score-pool/scorepool/probability/market.py
+++ b/tools/score-pool/scorepool/probability/market.py
@@ -1,0 +1,135 @@
+"""Turn a match's raw odds into de-vigged model targets, and shade those targets
+with tournament context.
+
+This is the bridge between the odds (``MarketOdds``) and the scoreline model
+(``MarketTargets``). Keeping it separate means the model never has to know about
+vig or context -- it only ever sees clean, fair targets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Optional, Tuple
+
+import numpy as np
+
+from ..config import ContextShading
+from ..models import MarketOdds, MatchContext
+from . import devig
+from .scoreline import MarketTargets
+
+
+def targets_from_odds(
+    odds: MarketOdds, method: str = "proportional", max_goals: int = 10
+) -> MarketTargets:
+    """Build fair-probability targets from a market snapshot."""
+    if odds.three_way is None:
+        raise ValueError("need at least a three-way (home/draw/away) market to build targets")
+
+    ph, pd, pa = devig.devig(
+        [odds.three_way.home, odds.three_way.draw, odds.three_way.away], method
+    )
+
+    p_over = ou_line = None
+    if odds.over_under is not None:
+        p_over = devig.devig_two_way(odds.over_under.over, odds.over_under.under, method)
+        ou_line = odds.over_under.line
+
+    p_btts = None
+    if odds.btts is not None:
+        p_btts = devig.devig_two_way(odds.btts.yes, odds.btts.no, method)
+
+    correct_score = None
+    if odds.correct_score:
+        # De-vig the correct-score market as a whole (it carries a large margin).
+        scores = list(odds.correct_score.keys())
+        prices = [odds.correct_score[s] for s in scores]
+        fair = devig.devig(prices, method)
+        correct_score = {s: p for s, p in zip(scores, fair)}
+
+    return MarketTargets(
+        p_home=ph,
+        p_draw=pd,
+        p_away=pa,
+        ou_line=ou_line,
+        p_over=p_over,
+        p_btts=p_btts,
+        correct_score=correct_score,
+        max_goals=max_goals,
+    )
+
+
+def _rebalance_draw(ph: float, pd: float, pa: float, new_draw: float) -> Tuple[float, float, float]:
+    """Set the draw mass to ``new_draw`` and rescale home/away to keep the sum 1,
+    preserving the home/away ratio."""
+    new_draw = float(np.clip(new_draw, 0.01, 0.97))
+    rest = 1.0 - new_draw
+    hw = ph + pa
+    if hw <= 0:
+        return rest / 2, new_draw, rest / 2
+    return rest * ph / hw, new_draw, rest * pa / hw
+
+
+def apply_context_shading(
+    targets: MarketTargets, ctx: MatchContext, cfg: ContextShading
+) -> MarketTargets:
+    """Nudge the targets to reflect tournament context.
+
+    The two levers are the expected number of goals (moved via the over target)
+    and the draw mass (moved directly). A game both teams are content to draw, or
+    a dead rubber with heavy rotation, pulls toward fewer goals and more draws.
+    These are heuristic shades on top of the market, applied modestly and always
+    disclosed on the pick sheet.
+    """
+    ph, pd, pa = targets.p_home, targets.p_draw, targets.p_away
+    total_factor = 1.0
+    draw_boost = 0.0
+
+    if ctx.dead_rubber:
+        total_factor *= cfg.dead_rubber_total_factor
+        draw_boost += cfg.dead_rubber_draw_boost
+    if ctx.draw_suits_both:
+        total_factor *= cfg.draw_suits_both_total_factor
+        draw_boost += cfg.draw_suits_both_draw_boost
+    if ctx.heavy_rotation_home:
+        total_factor *= cfg.heavy_rotation_total_factor
+    if ctx.heavy_rotation_away:
+        total_factor *= cfg.heavy_rotation_total_factor
+    if ctx.low_scoring:
+        total_factor *= cfg.low_scoring_total_factor
+    if ctx.high_scoring:
+        total_factor *= cfg.high_scoring_total_factor
+    if ctx.must_win_home or ctx.must_win_away:
+        total_factor *= cfg.must_win_total_factor
+        draw_boost -= cfg.must_win_draw_penalty
+
+    if draw_boost != 0.0:
+        ph, pd, pa = _rebalance_draw(ph, pd, pa, pd + draw_boost)
+
+    new = replace(targets, p_home=ph, p_draw=pd, p_away=pa)
+
+    # Shift the over/under target in the direction of the total factor. Fewer
+    # goals => lower P(over). We move the over probability toward 0/1 modestly.
+    if new.p_over is not None:
+        # total_factor < 1 lowers overs, > 1 raises them; scale the deviation.
+        shift = (total_factor - 1.0) * 0.9
+        new.p_over = float(np.clip(new.p_over + shift, 0.02, 0.98))
+
+    return new
+
+
+def line_movement(odds: MarketOdds, method: str = "proportional") -> Optional[dict]:
+    """Compare current three-way to the opening line, if both are present.
+
+    Returns the change in each fair outcome probability (current minus open), so
+    a positive ``home`` means the home side has shortened since the open."""
+    if odds.three_way is None or odds.three_way_open is None:
+        return None
+    cur = devig.devig(
+        [odds.three_way.home, odds.three_way.draw, odds.three_way.away], method
+    )
+    opn = devig.devig(
+        [odds.three_way_open.home, odds.three_way_open.draw, odds.three_way_open.away], method
+    )
+    labels = ("home", "draw", "away")
+    return {k: cur[i] - opn[i] for i, k in enumerate(labels)}

--- a/tools/score-pool/scorepool/probability/scoreline.py
+++ b/tools/score-pool/scorepool/probability/scoreline.py
@@ -1,0 +1,297 @@
+"""Scoreline distribution models.
+
+The job here is to turn the market (de-vigged win/draw/win, the over/under total,
+and optionally both-teams-to-score) into a full probability distribution over
+exact scorelines, not just the three outcomes. We do that by fitting a small
+goals model whose implied market quantities match what the book is pricing, so
+the scoreline probabilities are anchored to the market rather than pulled from
+nowhere.
+
+Three models sit behind one interface:
+
+  IndependentPoisson  home and away goals independent Poisson. Simple, but
+                      systematically under-weights draws.
+  BivariatePoisson    adds a shared component that lifts the draw mass; the
+                      default, and the model the market is easiest to match with.
+  DixonColes          independent Poisson with a low-score correction; a common
+                      football choice, offered as an alternative.
+
+Every model is *fit* to market targets rather than assumed, and every fit
+reports its residuals so the caller can see how well the distribution actually
+reproduces the market.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+from scipy.optimize import minimize
+from scipy.stats import poisson
+
+from ..models import Score
+
+# ---------------------------------------------------------------------------
+# Targets and the fitted distribution
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MarketTargets:
+    """The de-vigged market quantities a model tries to reproduce.
+
+    ``p_home``/``p_draw``/``p_away`` are the fair 90-minute outcome probabilities.
+    ``p_over`` (at ``ou_line``) and ``p_btts`` are optional refinements. When a
+    correct-score market is supplied it is used as extra soft targets.
+    """
+
+    p_home: float
+    p_draw: float
+    p_away: float
+    ou_line: Optional[float] = None
+    p_over: Optional[float] = None
+    p_btts: Optional[float] = None
+    correct_score: Optional[Dict[Score, float]] = None  # scoreline -> probability
+    max_goals: int = 10
+
+    def normalised_outcomes(self) -> Tuple[float, float, float]:
+        s = self.p_home + self.p_draw + self.p_away
+        return self.p_home / s, self.p_draw / s, self.p_away / s
+
+
+@dataclass
+class ScoreDistribution:
+    """A fitted distribution over scorelines.
+
+    ``grid[h, a]`` is P(home scores h, away scores a) for h, a in 0..max_goals,
+    normalised to sum to 1. Everything the optimizer and leaderboard need is
+    derived from this grid.
+    """
+
+    grid: np.ndarray
+    max_goals: int
+    params: Dict[str, float] = field(default_factory=dict)
+    residuals: Dict[str, float] = field(default_factory=dict)
+    model_name: str = ""
+
+    # --- market quantities implied by the fitted grid ---
+
+    def p_home(self) -> float:
+        return float(np.tril(self.grid, -1).sum())  # home goals > away goals
+
+    def p_away(self) -> float:
+        return float(np.triu(self.grid, 1).sum())
+
+    def p_draw(self) -> float:
+        return float(np.trace(self.grid))
+
+    def expected_total(self) -> float:
+        h = np.arange(self.grid.shape[0])
+        a = np.arange(self.grid.shape[1])
+        return float((self.grid.sum(axis=1) * h).sum() + (self.grid.sum(axis=0) * a).sum())
+
+    def p_over(self, line: float) -> float:
+        """P(total goals > line). For a .5 line this is unambiguous; for an
+        integer line the exact total is treated as a push and excluded."""
+        h = np.arange(self.grid.shape[0])[:, None]
+        a = np.arange(self.grid.shape[1])[None, :]
+        totals = h + a
+        return float(self.grid[totals > line].sum())
+
+    def p_btts(self) -> float:
+        return float(self.grid[1:, 1:].sum())
+
+    def fit_quality(self) -> float:
+        """Root-mean-square residual across all fitted targets (0 == perfect)."""
+        if not self.residuals:
+            return 0.0
+        return float(np.sqrt(np.mean(np.square(list(self.residuals.values())))))
+
+
+# ---------------------------------------------------------------------------
+# Grid builders
+# ---------------------------------------------------------------------------
+
+
+def _poisson_vec(mu: float, n: int) -> np.ndarray:
+    return poisson.pmf(np.arange(n + 1), max(mu, 1e-9))
+
+
+def independent_grid(mu_h: float, mu_a: float, max_goals: int) -> np.ndarray:
+    ph = _poisson_vec(mu_h, max_goals)
+    pa = _poisson_vec(mu_a, max_goals)
+    grid = np.outer(ph, pa)
+    return grid / grid.sum()
+
+
+def bivariate_grid(mu_h: float, mu_a: float, cov: float, max_goals: int) -> np.ndarray:
+    """Bivariate Poisson (Karlis & Ntzoufras).
+
+    home = Y1 + Y3, away = Y2 + Y3 with Y1~Pois(l1), Y2~Pois(l2), Y3~Pois(l3).
+    Then E[home] = l1 + l3, E[away] = l2 + l3, Cov(home, away) = l3. We
+    parameterise by the means and the shared component ``cov`` (= l3), which is
+    the intuitive knob: cov > 0 lifts the diagonal (more draws)."""
+    cov = float(np.clip(cov, 0.0, min(mu_h, mu_a) - 1e-6))
+    l1, l2, l3 = mu_h - cov, mu_a - cov, cov
+    p1 = _poisson_vec(l1, max_goals)
+    p2 = _poisson_vec(l2, max_goals)
+    p3 = _poisson_vec(l3, max_goals)
+    grid = np.zeros((max_goals + 1, max_goals + 1))
+    for k in range(max_goals + 1):
+        if p3[k] <= 0:
+            continue
+        # contribution where Y3 == k: home = k + i, away = k + j
+        contrib = np.outer(p1[: max_goals + 1 - k], p2[: max_goals + 1 - k]) * p3[k]
+        grid[k:, k:] += contrib
+    return grid / grid.sum()
+
+
+def dixon_coles_grid(mu_h: float, mu_a: float, rho: float, max_goals: int) -> np.ndarray:
+    """Independent Poisson with the Dixon-Coles low-score correction on the four
+    cells {0-0, 0-1, 1-0, 1-1}. ``rho`` > 0 inflates draws / deflates 1-0,0-1."""
+    grid = np.outer(_poisson_vec(mu_h, max_goals), _poisson_vec(mu_a, max_goals))
+    tau = np.ones_like(grid)
+    tau[0, 0] = 1.0 - mu_h * mu_a * rho
+    tau[0, 1] = 1.0 + mu_h * rho
+    tau[1, 0] = 1.0 + mu_a * rho
+    tau[1, 1] = 1.0 - rho
+    grid = grid * np.clip(tau, 1e-9, None)
+    return grid / grid.sum()
+
+
+# ---------------------------------------------------------------------------
+# The models
+# ---------------------------------------------------------------------------
+
+
+def _residuals(dist: ScoreDistribution, t: MarketTargets) -> Dict[str, float]:
+    ph, pd, pa = t.normalised_outcomes()
+    res = {
+        "home": dist.p_home() - ph,
+        "draw": dist.p_draw() - pd,
+        "away": dist.p_away() - pa,
+    }
+    if t.p_over is not None and t.ou_line is not None:
+        res["over"] = dist.p_over(t.ou_line) - t.p_over
+    if t.p_btts is not None:
+        res["btts"] = dist.p_btts() - t.p_btts
+    return res
+
+
+class ScorelineModel(ABC):
+    """Fit a scoreline distribution to de-vigged market targets."""
+
+    name = "abstract"
+
+    @abstractmethod
+    def _grid(self, params: np.ndarray, max_goals: int) -> np.ndarray: ...
+
+    @abstractmethod
+    def _initial(self, t: MarketTargets) -> Tuple[np.ndarray, list]: ...
+
+    def fit(self, t: MarketTargets) -> ScoreDistribution:
+        x0, bounds = self._initial(t)
+        # Weights: outcome masses matter most (they carry the moneyline), the
+        # total and BTTS are refinements.
+        w = {"home": 1.0, "draw": 1.4, "away": 1.0, "over": 0.8, "btts": 0.5}
+
+        def objective(x: np.ndarray) -> float:
+            grid = self._grid(x, t.max_goals)
+            dist = ScoreDistribution(grid, t.max_goals, model_name=self.name)
+            res = _residuals(dist, t)
+            err = sum(w.get(k, 1.0) * (v ** 2) for k, v in res.items())
+            if t.correct_score:  # soft-pull toward any quoted exact-score prices
+                for (h, a), p in t.correct_score.items():
+                    if 0 <= h <= t.max_goals and 0 <= a <= t.max_goals:
+                        err += 0.3 * (grid[h, a] - p) ** 2
+            return err
+
+        best = None
+        # A couple of restarts guards against the optimiser stalling in a flat spot.
+        for jitter in (0.0, 0.15, -0.15):
+            start = np.array(x0) * (1.0 + jitter)
+            start = np.clip(start, [b[0] for b in bounds], [b[1] for b in bounds])
+            r = minimize(objective, start, method="L-BFGS-B", bounds=bounds)
+            if best is None or r.fun < best.fun:
+                best = r
+
+        grid = self._grid(best.x, t.max_goals)
+        dist = ScoreDistribution(grid, t.max_goals, model_name=self.name)
+        dist.params = self._label_params(best.x)
+        dist.residuals = _residuals(dist, t)
+        return dist
+
+    @abstractmethod
+    def _label_params(self, x: np.ndarray) -> Dict[str, float]: ...
+
+
+def _init_means(t: MarketTargets) -> Tuple[float, float]:
+    """A reasonable starting split of the total into home/away expected goals,
+    tilted by the moneyline so the optimiser starts near the answer."""
+    total = 2.6
+    if t.p_over is not None and t.ou_line is not None:
+        # Nudge the assumed total toward/away from the line based on the over price.
+        total = t.ou_line + (t.p_over - 0.5) * 1.6
+    total = float(np.clip(total, 1.2, 5.5))
+    ph, _, pa = t.normalised_outcomes()
+    # supremacy: more home win prob -> larger home share
+    share = float(np.clip(0.5 + 0.5 * (ph - pa), 0.2, 0.8))
+    return total * share, total * (1.0 - share)
+
+
+class IndependentPoisson(ScorelineModel):
+    name = "independent_poisson"
+
+    def _initial(self, t):
+        mh, ma = _init_means(t)
+        return np.array([mh, ma]), [(0.15, 6.0), (0.15, 6.0)]
+
+    def _grid(self, x, max_goals):
+        return independent_grid(x[0], x[1], max_goals)
+
+    def _label_params(self, x):
+        return {"mu_home": float(x[0]), "mu_away": float(x[1])}
+
+
+class BivariatePoisson(ScorelineModel):
+    name = "bivariate_poisson"
+
+    def _initial(self, t):
+        mh, ma = _init_means(t)
+        return np.array([mh, ma, 0.12]), [(0.15, 6.0), (0.15, 6.0), (0.0, 1.5)]
+
+    def _grid(self, x, max_goals):
+        return bivariate_grid(x[0], x[1], x[2], max_goals)
+
+    def _label_params(self, x):
+        return {"mu_home": float(x[0]), "mu_away": float(x[1]), "cov": float(x[2])}
+
+
+class DixonColes(ScorelineModel):
+    name = "dixon_coles"
+
+    def _initial(self, t):
+        mh, ma = _init_means(t)
+        return np.array([mh, ma, 0.05]), [(0.15, 6.0), (0.15, 6.0), (-0.2, 0.25)]
+
+    def _grid(self, x, max_goals):
+        return dixon_coles_grid(x[0], x[1], x[2], max_goals)
+
+    def _label_params(self, x):
+        return {"mu_home": float(x[0]), "mu_away": float(x[1]), "rho": float(x[2])}
+
+
+_MODELS = {
+    "independent_poisson": IndependentPoisson,
+    "bivariate_poisson": BivariatePoisson,
+    "dixon_coles": DixonColes,
+}
+
+
+def get_model(name: str) -> ScorelineModel:
+    try:
+        return _MODELS[name]()
+    except KeyError:
+        raise ValueError(f"unknown model {name!r}; choose from {sorted(_MODELS)}")

--- a/tools/score-pool/scorepool/scaffold.py
+++ b/tools/score-pool/scorepool/scaffold.py
@@ -1,0 +1,90 @@
+"""Templates for ``scorepool init``: a commented config and a starter fixtures CSV.
+
+These are the same as ``config.example.toml`` and ``fixtures.example.csv`` at the
+tool root, kept here so ``init`` works without shipping data files.
+"""
+
+CONFIG_TEMPLATE = """# scorepool configuration
+# The pool rules and my standing drive every pick, so this is the first thing the
+# tool reads. Every value has a default; override only what your pool needs.
+
+[scoring]
+# Points for a submitted score against the actual result. The three tiers are
+# exact > right-winner-and-goal-difference > right-outcome-only. Defaults match a
+# 5 / 3 / 2 World Cup pool, but set them to whatever your pool pays.
+exact = 5
+result_and_goal_difference = 3
+result_only = 2
+# "regulation" scores the 90-minute result, so a 1-1 won on penalties counts as a
+# 1-1 draw. "final" scores the after-extra-time result. In the knockout rounds
+# this one line changes which picks are worth submitting.
+result_basis = "regulation"
+
+[standing]
+# Where I sit. Leave points_above out if I lead the pool; leave points_below out
+# if I am last. games_remaining counts the games still to be scored, including the
+# ones being analysed now; it scales how much a lead is worth protecting.
+my_points = 42
+points_above = 45      # nearest competitor ahead of me (omit if I lead)
+points_below = 41      # nearest competitor behind me (omit if I am last)
+pool_size = 30
+games_remaining = 6
+# "auto" derives protect/chase from the gaps; force it with "protect", "chase",
+# or "neutral".
+risk = "auto"
+
+[model]
+# Scoreline model: bivariate_poisson (default, lifts draws), independent_poisson,
+# or dixon_coles. De-vig method: proportional (default), shin, or additive.
+type = "bivariate_poisson"
+max_goals = 10
+devig = "proportional"
+# How the field is modelled for the leaderboard math: modal_scoreline (the single
+# most likely score, the usual chalk), ep_optimal (a sharper field), or
+# favorite_margin.
+field_model = "modal_scoreline"
+
+[model.context_shading]
+# Modest, configurable nudges applied when a match carries a context flag. Context
+# shades the distribution toward fewer goals and more draws; it does not overrule
+# the market. Factors < 1 lower the expected total; draw boosts add to the draw
+# probability before the model is fit.
+dead_rubber_total_factor = 0.90
+dead_rubber_draw_boost = 0.04
+draw_suits_both_total_factor = 0.92
+draw_suits_both_draw_boost = 0.06
+heavy_rotation_total_factor = 0.95
+low_scoring_total_factor = 0.88
+high_scoring_total_factor = 1.12
+must_win_total_factor = 1.05
+must_win_draw_penalty = 0.03
+
+[strategy]
+# variance_price is how many expected points I will trade for one unit of
+# differential standard deviation when protecting or chasing. Higher means the
+# standings tilt overrides raw expected points more aggressively.
+variance_price = 0.5
+safer_variance_penalty = 0.5
+differentiator_ep_tolerance = 1.5
+reach_quantile = 1.0
+pool_chase_scale = 0.08
+
+[odds]
+# manual/csv read odds straight from the fixtures file. the_odds_api pulls live
+# odds and merges them onto the fixtures, keeping any hand-entered odds as a
+# fallback for matches the API doesn't cover. The key is read from the named
+# environment variable, never stored here.
+source = "manual"           # the_odds_api | manual | csv
+api_key_env = "ODDS_API_KEY"
+sport_key = "soccer_fifa_world_cup"
+regions = "us,uk,eu"
+markets = "h2h,totals,btts"
+# bookmaker = "pinnacle"    # pin one book; otherwise prices are the median
+"""
+
+FIXTURES_TEMPLATE = """match_id,home,away,commence_time,odds_format,home_odds,draw_odds,away_odds,ou_line,over_odds,under_odds,btts_yes,btts_no,home_odds_open,draw_odds_open,away_odds_open,correct_score,context,note,lineup_unconfirmed,injury_question
+ESP-GER,Spain,Germany,2026-07-08T19:00:00Z,decimal,2.55,3.20,2.95,2.5,2.05,1.80,1.95,1.85,,,,1-0:7.5;0-0:9.0;1-1:8.0;2-1:9.0,draw_suits_both,"Knockout tie: level after 90 goes to extra time and penalties, but the pool scores the 90-minute result. Both sides may be content to take it deep.",true,false
+BRA-KOR,Brazil,South Korea,2026-07-09T15:00:00Z,decimal,1.40,4.80,8.00,2.5,1.75,2.05,2.10,1.70,,,,,"",Clear favourite; Brazil expected to control.,false,false
+FRA-POL,France,Poland,2026-07-09T19:00:00Z,american,-140,260,380,2.5,-105,-115,100,-120,,,,,dead_rubber;heavy_rotation_home,"France already through as group winners and likely to rotate heavily; Poland need the win.",true,true
+ARG-NED,Argentina,Netherlands,2026-07-10T19:00:00Z,decimal,2.30,3.10,3.30,2.5,1.95,1.90,1.90,1.90,2.60,3.20,2.90,,"",Argentina has shortened since the line opened.,false,false
+"""

--- a/tools/score-pool/scorepool/scoring/__init__.py
+++ b/tools/score-pool/scorepool/scoring/__init__.py
@@ -1,0 +1,10 @@
+"""Scoring rules live on ``ScoringRules`` in ``scorepool.models``.
+
+Re-exported here so the scoring logic can be imported as its own swappable piece
+(``from scorepool.scoring import ScoringRules``) and so an alternative pool's
+scorer can be dropped in alongside it.
+"""
+
+from ..models import ActualResult, ScoringRules
+
+__all__ = ["ScoringRules", "ActualResult"]

--- a/tools/score-pool/scorepool/state.py
+++ b/tools/score-pool/scorepool/state.py
@@ -1,0 +1,185 @@
+"""Persistent state so the tool can be re-run all tournament.
+
+The state file (JSON) remembers, per match, the score I submitted and the score
+the chalk/field was on, and -- once a result is entered -- the points each earned.
+That lets the tool keep a running total against the pool's scoring rules and show
+how my picks did versus just following the field, as results come in and I re-run.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .models import ActualResult, ScoringRules, Score
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def parse_score(text: str) -> Score:
+    h, a = str(text).replace(":", "-").split("-")
+    return (int(h), int(a))
+
+
+def fmt_score(score: Score) -> str:
+    return f"{score[0]}-{score[1]}"
+
+
+def default_state() -> Dict[str, Any]:
+    return {
+        "created_at": _now_iso(),
+        "updated_at": _now_iso(),
+        "scoring": None,
+        "matches": {},  # match_id -> record
+        "totals": {"mine": 0.0, "chalk": 0.0, "scored_games": 0},
+    }
+
+
+def load_state(path: str) -> Dict[str, Any]:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return default_state()
+
+
+def save_state(path: str, state: Dict[str, Any]) -> None:
+    state["updated_at"] = _now_iso()
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(state, fh, indent=2)
+
+
+def scoring_to_dict(rules: ScoringRules) -> Dict[str, Any]:
+    return {
+        "exact": rules.exact,
+        "result_and_goal_difference": rules.result_and_goal_difference,
+        "result_only": rules.result_only,
+        "result_basis": rules.result_basis,
+    }
+
+
+def upsert_pick(
+    state: Dict[str, Any],
+    match_id: str,
+    label: str,
+    pick: Score,
+    chalk: Optional[Score],
+    commence_time: Optional[str],
+    odds_fetched_at: Optional[str],
+    confidence: str = "",
+) -> None:
+    """Record (or update) the pick for a match, preserving any result already
+    entered. Re-running recommend refreshes the planned pick until a result lands."""
+    rec = state["matches"].get(match_id, {})
+    rec.update(
+        {
+            "label": label,
+            "pick": fmt_score(pick),
+            "chalk": fmt_score(chalk) if chalk else None,
+            "commence_time": commence_time,
+            "odds_fetched_at": odds_fetched_at,
+            "confidence": confidence,
+        }
+    )
+    rec.setdefault("result", None)
+    rec.setdefault("points_mine", None)
+    rec.setdefault("points_chalk", None)
+    # Overridden pick (if I submitted something other than the recommendation).
+    rec.setdefault("submitted_override", None)
+    state["matches"][match_id] = rec
+
+
+def set_submitted(state: Dict[str, Any], match_id: str, pick: Score) -> None:
+    """Override what I actually submitted, in case I deviated from the tool."""
+    rec = state["matches"].setdefault(match_id, {})
+    rec["submitted_override"] = fmt_score(pick)
+
+
+def _effective_pick(rec: Dict[str, Any]) -> Optional[Score]:
+    p = rec.get("submitted_override") or rec.get("pick")
+    return parse_score(p) if p else None
+
+
+def record_result(
+    state: Dict[str, Any],
+    match_id: str,
+    actual: ActualResult,
+    rules: ScoringRules,
+) -> Dict[str, Any]:
+    """Enter a finished result and score my pick (and the chalk) against it."""
+    if match_id not in state["matches"]:
+        raise KeyError(
+            f"no pick on file for match id {match_id!r}; run recommend with --save first, "
+            f"or add the pick with the submit command"
+        )
+    rec = state["matches"][match_id]
+    rec["result"] = {
+        "home_reg": actual.home_reg,
+        "away_reg": actual.away_reg,
+        "home_final": actual.home_final,
+        "away_final": actual.away_final,
+        "decided_by": actual.decided_by,
+    }
+    scoring_score = actual.scoring_score(rules.result_basis)
+    pick = _effective_pick(rec)
+    rec["points_mine"] = rules.score(pick, scoring_score) if pick else None
+    chalk = parse_score(rec["chalk"]) if rec.get("chalk") else None
+    rec["points_chalk"] = rules.score(chalk, scoring_score) if chalk else None
+    recompute_totals(state)
+    return rec
+
+
+def recompute_totals(state: Dict[str, Any]) -> None:
+    mine = chalk = 0.0
+    scored = 0
+    for rec in state["matches"].values():
+        if rec.get("points_mine") is not None:
+            mine += rec["points_mine"]
+            scored += 1
+        if rec.get("points_chalk") is not None:
+            chalk += rec["points_chalk"]
+    state["totals"] = {"mine": mine, "chalk": chalk, "scored_games": scored}
+
+
+def render_standings(state: Dict[str, Any], rules: ScoringRules) -> str:
+    """A running scorecard: what each settled game scored, and my total versus the
+    chalk baseline."""
+    basis = rules.result_basis
+    lines = [f"RUNNING TOTAL (scoring basis: {basis})", "-" * 56]
+    header = ["Match", "Pick", "Result", "Mine", "Chalk"]
+    widths = [26, 6, 10, 6, 6]
+    from .output.picksheet import render_table
+
+    rows = []
+    for rec in state["matches"].values():
+        res = rec.get("result")
+        if res:
+            reg = f"{res['home_reg']}-{res['away_reg']}"
+            if res.get("decided_by") and res["decided_by"] != "regulation":
+                reg += f" ({res['decided_by'][:3]})"
+        else:
+            reg = "pending"
+        rows.append(
+            [
+                rec.get("label", ""),
+                rec.get("submitted_override") or rec.get("pick", ""),
+                reg,
+                "-" if rec.get("points_mine") is None else f"{rec['points_mine']:g}",
+                "-" if rec.get("points_chalk") is None else f"{rec['points_chalk']:g}",
+            ]
+        )
+    if rows:
+        lines.append(render_table(header, rows, widths))
+    totals = state.get("totals", {})
+    mine = totals.get("mine", 0.0)
+    chalk = totals.get("chalk", 0.0)
+    scored = totals.get("scored_games", 0)
+    lines.append("")
+    lines.append(f"My points over {scored} settled game(s): {mine:g}")
+    lines.append(f"Chalk baseline (if I'd copied the field): {chalk:g}")
+    edge = mine - chalk
+    lines.append(f"Edge vs chalk: {edge:+g}")
+    return "\n".join(lines)

--- a/tools/score-pool/tests/test_devig.py
+++ b/tools/score-pool/tests/test_devig.py
@@ -1,0 +1,59 @@
+"""Odds conversion and vig removal."""
+
+import math
+
+import pytest
+
+from scorepool.probability import devig
+
+
+def test_decimal_passthrough():
+    assert devig.to_decimal(2.5, "decimal") == 2.5
+
+
+def test_american_conversion():
+    assert devig.to_decimal(150, "american") == pytest.approx(2.5)
+    assert devig.to_decimal(-200, "american") == pytest.approx(1.5)
+
+
+def test_fractional_conversion():
+    assert devig.to_decimal("3/2", "fractional") == pytest.approx(2.5)
+    assert devig.to_decimal("1/1", "fractional") == pytest.approx(2.0)
+
+
+def test_invalid_decimal_rejected():
+    with pytest.raises(ValueError):
+        devig.to_decimal(0.9, "decimal")
+
+
+def test_proportional_sums_to_one():
+    p = devig.devig([2.1, 3.4, 3.6], "proportional")
+    assert math.isclose(sum(p), 1.0, abs_tol=1e-12)
+    # favourite keeps the largest probability
+    assert p[0] == max(p)
+
+
+def test_shin_sums_to_one_and_corrects_longshot_bias():
+    decs = [1.5, 4.5, 7.0]
+    prop = devig.devig(decs, "proportional")
+    shin = devig.devig(decs, "shin")
+    assert math.isclose(sum(shin), 1.0, abs_tol=1e-9)
+    # Shin corrects the favourite-longshot bias: it lifts the favourite and trims
+    # the longshots relative to plain proportional de-vigging.
+    assert shin[0] >= prop[0] - 1e-9
+    assert shin[-1] <= prop[-1] + 1e-9
+
+
+def test_additive_sums_to_one():
+    p = devig.devig([1.8, 3.7, 4.5], "additive")
+    assert math.isclose(sum(p), 1.0, abs_tol=1e-9)
+    assert all(0.0 <= x <= 1.0 for x in p)
+
+
+def test_two_way_complementary():
+    p_over = devig.devig_two_way(1.91, 1.91, "proportional")
+    assert p_over == pytest.approx(0.5, abs=1e-9)
+
+
+def test_overround_positive_with_margin():
+    assert devig.overround([1.91, 1.91]) > 0

--- a/tools/score-pool/tests/test_integration.py
+++ b/tools/score-pool/tests/test_integration.py
@@ -1,0 +1,75 @@
+"""End-to-end: the example config and fixtures should produce a full pick sheet."""
+
+import os
+
+from scorepool.config import load_config
+from scorepool.engine import analyze_all
+from scorepool.odds.manual import load_fixtures
+from scorepool.output.picksheet import render_full_report, render_submission
+from scorepool.probability.market import apply_context_shading
+from scorepool.probability.scoreline import MarketTargets
+from scorepool.config import ContextShading
+from scorepool.models import MatchContext
+
+HERE = os.path.dirname(__file__)
+ROOT = os.path.join(HERE, "..")
+
+
+def _load():
+    cfg = load_config(os.path.join(ROOT, "config.example.toml"))
+    matches = load_fixtures(os.path.join(ROOT, "fixtures.example.csv"))
+    return cfg, matches
+
+
+def test_examples_load():
+    cfg, matches = _load()
+    assert cfg.scoring.exact == 5
+    assert cfg.scoring.result_basis == "regulation"
+    assert len(matches) == 4
+
+
+def test_full_pipeline_produces_picks():
+    cfg, matches = _load()
+    analyses = analyze_all(matches, cfg)
+    assert len(analyses) == 4
+    for a in analyses:
+        assert a.ok
+        h, w = a.selection.featured.score
+        assert isinstance(h, int) and isinstance(w, int)
+        assert a.confidence in ("low", "medium", "high")
+
+
+def test_report_and_submission_render():
+    cfg, matches = _load()
+    analyses = analyze_all(matches, cfg)
+    report = render_full_report(analyses, cfg)
+    assert "PICK SHEET" in report
+    assert "SUBMISSION" in report
+    sub = render_submission(analyses)
+    assert "Spain vs Germany" in sub
+
+
+def test_american_odds_row_parses():
+    # France-Poland is entered in American format; it must still yield a pick.
+    cfg, matches = _load()
+    fra = next(m for m in matches if m.match_id == "FRA-POL")
+    assert fra.odds is not None and fra.odds.three_way is not None
+    assert fra.odds.three_way.home > 1.0
+
+
+def test_context_shading_raises_draws_and_lowers_scoring():
+    t = MarketTargets(p_home=0.40, p_draw=0.30, p_away=0.30, ou_line=2.5, p_over=0.55)
+    ctx = MatchContext(draw_suits_both=True)
+    shaded = apply_context_shading(t, ctx, ContextShading())
+    assert shaded.p_draw > t.p_draw
+    assert shaded.p_over < t.p_over
+
+
+def test_missing_three_way_is_flagged_not_crashed():
+    from scorepool.models import Match
+
+    cfg, _ = _load()
+    blank = Match(match_id="X", home="A", away="B")
+    analyses = analyze_all([blank], cfg)
+    assert not analyses[0].ok
+    assert "three-way" in analyses[0].reason

--- a/tools/score-pool/tests/test_leaderboard.py
+++ b/tools/score-pool/tests/test_leaderboard.py
@@ -1,0 +1,110 @@
+"""Field model, differential math, the protect/chase tilt, and its effect on the pick."""
+
+import numpy as np
+
+from scorepool.config import StrategyConfig
+from scorepool.leaderboard.field import differential_stats, field_pick
+from scorepool.leaderboard.strategy import Tilt, derive_tilt, select_picks
+from scorepool.models import ScoringRules, Standing
+from scorepool.optimizer.expected_points import evaluate_pick, rank_candidates
+from scorepool.probability.scoreline import (
+    BivariatePoisson,
+    MarketTargets,
+    ScoreDistribution,
+)
+
+RULES = ScoringRules(5, 3, 2)
+GRID = np.array([[0.30, 0.20], [0.25, 0.25]])
+DIST = ScoreDistribution(GRID, max_goals=1)
+CFG = StrategyConfig()
+
+
+def test_field_pick_is_modal_scoreline():
+    assert field_pick(DIST, RULES, "modal_scoreline") == (0, 0)
+
+
+def test_differential_zero_against_identical_pick():
+    d = differential_stats((1, 0), (1, 0), DIST, RULES)
+    assert d.mean == 0.0
+    assert d.std == 0.0
+
+
+def test_differential_mean_equals_ep_gap():
+    # E[my points - their points] == EP(mine) - EP(theirs).
+    mine, theirs = (1, 0), (0, 0)
+    d = differential_stats(mine, theirs, DIST, RULES)
+    gap = evaluate_pick(mine, GRID, RULES).ep - evaluate_pick(theirs, GRID, RULES).ep
+    assert abs(d.mean - gap) < 1e-9
+    assert d.std > 0
+
+
+def test_tilt_protect_when_lead_is_thin():
+    st = Standing(my_points=50, points_below=49, pool_size=10, games_remaining=2)
+    tilt = derive_tilt(st, sigma0=1.5, games_remaining=2, cfg=CFG)
+    assert tilt.mode == "protect"
+    assert tilt.tau < 0
+
+
+def test_tilt_chase_when_behind():
+    st = Standing(my_points=40, points_above=45, pool_size=10, games_remaining=2)
+    tilt = derive_tilt(st, sigma0=1.5, games_remaining=2, cfg=CFG)
+    assert tilt.mode == "chase"
+    assert tilt.tau > 0
+
+
+def test_tilt_neutral_when_lead_is_safe():
+    st = Standing(my_points=100, points_below=50, pool_size=10, games_remaining=2)
+    tilt = derive_tilt(st, sigma0=1.5, games_remaining=2, cfg=CFG)
+    assert tilt.mode == "neutral"
+
+
+def test_tilt_scales_with_games_remaining():
+    # Same one-point lead is safer with fewer games left (less reachable swing).
+    st = Standing(my_points=50, points_below=49, pool_size=10)
+    thin_short = derive_tilt(st, 1.5, games_remaining=2, cfg=CFG)
+    thin_long = derive_tilt(st, 1.5, games_remaining=12, cfg=CFG)
+    assert thin_long.protect_pressure > thin_short.protect_pressure
+
+
+def test_risk_override_forces_posture():
+    st = Standing(my_points=40, points_above=45, risk="protect")
+    assert derive_tilt(st, 1.5, 3, CFG).mode == "protect"
+
+
+def _even_setup():
+    dist = BivariatePoisson().fit(
+        MarketTargets(p_home=0.37, p_draw=0.30, p_away=0.33, ou_line=2.5, p_over=0.5)
+    )
+    cands = rank_candidates(dist, RULES)
+    fp = field_pick(dist, RULES, "modal_scoreline")
+    return dist, cands, fp
+
+
+def test_chase_takes_more_differential_variance_than_protect():
+    dist, cands, fp = _even_setup()
+    st = Standing(my_points=40, points_above=44, pool_size=20, games_remaining=4)
+    protect = Tilt(-1.0, "protect", 1.0, 0.0, 3.0, "")
+    chase = Tilt(1.0, "chase", 0.0, 1.0, 3.0, "")
+    sel_p = select_picks(cands, dist, RULES, fp, st, protect, 1.5, 4, CFG)
+    sel_c = select_picks(cands, dist, RULES, fp, st, chase, 1.5, 4, CFG)
+    var_p = sel_p.diffs[sel_p.featured.score].std
+    var_c = sel_c.diffs[sel_c.featured.score].std
+    assert var_c >= var_p
+
+
+def test_protect_featured_moves_with_field():
+    # Under a protect tilt the featured pick should be low differential variance,
+    # i.e. close to (often equal to) the field's chalk.
+    dist, cands, fp = _even_setup()
+    st = Standing(my_points=50, points_below=49, pool_size=20, games_remaining=3)
+    protect = Tilt(-1.0, "protect", 1.0, 0.0, 2.0, "")
+    sel = select_picks(cands, dist, RULES, fp, st, protect, 1.5, 3, CFG)
+    assert sel.diffs[sel.featured.score].std <= sel.diffs[sel.differentiator.score].std
+
+
+def test_selection_reports_raw_best():
+    dist, cands, fp = _even_setup()
+    st = Standing(my_points=40, points_above=44, games_remaining=4)
+    chase = Tilt(1.0, "chase", 0.0, 1.0, 3.0, "")
+    sel = select_picks(cands, dist, RULES, fp, st, chase, 1.5, 4, CFG)
+    assert sel.raw_best.ep == max(c.ep for c in cands)

--- a/tools/score-pool/tests/test_optimizer.py
+++ b/tools/score-pool/tests/test_optimizer.py
@@ -1,0 +1,77 @@
+"""Expected-points arithmetic, on a hand-computable distribution.
+
+The distribution over the 2x2 grid {0,1} x {0,1}:
+    P(0-0)=0.30  P(0-1)=0.20  P(1-0)=0.25  P(1-1)=0.25
+so draws total 0.55, home win 0.25, away win 0.20.
+
+By hand, under 5 / 3 / 2 scoring:
+    EP(0-0) = 5*0.30 + 3*0.25            = 2.25   (exact 0-0, plus GD-tier on 1-1)
+    EP(1-1) = 5*0.25 + 3*0.30            = 2.15
+    EP(1-0) = 5*0.25                     = 1.25   (no other home-win cells here)
+    EP(0-1) = 5*0.20                     = 1.00
+This is the headline case: the draw picks beat the more-likely-per-outcome home
+pick, because a draw pick collects on every draw.
+"""
+
+import numpy as np
+import pytest
+
+from scorepool.models import ScoringRules
+from scorepool.optimizer.expected_points import evaluate_pick, rank_candidates
+from scorepool.probability.scoreline import ScoreDistribution
+
+RULES = ScoringRules(5, 3, 2)
+GRID = np.array([[0.30, 0.20], [0.25, 0.25]])
+DIST = ScoreDistribution(GRID, max_goals=1)
+
+
+def test_grid_outcome_masses():
+    assert DIST.p_draw() == 0.55
+    assert DIST.p_home() == 0.25
+    assert DIST.p_away() == 0.20
+
+
+def test_expected_points_exact_values():
+    assert evaluate_pick((0, 0), GRID, RULES).ep == pytest.approx(2.25)
+    assert evaluate_pick((1, 1), GRID, RULES).ep == pytest.approx(2.15)
+    assert evaluate_pick((1, 0), GRID, RULES).ep == pytest.approx(1.25)
+    assert evaluate_pick((0, 1), GRID, RULES).ep == pytest.approx(1.00)
+
+
+def test_draw_beats_the_favourite_pick():
+    best = rank_candidates(DIST, RULES)[0]
+    assert best.score == (0, 0)
+    assert best.ep > evaluate_pick((1, 0), GRID, RULES).ep
+
+
+def test_floor_excludes_outcome_only_tier():
+    # 1-0's only positive-scoring cell here is the exact 1-0, so floor == 25%.
+    c = evaluate_pick((1, 0), GRID, RULES)
+    assert c.floor == 0.25
+    assert c.hit_any == 0.25
+    # The draw pick has a broad meaningful floor: exact plus the other draw.
+    d = evaluate_pick((0, 0), GRID, RULES)
+    assert d.floor == 0.55
+
+
+def test_lopsided_winning_score_has_low_floor_not_high():
+    # On a heavy-favourite distribution, a 5-0 pick collects the outcome tier on
+    # most results but almost never the goal difference, so its floor stays low
+    # even though it 'scores something' often.
+    from scorepool.probability.scoreline import BivariatePoisson, MarketTargets
+
+    dist = BivariatePoisson().fit(
+        MarketTargets(p_home=0.80, p_draw=0.12, p_away=0.08, ou_line=2.5, p_over=0.6)
+    )
+    five_nil = evaluate_pick((5, 0), dist.grid, RULES)
+    assert five_nil.hit_any > 0.5  # it does score *something* often (the 2-tier)
+    # A meaningful (goal-difference-or-better) hit is a small fraction of that.
+    assert five_nil.floor < 0.2 * five_nil.hit_any
+
+
+def test_variance_is_nonnegative_and_zero_when_certain():
+    certain = np.zeros((2, 2))
+    certain[1, 0] = 1.0  # home always wins 1-0
+    d = ScoreDistribution(certain, max_goals=1)
+    assert evaluate_pick((1, 0), certain, RULES).variance == 0.0
+    assert evaluate_pick((1, 0), certain, RULES).ep == 5.0

--- a/tools/score-pool/tests/test_scoreline.py
+++ b/tools/score-pool/tests/test_scoreline.py
@@ -1,0 +1,59 @@
+"""The scoreline model must be anchored to the market: its implied outcome and
+total probabilities should reproduce the de-vigged prices it was fit to."""
+
+import numpy as np
+
+from scorepool.probability.scoreline import (
+    BivariatePoisson,
+    IndependentPoisson,
+    MarketTargets,
+    bivariate_grid,
+    independent_grid,
+)
+
+
+def test_grid_normalised():
+    g = bivariate_grid(1.4, 1.1, 0.3, 10)
+    assert abs(g.sum() - 1.0) < 1e-9
+    assert (g >= 0).all()
+
+
+def test_bivariate_lifts_draws_over_independent():
+    ind = independent_grid(1.3, 1.1, 10)
+    biv = bivariate_grid(1.3, 1.1, 0.4, 10)
+    assert np.trace(biv) > np.trace(ind)
+
+
+def test_fit_reproduces_outcome_masses():
+    t = MarketTargets(p_home=0.50, p_draw=0.27, p_away=0.23, ou_line=2.5, p_over=0.50)
+    dist = BivariatePoisson().fit(t)
+    assert abs(dist.p_home() - 0.50) < 0.03
+    assert abs(dist.p_draw() - 0.27) < 0.03
+    assert abs(dist.p_away() - 0.23) < 0.03
+
+
+def test_fit_reproduces_total_line():
+    t = MarketTargets(p_home=0.45, p_draw=0.28, p_away=0.27, ou_line=2.5, p_over=0.60)
+    dist = BivariatePoisson().fit(t)
+    assert abs(dist.p_over(2.5) - 0.60) < 0.05
+    # A 60% over-2.5 market should push the expected total above 2.5.
+    assert dist.expected_total() > 2.5
+
+
+def test_fit_quality_reported():
+    t = MarketTargets(p_home=0.40, p_draw=0.30, p_away=0.30, ou_line=2.5, p_over=0.50)
+    dist = BivariatePoisson().fit(t)
+    assert dist.fit_quality() < 0.03  # residual small on a coherent market
+
+
+def test_away_edge_survives_into_scoreline_masses():
+    # Targets favour the away side; the fitted grid should keep that ordering.
+    t = MarketTargets(p_home=0.32, p_draw=0.30, p_away=0.38, ou_line=2.5, p_over=0.45)
+    dist = BivariatePoisson().fit(t)
+    assert dist.p_away() > dist.p_home()
+
+
+def test_independent_model_also_fits_outcomes():
+    t = MarketTargets(p_home=0.55, p_draw=0.24, p_away=0.21, ou_line=2.5, p_over=0.55)
+    dist = IndependentPoisson().fit(t)
+    assert abs(dist.p_home() - 0.55) < 0.04

--- a/tools/score-pool/tests/test_scoring.py
+++ b/tools/score-pool/tests/test_scoring.py
@@ -1,0 +1,60 @@
+"""The scorer is the heart of the tool, so its tiers are pinned down exactly,
+including the draw goal-difference subtlety and the 90-minute-vs-final rule."""
+
+from scorepool.models import ActualResult, ScoringRules
+
+RULES = ScoringRules(exact=5, result_and_goal_difference=3, result_only=2)
+
+
+def test_exact():
+    assert RULES.score((2, 1), (2, 1)) == 5
+
+
+def test_result_and_goal_difference_home_win():
+    # Right winner, right margin (+1), wrong exact score.
+    assert RULES.score((2, 1), (3, 2)) == 3
+    assert RULES.score((2, 1), (1, 0)) == 3
+
+
+def test_result_only_home_win():
+    # Right winner, wrong margin.
+    assert RULES.score((2, 1), (3, 1)) == 2  # margin +2, not +1
+    assert RULES.score((2, 1), (2, 0)) == 2
+
+
+def test_wrong_outcome_scores_zero():
+    assert RULES.score((2, 1), (0, 1)) == 0  # picked home, away won
+    assert RULES.score((1, 1), (2, 1)) == 0  # picked draw, home won
+
+
+def test_draw_pick_banks_gd_on_every_draw():
+    # A draw pick never lands on the outcome-only tier: every actual draw matches
+    # the zero goal difference, so it is always at least the middle tier.
+    assert RULES.score((1, 1), (1, 1)) == 5  # exact
+    assert RULES.score((1, 1), (0, 0)) == 3  # other draw -> result + GD
+    assert RULES.score((1, 1), (2, 2)) == 3
+    assert RULES.score((0, 0), (3, 3)) == 3
+
+
+def test_regulation_basis_counts_ninety_minutes():
+    # 1-1 after 90, won on penalties. Under regulation scoring it is a 1-1 draw.
+    actual = ActualResult(home_reg=1, away_reg=1, home_final=2, away_final=1, decided_by="penalties")
+    assert actual.scoring_score("regulation") == (1, 1)
+    assert RULES.score((1, 1), actual.scoring_score("regulation")) == 5  # nailed the draw
+    # A "favourite to win" pick scores zero even though that team advanced.
+    assert RULES.score((2, 1), actual.scoring_score("regulation")) == 0
+
+
+def test_final_basis_counts_after_extra_time():
+    final_rules = ScoringRules(exact=5, result_and_goal_difference=3, result_only=2, result_basis="final")
+    actual = ActualResult(home_reg=1, away_reg=1, home_final=2, away_final=1, decided_by="extra_time")
+    assert actual.scoring_score("final") == (2, 1)
+    assert final_rules.score((1, 1), actual.scoring_score(final_rules.result_basis)) == 0
+    assert final_rules.score((2, 1), actual.scoring_score(final_rules.result_basis)) == 5
+
+
+def test_configurable_points():
+    rules = ScoringRules(exact=10, result_and_goal_difference=4, result_only=1)
+    assert rules.score((2, 1), (2, 1)) == 10
+    assert rules.score((2, 1), (3, 2)) == 4
+    assert rules.score((2, 1), (4, 0)) == 1

--- a/tools/score-pool/tests/test_state.py
+++ b/tools/score-pool/tests/test_state.py
@@ -1,0 +1,64 @@
+"""Running-total bookkeeping, including the regulation-vs-final settlement rule."""
+
+from scorepool.models import ActualResult, ScoringRules
+from scorepool.state import (
+    default_state,
+    fmt_score,
+    parse_score,
+    record_result,
+    upsert_pick,
+)
+
+RULES = ScoringRules(5, 3, 2, result_basis="regulation")
+RULES_FINAL = ScoringRules(5, 3, 2, result_basis="final")
+
+
+def test_score_roundtrip():
+    assert parse_score("2-1") == (2, 1)
+    assert parse_score("2:1") == (2, 1)
+    assert fmt_score((3, 0)) == "3-0"
+
+
+def test_penalties_score_as_draw_under_regulation():
+    state = default_state()
+    upsert_pick(state, "M1", "A vs B", pick=(1, 1), chalk=(1, 0),
+                commence_time=None, odds_fetched_at=None)
+    actual = ActualResult(home_reg=1, away_reg=1, home_final=2, away_final=1, decided_by="penalties")
+    rec = record_result(state, "M1", actual, RULES)
+    assert rec["points_mine"] == 5  # nailed the 1-1
+    assert rec["points_chalk"] == 0  # 1-0 pick busts on a draw
+    assert state["totals"]["mine"] == 5
+    assert state["totals"]["chalk"] == 0
+
+
+def test_final_basis_scores_after_extra_time():
+    state = default_state()
+    upsert_pick(state, "M1", "A vs B", pick=(1, 1), chalk=(2, 1),
+                commence_time=None, odds_fetched_at=None)
+    actual = ActualResult(home_reg=1, away_reg=1, home_final=2, away_final=1, decided_by="extra_time")
+    rec = record_result(state, "M1", actual, RULES_FINAL)
+    assert rec["points_mine"] == 0  # the 1-1 is void once ET counts
+    assert rec["points_chalk"] == 5  # 2-1 nails the after-ET score
+
+
+def test_submitted_override_is_scored():
+    from scorepool.state import set_submitted
+
+    state = default_state()
+    upsert_pick(state, "M1", "A vs B", pick=(1, 1), chalk=(1, 0),
+                commence_time=None, odds_fetched_at=None)
+    set_submitted(state, "M1", (2, 0))  # I actually submitted 2-0
+    actual = ActualResult(home_reg=2, away_reg=0)
+    rec = record_result(state, "M1", actual, RULES)
+    assert rec["points_mine"] == 5  # scored against 2-0, not the recommended 1-1
+
+
+def test_running_total_accumulates_edge():
+    state = default_state()
+    upsert_pick(state, "M1", "A vs B", (1, 1), (1, 0), None, None)
+    upsert_pick(state, "M2", "C vs D", (2, 1), (2, 1), None, None)
+    record_result(state, "M1", ActualResult(0, 0), RULES)  # mine 3, chalk 0
+    record_result(state, "M2", ActualResult(2, 1), RULES)  # mine 5, chalk 5
+    assert state["totals"]["mine"] == 8
+    assert state["totals"]["chalk"] == 5
+    assert state["totals"]["scored_games"] == 2


### PR DESCRIPTION
## What this is

A self-contained Python command-line tool under `tools/score-pool/` that runs the whole exact-score prediction pool workflow I used to do by hand each matchday. It pulls the odds, de-vigs them to fair probabilities, builds a distribution over scorelines that is anchored to the market, picks the score that earns the most expected points under my pool's rules, and then adjusts that pick for where I sit on the leaderboard. It is deliberately plain, and it tries to stay honest about how much it actually knows rather than presenting the model as sharper than it is.

It lives entirely in its own directory and touches nothing in the Next.js site. It is not wired into the web build, and it has no effect on the existing app.

## The decision logic

The pipeline is four swappable stages, so the same logic can point at a different sport or a different pool whose markets and rules don't match.

| Stage | What it does |
| --- | --- |
| de-vig | decimal / American / fractional odds to implied to fair, via proportional (default), Shin, or additive |
| scoreline | bivariate Poisson (default), independent Poisson, or Dixon-Coles, fit to the de-vigged moneyline + over/under (+ both-teams-to-score), with tournament-context shading |
| optimizer | expected points, variance, and a goal-difference-or-better floor over the full scoreline grid |
| leaderboard | model the field's chalk, then a Gaussian protect/chase tilt driven by the gap, the games remaining, and the pool size |

The scoreline model is fit to the market, so the win/draw/win masses line up with the de-vigged moneyline and the implied total lines up with the over/under. The optimizer then surfaces the effect that motivated the whole thing: a draw pick banks the result-and-goal-difference tier on every draw, not only on the exact score, so a 1-1 can beat backing the favourite outright on expected points. It also handles the 90-minute-versus-final distinction, so a 1-1 won on penalties scores as a draw under regulation rules, which is the case that kept costing favourite-to-win picks.

The leaderboard layer turns my standing into one risk tilt. A one-point lead with two games left and a ten-point lead with ten games left land in very different places because the reachable swing scales with the square root of the games remaining. Protecting favours low-variance picks that move with the field; chasing favours the high-quality contrarian spots the field will be off. The sheet shows the plain expected-points pick, the tilted pick, a safer higher-floor alternative, and the differentiator, so the trade is visible instead of hidden behind a label.

## Using it

```bash
cd tools/score-pool
pip install -r requirements.txt
python -m scorepool init                                   # scaffold config + fixtures
python -m scorepool recommend --fixtures fixtures.csv      # print the pick sheet
```

Odds come from The Odds API (key via an environment variable) or hand/CSV/JSON entry as a fallback, all timestamped. State persists so it can be re-run through a tournament: `recommend --save`, then `result` as games settle, then `standings` for a running total and an edge-versus-chalk comparison. There is a runnable example set (`config.example.toml`, `fixtures.example.csv`, `fixtures.example.json`).

## Output

A pick sheet with one row per match (Match, Pick, Confidence, Expected points, Safer alternative, Differentiator, Why), a clean copyable submission table, and a before-lock list of unconfirmed lineups, open injury questions, and standings that could still shift, each with the lock time and the odds timestamp.

## Testing

```bash
cd tools/score-pool && python -m pytest
```

52 tests, all passing, covering the parts that have to be right: the scoring tiers including the draw goal-difference subtlety and the penalties-count-as-a-draw rule, the de-vig math, the model reproducing the market it was fit to, the expected-points arithmetic on a hand-computable distribution, and the protect-versus-chase tilt. I also drove every command end to end, including the knockout penalties settlement.

## Honesty and limits

The scoreline distribution is only as good as the prices it is fit to, the leaderboard tilt is a Gaussian approximation of how the standings can move rather than a full simulation of the field, and the context shading is a set of modest heuristics. Confidence labels are conservative on purpose and coin flips are marked down. One deliberate deviation from the original sketch: the tabular output uses a small dependency-free renderer instead of pandas, which keeps the install to numpy and scipy and wraps the Why column more cleanly. Easy to revisit if you would rather have pandas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JC3LduDomVeMMBJzkKBNgL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC3LduDomVeMMBJzkKBNgL)_