### PR TITLE
docs: sync stale component names and workflow inventory with code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Footer variants:
 - Shared portfolio-shell primitives must not use `transition-all`. Transition specific properties instead.
 - Portfolio-shell routes must keep the primary message and main CTA visible in the initial mobile viewport whenever the route has a hero.
 - Portfolio and writing cards should surface role, problem space, and impact in the default scan state.
-- The `/portfolio` index is rendered by `src/components/portfolio/PortfolioV3.tsx`, which carries a client-side project search (tokenized AND match over title, description, role, timeline, metrics, summary, category, and tools) and a marquee band that sits between the project grid and the pager.
+- The `/portfolio` index is rendered by `src/components/portfolio/PortfolioInstrument.tsx`, which carries a client-side project search (tokenized AND match over title, description, role, timeline, metrics, summary, category, and tools) and a marquee band that sits between the project grid and the pager.
 - `/api/search` is still limited and mostly hardcoded. Do not describe it as comprehensive site search.
 - `ProjectsContent.tsx` and `WritingPreview.tsx` still exist, but they are not the primary live path for the current shell.
 
@@ -403,6 +403,7 @@ The MLB, NBA, and NFL dashboards read committed TypeScript snapshots at runtime.
 Checked-in operational workflows:
 
 - `.github/workflows/test.yml`
+- `.github/workflows/changelog-on-merge.yml`
 - `.github/workflows/update-investments.yml`
 - `.github/workflows/update-premier-league.yml`
 - `.github/workflows/update-la-liga.yml`
@@ -424,6 +425,7 @@ Checked-in operational workflows:
 Current behavior:
 
 - `test.yml` runs unit tests, build, sharded Chromium Playwright E2E, and lint on pushes to `main` or `develop`, plus pull requests targeting `main` or `develop`; full-matrix Playwright runs only on pushes to `main`
+- `changelog-on-merge.yml` appends a dated bullet to `CHANGELOG.md` on `main` for every merged pull request; add the `skip-changelog` label to opt a PR out. Snapshot-refresh bots push straight to `main` without a PR, so they never trigger it, and the commit lands with `[skip ci]` to avoid a trigger loop
 - `update-investments.yml` runs on manual dispatch and on Mondays and Thursdays at `22:15 UTC`, then commits refreshed compact snapshots under `public/data/investments`; raw provider responses are not committed
 - `update-premier-league.yml` runs on manual dispatch and daily at `06:15 UTC` during the season (August through May; skipped June and July), then commits `src/data/premierLeagueSnapshot.ts` when it changes
 - `update-la-liga.yml` runs on manual dispatch and daily at `06:30 UTC` during the season (August through May; skipped June and July), then commits `src/data/laLigaSnapshot.ts` when it changes
@@ -436,10 +438,11 @@ Current behavior:
 - `update-nfl.yml` runs on manual dispatch and Tuesdays September through February at `10:35 UTC`, then commits `src/data/nflSnapshot.ts` when it changes
 - `update-golf.yml` runs on manual dispatch and daily at `08:40 UTC`, then commits `src/data/golfSnapshot.ts` when it changes
 - `update-world-cup.yml` runs on manual dispatch and every six hours during June and July, then commits `src/data/worldCupSnapshot.ts` when it changes
+- `update-score-pools.yml` runs on manual dispatch and every six hours (minute 23), then commits `src/data/scorePoolsSnapshot.ts` when odds, results, or standings change
 - `update-bay-area-transit.yml` runs on manual dispatch and every six hours year-round, then commits `src/data/bayAreaTransitSnapshot.ts` when it changes
 - `update-earthquake.yml` runs on manual dispatch and hourly (minute 20), then commits `src/data/earthquakeSnapshot.ts` when it changes
 - The tech startup tracker has no workflow by design — its dataset is editorially curated, so refreshes happen by editing the seed and running `npm run update:tech-startups` locally
