### PR TITLE
Article cover images: license-safe photos and a writing-time workflow

### DIFF
--- a/.github/workflows/update-article-images.yml
+++ b/.github/workflows/update-article-images.yml
@@ -1,0 +1,115 @@
+name: Refresh Article Cover Images
+
+# Gives blog posts real, license-safe cover photos in place of the generated
+# editorial card, per the plan in scripts/data/articleCoverImages.ts.
+#
+# Runs where the network is open (GitHub-hosted runners), which the agent
+# sandbox is not — Wikimedia Commons is blocked there by egress policy. The
+# weekly pass only fetches covers that are still missing, so a newly published
+# `wikimedia` article picks one up automatically. Use the manual dispatch to
+# backfill, target a single slug, or force a re-fetch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Comma-separated slugs to limit to (blank = all missing)"
+        required: false
+        default: ""
+      force:
+        description: "Re-fetch even posts that already have a cover"
+        type: boolean
+        required: false
+        default: false
+  schedule:
+    # Weekly, Monday 06:40 UTC — backfill covers for any new articles.
+    - cron: "40 6 * * 1"
+
+concurrency:
+  group: refresh-article-images
+  cancel-in-progress: false
+
+jobs:
+  refresh-article-images:
+    name: Refresh Article Cover Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --fund=false
+
+      - name: Refresh article cover images
+        run: |
+          ARGS=""
+          if [ -n "${{ github.event.inputs.only }}" ]; then
+            ARGS="$ARGS --only=${{ github.event.inputs.only }}"
+          fi
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            ARGS="$ARGS --force"
+          fi
+          # Fail-soft: individual posts that error are skipped, so a single
+          # unreachable image never blocks committing the covers that landed.
+          npm run update:article-images -- $ARGS || true
+        env:
+          NODE_ENV: production
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if [ -z "$(git status --porcelain -- content/blog public/images/writing/covers)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No new cover images."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git status --porcelain -- content/blog public/images/writing/covers
+          fi
+
+      - name: Commit and push cover images
+        if: steps.check_changes.outputs.changed == 'true'
+        run: |
+          bash scripts/ci/commit-and-push-snapshot.sh \
+            "chore: refresh article cover images [automated] [skip ci]" \
+            content/blog public/images/writing/covers
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger Netlify deploy
+        if: steps.check_changes.outputs.changed == 'true'
+        env:
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
+        run: |
+          if [ -z "$NETLIFY_BUILD_HOOK" ]; then
+            echo "NETLIFY_BUILD_HOOK secret not configured; skipping deploy trigger."
+            exit 0
+          fi
+          curl -fsS -X POST -d '{}' "$NETLIFY_BUILD_HOOK" \
+            && echo "Netlify build hook triggered." \
+            || echo "::warning::Netlify build hook request failed; the daily scheduled rebuild will pick up the change."
+
+      - name: Create job summary
+        if: always()
+        run: |
+          echo "## Article Cover Image Refresh" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Status:** ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Run Date:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.check_changes.outputs.changed }}" = "true" ]; then
+            echo "**Result:** New cover images committed." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Result:** All planned covers already present." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,11 @@ The MLB, NBA, and NFL dashboards read committed TypeScript snapshots at runtime.
 - `npm run update:spacex` and its alias `npm run update:spacex-data` write `src/data/spacexSnapshot.generated.json`.
 - `npm run update:spacex-images` writes `src/data/spacexImageManifest.generated.json`, `public/data/spacex/image-reference-index.json`, and cached image files under `public/data/spacex/images/`.
 
+### Article cover image workflow
+
+- `npm run update:article-images` gives blog posts a real, license-safe cover photo in place of the generated `/writing/<slug>/opengraph-image` card, per the plan in `scripts/data/articleCoverImages.ts` (one entry per published slug). It fetches freely licensed photos from Wikimedia Commons, saves them under `public/images/writing/covers/`, and writes the `coverImage*` frontmatter. Pass `--only=<slug>` when publishing a single post, `--force` to re-fetch, or `--dry-run` to preview.
+- The agent sandbox blocks image hosts, so this runs in the `update-article-images.yml` Action or on a networked machine, not in-session. Adding a post means adding its plan entry in the same change; abstract pieces intentionally keep the editorial card. Full runbook: `docs/ARTICLE_IMAGE_WORKFLOW.md`.
+
 ### Build and asset workflow
 
 - `npm run build` runs `prebuild`, `next build --webpack`, and npm `postbuild`
@@ -381,6 +386,7 @@ The MLB, NBA, and NFL dashboards read committed TypeScript snapshots at runtime.
 | `npm run update:spacex` | Rebuild the checked-in SpaceX Mission Control data snapshot |
 | `npm run update:spacex-data` | Alias of `npm run update:spacex` |
 | `npm run update:spacex-images` | Rebuild cached SpaceX image snapshots and manifests |
+| `npm run update:article-images` | Fetch license-safe blog cover photos per `scripts/data/articleCoverImages.ts` |
 | `npm run generate:icons` | Regenerate PWA icons |
 
 ---
@@ -404,6 +410,7 @@ Checked-in operational workflows:
 - `.github/workflows/update-world-cup.yml`
 - `.github/workflows/update-bay-area-transit.yml`
 - `.github/workflows/update-earthquake.yml`
+- `.github/workflows/update-article-images.yml`
 - `netlify/functions/purge-cache.ts`
 
 Current behavior:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,15 @@ Shared conventions worth internalizing:
   from the route page — `ProjectsContent.tsx` still exists but is **not** the live path.
 - Writing posts live in `content/blog/`; `src/lib/blog.ts` reads frontmatter and
   converts MD/MDX to HTML via `remark`. Live routes: `/writing`, `/writing/[slug]`.
+- **Cover images are part of publishing, not an afterthought.** Every post has a
+  plan entry in `scripts/data/articleCoverImages.ts` (one per slug): a `wikimedia`
+  photo (fetched license-safe by `npm run update:article-images`, saved to
+  `public/images/writing/covers/`, written into `coverImage*` frontmatter), an
+  `editorial-card` for abstract pieces that keep the generated
+  `/writing/<slug>/opengraph-image`, or a hand-curated `manual` photo. When you
+  add a post, add its plan entry in the same change. The fetch is blocked in the
+  agent sandbox (image hosts are egress-denied) and runs in CI or locally.
+  Runbook: `docs/ARTICLE_IMAGE_WORKFLOW.md`.
 
 ### Browser-persisted tools
 
@@ -225,6 +234,7 @@ Subsystem references:
 - `PERSONAL_INTEREST_TOOLS.md` — the browser-persisted localStorage tools
 - `RETIREMENT_PLANNER_ENGINE.md` — the pure projection/Monte Carlo engine
 - `docs/DATA_UPDATE_OPERATIONS.md` — command → artifact → schedule runbook for every refresh
+- `docs/ARTICLE_IMAGE_WORKFLOW.md` — blog cover-image plan, the fetch builder, and the writing-time step
 
 **Legacy / historical** (keep for traceability; do not quote as current without checking
 code): `docs/archive/*` (incl. `docs/archive/plans/*`), `content-redesign/*`, root-level

