### PR TITLE
test: expand unit coverage for data libs, SEO, blog, and route state

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,10 +33,10 @@ const customJestConfig = {
   // Start at achievable levels; ratchet upward as coverage improves.
   coverageThreshold: {
     global: {
-      branches: 49,
-      functions: 61,
-      lines: 64,
-      statements: 62,
+      branches: 52,
+      functions: 62,
+      lines: 66,
+      statements: 65,
     },
   },
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -202,7 +202,7 @@
 <url><loc>https://isaacavazquez.com/nba</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/news-pulse</loc><lastmod>2026-04-01T00:00:00.000Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/nfl</loc><lastmod>2026-07-06T00:00:00.000Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
-<url><loc>https://isaacavazquez.com/polling-aggregator</loc><lastmod>2026-07-20T07:10:26.099Z</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/polling-aggregator</loc><lastmod>2026-07-20T15:01:44.387Z</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/premier-league</loc><lastmod>2026-07-06T06:03:32.536Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/score-pools</loc><lastmod>2026-07-20T06:27:09.599Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/spacex-mission-control</loc><lastmod>2026-04-01T00:00:00.000Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>

--- a/src/app/bay-area-transit/__tests__/bay-area-transit-state.test.ts
+++ b/src/app/bay-area-transit/__tests__/bay-area-transit-state.test.ts
@@ -1,0 +1,68 @@
+import {
+  buildTransitHref,
+  DEFAULT_TRANSIT_STATE,
+  normalizeTransitState,
+  TRANSIT_ROUTE,
+} from "../bay-area-transit-state";
+
+describe("bay-area-transit-state", () => {
+  describe("normalizeTransitState", () => {
+    it("keeps valid views and falls back to the default otherwise", () => {
+      expect(normalizeTransitState({ view: "stations" }).view).toBe("stations");
+      expect(normalizeTransitState({ view: "advisories" }).view).toBe(
+        "advisories"
+      );
+      expect(normalizeTransitState({ view: "unknown" }).view).toBe(
+        DEFAULT_TRANSIT_STATE.view
+      );
+      expect(normalizeTransitState({}).view).toBe(DEFAULT_TRANSIT_STATE.view);
+    });
+
+    it("normalizes the station param to a lowercase code", () => {
+      expect(normalizeTransitState({ station: "MONT" }).station).toBe("mont");
+      expect(normalizeTransitState({ station: "  12th  " }).station).toBe("12th");
+    });
+
+    it("rejects station codes outside the allowed length or charset", () => {
+      expect(normalizeTransitState({ station: "a" }).station).toBeNull();
+      expect(normalizeTransitState({ station: "toolongcode" }).station).toBeNull();
+      expect(normalizeTransitState({ station: "no-dash" }).station).toBeNull();
+      expect(normalizeTransitState({ station: null }).station).toBeNull();
+    });
+
+    it("reads from URLSearchParams instances", () => {
+      const params = new URLSearchParams("view=stations&station=embr");
+      expect(normalizeTransitState(params)).toEqual({
+        view: "stations",
+        station: "embr",
+      });
+    });
+
+    it("reads the first entry from array-valued record params", () => {
+      expect(
+        normalizeTransitState({ view: ["advisories", "lines"], station: ["woak"] })
+      ).toEqual({ view: "advisories", station: "woak" });
+    });
+  });
+
+  describe("buildTransitHref", () => {
+    it("omits the default view and empty station", () => {
+      expect(buildTransitHref({ view: "lines", station: null })).toBe(
+        TRANSIT_ROUTE
+      );
+    });
+
+    it("encodes non-default view and station", () => {
+      expect(buildTransitHref({ view: "stations", station: "mont" })).toBe(
+        `${TRANSIT_ROUTE}?view=stations&station=mont`
+      );
+    });
+
+    it("preserves unrelated base params and clears defaults", () => {
+      const base = new URLSearchParams("ref=nav&view=stations&station=old");
+      expect(buildTransitHref({ view: "lines", station: null }, base)).toBe(
+        `${TRANSIT_ROUTE}?ref=nav`
+      );
+    });
+  });
+});

--- a/src/app/world-cup-2026/__tests__/world-cup-state.test.ts
+++ b/src/app/world-cup-2026/__tests__/world-cup-state.test.ts
@@ -1,0 +1,94 @@
+import {
+  buildWorldCupHref,
+  DEFAULT_WORLD_CUP_STATE,
+  normalizeTeamParam,
+  normalizeWorldCupState,
+  WORLD_CUP_ROUTE,
+} from "../world-cup-state";
+
+describe("world-cup-state", () => {
+  describe("normalizeTeamParam", () => {
+    it("lowercases and trims valid slugs", () => {
+      expect(normalizeTeamParam("  United-States  ")).toBe("united-states");
+      expect(normalizeTeamParam("BRAZIL")).toBe("brazil");
+    });
+
+    it("returns null for empty or malformed ids", () => {
+      expect(normalizeTeamParam(null)).toBeNull();
+      expect(normalizeTeamParam("")).toBeNull();
+      expect(normalizeTeamParam("-leading-hyphen")).toBeNull();
+      expect(normalizeTeamParam("trailing-hyphen-")).toBeNull();
+      expect(normalizeTeamParam("has space")).toBeNull();
+      expect(normalizeTeamParam("a".repeat(65))).toBeNull();
+    });
+
+    it("accepts a single-character slug", () => {
+      expect(normalizeTeamParam("x")).toBe("x");
+    });
+  });
+
+  describe("normalizeWorldCupState", () => {
+    it("keeps valid views and falls back to the default otherwise", () => {
+      expect(normalizeWorldCupState({ view: "knockout" }).view).toBe("knockout");
+      expect(normalizeWorldCupState({ view: "schedule" }).view).toBe("schedule");
+      expect(normalizeWorldCupState({ view: "bogus" }).view).toBe(
+        DEFAULT_WORLD_CUP_STATE.view
+      );
+      expect(normalizeWorldCupState({}).view).toBe(DEFAULT_WORLD_CUP_STATE.view);
+    });
+
+    it("normalizes the team param", () => {
+      expect(normalizeWorldCupState({ view: "groups", team: "USA" }).team).toBe(
+        "usa"
+      );
+      expect(normalizeWorldCupState({ team: "not valid!" }).team).toBeNull();
+    });
+
+    it("reads from URLSearchParams instances", () => {
+      const params = new URLSearchParams("view=knockout&team=mexico");
+      expect(normalizeWorldCupState(params)).toEqual({
+        view: "knockout",
+        team: "mexico",
+      });
+    });
+
+    it("reads the first entry from array-valued record params", () => {
+      expect(
+        normalizeWorldCupState({ view: ["schedule", "groups"], team: ["canada"] })
+      ).toEqual({ view: "schedule", team: "canada" });
+    });
+
+    it("treats an empty array param as absent", () => {
+      expect(normalizeWorldCupState({ view: [], team: [] })).toEqual(
+        DEFAULT_WORLD_CUP_STATE
+      );
+    });
+  });
+
+  describe("buildWorldCupHref", () => {
+    it("omits the default view and empty team", () => {
+      expect(buildWorldCupHref({ view: "groups", team: null })).toBe(
+        WORLD_CUP_ROUTE
+      );
+    });
+
+    it("encodes non-default view and valid team", () => {
+      expect(buildWorldCupHref({ view: "knockout", team: "brazil" })).toBe(
+        `${WORLD_CUP_ROUTE}?view=knockout&team=brazil`
+      );
+    });
+
+    it("drops an invalid team from the href", () => {
+      expect(buildWorldCupHref({ view: "schedule", team: "bad team" })).toBe(
+        `${WORLD_CUP_ROUTE}?view=schedule`
+      );
+    });
+
+    it("preserves unrelated base params and clears defaults", () => {
+      const base = new URLSearchParams("ref=nav&view=knockout&team=old");
+      expect(
+        buildWorldCupHref({ view: "groups", team: null }, base)
+      ).toBe(`${WORLD_CUP_ROUTE}?ref=nav`);
+    });
+  });
+});

--- a/src/components/spacex/__tests__/formatters.test.ts
+++ b/src/components/spacex/__tests__/formatters.test.ts
@@ -1,13 +1,132 @@
-import { formatCurrencyCompact } from "../formatters";
+import type { MissionLaunchCard } from "@/types/spacex";
+import {
+  formatCurrencyCompact,
+  formatInteger,
+  formatMissionMoment,
+  formatMissionScheduleLabel,
+  humanizeMissionPrecision,
+} from "../formatters";
+
+function buildLaunch(overrides: Partial<MissionLaunchCard> = {}): MissionLaunchCard {
+  return {
+    dateUtc: "2026-04-20T17:30:00.000Z",
+    datePrecision: "hour",
+    tbd: false,
+    isStaleSchedule: false,
+    ...overrides,
+  } as MissionLaunchCard;
+}
 
 describe("SpaceX formatters", () => {
-  it("formats compact launch costs without trailing zero hydration drift", () => {
-    expect(formatCurrencyCompact(52_000_000)).toBe("$52M");
-    expect(formatCurrencyCompact(52_500_000)).toBe("$52.5M");
+  describe("formatCurrencyCompact", () => {
+    it("formats compact launch costs without trailing zero hydration drift", () => {
+      expect(formatCurrencyCompact(52_000_000)).toBe("$52M");
+      expect(formatCurrencyCompact(52_500_000)).toBe("$52.5M");
+    });
+
+    it("scales into billions", () => {
+      expect(formatCurrencyCompact(2_000_000_000)).toBe("$2B");
+      expect(formatCurrencyCompact(1_200)).toBe("$1.2K");
+    });
+
+    it("keeps small currency values as standard dollar amounts", () => {
+      expect(formatCurrencyCompact(950)).toBe("$950");
+      expect(formatCurrencyCompact(null)).toBe("Unavailable");
+    });
   });
 
-  it("keeps small currency values as standard dollar amounts", () => {
-    expect(formatCurrencyCompact(950)).toBe("$950");
-    expect(formatCurrencyCompact(null)).toBe("Unavailable");
+  describe("formatInteger", () => {
+    it("adds grouping separators for finite values", () => {
+      expect(formatInteger(1234567)).toBe("1,234,567");
+      expect(formatInteger(0)).toBe("0");
+    });
+
+    it("returns a placeholder for non-finite values", () => {
+      expect(formatInteger(null)).toBe("Unavailable");
+      expect(formatInteger(Number.NaN)).toBe("Unavailable");
+    });
+  });
+
+  describe("humanizeMissionPrecision", () => {
+    it("maps known precisions to readable labels", () => {
+      expect(humanizeMissionPrecision("hour")).toBe("hour");
+      expect(humanizeMissionPrecision("day")).toBe("day");
+      expect(humanizeMissionPrecision("month")).toBe("month");
+      expect(humanizeMissionPrecision("year")).toBe("year");
+      expect(humanizeMissionPrecision("quarter")).toBe("quarter");
+      expect(humanizeMissionPrecision("half")).toBe("half-year");
+    });
+
+    it("passes unknown precisions through untouched", () => {
+      expect(humanizeMissionPrecision("decade")).toBe("decade");
+    });
+  });
+
+  describe("formatMissionMoment", () => {
+    it("includes the time for hour precision", () => {
+      const label = formatMissionMoment({
+        dateUtc: "2026-04-20T17:30:00.000Z",
+        datePrecision: "hour",
+      });
+      // Time component present (contains AM/PM marker) for hour precision.
+      expect(label).toMatch(/AM|PM/);
+    });
+
+    it("renders month/year for coarse precisions", () => {
+      const label = formatMissionMoment({
+        dateUtc: "2026-04-20T17:30:00.000Z",
+        datePrecision: "month",
+      });
+      expect(label).toContain("2026");
+      expect(label).not.toMatch(/AM|PM/);
+    });
+
+    it("renders a bare year for year precision", () => {
+      expect(
+        formatMissionMoment({
+          dateUtc: "2026-04-20T17:30:00.000Z",
+          datePrecision: "year",
+        })
+      ).toBe("2026");
+    });
+
+    it("falls back to date formatting for unknown precision", () => {
+      const label = formatMissionMoment({
+        dateUtc: "2026-04-20T17:30:00.000Z",
+        datePrecision: "unknown" as MissionLaunchCard["datePrecision"],
+      });
+      expect(label).toContain("2026");
+    });
+  });
+
+  describe("formatMissionScheduleLabel", () => {
+    it("flags a stale schedule first", () => {
+      expect(
+        formatMissionScheduleLabel(buildLaunch({ isStaleSchedule: true }))
+      ).toBe("Awaiting refreshed schedule from upstream API");
+    });
+
+    it("describes TBD launches with their precision", () => {
+      expect(
+        formatMissionScheduleLabel(
+          buildLaunch({ tbd: true, datePrecision: "month" })
+        )
+      ).toBe("Date TBD (month precision)");
+    });
+
+    it("returns a bare moment for hour precision", () => {
+      const label = formatMissionScheduleLabel(
+        buildLaunch({ datePrecision: "hour" })
+      );
+      expect(label).not.toContain("Scheduled for");
+      expect(label).toMatch(/AM|PM/);
+    });
+
+    it("prefixes coarser precisions with 'Scheduled for'", () => {
+      const label = formatMissionScheduleLabel(
+        buildLaunch({ datePrecision: "day" })
+      );
+      expect(label).toContain("Scheduled for");
+    });
   });
 });

--- a/src/lib/__tests__/ai-seo.test.ts
+++ b/src/lib/__tests__/ai-seo.test.ts
@@ -1,5 +1,13 @@
 import {
+  generateAIMetaTags,
   generateArticleSchema,
+  generateBreadcrumbSchema,
+  generateEnhancedPersonSchema,
+  generateFAQSchema,
+  generateItemListSchema,
+  generateNavigationSchema,
+  generatePageSummary,
+  generateProfessionalServiceSchema,
   generateProfilePageSchema,
   generateProjectSchema,
 } from "../ai-seo";
@@ -48,5 +56,344 @@ describe("AI SEO structured-data generators", () => {
     }) as Record<string, unknown>;
 
     expect(schema.dateModified).toBeUndefined();
+  });
+
+  it("emits profile freshness and mainEntity when a reviewed date is supplied", () => {
+    const schema = generateProfilePageSchema({
+      person: { name: "Isaac Vazquez" },
+      lastReviewed: "2026-05-01",
+    }) as Record<string, unknown>;
+
+    expect(schema.dateModified).toBe("2026-05-01");
+    expect((schema.mainEntity as Record<string, unknown>)["@type"]).toBe(
+      "Person"
+    );
+  });
+});
+
+describe("generateAIMetaTags", () => {
+  it("returns an empty object when nothing is provided", () => {
+    expect(generateAIMetaTags({})).toEqual({});
+  });
+
+  it("serializes list fields with commas and duplicates topics into article:tag", () => {
+    const tags = generateAIMetaTags({
+      expertise: ["Product", "QA"],
+      specialty: "AI products",
+      profession: "PM",
+      industry: ["SaaS", "Civic"],
+      topics: ["evals", "agents"],
+      contentType: "article",
+      context: "portfolio",
+      summary: "A short summary",
+      primaryFocus: "product strategy",
+    });
+
+    expect(tags.expertise).toBe("Product, QA");
+    expect(tags.industry).toBe("SaaS, Civic");
+    expect(tags.topics).toBe("evals, agents");
+    expect(tags["article:tag"]).toBe("evals, agents");
+    expect(tags["content-type"]).toBe("article");
+    expect(tags["primary-focus"]).toBe("product strategy");
+  });
+
+  it("skips empty arrays", () => {
+    const tags = generateAIMetaTags({ expertise: [], industry: [], topics: [] });
+    expect(tags.expertise).toBeUndefined();
+    expect(tags.topics).toBeUndefined();
+  });
+});
+
+describe("generateEnhancedPersonSchema", () => {
+  it("applies site defaults when only minimal data is supplied", () => {
+    const schema = generateEnhancedPersonSchema({}) as Record<string, unknown>;
+    expect(schema["@type"]).toBe("Person");
+    expect(Array.isArray(schema.sameAs)).toBe(true);
+    expect(schema.jobTitle).toBeUndefined();
+    expect(schema.knowsAbout).toBeUndefined();
+  });
+
+  it("maps every optional block when fully populated", () => {
+    const schema = generateEnhancedPersonSchema({
+      name: "Isaac",
+      jobTitle: "PM",
+      email: "hi@example.com",
+      telephone: "+1-555-0100",
+      address: { addressLocality: "Austin", addressRegion: "TX" },
+      knowsAbout: ["Product"],
+      expertise: [
+        {
+          name: "Testing",
+          proficiencyLevel: "Expert",
+          yearsExperience: 8,
+          description: "QA",
+        },
+      ],
+      awards: [
+        { name: "Award A", dateAwarded: "2025", awarder: "Org" },
+        { name: "Award B", awarder: { name: "Committee" } },
+      ],
+      alumniOf: [
+        {
+          "@type": "CollegeOrUniversity",
+          name: "FSU",
+          address: { addressLocality: "Tallahassee" },
+          url: "https://fsu.edu",
+          startDate: "2012",
+          endDate: "2016",
+        },
+      ],
+      worksFor: {
+        name: "Civitech",
+        description: "Civic tech",
+        url: "https://civitech.io",
+        address: { addressLocality: "Austin" },
+      },
+      hasOccupation: [
+        {
+          "@type": "Occupation",
+          name: "PM",
+          skills: ["roadmapping"],
+          responsibilities: ["strategy"],
+          occupationLocation: { "@type": "City", name: "Austin" },
+          startDate: "2020",
+          endDate: "2024",
+          employer: { name: "Civitech" },
+        },
+      ],
+      memberOf: [{ name: "PMA", description: "Assoc", url: "https://pma.org" }],
+      seeks: "Product leadership roles",
+    }) as Record<string, unknown>;
+
+    expect(schema.jobTitle).toBe("PM");
+    expect(schema.email).toBe("hi@example.com");
+    expect(schema.telephone).toBe("+1-555-0100");
+    expect((schema.address as Record<string, unknown>)["@type"]).toBe(
+      "PostalAddress"
+    );
+    expect(schema.knowsAbout).toEqual(["Product"]);
+    const credentials = schema.hasCredential as Array<Record<string, unknown>>;
+    expect(credentials[0].validFor).toBe("P8Y");
+    const awards = schema.award as Array<Record<string, unknown>>;
+    expect(awards[0].awarder).toBe("Org");
+    expect((awards[1].awarder as Record<string, unknown>).name).toBe(
+      "Committee"
+    );
+    expect((schema.alumniOf as Array<Record<string, unknown>>)[0].url).toBe(
+      "https://fsu.edu"
+    );
+    expect((schema.worksFor as Record<string, unknown>).name).toBe("Civitech");
+    expect(
+      (schema.hasOccupation as Array<Record<string, unknown>>)[0].skills
+    ).toEqual(["roadmapping"]);
+    expect((schema.memberOf as Array<Record<string, unknown>>)[0].name).toBe(
+      "PMA"
+    );
+    expect(schema.seeks).toBe("Product leadership roles");
+  });
+});
+
+describe("generateProfessionalServiceSchema", () => {
+  it("falls back to defaults when nothing is provided", () => {
+    const schema = generateProfessionalServiceSchema({}) as Record<
+      string,
+      unknown
+    >;
+    expect(schema["@type"]).toBe("ProfessionalService");
+    expect(Array.isArray(schema.serviceType)).toBe(true);
+    expect((schema.provider as Record<string, unknown>)["@type"]).toBe("Person");
+    expect(schema.audience).toBeUndefined();
+  });
+
+  it("expands the provider schema and includes an audience when given", () => {
+    const schema = generateProfessionalServiceSchema({
+      name: "Advisory",
+      provider: { name: "Isaac", jobTitle: "PM" },
+      serviceType: ["Discovery"],
+      areaServed: ["Remote"],
+      audience: { "@type": "ProfessionalAudience", audienceType: "Founders" },
+    }) as Record<string, unknown>;
+
+    expect(schema.name).toBe("Advisory");
+    expect((schema.provider as Record<string, unknown>).jobTitle).toBe("PM");
+    expect((schema.audience as Record<string, unknown>).audienceType).toBe(
+      "Founders"
+    );
+  });
+});
+
+describe("generateArticleSchema (rich fields)", () => {
+  it("normalizes images, multiple authors, keywords, and metadata blocks", () => {
+    const schema = generateArticleSchema({
+      headline: "Piece",
+      image: ["a.png", "b.png"],
+      author: [{ name: "Isaac" }, "Guest Writer"],
+      publisher: { name: "Self", url: "https://isaacavazquez.com" },
+      articleSection: "Essays",
+      articleBody: "Body text",
+      wordCount: 1200,
+      keywords: ["a", "b"],
+      about: [{ "@type": "Thing", name: "AI" }],
+      mentions: [{ "@type": "Thing", name: "Next.js" }],
+      speakable: { "@type": "SpeakableSpecification", cssSelector: [".x"] },
+      genre: "Technical",
+      audience: { "@type": "Audience", audienceType: "PMs" },
+    }) as Record<string, unknown>;
+
+    expect(schema.image).toEqual(["a.png", "b.png"]);
+    expect(Array.isArray(schema.author)).toBe(true);
+    expect((schema.author as unknown[]).length).toBe(2);
+    expect(schema.articleSection).toBe("Essays");
+    expect(schema.wordCount).toBe(1200);
+    expect(schema.keywords).toBe("a, b");
+    expect(schema.genre).toBe("Technical");
+    expect((schema.publisher as Record<string, unknown>).url).toBe(
+      "https://isaacavazquez.com"
+    );
+  });
+
+  it("unwraps a single author into an object rather than an array", () => {
+    const schema = generateArticleSchema({
+      headline: "Piece",
+      author: "Solo Author",
+      keywords: "single-string",
+    }) as Record<string, unknown>;
+
+    expect(Array.isArray(schema.author)).toBe(false);
+    expect((schema.author as Record<string, unknown>).name).toBe("Solo Author");
+    expect(schema.keywords).toBe("single-string");
+  });
+});
+
+describe("generateProjectSchema (rich fields)", () => {
+  it("derives the id from the slug and maps skills, tech, and narrative", () => {
+    const schema = generateProjectSchema({
+      name: "QA Platform",
+      description: "desc",
+      image: "cover.png",
+      author: { name: "Isaac" },
+      creator: { name: "Isaac" },
+      keywords: ["qa"],
+      programmingLanguage: ["TypeScript"],
+      applicationCategory: "DeveloperApplication",
+      about: [{ "@type": "Thing", name: "Testing" }],
+      skillsUsed: ["Playwright"],
+      problemSolved: "flaky tests",
+      solutionDescription: "stable harness",
+      impact: "faster releases",
+      technologies: ["Jest"],
+      isPartOf: { "@type": "Thing", name: "Portfolio" },
+    }) as Record<string, unknown>;
+
+    expect(schema["@id"]).toBe(
+      "https://isaacavazquez.com/portfolio/qa-platform#project"
+    );
+    expect(schema.image).toEqual(["cover.png"]);
+    expect((schema.teaches as Array<Record<string, unknown>>)[0].name).toBe(
+      "Playwright"
+    );
+    expect(schema.abstract).toContain("Problem: flaky tests");
+    expect(schema.abstract).toContain("Impact: faster releases");
+    expect((schema.mentions as Array<Record<string, unknown>>)[0].name).toBe(
+      "Jest"
+    );
+    expect(schema.isPartOf).toEqual({ "@type": "Thing", name: "Portfolio" });
+  });
+});
+
+describe("generateFAQSchema", () => {
+  it("builds question/answer pairs with optional author and date", () => {
+    const schema = generateFAQSchema([
+      { question: "Q1?", answer: "A1", dateCreated: "2026-01-01" },
+      { question: "Q2?", answer: "A2", author: { name: "Isaac" } },
+    ]) as Record<string, unknown>;
+
+    const entities = schema.mainEntity as Array<Record<string, unknown>>;
+    expect(entities).toHaveLength(2);
+    const first = entities[0].acceptedAnswer as Record<string, unknown>;
+    expect(first.dateCreated).toBe("2026-01-01");
+    const second = entities[1].acceptedAnswer as Record<string, unknown>;
+    expect((second.author as Record<string, unknown>).name).toBe("Isaac");
+  });
+});
+
+describe("generateBreadcrumbSchema", () => {
+  it("resolves relative and absolute item urls", () => {
+    const schema = generateBreadcrumbSchema([
+      { name: "Home", url: "/" },
+      { name: "External", url: "https://example.com", position: 5 },
+    ]) as Record<string, unknown>;
+
+    const items = schema.itemListElement as Array<Record<string, unknown>>;
+    expect(items[0].item).toBe("https://isaacavazquez.com/");
+    expect(items[1].item).toBe("https://example.com");
+    expect(items[1].position).toBe(5);
+  });
+});
+
+describe("generateItemListSchema", () => {
+  it("counts items and includes optional per-item fields", () => {
+    const schema = generateItemListSchema({
+      name: "Portfolio",
+      items: [
+        { name: "One", url: "/one", description: "d", image: "i.png" },
+        { name: "Two", url: "/two" },
+      ],
+    }) as Record<string, unknown>;
+
+    expect(schema.numberOfItems).toBe(2);
+    const items = schema.itemListElement as Array<Record<string, unknown>>;
+    expect(items[0].description).toBe("d");
+    expect(items[0].image).toBe("i.png");
+    expect(items[1].description).toBeUndefined();
+  });
+});
+
+describe("generateNavigationSchema", () => {
+  it("builds webpage parts with resolved ids and urls", () => {
+    const schema = generateNavigationSchema([
+      { name: "About", url: "/about" },
+      { name: "Ext", url: "https://example.com/x" },
+    ]) as Record<string, unknown>;
+
+    const parts = schema.hasPart as Array<Record<string, unknown>>;
+    expect(parts[0]["@id"]).toBe("https://isaacavazquez.com/about#webpage");
+    expect(parts[1]["@id"]).toBe("https://example.com/x#webpage");
+    expect(parts[1].url).toBe("https://example.com/x");
+  });
+});
+
+describe("generatePageSummary", () => {
+  it("produces structured and natural-language summaries with optional fields", () => {
+    const summary = generatePageSummary({
+      title: "About",
+      purpose: "introduce Isaac",
+      mainTopics: ["product", "qa"],
+      targetAudience: "recruiters",
+      keyTakeaways: ["hire him"],
+      context: "portfolio site",
+    });
+
+    expect(summary.structured.title).toBe("About");
+    expect((summary.structured as Record<string, unknown>).targetAudience).toBe(
+      "recruiters"
+    );
+    expect(summary.text).toContain('titled "About"');
+    expect(summary.text).toContain("Key takeaways: hire him");
+    expect(summary.text).not.toMatch(/\s{2,}/);
+  });
+
+  it("omits optional clauses when not provided", () => {
+    const summary = generatePageSummary({
+      title: "Now",
+      purpose: "show current work",
+      mainTopics: ["projects"],
+    });
+
+    expect(
+      (summary.structured as Record<string, unknown>).targetAudience
+    ).toBeUndefined();
+    expect(summary.text).not.toContain("Target audience");
+    expect(summary.text).not.toContain("Key takeaways");
   });
 });

--- a/src/lib/__tests__/ai-seo.test.ts
+++ b/src/lib/__tests__/ai-seo.test.ts
@@ -10,7 +10,14 @@ import {
   generateProfessionalServiceSchema,
   generateProfilePageSchema,
   generateProjectSchema,
+  type PersonSchemaData,
 } from "../ai-seo";
+
+// generateArticleSchema handles string authors/keywords at runtime (via typeof /
+// Array.isArray guards), but ArticleSchemaData types them narrower. Cast the raw
+// strings so tsc is satisfied while still exercising those runtime branches.
+const stringAuthor = (name: string) => name as unknown as PersonSchemaData;
+const stringKeywords = (value: string) => value as unknown as string[];
 
 describe("AI SEO structured-data generators", () => {
   it("does not fabricate article freshness dates", () => {
@@ -227,7 +234,7 @@ describe("generateArticleSchema (rich fields)", () => {
     const schema = generateArticleSchema({
       headline: "Piece",
       image: ["a.png", "b.png"],
-      author: [{ name: "Isaac" }, "Guest Writer"],
+      author: [{ name: "Isaac" }, stringAuthor("Guest Writer")],
       publisher: { name: "Self", url: "https://isaacavazquez.com" },
       articleSection: "Essays",
       articleBody: "Body text",
@@ -255,8 +262,8 @@ describe("generateArticleSchema (rich fields)", () => {
   it("unwraps a single author into an object rather than an array", () => {
     const schema = generateArticleSchema({
       headline: "Piece",
-      author: "Solo Author",
-      keywords: "single-string",
+      author: stringAuthor("Solo Author"),
+      keywords: stringKeywords("single-string"),
     }) as Record<string, unknown>;
 
     expect(Array.isArray(schema.author)).toBe(false);

--- a/src/lib/__tests__/blog.test.ts
+++ b/src/lib/__tests__/blog.test.ts
@@ -19,6 +19,18 @@ import {
   getBlogPostSlugs,
   getBlogPostBySlug,
   getLatestBlogPostPreviews,
+  getAllBlogPosts,
+  getAllBlogPostPreviews,
+  getBlogPostsByCategory,
+  getBlogPostsByTag,
+  getFeaturedBlogPosts,
+  getAllCategories,
+  getAllTags,
+  searchBlogPosts,
+  getRelatedBlogPosts,
+  getArchiveBlogPostPreviews,
+  getCuratedBlogPostPreviewsByCluster,
+  isBlogPostPublished,
   BlogPost,
 } from '../blog';
 
@@ -361,5 +373,186 @@ describe('filtering helpers', () => {
       expect(sorted[1].slug).toBe('post-3'); // 2024-02-01
       expect(sorted[2].slug).toBe('post-2'); // 2024-01-01
     });
+  });
+});
+
+// ─── Aggregation helpers exercised through the real exported functions ─────
+// The block above tests re-implementations of the filter logic; this block
+// drives the actual exported functions end-to-end via the fs/matter mocks so
+// getAllBlogPosts and its consumers run for real.
+
+describe('aggregation helpers (real functions)', () => {
+  type FixturePost = {
+    frontmatter: ReturnType<typeof makeFrontmatter>;
+    content?: string;
+  };
+
+  function setupPosts(postsBySlug: Record<string, FixturePost>): void {
+    const slugs = Object.keys(postsBySlug);
+    mockFs.existsSync = jest.fn().mockReturnValue(true);
+    mockFs.mkdirSync = jest.fn();
+    (mockFs.readdirSync as jest.Mock).mockReturnValue(
+      slugs.map((slug) => `${slug}.mdx`)
+    );
+    // Return the resolved path so the matter mock can recover the slug from it.
+    (mockFs.readFileSync as jest.Mock).mockImplementation((filePath: string) =>
+      String(filePath)
+    );
+    mockMatter.mockImplementation((raw: string) => {
+      const slug = slugs.find((candidate) =>
+        String(raw).includes(`${candidate}.mdx`) ||
+        String(raw).includes(`${candidate}.md`)
+      );
+      const post = slug ? postsBySlug[slug] : undefined;
+      return {
+        data: post?.frontmatter ?? {},
+        content: post?.content ?? 'body content',
+      };
+    });
+  }
+
+  const FIXTURE: Record<string, FixturePost> = {
+    'tech-a': {
+      frontmatter: makeFrontmatter({
+        title: 'Testing at Scale',
+        category: 'Tech',
+        tags: ['js', 'node'],
+        featured: true,
+        publishedAt: '2024-03-01',
+      }),
+      content: 'alpha content',
+    },
+    'tech-b': {
+      frontmatter: makeFrontmatter({
+        title: 'React Patterns',
+        category: 'Tech',
+        tags: ['js', 'react'],
+        publishedAt: '2024-02-01',
+      }),
+      content: 'beta content',
+    },
+    'product-c': {
+      frontmatter: makeFrontmatter({
+        title: 'Roadmapping',
+        category: 'Product',
+        tags: ['pm', 'strategy'],
+        publishedAt: '2024-01-01',
+      }),
+      content: 'gamma content',
+    },
+  };
+
+  beforeEach(() => {
+    setupPosts(FIXTURE);
+  });
+
+  it('getAllBlogPostPreviews returns published previews sorted newest first', () => {
+    const previews = getAllBlogPostPreviews();
+    expect(previews.map((p) => p.slug)).toEqual(['tech-a', 'tech-b', 'product-c']);
+  });
+
+  it('excludes future-dated posts from listings', () => {
+    setupPosts({
+      published: {
+        frontmatter: makeFrontmatter({ title: 'Now', publishedAt: '2024-01-01' }),
+      },
+      future: {
+        frontmatter: makeFrontmatter({ title: 'Later', publishedAt: '2999-01-01' }),
+      },
+    });
+    const previews = getAllBlogPostPreviews();
+    expect(previews.map((p) => p.slug)).toEqual(['published']);
+  });
+
+  it('getAllBlogPosts renders and sorts every published post', async () => {
+    const all = await getAllBlogPosts();
+    expect(all.map((p) => p.slug)).toEqual(['tech-a', 'tech-b', 'product-c']);
+    expect(all[0].content).toContain('Processed content');
+  });
+
+  it('getBlogPostsByCategory matches case-insensitively', async () => {
+    const tech = await getBlogPostsByCategory('tech');
+    expect(tech.map((p) => p.slug).sort()).toEqual(['tech-a', 'tech-b']);
+  });
+
+  it('getBlogPostsByTag matches case-insensitively', async () => {
+    const withReact = await getBlogPostsByTag('REACT');
+    expect(withReact.map((p) => p.slug)).toEqual(['tech-b']);
+  });
+
+  it('getFeaturedBlogPosts returns only featured posts', async () => {
+    const featured = await getFeaturedBlogPosts();
+    expect(featured.map((p) => p.slug)).toEqual(['tech-a']);
+  });
+
+  it('getAllCategories returns unique sorted categories', async () => {
+    expect(await getAllCategories()).toEqual(['Product', 'Tech']);
+  });
+
+  it('getAllTags returns unique sorted tags', async () => {
+    expect(await getAllTags()).toEqual(['js', 'node', 'pm', 'react', 'strategy']);
+  });
+
+  it('searchBlogPosts matches title and tags case-insensitively', async () => {
+    expect((await searchBlogPosts('react')).map((p) => p.slug)).toEqual([
+      'tech-b',
+    ]);
+    expect((await searchBlogPosts('roadmapping')).map((p) => p.slug)).toEqual([
+      'product-c',
+    ]);
+  });
+
+  it('getRelatedBlogPosts ranks same-category, shared-tag posts first', async () => {
+    const related = await getRelatedBlogPosts('tech-a', 2);
+    expect(related[0].slug).toBe('tech-b'); // Tech + shared 'js'
+    expect(related).toHaveLength(2);
+    expect(related.some((p) => p.slug === 'tech-a')).toBe(false);
+  });
+
+  it('getRelatedBlogPosts returns [] for an unknown slug', async () => {
+    setupPosts({});
+    expect(await getRelatedBlogPosts('missing')).toEqual([]);
+  });
+
+  it('getArchiveBlogPostPreviews returns posts without a cluster', () => {
+    const archive = getArchiveBlogPostPreviews();
+    expect(archive).toHaveLength(3);
+  });
+
+  it('getCuratedBlogPostPreviewsByCluster returns a keyed record', () => {
+    const byCluster = getCuratedBlogPostPreviewsByCluster();
+    // No fixture post declares a cluster, so every bucket is empty but present.
+    for (const value of Object.values(byCluster)) {
+      expect(Array.isArray(value)).toBe(true);
+    }
+  });
+
+  it('drops posts with invalid frontmatter instead of throwing', () => {
+    setupPosts({
+      valid: {
+        frontmatter: makeFrontmatter({ title: 'Valid', publishedAt: '2024-01-01' }),
+      },
+      broken: {
+        // Missing required title -> assertValidFrontmatter throws -> preview null.
+        frontmatter: makeFrontmatter({ title: '', publishedAt: '2024-01-01' }),
+      },
+    });
+    const previews = getAllBlogPostPreviews();
+    expect(previews.map((p) => p.slug)).toEqual(['valid']);
+  });
+});
+
+describe('isBlogPostPublished', () => {
+  it('is true when the publish date has arrived and false when it is future', () => {
+    expect(isBlogPostPublished({ publishedAt: '2024-01-01' }, '2024-06-01')).toBe(
+      true
+    );
+    expect(isBlogPostPublished({ publishedAt: '2999-01-01' }, '2024-06-01')).toBe(
+      false
+    );
+    // Same-day counts as published.
+    expect(isBlogPostPublished({ publishedAt: '2024-06-01' }, '2024-06-01')).toBe(
+      true
+    );
   });
 });

--- a/src/lib/__tests__/laLigaData.test.ts
+++ b/src/lib/__tests__/laLigaData.test.ts
@@ -1,7 +1,12 @@
 /**
  * @jest-environment node
  */
-import { getLaLigaSummary } from "../laLigaData";
+import {
+  getLaLigaSummary,
+  getLaLigaTeamSnapshot,
+  isValidLaLigaTeamId,
+  createEmptyLaLigaSnapshot,
+} from "../laLigaData";
 
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
@@ -399,5 +404,283 @@ describe("getLaLigaSummary", () => {
     // No season dates -> fallback label, and matchday defaults to 0.
     expect(summary.season).toBe("Current season");
     expect(summary.matchday).toBe(0);
+  });
+});
+
+// --- Team snapshot fixture builders ---------------------------------------
+
+/**
+ * The team-detail endpoint (`/teams/{id}`) returns the club object directly
+ * (not wrapped in `{ team }`), and carries the extra profile fields — founded,
+ * clubColors, and coach.name — that the list/fixture endpoints omit.
+ */
+function teamDetailPayload() {
+  return {
+    id: 81,
+    name: "FC Barcelona",
+    shortName: "Barça",
+    tla: "FCB",
+    crest: "https://crests.example/FCB.png",
+    venue: "Spotify Camp Nou",
+    founded: 1899,
+    clubColors: "Blue / Garnet",
+    website: "https://www.fcbarcelona.com",
+    coach: { name: "Hansi Flick" },
+  };
+}
+
+function teamFinishedMatchesPayload() {
+  return {
+    matches: [
+      // Barça win at home (HOME_TEAM winner).
+      {
+        id: 3001,
+        utcDate: "2026-01-10T20:00:00Z",
+        status: "FINISHED",
+        matchday: 20,
+        stage: "REGULAR_SEASON",
+        homeTeam: BARCA,
+        awayTeam: ATLETI,
+        score: { winner: "HOME_TEAM", fullTime: { home: 3, away: 1 } },
+      },
+      // Barça draw away.
+      {
+        id: 3002,
+        utcDate: "2026-01-17T18:30:00Z",
+        status: "FINISHED",
+        matchday: 21,
+        stage: "REGULAR_SEASON",
+        homeTeam: MADRID,
+        awayTeam: BARCA,
+        score: { winner: "DRAW", fullTime: { home: 2, away: 2 } },
+      },
+      // Barça loss at home (AWAY_TEAM winner) — newest, sorts first.
+      {
+        id: 3003,
+        utcDate: "2026-01-24T21:00:00Z",
+        status: "FINISHED",
+        matchday: 22,
+        stage: "REGULAR_SEASON",
+        homeTeam: BARCA,
+        awayTeam: MADRID,
+        score: { winner: "AWAY_TEAM", fullTime: { home: 0, away: 2 } },
+      },
+      // Malformed: missing utcDate -> normalizeFixture returns null, dropped.
+      {
+        id: 3004,
+        status: "FINISHED",
+        matchday: 19,
+        homeTeam: BARCA,
+        awayTeam: ATLETI,
+        score: { winner: "HOME_TEAM", fullTime: { home: 1, away: 0 } },
+      },
+    ],
+  };
+}
+
+function teamScheduledMatchesPayload() {
+  return {
+    matches: [
+      {
+        id: 4002,
+        utcDate: "2026-02-07T20:00:00Z",
+        status: "SCHEDULED",
+        matchday: 24,
+        homeTeam: BARCA,
+        awayTeam: ATLETI,
+        score: { winner: null, fullTime: { home: null, away: null } },
+      },
+      {
+        id: 4001,
+        utcDate: "2026-02-01T16:15:00Z",
+        status: "SCHEDULED",
+        matchday: 23,
+        homeTeam: MADRID,
+        awayTeam: BARCA,
+        score: { winner: null, fullTime: { home: null, away: null } },
+      },
+    ],
+  };
+}
+
+/**
+ * Routes the three `getLaLigaTeamSnapshot` requests. The team-detail URL
+ * (`/teams/{id}`) and the fixtures URLs (`/teams/{id}/matches?...`) both
+ * contain `/teams/`, so `/matches` is matched first.
+ */
+function routeTeamFetch(detailPayload: unknown) {
+  return (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/matches")) {
+      if (url.includes("status=FINISHED")) {
+        return Promise.resolve(jsonResponse(teamFinishedMatchesPayload()));
+      }
+      if (url.includes("status=SCHEDULED")) {
+        return Promise.resolve(jsonResponse(teamScheduledMatchesPayload()));
+      }
+    }
+    if (url.includes("/teams/")) return Promise.resolve(jsonResponse(detailPayload));
+    throw new Error(`Unexpected fetch URL in test: ${url}`);
+  };
+}
+
+describe("getLaLigaTeamSnapshot", () => {
+  const ORIGINAL_TOKEN = process.env.FOOTBALL_DATA_API_TOKEN;
+
+  beforeEach(() => {
+    process.env.FOOTBALL_DATA_API_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (ORIGINAL_TOKEN === undefined) {
+      delete process.env.FOOTBALL_DATA_API_TOKEN;
+    } else {
+      process.env.FOOTBALL_DATA_API_TOKEN = ORIGINAL_TOKEN;
+    }
+  });
+
+  it("normalizes the team profile, splits fixtures, and derives form", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementation((input: RequestInfo | URL) => routeTeamFetch(teamDetailPayload())(input));
+
+    const snapshot = await getLaLigaTeamSnapshot("81");
+
+    // Profile carries the extra team-detail fields (founded, clubColors,
+    // manager) plus the venue and TLA-resolved accent color.
+    expect(snapshot.team).toMatchObject({
+      id: "81",
+      name: "FC Barcelona",
+      shortName: "Barça",
+      tla: "FCB",
+      crest: "https://crests.example/FCB.png",
+      venue: "Spotify Camp Nou",
+      accentColor: "#A50044",
+      founded: 1899,
+      clubColors: "Blue / Garnet",
+      manager: "Hansi Flick",
+    });
+
+    // Recent fixtures newest-first, capped at 5; the malformed (no utcDate)
+    // match is dropped.
+    expect(snapshot.recentFixtures.map((f) => f.id)).toEqual(["3003", "3002", "3001"]);
+    // Upcoming fixtures soonest-first.
+    expect(snapshot.upcomingFixtures.map((f) => f.id)).toEqual(["4001", "4002"]);
+
+    // Form derived over the newest-first recent fixtures: loss (0-2 at home),
+    // draw (2-2 away), win (3-1 at home) — exercising all three branches.
+    expect(snapshot.form).toEqual({
+      sequence: ["L", "D", "W"],
+      wins: 1,
+      draws: 1,
+      losses: 1,
+      points: 4,
+      goalsFor: 5,
+      goalsAgainst: 5,
+    });
+
+    expect(typeof snapshot.generatedAt).toBe("string");
+    expect(Number.isNaN(Date.parse(snapshot.generatedAt))).toBe(false);
+  });
+
+  it("falls back on missing profile fields and handles empty fixtures", async () => {
+    // Minimal detail: no shortName (falls back to name), crest via crestUrl,
+    // no venue/founded/clubColors/coach (all null).
+    const detail = {
+      id: 78,
+      name: "Club Atlético de Madrid",
+      tla: "ATM",
+      crestUrl: "https://crests.example/ATM-alt.png",
+    };
+    jest.spyOn(global, "fetch").mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/matches")) return Promise.resolve(jsonResponse({ matches: [] }));
+      if (url.includes("/teams/")) return Promise.resolve(jsonResponse(detail));
+      throw new Error(`Unexpected fetch URL in test: ${url}`);
+    });
+
+    const snapshot = await getLaLigaTeamSnapshot("78");
+
+    expect(snapshot.team).toMatchObject({
+      id: "78",
+      name: "Club Atlético de Madrid",
+      shortName: "Club Atlético de Madrid", // no shortName -> name
+      tla: "ATM",
+      crest: "https://crests.example/ATM-alt.png", // crest -> crestUrl fallback
+      venue: null,
+      accentColor: "#CB3524",
+      founded: null,
+      clubColors: null,
+      manager: null,
+    });
+    expect(snapshot.recentFixtures).toEqual([]);
+    expect(snapshot.upcomingFixtures).toEqual([]);
+    expect(snapshot.form).toEqual({
+      sequence: [],
+      wins: 0,
+      draws: 0,
+      losses: 0,
+      points: 0,
+      goalsFor: 0,
+      goalsAgainst: 0,
+    });
+  });
+
+  it("rejects an invalid team id before hitting the network", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+    await expect(getLaLigaTeamSnapshot("bad-id")).rejects.toMatchObject({ status: 400 });
+    await expect(getLaLigaTeamSnapshot("0")).rejects.toMatchObject({ status: 400 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 404 from the upstream team-detail feed", async () => {
+    // 404 is a 4xx, so fetchFootballDataJson throws immediately with no retry
+    // backoff — keeps the test fast.
+    jest.spyOn(global, "fetch").mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/matches")) return Promise.resolve(jsonResponse({ matches: [] }));
+      if (url.includes("/teams/")) return Promise.resolve(jsonResponse({}, 404));
+      throw new Error(`Unexpected fetch URL in test: ${url}`);
+    });
+
+    await expect(getLaLigaTeamSnapshot("81")).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe("isValidLaLigaTeamId", () => {
+  it("accepts positive-integer ids and rejects everything else", () => {
+    expect(isValidLaLigaTeamId("81")).toBe(true);
+    expect(isValidLaLigaTeamId("1")).toBe(true);
+    expect(isValidLaLigaTeamId("100")).toBe(true);
+    expect(isValidLaLigaTeamId("0")).toBe(false); // zero
+    expect(isValidLaLigaTeamId("01")).toBe(false); // leading zero
+    expect(isValidLaLigaTeamId("")).toBe(false);
+    expect(isValidLaLigaTeamId("12a")).toBe(false);
+    expect(isValidLaLigaTeamId("abc")).toBe(false);
+    expect(isValidLaLigaTeamId("-5")).toBe(false);
+    expect(isValidLaLigaTeamId(" 81")).toBe(false); // leading space
+  });
+});
+
+describe("createEmptyLaLigaSnapshot", () => {
+  it("returns a fully-formed empty snapshot shell", () => {
+    const snap = createEmptyLaLigaSnapshot();
+    expect(snap).toMatchObject({
+      season: "2025/26",
+      matchday: 0,
+      sourceLabel: "football-data.org",
+      sourceUrls: { standings: "", scorers: "", assists: "" },
+      clubs: [],
+      scorers: [],
+      assists: [],
+      goalsPerMatchday: [],
+      recentFixtures: [],
+      upcomingFixtures: [],
+      teams: [],
+      teamSnapshots: {},
+    });
+    // updatedAt is today's date, YYYY-MM-DD.
+    expect(snap.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });

--- a/src/lib/__tests__/mlbData.test.ts
+++ b/src/lib/__tests__/mlbData.test.ts
@@ -1,7 +1,13 @@
 /**
  * @jest-environment node
  */
-import { getCurrentSeason, getMlbSummary } from "../mlbData";
+import {
+  getCurrentSeason,
+  getMlbSummary,
+  getMlbTeamSnapshot,
+  isValidMlbTeamId,
+  createEmptyMlbSnapshot,
+} from "../mlbData";
 
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
@@ -494,5 +500,345 @@ describe("getMlbSummary", () => {
     expect(summary.pitchingLeaders.wins).toEqual([]);
     expect(summary.pitchingLeaders.strikeouts).toEqual([]);
     expect(typeof summary.season).toBe("string");
+  });
+});
+
+// ---- Team snapshot fixtures ----------------------------------------------
+
+function teamDetailPayload() {
+  return {
+    teams: [
+      {
+        id: 147,
+        name: "New York Yankees",
+        teamName: "Yankees",
+        shortName: "NY Yankees",
+        locationName: "New York",
+        abbreviation: "NYY",
+        league: { id: AL_LEAGUE_ID, name: "American League" },
+        division: { id: 201, name: "American League East" },
+        venue: { name: "Yankee Stadium" },
+        firstYearOfPlay: "1903",
+      },
+    ],
+  };
+}
+
+function teamRecentSchedulePayload() {
+  return {
+    dates: [
+      {
+        date: "2026-06-10",
+        games: [
+          // past-1: Yankees (147) at home, win.
+          {
+            gamePk: 910001,
+            gameDate: "2026-06-10T23:05:00Z",
+            gameType: "R",
+            status: { abstractGameState: "Final", detailedState: "Final" },
+            teams: {
+              home: {
+                team: { id: 147, name: "New York Yankees", abbreviation: "NYY" },
+                score: 6,
+                isWinner: true,
+              },
+              away: {
+                team: { id: 111, name: "Boston Red Sox", abbreviation: "BOS" },
+                score: 3,
+                isWinner: false,
+              },
+            },
+          },
+        ],
+      },
+      {
+        date: "2026-06-12",
+        games: [
+          // past-2: Yankees (147) on the road, loss (home team wins).
+          {
+            gamePk: 910002,
+            gameDate: "2026-06-12T23:05:00Z",
+            gameType: "R",
+            status: { abstractGameState: "Final", detailedState: "Final" },
+            teams: {
+              home: {
+                team: { id: 111, name: "Boston Red Sox", abbreviation: "BOS" },
+                score: 5,
+                isWinner: true,
+              },
+              away: {
+                team: { id: 147, name: "New York Yankees", abbreviation: "NYY" },
+                score: 2,
+                isWinner: false,
+              },
+            },
+          },
+          // A non-final game inside the recent window must be excluded from recentGames.
+          {
+            gamePk: 910003,
+            gameDate: "2026-06-12T20:00:00Z",
+            gameType: "R",
+            status: { abstractGameState: "Live", detailedState: "In Progress" },
+            teams: {
+              home: {
+                team: { id: 147, name: "New York Yankees", abbreviation: "NYY" },
+                score: 1,
+              },
+              away: {
+                team: { id: 119, name: "Los Angeles Dodgers", abbreviation: "LAD" },
+                score: 1,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function teamUpcomingSchedulePayload() {
+  return {
+    dates: [
+      {
+        date: "2026-06-25",
+        games: [
+          // future-1: scheduled, soonest.
+          {
+            gamePk: 920001,
+            gameDate: "2026-06-25T23:05:00Z",
+            gameType: "R",
+            status: { abstractGameState: "Preview", detailedState: "Scheduled" },
+            teams: {
+              home: { team: { id: 147, name: "New York Yankees", abbreviation: "NYY" } },
+              away: { team: { id: 119, name: "Los Angeles Dodgers", abbreviation: "LAD" } },
+            },
+          },
+          // A FINISHED game inside the upcoming window must be excluded from upcomingGames.
+          {
+            gamePk: 920003,
+            gameDate: "2026-06-25T18:00:00Z",
+            gameType: "R",
+            status: { abstractGameState: "Final", detailedState: "Final" },
+            teams: {
+              home: {
+                team: { id: 147, name: "New York Yankees", abbreviation: "NYY" },
+                score: 4,
+                isWinner: true,
+              },
+              away: {
+                team: { id: 111, name: "Boston Red Sox", abbreviation: "BOS" },
+                score: 2,
+                isWinner: false,
+              },
+            },
+          },
+        ],
+      },
+      {
+        date: "2026-06-27",
+        games: [
+          // future-2: scheduled, later.
+          {
+            gamePk: 920002,
+            gameDate: "2026-06-27T23:05:00Z",
+            gameType: "R",
+            status: { abstractGameState: "Preview", detailedState: "Scheduled" },
+            teams: {
+              home: { team: { id: 111, name: "Boston Red Sox", abbreviation: "BOS" } },
+              away: { team: { id: 147, name: "New York Yankees", abbreviation: "NYY" } },
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// Routes the four endpoints getMlbTeamSnapshot can hit: the teams list (used to
+// build the lookup when none is passed), the single-team detail (/teams/:id?),
+// and the recent/upcoming schedule windows (split by their start/end dates).
+function makeTeamRouter(payloads: {
+  teams?: unknown;
+  detail: unknown;
+  recent: unknown;
+  upcoming: unknown;
+}) {
+  return async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (/\/teams\/\d+\?/.test(url)) {
+      return jsonResponse(payloads.detail);
+    }
+    if (url.includes("/teams?")) {
+      return jsonResponse(payloads.teams ?? teamsPayload());
+    }
+    if (url.includes("/schedule?")) {
+      const startMatch = url.match(/startDate=([^&]+)/);
+      const endMatch = url.match(/endDate=([^&]+)/);
+      const start = startMatch ? startMatch[1] : "";
+      const end = endMatch ? endMatch[1] : "";
+      const today = new Date().toISOString().slice(0, 10);
+      if (end && end < today) return jsonResponse(payloads.recent);
+      if (start && start >= today) return jsonResponse(payloads.upcoming);
+      return jsonResponse(payloads.recent);
+    }
+    throw new Error(`Unexpected fetch URL in test: ${url}`);
+  };
+}
+
+describe("isValidMlbTeamId", () => {
+  it("accepts positive integer ids and rejects everything else", () => {
+    expect(isValidMlbTeamId("147")).toBe(true);
+    expect(isValidMlbTeamId("1")).toBe(true);
+    expect(isValidMlbTeamId("119")).toBe(true);
+    expect(isValidMlbTeamId("0")).toBe(false); // leading zero / zero not allowed
+    expect(isValidMlbTeamId("012")).toBe(false); // leading zero
+    expect(isValidMlbTeamId("")).toBe(false);
+    expect(isValidMlbTeamId("-1")).toBe(false);
+    expect(isValidMlbTeamId("12a")).toBe(false);
+    expect(isValidMlbTeamId("1.5")).toBe(false);
+    expect(isValidMlbTeamId("abc")).toBe(false);
+    expect(isValidMlbTeamId(" 147")).toBe(false);
+  });
+});
+
+describe("createEmptyMlbSnapshot", () => {
+  it("returns a fully-shaped empty snapshot", () => {
+    const snap = createEmptyMlbSnapshot();
+
+    expect(typeof snap.season).toBe("string");
+    expect(snap.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(snap.sourceLabel).toBe("MLB Stats API");
+    expect(snap.sourceUrls.standings).toContain("statsapi.mlb.com/api/v1/standings");
+    expect(snap.sourceUrls.schedule).toContain("statsapi.mlb.com/api/v1/schedule");
+    expect(snap.sourceUrls.leaders).toContain("statsapi.mlb.com/api/v1/stats/leaders");
+
+    expect(snap.teams).toEqual([]);
+    expect(snap.standings).toEqual([]);
+    expect(snap.recentGames).toEqual([]);
+    expect(snap.upcomingGames).toEqual([]);
+    expect(snap.hittingLeaders).toEqual({
+      homeRuns: [],
+      runsBattedIn: [],
+      battingAverage: [],
+    });
+    expect(snap.pitchingLeaders).toEqual({
+      earnedRunAverage: [],
+      wins: [],
+      strikeouts: [],
+    });
+    expect(snap.teamSnapshots).toEqual({});
+  });
+});
+
+describe("getMlbTeamSnapshot", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("rejects an invalid team id before hitting the network", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+    await expect(getMlbTeamSnapshot("bad-id")).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("normalizes the profile, splits recent/upcoming games, and derives form", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementation(
+        makeTeamRouter({
+          detail: teamDetailPayload(),
+          recent: teamRecentSchedulePayload(),
+          upcoming: teamUpcomingSchedulePayload(),
+        }) as unknown as typeof fetch
+      );
+
+    const snapshot = await getMlbTeamSnapshot("147");
+
+    // --- Profile: normalized from the /teams/:id detail feed. ---
+    expect(snapshot.team).not.toBeNull();
+    expect(snapshot.team).toMatchObject({
+      id: "147",
+      name: "New York Yankees",
+      shortName: "Yankees",
+      abbreviation: "NYY",
+      league: "AL",
+      division: "AL East",
+      venue: "Yankee Stadium",
+      founded: 1903,
+      primaryColor: null,
+    });
+    expect(snapshot.team?.logo).toContain("147.svg");
+
+    // --- Recent games: only FINISHED, newest-first; live game dropped. ---
+    expect(snapshot.recentGames.map((g) => g.id)).toEqual(["910002", "910001"]);
+    expect(snapshot.recentGames.every((g) => g.status === "FINISHED")).toBe(true);
+    // Enrichment: known team lookup supplies the shortName on the home side.
+    const past1 = snapshot.recentGames.find((g) => g.id === "910001");
+    expect(past1?.homeTeam.shortName).toBe("Yankees");
+    expect(past1?.score.winner).toBe("HOME_TEAM");
+
+    // --- Upcoming games: only non-FINISHED, soonest-first; final game dropped. ---
+    expect(snapshot.upcomingGames.map((g) => g.id)).toEqual(["920001", "920002"]);
+    expect(snapshot.upcomingGames.every((g) => g.status !== "FINISHED")).toBe(true);
+
+    // --- Form: derived from the (ordered) recent games. ---
+    // Iteration order is [910002 (away loss), 910001 (home win)].
+    expect(snapshot.form.wins).toBe(1);
+    expect(snapshot.form.losses).toBe(1);
+    expect(snapshot.form.sequence).toEqual(["L", "W"]);
+    expect(snapshot.form.runsFor).toBe(8); // 2 (away) + 6 (home)
+    expect(snapshot.form.runsAgainst).toBe(8); // 5 (away) + 3 (home)
+
+    expect(typeof snapshot.generatedAt).toBe("string");
+    expect(() => new Date(snapshot.generatedAt).toISOString()).not.toThrow();
+  });
+
+  it("returns a null profile when the detail feed has no team, keeping games/form empty", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementation(
+        makeTeamRouter({
+          detail: { teams: [] },
+          recent: { dates: [] },
+          upcoming: { dates: [] },
+        }) as unknown as typeof fetch
+      );
+
+    const snapshot = await getMlbTeamSnapshot("147");
+
+    expect(snapshot.team).toBeNull();
+    expect(snapshot.recentGames).toEqual([]);
+    expect(snapshot.upcomingGames).toEqual([]);
+    expect(snapshot.form).toEqual({
+      sequence: [],
+      wins: 0,
+      losses: 0,
+      runsFor: 0,
+      runsAgainst: 0,
+    });
+  });
+
+  it("surfaces a 404 from the upstream team detail feed", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (/\/teams\/\d+\?/.test(url)) {
+          return jsonResponse({}, 404);
+        }
+        if (url.includes("/teams?")) {
+          return jsonResponse(teamsPayload());
+        }
+        if (url.includes("/schedule?")) {
+          return jsonResponse({ dates: [] });
+        }
+        throw new Error(`Unexpected fetch URL in test: ${url}`);
+      });
+
+    await expect(getMlbTeamSnapshot("147")).rejects.toMatchObject({
+      status: 404,
+    });
   });
 });

--- a/src/lib/__tests__/nbaData.test.ts
+++ b/src/lib/__tests__/nbaData.test.ts
@@ -3,6 +3,8 @@
  */
 import {
   getNbaSummary,
+  getNbaTeamSnapshot,
+  isValidNbaTeamId,
   buildSeasonLabel,
   resolveNbaSeasonEndYear,
   createEmptyNbaSnapshot,
@@ -591,6 +593,156 @@ describe("season labelling", () => {
     expect(resolveNbaSeasonEndYear(new Date("2026-09-30T00:00:00Z"))).toBe(2026); // pre-tip
     expect(resolveNbaSeasonEndYear(new Date("2026-10-15T00:00:00Z"))).toBe(2027); // new season
     expect(resolveNbaSeasonEndYear(new Date("2027-01-10T00:00:00Z"))).toBe(2027); // mid new season
+  });
+});
+
+describe("isValidNbaTeamId", () => {
+  it("accepts 2-4 character alphanumeric ids and rejects others", () => {
+    expect(isValidNbaTeamId("lal")).toBe(true);
+    expect(isValidNbaTeamId("BOS")).toBe(true);
+    expect(isValidNbaTeamId("13")).toBe(true);
+    expect(isValidNbaTeamId("a")).toBe(false); // too short
+    expect(isValidNbaTeamId("toolong")).toBe(false); // too long
+    expect(isValidNbaTeamId("la-l")).toBe(false); // hyphen
+    expect(isValidNbaTeamId("")).toBe(false);
+  });
+});
+
+describe("getNbaTeamSnapshot", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function routeTeamFetch(payloads: { schedule: unknown; detail: unknown }) {
+    return (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/schedule")) {
+        return Promise.resolve(jsonResponse(payloads.schedule));
+      }
+      if (url.includes("/teams/")) {
+        return Promise.resolve(jsonResponse(payloads.detail));
+      }
+      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`));
+    };
+  }
+
+  it("rejects an invalid team id before hitting the network", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+    await expect(getNbaTeamSnapshot("bad-id")).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("normalizes the profile, splits fixtures, and derives form from wins", async () => {
+    const detail = {
+      team: {
+        id: "13",
+        abbreviation: "LAL",
+        displayName: "Los Angeles Lakers",
+        shortDisplayName: "Lakers",
+        color: "552583",
+        logo: "https://logos.example/LAL.png",
+        venue: { fullName: "Crypto.com Arena" },
+      },
+    };
+    const schedule = {
+      team: detail.team,
+      season: { year: 2025 },
+      events: [
+        makeEvent({
+          id: "past-1",
+          date: "2026-06-10T00:00:00Z",
+          completed: true,
+          homeAbbr: "LAL",
+          homeName: "Los Angeles Lakers",
+          awayAbbr: "BOS",
+          awayName: "Boston Celtics",
+          homeScore: "110",
+          awayScore: "100",
+          homeWinner: true,
+        }),
+        makeEvent({
+          id: "past-2",
+          date: "2026-06-12T00:00:00Z",
+          completed: true,
+          homeAbbr: "DEN",
+          homeName: "Denver Nuggets",
+          awayAbbr: "LAL",
+          awayName: "Los Angeles Lakers",
+          homeScore: "120",
+          awayScore: "98",
+          homeWinner: true,
+        }),
+        makeEvent({
+          id: "future-1",
+          date: "2026-06-25T00:00:00Z",
+          completed: false,
+          homeAbbr: "LAL",
+          homeName: "Los Angeles Lakers",
+          awayAbbr: "OKC",
+          awayName: "Oklahoma City Thunder",
+        }),
+      ],
+    };
+
+    jest.spyOn(global, "fetch").mockImplementation(
+      routeTeamFetch({ schedule, detail }) as unknown as typeof fetch
+    );
+
+    const snapshot = await getNbaTeamSnapshot("lal", "west");
+
+    expect(snapshot.team?.id).toBe("lal");
+    expect(snapshot.team?.name).toBe("Los Angeles Lakers");
+    expect(snapshot.team?.conference).toBe("west");
+    expect(snapshot.team?.primaryColor).toBe("552583");
+
+    // Fixtures: two finished (newest first), one upcoming.
+    expect(snapshot.recentFixtures.map((f) => f.id)).toEqual(["past-2", "past-1"]);
+    expect(snapshot.upcomingFixtures.map((f) => f.id)).toEqual(["future-1"]);
+
+    // Form: won past-1 (home win) but lost past-2 (away, home won).
+    expect(snapshot.form.wins).toBe(1);
+    expect(snapshot.form.losses).toBe(1);
+    expect(snapshot.form.sequence).toHaveLength(2);
+    expect(typeof snapshot.generatedAt).toBe("string");
+  });
+
+  it("falls back to the schedule team when the detail feed has no team", async () => {
+    const scheduleTeam = {
+      id: "2",
+      abbreviation: "BOS",
+      displayName: "Boston Celtics",
+      shortDisplayName: "Celtics",
+      logo: "https://logos.example/BOS.png",
+    };
+    jest.spyOn(global, "fetch").mockImplementation(
+      routeTeamFetch({
+        schedule: { team: scheduleTeam, events: [] },
+        detail: { team: null },
+      }) as unknown as typeof fetch
+    );
+
+    const snapshot = await getNbaTeamSnapshot("bos");
+    expect(snapshot.team?.id).toBe("bos");
+    expect(snapshot.recentFixtures).toEqual([]);
+    expect(snapshot.form.sequence).toEqual([]);
+  });
+
+  it("surfaces a 404 from the upstream schedule feed", async () => {
+    jest.spyOn(global, "fetch").mockImplementation(
+      ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/schedule")) {
+          return Promise.resolve(jsonResponse({}, 404));
+        }
+        return Promise.resolve(jsonResponse({ team: null }));
+      }) as unknown as typeof fetch
+    );
+
+    await expect(getNbaTeamSnapshot("lal")).rejects.toMatchObject({
+      status: 404,
+    });
   });
 });
 

--- a/src/lib/__tests__/premierLeagueData.test.ts
+++ b/src/lib/__tests__/premierLeagueData.test.ts
@@ -1,7 +1,14 @@
 /**
  * @jest-environment node
  */
-import { getPremierLeagueSummary, sumPlayedGames } from "../premierLeagueData";
+import {
+  getPremierLeagueSummary,
+  getPremierLeagueTeamSnapshot,
+  isValidPremierLeagueTeamId,
+  createEmptyPremierLeagueSummary,
+  createEmptyPremierLeagueTeamSnapshot,
+  sumPlayedGames,
+} from "../premierLeagueData";
 
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
@@ -411,5 +418,295 @@ describe("getPremierLeagueSummary", () => {
     expect(summary.goalsPerMatchday).toEqual([]);
     // Falls back to the default season label when dates are absent.
     expect(summary.competition?.seasonLabel).toBe("Current season");
+  });
+});
+
+describe("sumPlayedGames edge cases", () => {
+  it("treats a missing/nullish playedGames as zero", () => {
+    // The `?? 0` guard: rows whose playedGames is absent (older/partial upstream
+    // rows) must not turn the running total into NaN.
+    expect(
+      sumPlayedGames([
+        { playedGames: undefined as unknown as number },
+        { playedGames: 12 },
+      ])
+    ).toBe(12);
+    expect(
+      sumPlayedGames([{ playedGames: null as unknown as number }])
+    ).toBe(0);
+  });
+});
+
+describe("isValidPremierLeagueTeamId", () => {
+  it("accepts positive integer id strings", () => {
+    expect(isValidPremierLeagueTeamId("57")).toBe(true);
+    expect(isValidPremierLeagueTeamId("1")).toBe(true);
+    expect(isValidPremierLeagueTeamId("64")).toBe(true);
+    expect(isValidPremierLeagueTeamId("1000")).toBe(true);
+  });
+
+  it("rejects zero, leading zeros, non-numeric, and empty ids", () => {
+    expect(isValidPremierLeagueTeamId("0")).toBe(false);
+    expect(isValidPremierLeagueTeamId("01")).toBe(false);
+    expect(isValidPremierLeagueTeamId("abc")).toBe(false);
+    expect(isValidPremierLeagueTeamId("")).toBe(false);
+    expect(isValidPremierLeagueTeamId("-5")).toBe(false);
+    expect(isValidPremierLeagueTeamId("1.5")).toBe(false);
+    expect(isValidPremierLeagueTeamId("57a")).toBe(false);
+    expect(isValidPremierLeagueTeamId(" 57")).toBe(false);
+  });
+});
+
+describe("createEmptyPremierLeagueSummary", () => {
+  it("returns an all-empty summary with a valid generatedAt timestamp", () => {
+    const summary = createEmptyPremierLeagueSummary();
+
+    expect(summary.competition).toBeNull();
+    expect(summary.standings).toEqual([]);
+    expect(summary.scorers).toEqual([]);
+    expect(summary.recentFixtures).toEqual([]);
+    expect(summary.upcomingFixtures).toEqual([]);
+    expect(summary.teams).toEqual([]);
+    expect(summary.goalsPerMatchday).toEqual([]);
+    expect(typeof summary.generatedAt).toBe("string");
+    expect(() => new Date(summary.generatedAt).toISOString()).not.toThrow();
+  });
+});
+
+describe("createEmptyPremierLeagueTeamSnapshot", () => {
+  it("returns a null-team snapshot with a zeroed default form", () => {
+    const snapshot = createEmptyPremierLeagueTeamSnapshot();
+
+    expect(snapshot.team).toBeNull();
+    expect(snapshot.recentFixtures).toEqual([]);
+    expect(snapshot.upcomingFixtures).toEqual([]);
+    expect(snapshot.form).toEqual({
+      sequence: [],
+      wins: 0,
+      draws: 0,
+      losses: 0,
+      points: 0,
+      goalsFor: 0,
+      goalsAgainst: 0,
+    });
+    expect(typeof snapshot.generatedAt).toBe("string");
+    expect(() => new Date(snapshot.generatedAt).toISOString()).not.toThrow();
+  });
+});
+
+// Team-detail endpoint returns the raw team object directly (not wrapped), and
+// carries the club-detail-only fields (founded, clubColors, website, address,
+// coach) that the summary team-list objects omit.
+const ARSENAL_DETAIL = {
+  id: 57,
+  name: "Arsenal FC",
+  shortName: "Arsenal",
+  tla: "ARS",
+  crest: "https://crests/ars.png",
+  venue: "Emirates Stadium",
+  founded: 1886,
+  clubColors: "Red / White",
+  website: "https://www.arsenal.com",
+  address: "75 Drayton Park London N5 1BU",
+  coach: { name: "Mikel Arteta" },
+};
+
+function arsenalFinishedPayload() {
+  return {
+    matches: [
+      // Arsenal home win (older).
+      {
+        id: 3001,
+        utcDate: "2026-03-01T15:00:00Z",
+        status: "FINISHED",
+        matchday: 28,
+        stage: "REGULAR_SEASON",
+        homeTeam: ARSENAL,
+        awayTeam: CHELSEA,
+        score: { winner: "HOME_TEAM", fullTime: { home: 2, away: 1 } },
+      },
+      // Arsenal away draw (newest).
+      {
+        id: 3002,
+        utcDate: "2026-03-08T17:30:00Z",
+        status: "FINISHED",
+        matchday: 29,
+        stage: "REGULAR_SEASON",
+        homeTeam: LIVERPOOL,
+        awayTeam: ARSENAL,
+        score: { winner: "DRAW", fullTime: { home: 1, away: 1 } },
+      },
+      // Arsenal away loss (oldest).
+      {
+        id: 3003,
+        utcDate: "2026-02-20T15:00:00Z",
+        status: "FINISHED",
+        matchday: 27,
+        stage: "REGULAR_SEASON",
+        homeTeam: CHELSEA,
+        awayTeam: ARSENAL,
+        score: { winner: "HOME_TEAM", fullTime: { home: 3, away: 0 } },
+      },
+      // Malformed match (no home team) should be dropped.
+      {
+        id: 3004,
+        utcDate: "2026-02-25T15:00:00Z",
+        status: "FINISHED",
+        homeTeam: null,
+        awayTeam: ARSENAL,
+        score: { winner: null, fullTime: { home: null, away: null } },
+      },
+    ],
+  };
+}
+
+function arsenalScheduledPayload() {
+  return {
+    matches: [
+      // Later fixture, listed first to prove the ascending sort runs.
+      {
+        id: 4002,
+        utcDate: "2026-03-22T15:00:00Z",
+        status: "SCHEDULED",
+        matchday: 31,
+        stage: "REGULAR_SEASON",
+        homeTeam: ARSENAL,
+        awayTeam: LIVERPOOL,
+        score: { winner: null, fullTime: { home: null, away: null } },
+      },
+      // Earlier fixture.
+      {
+        id: 4001,
+        utcDate: "2026-03-15T15:00:00Z",
+        status: "SCHEDULED",
+        matchday: 30,
+        stage: "REGULAR_SEASON",
+        homeTeam: CHELSEA,
+        awayTeam: ARSENAL,
+        score: { winner: null, fullTime: { home: null, away: null } },
+      },
+    ],
+  };
+}
+
+/**
+ * Routes a team-scoped football-data.org request URL to the right canned
+ * payload. The team-matches URL (`/teams/57/matches?...`) contains both
+ * `/teams/` and `/matches`, so `/matches` must be checked first.
+ */
+function routeTeamFetch(url: string): Response {
+  if (url.includes("/matches")) {
+    if (url.includes("status=FINISHED")) return jsonResponse(arsenalFinishedPayload());
+    if (url.includes("status=SCHEDULED")) return jsonResponse(arsenalScheduledPayload());
+  }
+  if (url.includes("/teams/")) return jsonResponse(ARSENAL_DETAIL);
+  throw new Error(`Unexpected fetch URL in test: ${url}`);
+}
+
+describe("getPremierLeagueTeamSnapshot", () => {
+  let previousToken: string | undefined;
+
+  beforeAll(() => {
+    previousToken = process.env.FOOTBALL_DATA_API_TOKEN;
+  });
+
+  beforeEach(() => {
+    process.env.FOOTBALL_DATA_API_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    if (previousToken === undefined) {
+      delete process.env.FOOTBALL_DATA_API_TOKEN;
+    } else {
+      process.env.FOOTBALL_DATA_API_TOKEN = previousToken;
+    }
+  });
+
+  it("rejects an invalid team id before hitting the network", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+
+    await expect(getPremierLeagueTeamSnapshot("not-an-id")).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("normalizes the club profile, splits fixtures, and derives form", async () => {
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockImplementation((input: Parameters<typeof fetch>[0]) =>
+        Promise.resolve(routeTeamFetch(String(input)))
+      );
+
+    const snapshot = await getPremierLeagueTeamSnapshot("57");
+
+    // Requests carry the configured auth token header.
+    const lastCallInit = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect((lastCallInit?.headers as Record<string, string>)["X-Auth-Token"]).toBe("test-token");
+
+    // Profile: normalized team option fields plus the club-detail-only fields
+    // that only the `/teams/{id}` endpoint exposes.
+    expect(snapshot.team?.id).toBe("57");
+    expect(snapshot.team?.name).toBe("Arsenal FC");
+    expect(snapshot.team?.shortName).toBe("Arsenal");
+    expect(snapshot.team?.tla).toBe("ARS");
+    expect(snapshot.team?.venue).toBe("Emirates Stadium");
+    // Accent color resolved from src/data/clubColors.ts by TLA.
+    expect(snapshot.team?.accentColor).toBe("#EF0107");
+    expect(snapshot.team?.founded).toBe(1886);
+    expect(snapshot.team?.clubColors).toBe("Red / White");
+    expect(snapshot.team?.website).toBe("https://www.arsenal.com");
+    expect(snapshot.team?.address).toBe("75 Drayton Park London N5 1BU");
+    // Manager is read from the upstream `coach.name`.
+    expect(snapshot.team?.manager).toBe("Mikel Arteta");
+
+    // Recent (finished) fixtures: malformed dropped, sorted newest-first.
+    expect(snapshot.recentFixtures.map((f) => f.id)).toEqual(["3002", "3001", "3003"]);
+
+    // Upcoming (scheduled) fixtures sorted oldest-first.
+    expect(snapshot.upcomingFixtures.map((f) => f.id)).toEqual(["4001", "4002"]);
+
+    // Form is derived over the recent fixtures in their (newest-first) order:
+    // draw (3002), win (3001), loss (3003).
+    expect(snapshot.form.sequence).toEqual(["D", "W", "L"]);
+    expect(snapshot.form.wins).toBe(1);
+    expect(snapshot.form.draws).toBe(1);
+    expect(snapshot.form.losses).toBe(1);
+    expect(snapshot.form.points).toBe(4);
+    // Goals for/against are counted from Arsenal's perspective per fixture.
+    expect(snapshot.form.goalsFor).toBe(3);
+    expect(snapshot.form.goalsAgainst).toBe(5);
+
+    expect(typeof snapshot.generatedAt).toBe("string");
+    expect(() => new Date(snapshot.generatedAt).toISOString()).not.toThrow();
+  });
+
+  it("surfaces a 404 from the upstream team-detail feed without retrying", async () => {
+    // 404 is a client error, so fetchFootballDataJson throws immediately rather
+    // than backing off — keeping the mock fast and the retry path untriggered.
+    jest.spyOn(global, "fetch").mockImplementation((input: Parameters<typeof fetch>[0]) => {
+      const url = String(input);
+      if (url.includes("/matches")) {
+        if (url.includes("status=FINISHED")) return Promise.resolve(jsonResponse(arsenalFinishedPayload()));
+        if (url.includes("status=SCHEDULED")) return Promise.resolve(jsonResponse(arsenalScheduledPayload()));
+      }
+      if (url.includes("/teams/")) return Promise.resolve(jsonResponse({}, 404));
+      throw new Error(`Unexpected fetch URL in test: ${url}`);
+    });
+
+    await expect(getPremierLeagueTeamSnapshot("57")).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it("throws when the API token is not configured", async () => {
+    delete process.env.FOOTBALL_DATA_API_TOKEN;
+    jest.spyOn(global, "fetch").mockResolvedValue(jsonResponse({}));
+
+    await expect(getPremierLeagueTeamSnapshot("57")).rejects.toThrow(/not configured/i);
   });
 });

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -1,8 +1,14 @@
 import {
+  absoluteUrl,
+  calculateReadingTime,
   constructMetadata,
   fitMetaDescription,
   fitSearchTitle,
   generateAIOptimizedMetadata,
+  generateArticleStructuredData,
+  generateOrganizationStructuredData,
+  generatePersonStructuredData,
+  generateProjectStructuredData,
   safeJsonLd,
   siteConfig,
 } from "../seo";
@@ -96,6 +102,186 @@ describe("generateAIOptimizedMetadata", () => {
     expect((metadata.twitter as { title: string }).title).toBe(
       `About | ${siteConfig.name}`
     );
+  });
+});
+
+describe("absoluteUrl", () => {
+  it("returns the site url when given no path", () => {
+    expect(absoluteUrl()).toBe(siteConfig.url);
+  });
+
+  it("passes absolute http(s) urls through untouched", () => {
+    expect(absoluteUrl("https://example.com/x")).toBe("https://example.com/x");
+  });
+
+  it("prefixes relative paths with the site origin and a leading slash", () => {
+    expect(absoluteUrl("about")).toBe(`${siteConfig.url}/about`);
+    expect(absoluteUrl("/about")).toBe(`${siteConfig.url}/about`);
+  });
+});
+
+describe("calculateReadingTime", () => {
+  it("rounds up to whole minutes at 200 wpm", () => {
+    expect(calculateReadingTime("word ".repeat(200).trim())).toBe(1);
+    expect(calculateReadingTime("word ".repeat(201).trim())).toBe(2);
+    expect(calculateReadingTime("just a few words")).toBe(1);
+  });
+});
+
+describe("generateProjectStructuredData", () => {
+  it("builds a SoftwareApplication node with sensible defaults", () => {
+    const data = generateProjectStructuredData({
+      name: "QA Platform",
+      description: "A testing platform",
+      author: "Isaac Vazquez",
+    }) as Record<string, unknown>;
+
+    expect(data["@type"]).toBe("SoftwareApplication");
+    expect(data.name).toBe("QA Platform");
+    expect(data.applicationCategory).toBe("WebApplication");
+    expect(typeof data.dateModified).toBe("string");
+    expect((data.author as Record<string, unknown>).name).toBe("Isaac Vazquez");
+  });
+
+  it("honors provided category, keywords, and dateModified", () => {
+    const data = generateProjectStructuredData({
+      name: "N",
+      description: "D",
+      author: "A",
+      keywords: ["a", "b"],
+      applicationCategory: "DeveloperApplication",
+      dateModified: "2026-01-01T00:00:00.000Z",
+    }) as Record<string, unknown>;
+
+    expect(data.keywords).toBe("a, b");
+    expect(data.applicationCategory).toBe("DeveloperApplication");
+    expect(data.dateModified).toBe("2026-01-01T00:00:00.000Z");
+  });
+});
+
+describe("generatePersonStructuredData", () => {
+  it("includes credentials, socials, and organizations by default", () => {
+    const data = generatePersonStructuredData() as Record<string, unknown>;
+    expect(data["@type"]).toBe("Person");
+    expect(Array.isArray(data.sameAs)).toBe(true);
+    expect(Array.isArray(data.knowsAbout)).toBe(true);
+    expect(Array.isArray(data.hasCredential)).toBe(true);
+    expect(data.worksFor).toBeDefined();
+    expect(Array.isArray(data.alumniOf)).toBe(true);
+  });
+
+  it("omits optional sections when toggled off", () => {
+    const data = generatePersonStructuredData({
+      includeCredentials: false,
+      includeSocials: false,
+      includeOrganizations: false,
+    }) as Record<string, unknown>;
+    expect(data.sameAs).toBeUndefined();
+    expect(data.knowsAbout).toBeUndefined();
+    expect(data.hasCredential).toBeUndefined();
+    expect(data.worksFor).toBeUndefined();
+    expect(data.alumniOf).toBeUndefined();
+  });
+});
+
+describe("generateArticleStructuredData", () => {
+  it("falls back to defaults for author, image, and dateModified", () => {
+    const data = generateArticleStructuredData({
+      title: "Post",
+      description: "About the post",
+      datePublished: "2026-02-01",
+      url: "https://isaacavazquez.com/writing/post",
+    }) as Record<string, unknown>;
+
+    expect(data["@type"]).toBe("Article");
+    expect(data.headline).toBe("Post");
+    expect(data.dateModified).toBe("2026-02-01");
+    expect((data.author as Record<string, unknown>).name).toBe(siteConfig.name);
+    expect(data.image).toContain(siteConfig.url);
+  });
+
+  it("uses explicit author, image, keywords, and dateModified", () => {
+    const data = generateArticleStructuredData({
+      title: "Post",
+      description: "D",
+      author: "Guest",
+      datePublished: "2026-02-01",
+      dateModified: "2026-03-01",
+      image: "https://cdn.example/cover.png",
+      keywords: ["seo", "next"],
+      url: "https://isaacavazquez.com/writing/post",
+    }) as Record<string, unknown>;
+
+    expect((data.author as Record<string, unknown>).name).toBe("Guest");
+    expect(data.image).toBe("https://cdn.example/cover.png");
+    expect(data.dateModified).toBe("2026-03-01");
+    expect(data.keywords).toBe("seo, next");
+  });
+});
+
+describe("generateOrganizationStructuredData", () => {
+  it("omits the location node when no location is given", () => {
+    const data = generateOrganizationStructuredData({
+      name: "Civitech",
+      description: "Civic tech",
+    }) as Record<string, unknown>;
+    expect(data["@type"]).toBe("Organization");
+    expect(data.location).toBeUndefined();
+  });
+
+  it("adds a Place node when a location is given", () => {
+    const data = generateOrganizationStructuredData({
+      name: "Civitech",
+      description: "Civic tech",
+      location: "Austin, TX",
+      foundingDate: "2019",
+    }) as Record<string, unknown>;
+    expect((data.location as Record<string, unknown>)["@type"]).toBe("Place");
+    expect((data.location as Record<string, unknown>).name).toBe("Austin, TX");
+    expect(data.foundingDate).toBe("2019");
+  });
+});
+
+describe("generateAIOptimizedMetadata (enhanced description + dates)", () => {
+  it("prepends the summary and appends expertise to the description", () => {
+    const metadata = generateAIOptimizedMetadata({
+      title: "About",
+      description: "Base description",
+      summary: "TL;DR",
+      expertise: ["Product", "QA"],
+    });
+    expect(metadata.description).toBe(
+      "TL;DR | Base description | Expertise: Product, QA"
+    );
+  });
+
+  it("emits article date meta tags when publish/modify dates are set", () => {
+    const metadata = generateAIOptimizedMetadata({
+      title: "About",
+      description: "Base",
+      datePublished: "2026-02-01",
+      dateModified: "2026-03-01",
+      readingTime: 4,
+      author: { name: "Isaac", title: "PM", credentials: ["MBA"] },
+    });
+    const other = metadata.other as Record<string, string>;
+    expect(other["article:published_time"]).toBe("2026-02-01");
+    expect(other["article:modified_time"]).toBe("2026-03-01");
+    expect(other["og:updated_time"]).toBe("2026-03-01");
+    expect(other["ai:readingTime"]).toBe("4 minutes");
+    expect(metadata.authors).toEqual([
+      expect.objectContaining({ name: "Isaac" }),
+    ]);
+  });
+
+  it("sets noindex robots when requested", () => {
+    const metadata = generateAIOptimizedMetadata({
+      title: "Hidden",
+      description: "Base",
+      noIndex: true,
+    });
+    const robots = metadata.robots as { index: boolean };
+    expect(robots.index).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What this does

Adds and extends Jest unit tests across previously thin or untested pure-logic surfaces, then ratchets the global coverage thresholds up (per the documented "ratchet upward as coverage improves" convention) to lock in the gains. Also refreshes stale `lastmod` values in the committed sitemap to keep `sitemap-consistency.test.ts` green. No product source logic was changed — only test files, `jest.config.js`, and `public/sitemap.xml`.

## Coverage impact

Measured on the rebased tree (thresholds bumped from 62/49/61/64 to 65/52/62/66 for statements/branches/functions/lines):

| Metric | Threshold | Actual |
|---|---|---|
| Statements | 65 | 68.4% |
| Branches | 52 | 55.2% |
| Functions | 62 | 65.9% |
| Lines | 66 | 70.2% |

Full Jest suite on the rebased tree: 1395 passing (see the note below re: one inherited failure).

## New / extended tests

- **Route state (were at 0%):** `world-cup-2026` and `bay-area-transit` state helpers — param normalization, href building, default clearing, array-valued params.
- **SpaceX formatters:** mission precision/moment/schedule labels and integer formatting, alongside the existing currency helper.
- **`seo.ts`:** structured-data generators (project, person, article, organization), `absoluteUrl`, `calculateReadingTime`, and the `generateAIOptimizedMetadata` description/date branches.
- **`ai-seo.ts`:** every schema generator (person, professional-service, article, project, FAQ, breadcrumb, item-list, navigation, page-summary) plus `generateAIMetaTags`, covering their conditional field branches.
- **`blog.ts`:** drives the real aggregation/filter functions (`getAllBlogPosts`, by-category/by-tag, featured, categories, tags, search, related, archive, publish-gating) through the fs/matter mocks, instead of the prior block that re-implemented the filter logic inline and left the exported functions uncovered.
- **Sports data libs (nba/mlb/laLiga/premier-league):** `getXTeamSnapshot` happy path with profile/fixture-split/form derivation, `isValidXTeamId`, `createEmptyX` shapes, and upstream 404 / invalid-id error paths via routed `fetch` mocks. Error paths deliberately avoid 5xx so no retry-backoff timers fire.

## Sitemap timestamp fix

`public/sitemap.xml` only regenerates at `postbuild`, so automated snapshot-refresh commits update the underlying snapshot data (and thus the `lastmod` values `getPublicSitemapEntries` derives from it) faster than the XML is refreshed. This reconciles the drifted `lastmod` values with what the code computes; the loc set, `changefreq`, and `priority` are unchanged. (Rebased onto the latest main, which regenerated the sitemap; 6 residual drifted entries were reconciled.)

## Notes on CI (both failures are unrelated to this change)

1. **Netlify deploy checks** (`Pages changed` / `Header rules` / `Redirect rules`) fail because the Netlify **deploy build** is failing in that environment — reproduces identically across every commit regardless of content, and nothing here touches the `next build` path (the GitHub Actions `Build` job passes). Deploy logs are Netlify-auth-gated.
2. **`blog-seo-content.test.ts`** (`uses explicit object cover metadata for every World Cup article`) fails on `main` itself — `building-a-world-cup-dashboard` now ships a real wikimedia cover image while that test still asserts the editorial `opengraph-image` card. The test and article are byte-identical to `main` here; this change does not touch blog content or that test. Whether to update the article frontmatter or the test is a content-policy call, so I left it for the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)