-- All 14 snapshot `update-*.yml` workflows commit and push through the shared `scripts/ci/commit-and-push-snapshot.sh` helper (usage: `commit-and-push-snapshot.sh <commit-message> <pathspec...>`). It sets the `github-actions[bot]` identity, exits cleanly on a no-op refresh, and pushes to `HEAD:main` with a fetch/`rebase --autostash` retry loop (default 8 attempts, `SNAPSHOT_PUSH_ATTEMPTS` override) plus capped exponential backoff to absorb concurrent snapshot-bot pushes. Behavior is asserted by `.github/workflows/__tests__/snapshot-workflows.test.ts` and `update-investments.test.ts`.
+- All 16 `update-*.yml` workflows commit and push through the shared `scripts/ci/commit-and-push-snapshot.sh` helper (usage: `commit-and-push-snapshot.sh <commit-message> <pathspec...>`). It sets the `github-actions[bot]` identity, exits cleanly on a no-op refresh, and pushes to `HEAD:main` with a fetch/`rebase --autostash` retry loop (default 8 attempts, `SNAPSHOT_PUSH_ATTEMPTS` override) plus capped exponential backoff to absorb concurrent snapshot-bot pushes. Behavior is asserted by `.github/workflows/__tests__/snapshot-workflows.test.ts` and `update-investments.test.ts`.
 - A daily cron-job.org ping to the Netlify build hook triggers a production deploy of the latest committed snapshots; data refreshes remain separate workflows
 - `purge-cache.ts` is protected by `Authorization: Bearer <CRON_SECRET>` or `x-cron-secret` and calls Netlify Durable Cache purge; query-string secrets are intentionally rejected
 - Historical caveat: `vercel.json` still declares a cron for `/api/scheduled-update`, but no matching route exists. Treat that config as historical until confirmed.

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -4,8 +4,8 @@ Current component map for the live application.
 
 **Last updated:** 2026-06-19
 
-> The homepage, about, portfolio, contact, and writing-archive surfaces moved to
-> dedicated `*V3` composition roots in the 2026-05-31 refresh (commit `66063bb`).
+> The homepage, about, portfolio, contact, and writing-archive surfaces each render
+> a single dedicated `*Instrument` composition root (the Working Instrument redesign).
 > The older single-purpose homepage components (`ModernHero`, `ThinkingPreview`,
 > `ContactSection`) and the `FeaturedWorkSection`/`ContactContent` names this doc
 > previously listed are no longer wired into any route — see *Legacy Or Unwired
@@ -29,17 +29,17 @@ Current component map for the live application.
 
 ### Homepage, about, portfolio, contact, writing
 
-Each of these editorial surfaces renders a single dedicated `*V3` composition
-root (introduced in the 2026-05-31 refresh). The route page is a thin server
-shell that passes data in.
+Each of these editorial surfaces renders a single dedicated `*Instrument`
+composition root (the Working Instrument redesign). The route page is a thin
+server shell that passes data in.
 
 | Component | File | Role |
 |----------|------|------|
-| `HomePageV3` | `src/components/home/HomePageV3.tsx` | Homepage composition root (hero, featured work, writing, contact). Props: `featuredProjects`, `recentPosts`, `heroIndex` |
-| `AboutV3` | `src/components/about/AboutV3.tsx` | `/about` content |
-| `PortfolioV3` | `src/components/portfolio/PortfolioV3.tsx` | `/portfolio` project grid and surfacing |
-| `ContactV3` | `src/components/contact/ContactV3.tsx` | `/contact` content |
-| `WritingArchiveV3` | `src/components/writing/WritingArchiveV3.tsx` | `/writing` archive index |
+| `HomeInstrument` | `src/components/home/HomeInstrument.tsx` | Homepage composition root (hero, featured work, writing, contact). Props: `featuredProjects`, `recentPosts`, `heroIndex`, `liveToolGroups`, `liveFeed` |
+| `AboutInstrument` | `src/components/about/AboutInstrument.tsx` | `/about` content |
+| `PortfolioInstrument` | `src/components/portfolio/PortfolioInstrument.tsx` | `/portfolio` project grid and surfacing |
+| `ContactInstrument` | `src/components/contact/ContactInstrument.tsx` | `/contact` content |
+| `WritingInstrument` | `src/components/writing/WritingInstrument.tsx` | `/writing` archive index |
 | `ProjectDetailModal` | `src/components/ProjectDetailModal.tsx` | Legacy project modal, imported only by `ProjectsContent.tsx` (non-primary flow) |
 
 ### Writing and structured data