--- a/docs/ARTICLE_IMAGE_WORKFLOW.md
+++ b/docs/ARTICLE_IMAGE_WORKFLOW.md
@@ -1,0 +1,81 @@
+# Article cover images
+
+Every post under `content/blog` gets a cover image that shows up in the hero on
+`/writing/<slug>` and on the listing cards. Historically most posts fell back to
+`/writing/<slug>/opengraph-image`, an auto-generated typographic card, and only
+the World Cup contender posts carried a real photo. This system replaces that
+placeholder with a real, license-safe photo wherever a post has a genuine
+subject to picture, and keeps the editorial card on purpose where it does not.
+
+The plan for all of this lives in one file, `scripts/data/articleCoverImages.ts`.
+It lists every published slug exactly once so nothing is silently skipped, and it
+assigns each one a strategy. A `wikimedia` entry carries a search phrase and alt
+text, and the builder fetches a freely licensed photo for it. An `editorial-card`
+entry records why a post keeps the generated card, which is the right call for the
+abstract AI, PM-workflow, QA, and fintech-product pieces where the only available
+stock photo would be generic filler that reads worse than the clean card. A
+`manual` entry is a post whose photo is curated by hand in frontmatter, which is
+how the World Cup team photos are managed, and the builder leaves those alone.
+
+## How the builder works
+
+`npm run update:article-images` reads the plan and, for each `wikimedia` entry
+that does not already have a saved cover, searches Wikimedia Commons with the
+entry's query, picks the top result that is landscape, large enough for the
+1200x630 hero, and published under a license that clearly permits reuse (Creative
+Commons or public domain, never anything it cannot positively identify as free).
+It saves a scaled copy under `public/images/writing/covers/<slug>.<ext>` and
+writes four frontmatter fields onto the post: `coverImage`, `coverImageAlt`,
+`coverImageCredit`, and `coverImageCreditUrl`. The credit and license come
+straight from the Commons API at fetch time, so attribution always matches the
+file that actually landed rather than anything guessed in advance.
+
+The run is fail-soft. If a search finds nothing usable or a download fails, that
+one post is logged and skipped and keeps whatever cover it already had, so a
+single unreachable image never blocks the others. Posts that already have a saved
+cover are skipped unless you pass `--force`, which makes the whole thing safe to
+re-run.
+
+One important constraint: the agent sandbox blocks outbound requests to image
+hosts, so the fetch cannot run there and will report every `wikimedia` entry as
+failed. The builder is meant to run where the network is open, which is the
+`Refresh Article Cover Images` GitHub Action or a local machine. The Action runs
+weekly to backfill covers for new articles and can be dispatched by hand to
+backfill everything, target a slug, or force a re-fetch.
+
+| Command | What it does |
+| --- | --- |
+| `npm run update:article-images` | Fetch every `wikimedia` cover that is still missing |
+| `npm run update:article-images -- --only=<slug>` | Fetch just one post's cover |
+| `npm run update:article-images -- --force` | Re-fetch even posts that already have a cover |
+| `npm run update:article-images -- --dry-run` | Print the plan with no network calls and no writes |
+
+## When you write a new article
+
+Sourcing the cover is part of publishing a post, not an afterthought. When you
+add a new file to `content/blog`, add a matching entry to
+`scripts/data/articleCoverImages.ts` in the same change. If the post has a real
+subject that a photo would serve, from a sport, to a rocket, to a city, to a
+piece of hardware, give it a `wikimedia` entry with a broad, neutral query and
+alt text that stays true for any reasonable top result. If the post is abstract
+commentary with no natural subject, give it an `editorial-card` entry with a
+short reason, which is a legitimate outcome and keeps the listing from filling up
+with stock filler.
+
+Then run `npm run update:article-images -- --only=<slug>` to pull the image and
+write the frontmatter, and open the post at `/writing/<slug>` to confirm the
+photo reads well and the credit line is right. If you are working in the agent
+sandbox where the fetch is blocked, add the plan entry anyway and let the GitHub
+Action pull the image on its next run, or run the builder on a machine with
+network access. The builder warns whenever the plan and the blog directory have
+drifted, so a post left out of the plan will not go unnoticed.
+
+## Overriding a specific image
+
+The automated search is a good default, not a mandate. If you want an exact
+image, do what the World Cup posts do: drop the file into
+`public/images/writing/covers/` (or another folder under `public/images/writing`)
+and set `coverImage`, `coverImageAlt`, `coverImageCredit`, and
+`coverImageCreditUrl` by hand, then mark the post `manual` in the plan so the
+builder does not overwrite it. Keep the attribution honest and the license free,
+since these render publicly with a visible credit line.

--- a/docs/DATA_UPDATE_OPERATIONS.md
+++ b/docs/DATA_UPDATE_OPERATIONS.md
@@ -40,6 +40,7 @@ changes.
 | SpaceX images | `update:spacex-images` | `buildSpaceXImageSnapshots.ts` | launch image assets | `src/data/spacexImageManifest.generated.json`, `public/data/spacex/*` | `update-spacex.yml` | daily 09:25 + 21:25 UTC |
 | Tech startups | `update:tech-startups` | `buildTechStartupSnapshot.ts` | curated seed *(in script)* | `src/data/techStartupSnapshot.ts` | none — curated | manual |
 | Frontier models | `update:frontier-models` | `buildFrontierModelsSnapshot.ts` | `scripts/data/frontierModels.source.ts` | `src/data/frontierModelsSnapshot.ts` | none — curated | manual |
+| Article cover images | `update:article-images` | `buildArticleCoverImages.ts` (plan: `scripts/data/articleCoverImages.ts`) | Wikimedia Commons *(no token)* | `public/images/writing/covers/*` + `content/blog/*.mdx` frontmatter | `update-article-images.yml` | weekly Mon 06:40 UTC + dispatch |
 
 **No update path (not snapshot-built):**
 - `/polling-aggregator` — static committed `src/data/pollingSnapshot.ts`, edited by hand.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "update:spacex-images": "tsx scripts/buildSpaceXImageSnapshots.ts",
     "update:fantasy": "tsx scripts/buildFantasyPositionData.ts && tsx scripts/buildFantasyAdpData.ts && tsx scripts/buildFantasySnapshots.ts",
     "update:investments": ".venv/bin/python3 scripts/fetch_investments_data.py && tsx scripts/buildInvestmentsSnapshots.ts",
