### PR TITLE
docs: backfill changelog with missing PRs #296 and #297

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this repository are documented here. Format: `YYYY-MM-DD`
 - Refresh README routes and build notes ([#293](https://github.com/IsaacAVazquez/Website/pull/293)).
 - Add Travel Deal Lab, a trip cost optimizer at /travel-deals ([#295](https://github.com/IsaacAVazquez/Website/pull/295)).
 - Add La Liga 2025-26 season article series ([#294](https://github.com/IsaacAVazquez/Website/pull/294)).
+- Add backdated 2025-26 Premier League season article series ([#296](https://github.com/IsaacAVazquez/Website/pull/296)).
+- Add 2026 Formula 1 race review articles (rounds 1-9) ([#297](https://github.com/IsaacAVazquez/Website/pull/297)).
 - Design review (July 2026) + first-batch quick-win fixes ([#300](https://github.com/IsaacAVazquez/Website/pull/300)).
 
 ---


### PR DESCRIPTION
## What this does

Backfills `CHANGELOG.md` with two article-series pull requests that merged on 2026-07-07 but never made it into the log. The auto-append workflow (`changelog-on-merge.yml`) missed them, most likely because they merged within seconds of several other PRs that day and the append step raced against the concurrent runs.

The two entries land in the existing `## 2026-07-07` section, in the same one-line house format the workflow produces:

- Add backdated 2025-26 Premier League season article series ([#296](https://github.com/IsaacAVazquez/Website/pull/296)).
- Add 2026 Formula 1 race review articles (rounds 1-9) ([#297](https://github.com/IsaacAVazquez/Website/pull/297)).

## How I found them

Cross-checked every merged PR against the changelog. Everything else is either already present or predates the auto-append workflow and is covered by the older prose-style entries. These two were the only genuine gaps.

## Notes

Docs only, no code changes. The release-notes doc under `docs/` is a point-in-time historical record for a specific 2026-03-16 release and did not need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJaos6JyndbYUexhUskEdq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJaos6JyndbYUexhUskEdq)_