@@ -153,7 +153,6 @@ Most reused primitives:
 - `ThemeToggle`
 - `SectionIntro`
 - `ServerIcons`
-- `button.tsx`
 - `dropdown-menu.tsx`
 
 Editorial shared components also live under `src/components/editorial/`; use them when working in the current `--home-*` visual system.
@@ -171,8 +170,8 @@ Styling guidance for these lives in `STYLING.md`.
 
 ### Homepage
 
-`src/app/page.tsx` renders `HomePageV3` (plus the `StructuredData` /
-`AIStructuredData` JSON-LD injectors). `HomePageV3` is a self-contained
+`src/app/page.tsx` renders `HomeInstrument` (plus the `StructuredData` /
+`AIStructuredData` JSON-LD injectors). `HomeInstrument` is a self-contained
 composition; the older `ModernHero` / `ThinkingPreview` / `ContactSection` files
 and `WritingPreview.tsx` still exist in the repo but are no longer wired into the
 homepage.
@@ -213,7 +212,7 @@ These files still exist, but should not be described as the primary live path wi
 - `src/components/ProjectDetailModal.tsx` (imported only by `ProjectsContent.tsx`)
 
 They remain useful as historical or alternate implementation context. The
-`*V3` composition roots replaced them on the live routes.
+`*Instrument` composition roots replaced them on the live routes.
 
 ---
 

--- a/PAGES.md
+++ b/PAGES.md
@@ -15,7 +15,7 @@ Current route inventory and page ownership for the live app.
 |------|------|-------|
 | `/` | `src/app/page.tsx` | Composes hero, featured projects, product-thinking preview, and homepage contact section |
 | `/about` | `src/app/about/page.tsx` | Renders `About` tabbed client UI |
-| `/portfolio` | `src/app/portfolio/page.tsx` | Renders project cards directly from route code; `PortfolioV3.tsx` adds a client-side project search/filter, with the marquee band sitting between the project grid and the pager |
+| `/portfolio` | `src/app/portfolio/page.tsx` | Renders project cards directly from route code; `PortfolioInstrument.tsx` adds a client-side project search/filter, with the marquee band sitting between the project grid and the pager |
 | `/portfolio/[slug]` | `src/app/portfolio/[slug]/page.tsx` | Project detail page |
 | `/resume` | `src/app/resume/page.tsx` | Resume route with client-rendered resume shell |
 | `/contact` | `src/app/contact/page.tsx` | Contact page using `ContactContent` |