+    "update:article-images": "tsx scripts/buildArticleCoverImages.ts",
     "generate:icons": "node scripts/generate-pwa-icons.mjs"
   },
   "dependencies": {

--- a/scripts/__tests__/buildArticleCoverImages.test.ts
+++ b/scripts/__tests__/buildArticleCoverImages.test.ts
@@ -1,0 +1,252 @@
+/**
+ * @jest-environment node
+ */
+import os from "os";
+import path from "path";
+import { promises as fs } from "fs";
+
+import {
+  applyCoverFrontmatter,
+  buildArticleCoverImages,
+} from "../buildArticleCoverImages";
+
+const THUMB_URL = "https://upload.wikimedia.org/thumb/example/1600px-example.jpg";
+
+function commonsSearchResponse(overrides: Record<string, unknown> = {}): Response {
+  const body = {
+    query: {
+      pages: {
+        "42": {
+          index: 1,
+          title: "File:Example.jpg",
+          imageinfo: [
+            {
+              thumburl: THUMB_URL,
+              descriptionurl: "https://commons.wikimedia.org/wiki/File:Example.jpg",
+              mime: "image/jpeg",
+              width: 1600,
+              height: 900,
+              extmetadata: {
+                License: { value: "cc-by-2.0" },
+                LicenseShortName: { value: "CC BY 2.0" },
+                Artist: { value: '<a href="/wiki/User:Jane">Jane Doe</a>' },
+                ImageDescription: { value: "An example subject" },
+                ...(overrides.extmetadata as Record<string, unknown> | undefined),
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function imageResponse(): Response {
+  return new Response(Buffer.from("fake-image-bytes", "utf8"), {
+    headers: { "content-type": "image/jpeg" },
+  });
+}
+
+/** A mock fetch that answers Commons API searches and thumbnail downloads. */
+function makeFetch(
+  searchResponse: () => Response
+): jest.MockedFunction<typeof fetch> {
+  return jest.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/w/api.php")) {
+      return searchResponse();
+    }
+    if (url === THUMB_URL) {
+      return imageResponse();
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as jest.MockedFunction<typeof fetch>;
+}
+
+async function makeProjectRoot(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "article-covers-"));
+}
+
+async function writeArticle(
+  projectRoot: string,
+  slug: string,
+  frontmatter: string
+): Promise<string> {
+  const dir = path.join(projectRoot, "content", "blog");
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `${slug}.mdx`);
+  await fs.writeFile(filePath, `${frontmatter}\n\n# ${slug}\n\nBody.\n`, "utf8");
+  return filePath;
+}
+
+const HOROLOGY_FRONTMATTER = `---
+title: "A Short History of Horology"
+excerpt: "From sundials to atomic clocks."
+publishedAt: "2026-06-09"
+category: "Essay"
+tags: ["Horology"]
+featured: false
+archiveBucket: "Signals & Commentary"
+author: "Isaac Vazquez"
+seo:
+  title: "A Short History of Horology"
+  description: "A history of timekeeping."
+---`;
+
+const EARTHQUAKE_FRONTMATTER = `---
+title: "Building an Earthquake Dashboard"
+excerpt: "A calm read on a firehose."
+publishedAt: "2026-05-01"
+category: "Data Product"
+tags: ["Dashboards"]
+featured: false
+archiveBucket: "Space & Experiments"
+author: "Isaac Vazquez"
+coverImage: "/writing/building-an-earthquake-dashboard/opengraph-image"
+---`;
+
+describe("applyCoverFrontmatter", () => {
+  const fields = {
+    coverImage: "/images/writing/covers/x.jpg",
+    coverImageAlt: "Alt text",
+    coverImageCredit: "Jane Doe, CC BY 2.0 via Wikimedia Commons",
+    coverImageCreditUrl: "https://commons.wikimedia.org/wiki/File:Example.jpg",
+  };
+
+  it("inserts the four fields after author, before seo", () => {
+    const out = applyCoverFrontmatter(HOROLOGY_FRONTMATTER, fields);
+    expect(out).toContain('coverImage: "/images/writing/covers/x.jpg"');
+    expect(out).toContain('coverImageAlt: "Alt text"');
+    expect(out).toContain(
+      'coverImageCredit: "Jane Doe, CC BY 2.0 via Wikimedia Commons"'
+    );
+    // Placed between author and the seo block.
+    expect(out.indexOf("author:")).toBeLessThan(out.indexOf("coverImage:"));
+    expect(out.indexOf("coverImage:")).toBeLessThan(out.indexOf("seo:"));
+    // Untouched fields survive.
+    expect(out).toContain('title: "A Short History of Horology"');
+  });
+
+  it("replaces an existing coverImage line in place", () => {
+    const out = applyCoverFrontmatter(EARTHQUAKE_FRONTMATTER, fields);
+    expect(out).not.toContain("opengraph-image");
+    expect(out).toContain('coverImage: "/images/writing/covers/x.jpg"');
+    // Exactly one coverImage line.
+    expect(out.match(/^coverImage:/gm)).toHaveLength(1);
+  });
+
+  it("is idempotent", () => {
+    const once = applyCoverFrontmatter(HOROLOGY_FRONTMATTER, fields);
+    const twice = applyCoverFrontmatter(once, fields);
+    expect(twice).toEqual(once);
+  });
+});
+
+describe("buildArticleCoverImages", () => {
+  it("downloads a photo and writes attribution for a wikimedia entry", async () => {
+    const projectRoot = await makeProjectRoot();
+    await writeArticle(projectRoot, "a-history-of-horology", HOROLOGY_FRONTMATTER);
+    const fetchImpl = makeFetch(() => commonsSearchResponse());
+
+    const result = await buildArticleCoverImages({
+      projectRoot,
+      fetchImpl,
+      only: ["a-history-of-horology"],
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+
+    expect(result.updated).toEqual(["a-history-of-horology"]);
+    expect(result.failed).toEqual([]);
+
+    const savedImage = path.join(
+      projectRoot,
+      "public/images/writing/covers/a-history-of-horology.jpg"
+    );
+    expect(await fs.readFile(savedImage, "utf8")).toBe("fake-image-bytes");
+
+    const article = await fs.readFile(
+      path.join(projectRoot, "content/blog/a-history-of-horology.mdx"),
+      "utf8"
+    );
+    expect(article).toContain(
+      'coverImage: "/images/writing/covers/a-history-of-horology.jpg"'
+    );
+    expect(article).toContain(
+      'coverImageCredit: "Jane Doe, CC BY 2.0 via Wikimedia Commons"'
+    );
+    expect(article).toContain(
+      'coverImageCreditUrl: "https://commons.wikimedia.org/wiki/File:Example.jpg"'
+    );
+  });
+
+  it("skips a post that already has a cover unless forced", async () => {
+    const projectRoot = await makeProjectRoot();
+    await writeArticle(projectRoot, "a-history-of-horology", HOROLOGY_FRONTMATTER);
+    const coversDir = path.join(projectRoot, "public/images/writing/covers");
+    await fs.mkdir(coversDir, { recursive: true });
+    await fs.writeFile(
+      path.join(coversDir, "a-history-of-horology.jpg"),
+      "existing"
+    );
+    const fetchImpl = makeFetch(() => commonsSearchResponse());
+
+    const result = await buildArticleCoverImages({
+      projectRoot,
+      fetchImpl,
+      only: ["a-history-of-horology"],
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+
+    expect(result.skipped).toEqual(["a-history-of-horology"]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("fails soft when only non-free images match, leaving frontmatter intact", async () => {
+    const projectRoot = await makeProjectRoot();
+    const articlePath = await writeArticle(
+      projectRoot,
+      "a-history-of-horology",
+      HOROLOGY_FRONTMATTER
+    );
+    const fetchImpl = makeFetch(() =>
+      commonsSearchResponse({
+        extmetadata: {
+          License: { value: "fair use" },
+          LicenseShortName: { value: "Fair use" },
+        },
+      })
+    );
+
+    const result = await buildArticleCoverImages({
+      projectRoot,
+      fetchImpl,
+      only: ["a-history-of-horology"],
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+
+    expect(result.updated).toEqual([]);
+    expect(result.failed).toHaveLength(1);
+    expect(await fs.readFile(articlePath, "utf8")).toEqual(
+      `${HOROLOGY_FRONTMATTER}\n\n# a-history-of-horology\n\nBody.\n`
+    );
+  });
+
+  it("leaves editorial-card and manual entries untouched", async () => {
+    const projectRoot = await makeProjectRoot();
+    const fetchImpl = makeFetch(() => commonsSearchResponse());
+
+    const result = await buildArticleCoverImages({
+      projectRoot,
+      fetchImpl,
+      only: ["is-rag-dead-2026", "world-cup-2026-contenders-1-spain"],
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+
+    expect(result.keptCard).toEqual(["is-rag-dead-2026"]);
+    expect(result.manual).toEqual(["world-cup-2026-contenders-1-spain"]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/buildArticleCoverImages.ts
+++ b/scripts/buildArticleCoverImages.ts
@@ -1,0 +1,545 @@
+#!/usr/bin/env tsx
+/**
+ * Gives each blog post a real, license-safe cover photo in place of the
+ * auto-generated `/writing/<slug>/opengraph-image` editorial card.
+ *
+ *   npm run update:article-images                 # every wikimedia entry missing a photo
+ *   npm run update:article-images -- --only=slug  # a single post (used by the writing workflow)
+ *   npm run update:article-images -- --force      # re-fetch even posts that already have a photo
+ *   npm run update:article-images -- --dry-run    # report the plan; no network, no writes
+ *
+ * The plan lives in `scripts/data/articleCoverImages.ts`. For each `wikimedia`
+ * entry this searches Wikimedia Commons, picks the top freely licensed
+ * landscape photo, saves a scaled copy under `public/images/writing/covers/`,
+ * and writes the four cover-image frontmatter fields. Credit and license are
+ * read from the Commons API at fetch time, so attribution always matches the
+ * file that actually lands. `editorial-card` and `manual` entries are left
+ * alone.
+ *
+ * Fail-soft: a failed search or download for one post is logged and skipped;
+ * the post keeps whatever cover it already had. No source is hammered — a
+ * malformed 4xx fails that post immediately rather than retrying.
+ */
+
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import {
+  ARTICLE_COVER_IMAGES,
+  type ArticleCoverImageSpec,
+} from "./data/articleCoverImages";
+
+const COMMONS_API = "https://commons.wikimedia.org/w/api.php";
+const COVERS_DIR_SEGMENTS = ["public", "images", "writing", "covers"] as const;
+const PUBLIC_COVERS_PREFIX = "/images/writing/covers";
+const BLOG_DIR_SEGMENTS = ["content", "blog"] as const;
+const REQUEST_TIMEOUT_MS = 15_000;
+const SEARCH_RESULT_LIMIT = 20;
+const THUMB_WIDTH = 1600;
+const MIN_IMAGE_WIDTH = 800;
+// A polite, identifying UA is required by the Wikimedia API etiquette policy.
+const USER_AGENT =
+  "isaacavazquez.com article-cover-image builder (https://isaacavazquez.com)";
+
+const ALLOWED_MIME: Record<string, string> = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+};
+
+type Logger = Pick<Console, "log" | "warn" | "error">;
+
+export interface BuildArticleCoverImagesOptions {
+  projectRoot?: string;
+  fetchImpl?: typeof fetch;
+  logger?: Logger;
+  /** Restrict to these slugs (the `--only` flag). */
+  only?: string[];
+  /** Re-fetch even posts that already have a saved cover. */
+  force?: boolean;
+  /** Report the plan without any network calls or file writes. */
+  dryRun?: boolean;
+}
+
+export interface BuildArticleCoverImagesResult {
+  updated: string[];
+  skipped: string[];
+  keptCard: string[];
+  manual: string[];
+  failed: Array<{ slug: string; error: string }>;
+}
+
+interface CommonsImageInfo {
+  url?: string;
+  thumburl?: string;
+  descriptionurl?: string;
+  mime?: string;
+  width?: number;
+  height?: number;
+  extmetadata?: Record<string, { value?: string } | undefined>;
+}
+
+interface CommonsPage {
+  index?: number;
+  title?: string;
+  imageinfo?: CommonsImageInfo[];
+}
+
+interface SelectedImage {
+  downloadUrl: string;
+  extension: string;
+  alt: string;
+  credit: string;
+  creditUrl: string;
+}
+
+class CoverImageFetchError extends Error {
+  status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "CoverImageFetchError";
+    this.status = status;
+  }
+}
+
+function projectPath(projectRoot: string, segments: readonly string[]): string {
+  return path.join(projectRoot, ...segments);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Any of covers/<slug>.{jpg,png,webp} already on disk. */
+async function existingCoverPath(
+  projectRoot: string,
+  slug: string
+): Promise<string | null> {
+  for (const extension of Object.values(ALLOWED_MIME)) {
+    const candidate = projectPath(projectRoot, [
+      ...COVERS_DIR_SEGMENTS,
+      `${slug}${extension}`,
+    ]);
+    if (await fileExists(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<[^>]*>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extMetaValue(
+  info: CommonsImageInfo,
+  key: string
+): string | undefined {
+  const raw = info.extmetadata?.[key]?.value;
+  return typeof raw === "string" ? raw : undefined;
+}
+
+/**
+ * Only accept licenses that clearly permit reuse with attribution: Creative
+ * Commons (CC0/BY/BY-SA), public domain, or an explicit PD mark. Anything we
+ * cannot positively identify as free is rejected rather than guessed at.
+ */
+function isFreeLicense(info: CommonsImageInfo): boolean {
+  const license = (extMetaValue(info, "License") ?? "").toLowerCase();
+  const shortName = (extMetaValue(info, "LicenseShortName") ?? "").toLowerCase();
+  const haystack = `${license} ${shortName}`;
+  if (/non-?free|fair use|copyright|all rights reserved/.test(haystack)) {
+    return false;
+  }
+  return (
+    license.startsWith("cc0") ||
+    license.startsWith("cc-") ||
+    license.startsWith("pd") ||
+    /public domain/.test(haystack) ||
+    /\bcc0\b/.test(haystack) ||
+    /\bcc by\b/.test(shortName)
+  );
+}
+
+function buildCredit(info: CommonsImageInfo): string {
+  const artist = extMetaValue(info, "Artist");
+  const licenseShort = extMetaValue(info, "LicenseShortName");
+  const artistPlain = artist ? stripHtml(artist).slice(0, 120) : "";
+  const licensePlain = licenseShort ? stripHtml(licenseShort) : "Public domain";
+  const parts = [artistPlain, licensePlain].filter(Boolean);
+  return `${parts.join(", ")} via Wikimedia Commons`;
+}
+
+async function fetchJson(
+  fetchImpl: typeof fetch,
+  url: string
+): Promise<unknown> {
+  const response = await fetchImpl(url, {
+    headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new CoverImageFetchError(
+      `Commons API responded ${response.status}`,
+      response.status
+    );
+  }
+  return response.json();
+}
+
+/** Search Commons and return the best free landscape photo for `query`. */
+async function selectCommonsImage(
+  fetchImpl: typeof fetch,
+  query: string,
+  fallbackAlt: string
+): Promise<SelectedImage | null> {
+  const params = new URLSearchParams({
+    action: "query",
+    format: "json",
+    generator: "search",
+    gsrsearch: query,
+    gsrnamespace: "6",
+    gsrlimit: String(SEARCH_RESULT_LIMIT),
+    prop: "imageinfo",
+    iiprop: "url|extmetadata|mime|size",
+    iiurlwidth: String(THUMB_WIDTH),
+  });
+  const payload = (await fetchJson(
+    fetchImpl,
+    `${COMMONS_API}?${params.toString()}`
+  )) as { query?: { pages?: Record<string, CommonsPage> } };
+
+  const pages = Object.values(payload.query?.pages ?? {}).sort(
+    (a, b) => (a.index ?? 0) - (b.index ?? 0)
+  );
+
+  const eligible = pages
+    .map((page) => page.imageinfo?.[0])
+    .filter((info): info is CommonsImageInfo => Boolean(info?.thumburl))
+    .filter((info) => Boolean(ALLOWED_MIME[info.mime ?? ""]))
+    .filter((info) => (info.width ?? 0) >= MIN_IMAGE_WIDTH)
+    .filter(isFreeLicense);
+
+  // Prefer landscape (works in the 1200x630 hero); fall back to any free hit.
+  const chosen =
+    eligible.find((info) => (info.width ?? 0) >= (info.height ?? 0)) ??
+    eligible[0];
+  if (!chosen) {
+    return null;
+  }
+
+  const description = extMetaValue(chosen, "ImageDescription");
+  const descriptionPlain = description ? stripHtml(description) : "";
+  return {
+    downloadUrl: chosen.thumburl!,
+    extension: ALLOWED_MIME[chosen.mime ?? ""] ?? ".jpg",
+    // Prefer a short real description; otherwise the manifest's generic alt.
+    alt:
+      descriptionPlain && descriptionPlain.length <= 140
+        ? descriptionPlain
+        : fallbackAlt,
+    credit: buildCredit(chosen),
+    creditUrl: chosen.descriptionurl ?? "",
+  };
+}
+
+async function downloadImage(
+  fetchImpl: typeof fetch,
+  url: string
+): Promise<Buffer> {
+  const response = await fetchImpl(url, {
+    headers: { "User-Agent": USER_AGENT, Accept: "image/*" },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new CoverImageFetchError(
+      `Image download responded ${response.status}`,
+      response.status
+    );
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+/**
+ * Insert or replace the four cover-image frontmatter fields, preserving the
+ * rest of the block and its formatting. Idempotent: running twice is a no-op.
+ * New fields are placed just after `author:` (mirroring the curated World Cup
+ * posts), otherwise before `seo:`, otherwise at the end of the block.
+ */
+export function applyCoverFrontmatter(
+  source: string,
+  fields: {
+    coverImage: string;
+    coverImageAlt: string;
+    coverImageCredit: string;
+    coverImageCreditUrl: string;
+  }
+): string {
+  const match = source.match(/^(---\r?\n)([\s\S]*?)(\r?\n---\r?\n?)/);
+  if (!match) {
+    throw new Error("Article is missing a frontmatter block");
+  }
+  const [, open, block, close] = match;
+  const body = source.slice(match[0].length);
+  const lines = block.split(/\r?\n/);
+
+  const topLevelKey = (line: string): string | null => {
+    const keyMatch = line.match(/^([A-Za-z0-9_]+):/);
+    return keyMatch ? keyMatch[1] : null;
+  };
+
+  const pending: string[] = [];
+  for (const [key, value] of Object.entries(fields)) {
+    const yamlLine = `${key}: ${JSON.stringify(value)}`;
+    const existing = lines.findIndex((line) => topLevelKey(line) === key);
+    if (existing >= 0) {
+      lines[existing] = yamlLine;
+    } else {
+      pending.push(yamlLine);
+    }
+  }
+
+  if (pending.length > 0) {
+    const authorAt = lines.findIndex((line) => topLevelKey(line) === "author");
+    let insertAt: number;
+    if (authorAt >= 0) {
+      insertAt = authorAt + 1;
+    } else {
+      const seoAt = lines.findIndex((line) => topLevelKey(line) === "seo");
+      insertAt = seoAt >= 0 ? seoAt : lines.length;
+    }
+    lines.splice(insertAt, 0, ...pending);
+  }
+
+  return `${open}${lines.join("\n")}${close}${body}`;
+}
+
+async function resolveArticlePath(
+  projectRoot: string,
+  slug: string
+): Promise<string | null> {
+  for (const extension of [".mdx", ".md"]) {
+    const candidate = projectPath(projectRoot, [
+      ...BLOG_DIR_SEGMENTS,
+      `${slug}${extension}`,
+    ]);
+    if (await fileExists(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+async function processWikimediaEntry(
+  entry: Extract<ArticleCoverImageSpec, { strategy: "wikimedia" }>,
+  options: Required<Pick<BuildArticleCoverImagesOptions, "force" | "dryRun">> & {
+    projectRoot: string;
+    fetchImpl: typeof fetch;
+    logger: Logger;
+  }
+): Promise<"updated" | "skipped"> {
+  const { projectRoot, fetchImpl, logger, force, dryRun } = options;
+
+  const articlePath = await resolveArticlePath(projectRoot, entry.slug);
+  if (!articlePath) {
+    throw new CoverImageFetchError(`No article file for slug "${entry.slug}"`);
+  }
+
+  const alreadyDownloaded = await existingCoverPath(projectRoot, entry.slug);
+  if (alreadyDownloaded && !force) {
+    logger.log(`• ${entry.slug}: cover already present, skipping (use --force)`);
+    return "skipped";
+  }
+
+  if (dryRun) {
+    logger.log(`• ${entry.slug}: would search Commons for "${entry.query}"`);
+    return "skipped";
+  }
+
+  const selection = await selectCommonsImage(fetchImpl, entry.query, entry.alt);
+  if (!selection) {
+    throw new CoverImageFetchError(
+      `No freely licensed image found for "${entry.query}"`
+    );
+  }
+
+  const buffer = await downloadImage(fetchImpl, selection.downloadUrl);
+  const coversDir = projectPath(projectRoot, [...COVERS_DIR_SEGMENTS]);
+  await fs.mkdir(coversDir, { recursive: true });
+
+  // Store under a single canonical extension per slug; clear stale variants so
+  // a jpg->png change never leaves two covers for one post.
+  for (const extension of Object.values(ALLOWED_MIME)) {
+    if (extension !== selection.extension) {
+      await fs
+        .rm(path.join(coversDir, `${entry.slug}${extension}`), { force: true })
+        .catch(() => undefined);
+    }
+  }
+
+  const fileName = `${entry.slug}${selection.extension}`;
+  await fs.writeFile(path.join(coversDir, fileName), buffer);
+
+  const source = await fs.readFile(articlePath, "utf8");
+  const updated = applyCoverFrontmatter(source, {
+    coverImage: `${PUBLIC_COVERS_PREFIX}/${fileName}`,
+    coverImageAlt: selection.alt,
+    coverImageCredit: selection.credit,
+    coverImageCreditUrl: selection.creditUrl,
+  });
+  if (updated !== source) {
+    await fs.writeFile(articlePath, updated, "utf8");
+  }
+
+  logger.log(`✓ ${entry.slug}: ${selection.credit}`);
+  return "updated";
+}
+
+/** Warn if the manifest and the blog directory have drifted out of sync. */
+async function reportCoverage(
+  projectRoot: string,
+  logger: Logger
+): Promise<void> {
+  const blogDir = projectPath(projectRoot, [...BLOG_DIR_SEGMENTS]);
+  let files: string[];
+  try {
+    files = await fs.readdir(blogDir);
+  } catch {
+    return;
+  }
+  const slugs = new Set(
+    files
+      .filter((file) => file.endsWith(".mdx") || file.endsWith(".md"))
+      .map((file) => file.replace(/\.(mdx|md)$/, ""))
+  );
+  const planned = new Set(ARTICLE_COVER_IMAGES.map((entry) => entry.slug));
+
+  const missing = [...slugs].filter((slug) => !planned.has(slug)).sort();
+  const stale = [...planned].filter((slug) => !slugs.has(slug)).sort();
+  if (missing.length > 0) {
+    logger.warn(
+      `⚠ ${missing.length} article(s) have no cover plan (add to articleCoverImages.ts): ${missing.join(", ")}`
+    );
+  }
+  if (stale.length > 0) {
+    logger.warn(
+      `⚠ ${stale.length} cover plan entr(ies) reference missing articles: ${stale.join(", ")}`
+    );
+  }
+}
+
+export async function buildArticleCoverImages(
+  options: BuildArticleCoverImagesOptions = {}
+): Promise<BuildArticleCoverImagesResult> {
+  const projectRoot = options.projectRoot ?? process.cwd();
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const logger = options.logger ?? console;
+  const force = options.force ?? false;
+  const dryRun = options.dryRun ?? false;
+  const only = options.only && options.only.length > 0 ? new Set(options.only) : null;
+
+  const result: BuildArticleCoverImagesResult = {
+    updated: [],
+    skipped: [],
+    keptCard: [],
+    manual: [],
+    failed: [],
+  };
+
+  await reportCoverage(projectRoot, logger);
+
+  const entries = only
+    ? ARTICLE_COVER_IMAGES.filter((entry) => only.has(entry.slug))
+    : ARTICLE_COVER_IMAGES;
+
+  if (only) {
+    const unknown = [...only].filter(
+      (slug) => !ARTICLE_COVER_IMAGES.some((entry) => entry.slug === slug)
+    );
+    for (const slug of unknown) {
+      logger.warn(`⚠ ${slug}: not in the cover plan, ignoring`);
+    }
+  }
+
+  for (const entry of entries) {
+    if (entry.strategy === "manual") {
+      result.manual.push(entry.slug);
+      continue;
+    }
+    if (entry.strategy === "editorial-card") {
+      result.keptCard.push(entry.slug);
+      continue;
+    }
+    try {
+      const outcome = await processWikimediaEntry(entry, {
+        projectRoot,
+        fetchImpl,
+        logger,
+        force,
+        dryRun,
+      });
+      result[outcome].push(entry.slug);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`✗ ${entry.slug}: ${message}`);
+      result.failed.push({ slug: entry.slug, error: message });
+    }
+  }
+
+  logger.log(
+    `Article covers: ${result.updated.length} updated, ${result.skipped.length} skipped, ` +
+      `${result.keptCard.length} editorial cards, ${result.manual.length} manual, ${result.failed.length} failed.`
+  );
+
+  return result;
+}
+
+function parseCliOptions(argv: string[]): BuildArticleCoverImagesOptions {
+  const options: BuildArticleCoverImagesOptions = {};
+  for (const arg of argv) {
+    if (arg === "--force") {
+      options.force = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg.startsWith("--only=")) {
+      options.only = arg
+        .slice("--only=".length)
+        .split(",")
+        .map((slug) => slug.trim())
+        .filter(Boolean);
+    }
+  }
+  return options;
+}
+
+async function main(): Promise<void> {
+  const result = await buildArticleCoverImages(parseCliOptions(process.argv.slice(2)));
+  if (result.failed.length > 0) {
+    // Fail-soft overall, but signal partial failure for CI visibility.
+    process.exitCode = 1;
+  }
+}
+
+const isMainModule =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  main().catch((error) => {
+    console.error("Failed to build article cover images:", error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/data/articleCoverImages.ts
+++ b/scripts/data/articleCoverImages.ts
@@ -1,0 +1,219 @@
+/**
+ * Cover-image plan for every article under `content/blog`.
+ *
+ * This is the source of truth the `update:article-images` builder reads to give
+ * each post a real, license-safe cover photo instead of the auto-generated
+ * `/writing/<slug>/opengraph-image` editorial card. It also doubles as a
+ * complete coverage record: every published slug appears here exactly once, so
+ * nothing is silently skipped.
+ *
+ * Three strategies:
+ *
+ *   - `wikimedia`  Fetch a freely licensed photo from Wikimedia Commons using
+ *                  `query`, save it under `public/images/writing/covers/`, and
+ *                  write the four cover-image frontmatter fields (coverImage,
+ *                  coverImageAlt, coverImageCredit, coverImageCreditUrl). The
+ *                  builder derives credit + license from the Commons API at
+ *                  fetch time, so attribution is always accurate to the file
+ *                  that actually lands. `alt` is written verbatim — keep it
+ *                  broad enough to stay true for any top result of `query`.
+ *
+ *   - `editorial-card`  Deliberately keep the generated editorial card. Used for
+ *                  abstract commentary (AI, PM workflows, QA, fintech product
+ *                  pieces) where the only available stock photo would be generic
+ *                  filler ("laptop with code") that reads worse than the clean
+ *                  typographic card. `reason` records why.
+ *
+ *   - `manual`     A cover photo is already curated by hand in frontmatter (the
+ *                  World Cup contender team photos). The builder leaves these
+ *                  untouched.
+ *
+ * To move a post from a card to a photo, change its `strategy` to `wikimedia`
+ * and add a `query` + `alt`, then run `npm run update:article-images -- --only=<slug>`.
+ */
+
+export type ArticleCoverImageSpec =
+  | {
+      slug: string;
+      strategy: "wikimedia";
+      /** Wikimedia Commons full-text search phrase (File namespace). */
+      query: string;
+      /** Alt text written to frontmatter. Keep true for any top result. */
+      alt: string;
+    }
+  | {
+      slug: string;
+      strategy: "editorial-card";
+      reason: string;
+    }
+  | {
+      slug: string;
+      strategy: "manual";
+      note: string;
+    };
+
+const ABSTRACT_AI = "Abstract AI/agent commentary; no natural photo, stock would be filler.";
+const ABSTRACT_PM = "Abstract PM-workflow piece; no natural photo, stock would be filler.";
+const ABSTRACT_QA = "Abstract QA/engineering piece; no natural photo, stock would be filler.";
+const ABSTRACT_PRODUCT = "Product/process piece about software; no non-generic subject photo.";
+const ABSTRACT_MACRO = "Diffuse macro/markets commentary; no single neutral subject to picture.";
+const ABSTRACT_FINTECH = "Fintech product piece; only generic money/calculator stock available.";
+
+export const ARTICLE_COVER_IMAGES: ArticleCoverImageSpec[] = [
+  // ---------------------------------------------------------------------------
+  // Sports & Fantasy — concrete sport imagery
+  // ---------------------------------------------------------------------------
+  { slug: "2025-fantasy-football-draft-strategy", strategy: "wikimedia", query: "American football NFL game action", alt: "American football players during a game" },
+  { slug: "fantasy-football-beginners-complete-guide", strategy: "wikimedia", query: "American football stadium NFL game day", alt: "An American football stadium on game day" },
+  { slug: "june-fantasy-football-prep-2026", strategy: "wikimedia", query: "American football on field NFL", alt: "An American football on the field" },
+  { slug: "mastering-fantasy-football-analytics", strategy: "wikimedia", query: "American football NFL play line of scrimmage", alt: "American football players lined up for a play" },
+  { slug: "rb-vs-wr-draft-strategy-modeling-positional-value", strategy: "wikimedia", query: "American football running back NFL carry", alt: "An American football running back carrying the ball" },
+  { slug: "understanding-fantasy-football-analytics", strategy: "wikimedia", query: "American football NFL quarterback pass", alt: "An American football quarterback passing" },
+  { slug: "waiver-wire-mastery-hidden-gems", strategy: "wikimedia", query: "American football wide receiver NFL catch", alt: "An American football receiver making a catch" },
+  { slug: "building-a-fantasy-football-rankings-platform", strategy: "wikimedia", query: "American football NFL huddle team", alt: "An American football team on the field" },
+
+  { slug: "2026-march-madness-bracket-analysis", strategy: "wikimedia", query: "NCAA college basketball tournament game", alt: "College basketball players during a game" },
+  { slug: "2026-march-madness-postmortem", strategy: "wikimedia", query: "college basketball arena crowd game", alt: "A packed arena during a college basketball game" },
+
+  { slug: "building-a-fantasy-formula-1-optimizer", strategy: "wikimedia", query: "Formula 1 car racing Grand Prix", alt: "A Formula 1 car during a Grand Prix" },
+  { slug: "building-a-formula-1-dashboard", strategy: "wikimedia", query: "Formula 1 Grand Prix cars circuit", alt: "Formula 1 cars racing on a circuit" },
+
+  { slug: "building-a-la-liga-dashboard", strategy: "wikimedia", query: "football soccer match stadium Spain", alt: "A football match at a packed stadium" },
+  { slug: "building-a-premier-league-dashboard", strategy: "wikimedia", query: "Premier League football stadium match", alt: "A Premier League football match at a stadium" },
+  { slug: "building-a-world-cup-dashboard", strategy: "wikimedia", query: "football soccer stadium pitch", alt: "A football stadium set for a match" },
+  { slug: "what-the-48-team-world-cup-changes", strategy: "wikimedia", query: "soccer ball football pitch stadium", alt: "A football on the pitch at a stadium" },
+  { slug: "world-cup-2026-groups-a-b-c-decided", strategy: "wikimedia", query: "football soccer stadium crowd fans", alt: "A football stadium filled with fans" },
+  { slug: "world-cup-2026-groups-d-e-f-final-round", strategy: "wikimedia", query: "football soccer match action players", alt: "Action from a football match" },
+  { slug: "world-cup-2026-groups-g-h-i-final-round", strategy: "wikimedia", query: "football soccer pitch players match", alt: "Players on a football pitch" },
+  { slug: "world-cup-2026-groups-j-k-l-final-round", strategy: "wikimedia", query: "football soccer goal net pitch", alt: "A football and goal net" },
+  { slug: "world-cup-2026-top-ten-contenders", strategy: "wikimedia", query: "football soccer stadium match large", alt: "A football match at a large stadium" },
+
+  { slug: "building-a-pga-tour-dashboard", strategy: "wikimedia", query: "golf tournament player green PGA", alt: "A golfer on the green during a tournament" },
+  { slug: "building-an-mlb-dashboard", strategy: "wikimedia", query: "MLB baseball stadium game", alt: "A Major League Baseball game at a stadium" },
+  { slug: "building-an-nba-dashboard", strategy: "wikimedia", query: "NBA basketball arena game", alt: "An NBA basketball game at an arena" },
+  { slug: "building-an-nfl-dashboard", strategy: "wikimedia", query: "NFL football stadium game day", alt: "An NFL stadium on game day" },
+
+  // ---------------------------------------------------------------------------
+  // Signals & Commentary — concrete where a neutral subject exists
+  // ---------------------------------------------------------------------------
+  { slug: "2026-week-april-6-tariffs-trade-war-market-reaction", strategy: "wikimedia", query: "container ship cargo port shipping", alt: "A container ship at a cargo port" },
+  { slug: "2026-week-in-tech-agentic-ai-infrastructure-arms-race", strategy: "wikimedia", query: "data center server room racks", alt: "Rows of servers in a data center" },
+  { slug: "2026-week-in-tech-ai-infra-geopolitics", strategy: "wikimedia", query: "semiconductor silicon wafer microchip", alt: "A semiconductor wafer of microchips" },
+  { slug: "a-history-of-horology", strategy: "wikimedia", query: "antique mechanical pocket watch movement", alt: "The movement of an antique mechanical pocket watch" },
+  { slug: "aws-vs-azure-vs-gcp-cloud-provider-comparison", strategy: "wikimedia", query: "data center servers cloud computing", alt: "Servers in a cloud data center" },
+  { slug: "companies-and-watches-that-shaped-horology", strategy: "wikimedia", query: "luxury mechanical wristwatch", alt: "A mechanical luxury wristwatch" },
+  { slug: "is-the-ai-mega-cap-rally-a-bubble", strategy: "wikimedia", query: "New York Stock Exchange trading floor", alt: "The floor of a stock exchange" },
+  { slug: "reading-q1-2026-earnings-ai-capex-lens", strategy: "wikimedia", query: "stock exchange financial district building", alt: "A financial district and stock exchange" },
+  { slug: "spacex-ipo-case-for-going-public", strategy: "wikimedia", query: "SpaceX Falcon 9 rocket launch", alt: "A SpaceX Falcon 9 rocket launching" },
+
+  // ---------------------------------------------------------------------------
+  // Space & Experiments — concrete subjects (rockets, transit, food, wine, etc.)
+  // ---------------------------------------------------------------------------
+  { slug: "artemis-ii-first-crewed-lunar-mission", strategy: "wikimedia", query: "NASA Artemis Space Launch System rocket", alt: "NASA's Artemis Moon rocket" },
+  { slug: "building-a-bart-transit-dashboard", strategy: "wikimedia", query: "BART train Bay Area Rapid Transit", alt: "A Bay Area Rapid Transit (BART) train" },
+  { slug: "building-a-museum-log", strategy: "wikimedia", query: "art museum gallery interior", alt: "The interior gallery of an art museum" },
+  { slug: "building-a-pantry-aware-recipe-finder", strategy: "wikimedia", query: "kitchen fresh ingredients vegetables", alt: "Fresh ingredients in a kitchen" },
+  { slug: "building-a-travel-planner", strategy: "wikimedia", query: "travel suitcase map airport", alt: "A map and luggage for travel" },
+  { slug: "building-a-wine-cellar-app", strategy: "wikimedia", query: "wine cellar bottles rack", alt: "Bottles in a wine cellar" },
+  { slug: "building-an-austin-food-map", strategy: "wikimedia", query: "Austin Texas skyline downtown", alt: "The Austin, Texas skyline" },
+  { slug: "building-an-earthquake-dashboard", strategy: "wikimedia", query: "seismograph seismogram earthquake recording", alt: "A seismograph recording ground motion" },
+  { slug: "building-news-pulse-dashboard", strategy: "wikimedia", query: "stack of newspapers printed press", alt: "A stack of printed newspapers" },
+  { slug: "building-spacex-mission-control", strategy: "wikimedia", query: "SpaceX Falcon 9 rocket launch pad", alt: "A SpaceX Falcon 9 rocket at the launch pad" },
+
+  // ---------------------------------------------------------------------------
+  // Systems & Quality — one concrete framing subject
+  // ---------------------------------------------------------------------------
+  { slug: "qa-engineering-silicon-valley-uc-berkeley-mba-perspective", strategy: "wikimedia", query: "UC Berkeley campus Sather Tower", alt: "The UC Berkeley campus" },
+
+  // ---------------------------------------------------------------------------
+  // Manual — curated team photos already in frontmatter
+  // ---------------------------------------------------------------------------
+  { slug: "world-cup-2026-contenders-1-spain", strategy: "manual", note: "Wikimedia team photo curated in frontmatter." },
+  { slug: "world-cup-2026-contenders-2-france", strategy: "manual", note: "Wikimedia team photo curated in frontmatter." },
+  { slug: "world-cup-2026-contenders-3-england", strategy: "manual", note: "Wikimedia team photo curated in frontmatter." },
+  { slug: "world-cup-2026-contenders-4-argentina", strategy: "manual", note: "Wikimedia team photo curated in frontmatter." },
+  { slug: "world-cup-2026-contenders-5-brazil", strategy: "manual", note: "Wikimedia team photo curated in frontmatter." },
+  { slug: "world-cup-2026-contenders-6-portugal", strategy: "manual", note: "Wikimedia team photo curated in frontmatter." },
+  { slug: "world-cup-2026-contenders-7-germany", strategy: "manual", note: "Wikimedia team photo curated in frontmatter." },
+  { slug: "world-cup-2026-contenders-8-netherlands", strategy: "manual", note: "Wikimedia team photo curated in frontmatter." },
+  { slug: "world-cup-2026-contenders-9-morocco", strategy: "manual", note: "Wikimedia team photo curated in frontmatter." },
+  { slug: "world-cup-2026-contenders-10-belgium", strategy: "manual", note: "Wikimedia team photo curated in frontmatter." },
+
+  // ---------------------------------------------------------------------------
+  // Editorial card — abstract pieces that read better with the typographic card
+  // ---------------------------------------------------------------------------
+  // Signals & Commentary
+  { slug: "2026-week-april-6-ai-coding-tools-developer-displacement", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "2026-week-march-23-30-economy-politics", strategy: "editorial-card", reason: ABSTRACT_MACRO },
+  { slug: "agentic-ai-line-item-not-pilot", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "ai-coding-tools-developer-displacement-2026", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "ai-productivity-not-in-macro-data-yet", strategy: "editorial-card", reason: ABSTRACT_MACRO },
+  { slug: "building-a-polling-aggregator", strategy: "editorial-card", reason: "Election-polling tool; avoid charged/partisan imagery on portfolio." },
+  { slug: "building-a-tech-startup-tracker", strategy: "editorial-card", reason: ABSTRACT_PRODUCT },
+  { slug: "mcp-winning-integration-war-enterprise-default", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "new-model-economics-tier-collapse-2026", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "tech-job-market-splitting-2026-macro-backdrop", strategy: "editorial-card", reason: ABSTRACT_MACRO },
+
+  // Space & Experiments (software-only subjects)
+  { slug: "building-a-github-trending-dashboard", strategy: "editorial-card", reason: ABSTRACT_PRODUCT },
+  { slug: "building-an-mba-recruiting-tracker", strategy: "editorial-card", reason: ABSTRACT_PRODUCT },
+  { slug: "building-the-pulse-dashboard-family", strategy: "editorial-card", reason: ABSTRACT_PRODUCT },
+
+  // Agentic AI cluster
+  { slug: "agentic-ai-explained-for-product-managers", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "agentic-ai-marketing-content-workflows", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "agentic-ai-research-to-deck-workflow", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "ai-agent-delegation-failure-modes", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "ai-agents-customer-support-what-works", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "build-vs-buy-agentic-ai-platform", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "building-a-frontier-model-tracker", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "context-engineering-replacing-prompt-engineering", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "evaluate-agentic-ai-product-pm-framework", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "is-rag-dead-2026", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "mapping-the-ai-dev-tool-ecosystem", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "mcp-integration-layer-what-it-means", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "multi-agent-ai-architectures-business", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "prompt-injection-is-a-product-problem", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "reasoning-model-economics-when-to-use-which", strategy: "editorial-card", reason: ABSTRACT_AI },
+  { slug: "what-an-ai-agent-actually-costs-in-production", strategy: "editorial-card", reason: ABSTRACT_AI },
+
+  // Systems & Quality cluster
+  { slug: "ai-in-software-testing-future-of-qa", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "building-ai-powered-analytics-fantasy-football-to-enterprise", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "building-reliable-software-systems", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "complete-guide-qa-engineering", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "cybersecurity-in-age-of-ai-software-engineer-perspective", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "evals-are-the-new-test-suite", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "evolution-software-architecture-monoliths-ai-native-systems", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "getting-started-with-automated-testing", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "low-code-no-code-vs-traditional-development-when-to-choose", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "proactive-performance-intelligence", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "qa-automation-daily-deploys", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "qa-engineer-guide-testing-ai-systems", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "runningmate-platform-launch", strategy: "editorial-card", reason: ABSTRACT_PRODUCT },
+  { slug: "scaling-civic-engagement-platform", strategy: "editorial-card", reason: ABSTRACT_QA },
+  { slug: "vibe-coding-where-the-line-is", strategy: "editorial-card", reason: ABSTRACT_QA },
+
+  // PM Workflows cluster
+  { slug: "ai-competitive-analysis-workflow", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "ai-email-stakeholder-comms-pm", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "ai-prd-writing-prompts-structure", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "ai-product-discovery-workflow", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "ai-product-manager-interview-2026", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "ai-quant-cases-financial-modeling", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "ai-roadmapping-from-feedback", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "ai-skills-pm-internship-2026", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "ai-user-research-synthesis-workflow", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "ai-workflow-mba-product-manager-daily", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "building-decision-lab", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "campaign-self-service-analytics", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "digital-acquisition-strategy", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "mba-ai-misuse-how-to-stand-out", strategy: "editorial-card", reason: ABSTRACT_PM },
+  { slug: "textout-platform", strategy: "editorial-card", reason: ABSTRACT_PRODUCT },
+
+  // Fintech Product & Pricing
+  { slug: "building-a-budget-planner", strategy: "editorial-card", reason: ABSTRACT_FINTECH },
+  { slug: "building-an-investment-research-platform", strategy: "editorial-card", reason: ABSTRACT_FINTECH },
+  { slug: "interchange-iq-payment-fee-analyzer", strategy: "editorial-card", reason: ABSTRACT_FINTECH },
+  { slug: "pricing-strategy-initiative", strategy: "editorial-card", reason: ABSTRACT_FINTECH },
+];


### PR DESCRIPTION
## What this does

Most posts under `content/blog` fall back to the auto-generated `/writing/<slug>/opengraph-image` typographic card, and only the ten World Cup contender posts carry a real photo. This adds the machinery to give every post a real, license-safe cover photo where it has a genuine subject to picture, and it makes sourcing a cover part of publishing an article rather than an afterthought.

The plan lives in one file, `scripts/data/articleCoverImages.ts`, which lists all 118 published slugs exactly once so coverage is complete and auditable. `npm run update:article-images` reads that plan, searches Wikimedia Commons, downloads a freely licensed landscape photo to `public/images/writing/covers/`, and writes the four `coverImage*` frontmatter fields, with credit and license read from the Commons API at fetch time so attribution always matches the file that actually lands.

## The constraint that shaped the design

The agent sandbox blocks outbound requests to image hosts (Wikimedia, Unsplash, Pexels, and Pixabay all return 403 from the egress proxy), so the fetch cannot run in-session. The builder is built to run where the network is open, which is the new `update-article-images.yml` Action (weekly backfill plus manual dispatch) or a local machine, exactly like the existing SpaceX and fantasy fetchers. That is why this PR contains the plan, the fetcher, the Action, and the docs, but not the image binaries yet. The covers land on the first Action run (or local `npm run update:article-images`).

## Two calls I made without confirmation

I tried to confirm these first, but the question prompt failed to deliver, so I went with the recommended defaults. Both are easy to change.

Approach: a fetch-in-CI workflow rather than generating original art, because it fits the repo's snapshot-to-builder-to-Action pattern and the World Cup precedent, keeps licensing clean, and lands real photos.

Coverage: photos where a post has a concrete subject (sports, space, transit, food, wine, museums, watches, markets, data centers), and the editorial card kept on purpose for the roughly 63 abstract AI, PM-workflow, QA, and fintech-product pieces where the only stock option is generic filler. The split is 45 `wikimedia` photos, 63 `editorial-card`, 10 `manual`. To turn any card into a photo, change its `strategy` to `wikimedia` and add a `query` plus `alt`, then re-run. If you would rather every article get an image, say so and I will flip them.

## Files

- `scripts/data/articleCoverImages.ts` — the per-slug plan (source of truth and coverage record).
- `scripts/buildArticleCoverImages.ts` — the fetcher. Fail-soft (one bad post is skipped, never blocks the rest), idempotent, and supports `--only=<slug>`, `--force`, and `--dry-run`.
- `scripts/__tests__/buildArticleCoverImages.test.ts` — 7 tests exercising search, the free-license filter, download, and frontmatter insert/replace/idempotency with mocked fetch.
- `.github/workflows/update-article-images.yml` — runs the fetch and commits new covers.
- `docs/ARTICLE_IMAGE_WORKFLOW.md` — the runbook and the writing-time step, with pointers added to `AGENTS.md`, `CLAUDE.md`, and `docs/DATA_UPDATE_OPERATIONS.md`.

## How to run it

```
npm run update:article-images            # every wikimedia cover still missing
npm run update:article-images -- --only=<slug>   # a single post
npm run update:article-images -- --dry-run       # preview, no network, no writes
```

Or dispatch the `Refresh Article Cover Images` Action.

## Validation

Verified offline with the mocked-fetch test suite (7 passing) and a dry-run over all 118 posts (0 missing, 0 stale in the coverage check). A real run in-sandbox fails soft against the blocked proxy and leaves every article and image untouched, as intended. ESLint is clean on the new files. The live image fetch is the one thing that has to happen in CI or locally because Wikimedia is unreachable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhMELagw25N3Cv1YDZ6eZu

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhMELagw25N3Cv1YDZ6eZu)_