### PR TITLE
feat: World Cup 2026 knockout-stage recap articles

### DIFF
--- a/content/blog/world-cup-2026-round-of-16-recap.mdx
+++ b/content/blog/world-cup-2026-round-of-16-recap.mdx
@@ -1,0 +1,47 @@
+---
+title: "World Cup 2026 Round of 16: Norway Knock Out Brazil as the Top Half Falls Into Place"
+excerpt: "The top half of the bracket delivered the earthquake the first knockout round avoided. Norway put Brazil out, Morocco routed host Canada, France ended Paraguay's run, and England knocked out host Mexico. Here is who reached the quarterfinals and what it sets up."
+publishedAt: "2026-07-06"
+category: "Sports Analytics"
+tags: ["World Cup", "World Cup 2026", "Round of 16", "Knockout Stage", "Norway", "Brazil", "Morocco", "Sports Analytics"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/world-cup-2026-round-of-16-recap/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open World Cup Pulse"
+  description: "Every group table, the new 32-team bracket, and the full schedule update in one place as results land."
+  href: "/world-cup-2026"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "World Cup 2026 Round of 16 Recap: Norway Stun Brazil, Hosts Fall"
+  description: "A recap of the completed 2026 World Cup Round of 16 ties. Norway knock out Brazil, Morocco rout Canada, France beat Paraguay, and England end host Mexico's run, with the top half of the quarterfinal bracket now set."
+  keywords: ["World Cup 2026 Round of 16", "Norway Brazil", "World Cup 2026 quarterfinals", "Morocco Canada", "England Mexico World Cup", "World Cup 2026 bracket"]
+---
+
+# World Cup 2026 Round of 16: Norway Knock Out Brazil as the Top Half Falls Into Place
+
+The [Round of 32](/writing/world-cup-2026-round-of-32-recap) mostly protected the favorites, and I said at the time that a bracket which lets the big teams through usually settles its debts in the next round. It did not take long. The top half of the Round of 16 has played out, and it produced the single biggest result of this tournament so far, along with two host nations going home on back-to-back nights. The bottom half is still to come over the next day, so treat this as the first verdicts rather than the full round, but the first verdicts are loud. You can see the reseeded quarterfinal draw on my [World Cup dashboard](/world-cup-2026) as it fills in.
+
+## Norway put Brazil out, and it was not a smash-and-grab
+
+I had [Brazil](/world-cup-2026?team=brazil) fifth in my [top ten](/world-cup-2026), and they are gone, beaten two-one by [Norway](/world-cup-2026?team=norway) at MetLife. This is the result that reorders the tournament. Norway were the team I flagged in the last round for winning ugly against [Ivory Coast](/world-cup-2026?team=ivory-coast) and not looking like a soft out, and they backed it up in the only way that counts, by taking the lead against a genuine favorite and refusing to give it back. Brazil got one goal but never the equalizer, and a two-one that felt closer to comfortable than the scoreline suggests is exactly the kind of loss that ends a Brazilian cycle.
+
+I try not to lurch from underrating a team to overrating them on the back of one night, so I will say the measured thing. Norway did not steal this. They led, they defended a lead against a side that is supposed to break defenses like theirs, and they are now a quarterfinalist with every right to be there. Brazil, meanwhile, become the third of my pre-tournament top ten to exit, after Germany and the Netherlands went out on penalties a round earlier, and that is three of the ten teams I thought could win it all already eliminated before the last eight is even set.
+
+## Morocco keep rolling, and France do the professional thing
+
+The rest of the top half went closer to form, but not without weight. [Morocco](/world-cup-2026?team=morocco) followed up knocking out the Netherlands by routing host [Canada](/world-cup-2026?team=canada) three-nil, and a team I had ninth is now through to the quarterfinals having beaten a top-eight side and then dismantled a host on the road. I keep waiting for the giant-killing run to run out of road, and it keeps not happening, which at some point stops being a run and starts being who Morocco are.
+
+[France](/world-cup-2026?team=france) took care of [Paraguay](/world-cup-2026?team=paraguay) one-nil, which is the least dramatic sentence in this recap and, if you back France, the most reassuring. Paraguay had knocked out Germany from the spot in the previous round, so this was not a gimme, and France answered it the way the best teams answer a dangerous underdog, by winning the game without ever letting it become the kind of game the underdog wants. One-nil is not a statement, but advancing while barely raising your heart rate in July is its own kind of statement.
+
+## England end host Mexico's run in the thriller of the round
+
+The one that will sting for the neutral hosts was [Mexico](/world-cup-2026?team=mexico) going out three-two to [England](/world-cup-2026?team=england) at Estadio Banorte. Mexico came into the knockouts with the cleanest group-stage record in the field, three wins and no goals conceded, and they finally met a side that could both take the crowd out of it and score enough to survive a Mexican push. Five goals in a knockout game usually means someone defended badly, and I would not hold this result up as proof England are fixing their old problems, but they scored three on the road against a host and that is a hard thing to do however you frame it.
+
+## What the top half sets up
+
+So the quarterfinal draw fills in from the top, and it is a good one. France against Morocco is the tie everyone will circle, partly because it echoes their 2022 semifinal and partly because Morocco have spent this tournament proving that echo does not have to repeat. Norway against England is the other, and after what Norway just did to Brazil I would not walk into that one assuming England stroll through. Two of the four quarterfinalists on this side, Morocco and Norway, are teams I had outside my top five, which is the clearest sign yet that this bracket is not going to hand itself to the seeds.
+
+The other half of the Round of 16 is hours away, not days. [Portugal](/world-cup-2026?team=portugal) and [Spain](/world-cup-2026?team=spain) meet in the tie of the round on paper, and [the United States](/world-cup-2026?team=united-states), [Argentina](/world-cup-2026?team=argentina), [Belgium](/world-cup-2026?team=belgium), [Egypt](/world-cup-2026?team=egypt), [Switzerland](/world-cup-2026?team=switzerland), and [Colombia](/world-cup-2026?team=colombia) close out the bottom half after that. The host angle carries over too, because with Canada and Mexico both out, the United States are the last of the three co-hosts standing, and they walk into their own Round of 16 tie carrying the whole home story on their own. I will have the bottom-half recap once those games are played. Until then, the full reseeded bracket lives on the [World Cup dashboard](/world-cup-2026).

--- a/content/blog/world-cup-2026-round-of-32-recap.mdx
+++ b/content/blog/world-cup-2026-round-of-32-recap.mdx
@@ -1,0 +1,49 @@
+---
+title: "World Cup 2026 Round of 32: The Favorites Held, But Germany and the Netherlands Did Not"
+excerpt: "The first knockout round of the 48-team World Cup mostly protected the seeds, but two of my pre-tournament top ten went out on penalties, Morocco knocked out the Netherlands, and all three hosts survived. Here is what the Round of 32 actually told me."
+publishedAt: "2026-07-04"
+category: "Sports Analytics"
+tags: ["World Cup", "World Cup 2026", "Round of 32", "Knockout Stage", "Morocco", "Germany", "Netherlands", "Sports Analytics"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+coverImage: "/writing/world-cup-2026-round-of-32-recap/opengraph-image"
+cta:
+  eyebrow: "Related tool"
+  title: "Open World Cup Pulse"
+  description: "Every group table, the new 32-team bracket, and the full schedule update in one place as results land."
+  href: "/world-cup-2026"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "World Cup 2026 Round of 32 Recap: Results, Upsets, and Who Advanced"
+  description: "A full recap of the 2026 World Cup Round of 32. Germany and the Netherlands out on penalties, Morocco's giant-killing run, France and Spain cruising, and all three hosts through to the Round of 16."
+  keywords: ["World Cup 2026 Round of 32", "World Cup 2026 knockout results", "Germany Paraguay penalties", "Morocco Netherlands", "World Cup 2026 upsets", "World Cup 2026 bracket"]
+---
+
+# World Cup 2026 Round of 32: The Favorites Held, But Germany and the Netherlands Did Not
+
+The extra knockout round is the part of the 48-team format I was most worried would feel like padding, sixteen ties bolted onto the front of the bracket mostly so more teams get a day out. What it actually produced was the round that has done the most damage so far, because two of the sides I ranked inside my pre-tournament top ten are already on planes home. Most of the favorites did their jobs, which is the honest headline, but the exceptions were big enough that the shape of this tournament looks different than it did a week ago. You can walk the full 32-team bracket on my [World Cup dashboard](/world-cup-2026), and I would keep it open while you read this, because the reseeding after these results is the whole story.
+
+## The seeds mostly held, and a couple held emphatically
+
+If you only glanced at the scores you would conclude the Round of 32 went to form, and you would be mostly right. [France](/world-cup-2026?team=france) put three past [Sweden](/world-cup-2026?team=sweden) without replying, and [Spain](/world-cup-2026?team=spain) did the same to [Austria](/world-cup-2026?team=austria), which is the two teams I had first and second in my [top ten contenders](/world-cup-2026) telling everyone they intend to be here in three weeks. Neither game was ever really a contest, and that matters at this stage, because the sides that win comfortably in the first knockout round are the ones with legs left for the sixth game.
+
+The rest of the favorites advanced without ever looking threatened. [Mexico](/world-cup-2026?team=mexico) handled [Ecuador](/world-cup-2026?team=ecuador) two-nil and carried the clean-sheet form from a flawless group stage straight into the knockouts, the [United States](/world-cup-2026?team=united-states) beat [Bosnia-Herzegovina](/world-cup-2026?team=bosnia-herzegovina) by the same score in front of a home crowd at Levi's, and [Switzerland](/world-cup-2026?team=switzerland) saw off [Algeria](/world-cup-2026?team=algeria) two-nil in Vancouver. [Colombia](/world-cup-2026?team=colombia) were the grinders of the group, a single goal past [Ghana](/world-cup-2026?team=ghana) and nothing more, but a one-nil that never felt in doubt is a perfectly good way to spend a knockout game you are supposed to win. [Brazil](/world-cup-2026?team=brazil) needed a little more to get past [Japan](/world-cup-2026?team=japan), winning two-one, and I filed that away at the time as the kind of scrappy result that tends to catch up with a favorite later. It did.
+
+## Two of my top ten went out on penalties
+
+Here is the part that actually reshaped the bracket. [Germany](/world-cup-2026?team=germany), who I had seventh, drew [Paraguay](/world-cup-2026?team=paraguay) one-one and then lost the shootout four-three, and [the Netherlands](/world-cup-2026?team=netherlands), who I had eighth, drew [Morocco](/world-cup-2026?team=morocco) one-one and lost their shootout three-two. Two of the ten teams I thought could realistically win this thing are gone before the Round of 16, and both went out in the cruelest way the sport offers, on a night where they were level after 120 minutes and then lost a coin flip with technique attached.
+
+I want to be careful not to overrate a penalty result, because a shootout is close to noise and I do not think either Germany or the Netherlands played badly enough to deserve a lecture. But the outcome is the outcome, and Morocco knocking out a top-eight side is not a fluke in the way it would have been a decade ago. I ranked Morocco ninth for a reason, and a team that can hang with the Netherlands for two hours and then hold its nerve from the spot is exactly the kind of side that ruins a bracket. The third shootout of the round sent [Australia](/world-cup-2026?team=australia) home too, [Egypt](/world-cup-2026?team=egypt) winning it four-two after another one-one, which was the quieter upset but a real one all the same.
+
+## The scares that the favorites survived
+
+A few of the teams that advanced did it with their hearts in their mouths, and those games tell me more about the Round of 16 than the routs do. [Belgium](/world-cup-2026?team=belgium) beat [Senegal](/world-cup-2026?team=senegal) three-two in the most open game of the round, which is thrilling to watch and slightly alarming if you back them to go deep, because a defense that concedes twice to Senegal will concede against the sides left in this half of the bracket. [Argentina](/world-cup-2026?team=argentina) got the same scoreline against [Cape Verde](/world-cup-2026?team=cape-verde), three-two, and a tournament favorite needing a two-goal cushion to hold off a debutant nation is the kind of result you note without panicking over. [Norway](/world-cup-2026?team=norway) came from behind to beat [Ivory Coast](/world-cup-2026?team=ivory-coast) two-one, and I mention them here rather than in the routs section on purpose, because the way they won told me they were not going to be a soft out for whoever drew them next.
+
+The rest went by without drama worth dwelling on. [England](/world-cup-2026?team=england) beat [Congo DR](/world-cup-2026?team=congo-dr) two-one, and [Portugal](/world-cup-2026?team=portugal) got past [Croatia](/world-cup-2026?team=croatia) by the same margin in Toronto, both of them doing enough and no more.
+
+## All three hosts made it through
+
+The subplot I care most about heading into the Round of 16 is that every host nation survived the first cut. [Canada](/world-cup-2026?team=canada) beat [South Africa](/world-cup-2026?team=south-africa) one-nil, and with Mexico and the United States also winning, all three co-hosts are still standing. That almost never happens, and it sets up the loudest possible middle weekend, three home crowds still with something to cheer for. The thing about hosts is that the schedule and the noise carry you exactly as far as your squad can go and not an inch further, so I was not ready to call any of the three a contender on the strength of a first-round win. The Round of 16 is where that gets tested, and it did not wait long to start testing it.
+
+If you want to see how the reseeded bracket lines up after all of this, the [World Cup dashboard](/world-cup-2026) has the full 32-team draw and the schedule for the Round of 16, which is already producing the shocks this round mostly avoided.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -140,6 +140,8 @@
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-groups-d-e-f-final-round</loc><lastmod>2026-06-25T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-groups-g-h-i-final-round</loc><lastmod>2026-06-25T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-groups-j-k-l-final-round</loc><lastmod>2026-06-25T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/world-cup-2026-round-of-16-recap</loc><lastmod>2026-07-06T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/writing/world-cup-2026-round-of-32-recap</loc><lastmod>2026-07-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-top-ten-contenders</loc><lastmod>2026-05-31T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/ai-dev-tools</loc><lastmod>2026-04-28T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/bay-area-transit</loc><lastmod>2026-07-02T19:52:48.741Z</lastmod><changefreq>hourly</changefreq><priority>0.6</priority></url>


### PR DESCRIPTION
## Summary

Adds two World Cup 2026 knockout-stage recap articles under `/writing`, both written in Isaac's voice and sourced entirely from the committed `/world-cup-2026` dashboard snapshot so they stay consistent with the live data.

- **Round of 32 recap** — covers all sixteen ties.
- **Round of 16 recap** — covers the completed top half of the bracket (Norway over Brazil, Morocco past Canada, France past Paraguay, England past Mexico); the bottom half is still to play.
- Regenerates `public/sitemap.xml` for the two new routes.

## Notes / follow-up

- These posts do **not** yet have plan entries in `scripts/data/articleCoverImages.ts` (CLAUDE.md asks for one per post). They'll fall back to the generated `/writing/<slug>/opengraph-image` until an entry is added. Worth adding an `editorial-card` or `wikimedia` entry before or after merge.

## Test plan

- [ ] `/writing` lists both new posts
- [ ] Each post renders and reads cleanly against the current snapshot
- [ ] Sitemap includes both new routes