--- a/STYLING.md
+++ b/STYLING.md
@@ -31,7 +31,7 @@ Legacy semantic tokens (`--surface-*`, `--text-*`, `--border-*`, `--color-primar
 - `src/app/globals.css`
 - `tailwind.config.ts`
 - `src/components/ui/*`
-- `src/components/home/HomePageContent.tsx`
+- `src/components/home/HomeInstrument.tsx`
 
 ---
 
@@ -344,7 +344,7 @@ Base: `.home-button` — 48px min-height, pill shape (radius 999px), Instrument 
 
 ### Writing Archive Cards (`/writing`)
 
-The archive cards on `/writing` are owned by `src/app/writing/page.tsx`, not `src/components/home/HomePageContent.tsx`.
+The archive cards on `/writing` are owned by `src/app/writing/page.tsx`, not `src/components/home/HomeInstrument.tsx`.
 Do not use the home writing-preview card as the visual source of truth for the archive page.
 
 The footer metadata row on both `CuratedWritingCard` and `ArchiveWritingCard` is a locked pattern and should stay visually stable:

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,8 +100,6 @@ These remain in the repo for context, but they should not be treated as live sou
 - `../content-redesign/*`
 - `../content/*`
 - `../public/project-screenshots/README.md`
-- `../src/app/admin/README_scoring_format.md`
-- `../.open-next/assets/project-screenshots/README.md`
 
 Historical files should have an explicit banner where practical. If one conflicts with code or a current doc, trust the current doc and then the code.
 

--- a/docs/ai-context/PAGES.md
+++ b/docs/ai-context/PAGES.md
@@ -12,7 +12,7 @@ Fast route reference for the current app.
 |------|------|----------------|
 | `/` | `src/app/page.tsx` | Server page composing client sections |
 | `/about` | `src/app/about/page.tsx` | Server page -> `About` client component |
-| `/portfolio` | `src/app/portfolio/page.tsx` | Server page -> `PortfolioV3` client (searchable, filtered project index) |
+| `/portfolio` | `src/app/portfolio/page.tsx` | Server page -> `PortfolioInstrument` client (searchable, filtered project index) |
 | `/portfolio/[slug]` | `src/app/portfolio/[slug]/page.tsx` | Server detail page |
 | `/resume` | `src/app/resume/page.tsx` | Server page -> client resume UI |
 | `/contact` | `src/app/contact/page.tsx` | Server page -> `ContactContent` |
@@ -120,8 +120,8 @@ Footer behavior:
 
 ### `/portfolio`
 
-- server page calls `getPortfolioProjects()` and hands the full non-`comingSoon` project index to the `PortfolioV3` client (`src/components/portfolio/PortfolioV3.tsx`)
-- `PortfolioV3` adds a client-side project search, category filter tablist, a featured project, sortable + paginated grid, and a marquee band that sits between the project grid and the pager
+- server page calls `getPortfolioProjects()` and hands the full non-`comingSoon` project index to the `PortfolioInstrument` client (`src/components/portfolio/PortfolioInstrument.tsx`)
+- `PortfolioInstrument` adds a client-side project search, category filter tablist, a featured project, sortable + paginated grid, and a marquee band that sits between the project grid and the pager
 - cards should make role, problem space, and impact scannable before click-through
 - do not document `ProjectsContent.tsx` as the primary live implementation
 


### PR DESCRIPTION
## What

I audited the living Markdown documentation for references that no longer match the code and fixed the drift I could verify against source. Every change was checked against the actual files in `src/` and `.github/workflows/`.

## Findings and fixes

The editorial composition roots were renamed from the old `*V3` / `HomePageContent` names to the shipped `*Instrument` family, but several source-of-truth docs still referenced the old names. Updated `COMPONENTS.md`, `PAGES.md`, `AGENTS.md`, `STYLING.md`, and `docs/ai-context/PAGES.md` to use `HomeInstrument`, `AboutInstrument`, `PortfolioInstrument`, `ContactInstrument`, and `WritingInstrument`, and added the missing `liveToolGroups` / `liveFeed` props to the `HomeInstrument` entry. `ProjectsContent.tsx` and `WritingPreview.tsx` still exist and are correctly described as non-primary, so I left those alone.

`COMPONENTS.md` listed a `button.tsx` UI primitive that does not exist; only `ModernButton.tsx` (already listed) and `dropdown-menu.tsx` are in `src/components/ui/`, so I dropped the dead entry.

The `docs/README.md` index pointed at two files that do not exist in a checkout: `src/app/admin/README_scoring_format.md` and a `.open-next/assets/...` build-artifact mirror. Removed both.

The `AGENTS.md` automation inventory was off: it claimed 14 snapshot workflows share the commit-and-push helper when all 16 `update-*.yml` workflows do, it omitted `update-score-pools.yml` from the behavior list entirely, and it never documented the `changelog-on-merge.yml` workflow. Corrected the count, added a score-pools bullet, and documented changelog-on-merge (appends a dated `CHANGELOG.md` bullet per merged PR, `skip-changelog` opt-out label).

## Scope

I limited changes to current source-of-truth docs. I deliberately left the dated point-in-time audits, `CHANGELOG.md`, `docs/archive/*`, and `content-redesign/*` untouched, since rewriting the historical `*V3` references there would falsify the record of what the code looked like at those dates.

## Verification

Broken-link and backtick-reference scans over the doc set now come back clean apart from known false positives (relative `ai-context/*` links that resolve from `docs/`, an intentional "no live `src/lib/database.ts`" note, and URL paths like `/manifest.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hw6rxrSWTDFf3HA6WJ6kT4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw6rxrSWTDFf3HA6WJ6kT4)_