### PR TITLE
Restyle food map with its own "After Hours" field-guide identity

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -182,15 +182,15 @@
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-round-of-32-recap</loc><lastmod>2026-07-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/writing/world-cup-2026-top-ten-contenders</loc><lastmod>2026-05-31T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/ai-dev-tools</loc><lastmod>2026-04-28T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
-<url><loc>https://isaacavazquez.com/bay-area-transit</loc><lastmod>2026-07-20T04:24:59.932Z</lastmod><changefreq>hourly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/bay-area-transit</loc><lastmod>2026-07-20T09:44:19.920Z</lastmod><changefreq>hourly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/decision-lab</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
-<url><loc>https://isaacavazquez.com/earthquake-pulse</loc><lastmod>2026-07-20T07:29:58.866Z</lastmod><changefreq>hourly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/earthquake-pulse</loc><lastmod>2026-07-20T13:17:46.972Z</lastmod><changefreq>hourly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/fantasy-football</loc><lastmod>2026-07-15T18:14:30.491Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
 <url><loc>https://isaacavazquez.com/fantasy-formula-1</loc><lastmod>2026-07-19T09:59:47.946Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/food-map</loc><lastmod>2026-04-28T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/formula-1</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/frontier-models</loc><lastmod>2026-04-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
-<url><loc>https://isaacavazquez.com/github-trending-pulse</loc><lastmod>2026-07-19T09:32:17.966Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/github-trending-pulse</loc><lastmod>2026-07-20T10:30:37.590Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/golf</loc><lastmod>2026-04-16T00:00:00.000Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/investments</loc><lastmod>2026-07-16T23:33:57.124Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
 <url><loc>https://isaacavazquez.com/la-liga</loc><lastmod>2026-07-06T00:00:00.000Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
@@ -206,5 +206,5 @@
 <url><loc>https://isaacavazquez.com/score-pools</loc><lastmod>2026-07-20T06:27:09.599Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/spacex-mission-control</loc><lastmod>2026-04-01T00:00:00.000Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacavazquez.com/tech-startup-tracker</loc><lastmod>2026-07-06T06:37:54.246Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
-<url><loc>https://isaacavazquez.com/world-cup-2026</loc><lastmod>2026-07-20T04:27:20.730Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacavazquez.com/world-cup-2026</loc><lastmod>2026-07-20T13:31:12.610Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
 </urlset>

--- a/src/app/food-map/food-map-client.tsx
+++ b/src/app/food-map/food-map-client.tsx
@@ -5,10 +5,10 @@ import {
   useEffect,
   useMemo,
   useState,
-  type CSSProperties,
 } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useTheme } from "next-themes";
 import { IconSearch } from "@tabler/icons-react";
 import {
   FOOD_MAP_AS_OF,
@@ -40,35 +40,68 @@ import {
   toggleCurator,
   type FoodMapState,
 } from "./food-map-state";
-import { HomeStatsPanel, type HomeStatsCell } from "@/components/home/HomeStatsPanel";
 import { FoodMapLeaflet } from "./food-map-leaflet";
+import "./food-map.css";
 
 interface FoodMapClientProps {
   initialState: FoodMapState;
 }
 
 const fadeIn = {
-  hidden: { opacity: 0, y: 12 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.35 } },
+  hidden: { opacity: 0, y: 14 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.4 } },
 };
 
 const noMotion = {
-  hidden: { opacity: 0, y: 12 },
+  hidden: { opacity: 0, y: 14 },
   visible: { opacity: 1, y: 0, transition: { duration: 0 } },
 };
 
-function getPanelStyle(): CSSProperties {
-  return {
-    background: "color-mix(in srgb, var(--home-paper-alt) 74%, var(--home-elev-mix))",
-    border: "1px solid var(--home-rule)",
-    boxShadow: "var(--shadow-sm)",
-  };
+/* -------------------------------------------------------------------------- */
+/* Masthead ticker                                                            */
+/* -------------------------------------------------------------------------- */
+
+function HeroTicker() {
+  // A printed marquee of the cities and a few flagship cuisines, doubled so the
+  // CSS translate loops seamlessly. Motion is paused under prefers-reduced-motion.
+  const words = useMemo(() => {
+    const cities = FOOD_MAP_CITIES.map((c) => c.name);
+    const cuisines = [
+      "Barbecue",
+      "Tacos",
+      "Ramen",
+      "Oysters",
+      "Pintxos",
+      "New Nordic",
+      "Pastrami",
+      "Wood-fired pizza",
+    ];
+    return [...cities, ...cuisines];
+  }, []);
+
+  const line = (
+    <span aria-hidden="true">
+      {words.map((word) => (
+        <span key={word}>{word}</span>
+      ))}
+    </span>
+  );
+
+  return (
+    <div className="fm-ticker" aria-hidden="true">
+      <div className="fm-ticker-track">
+        {line}
+        {line}
+      </div>
+    </div>
+  );
 }
 
-const FILTER_LABEL_CLASS =
-  "text-2xs font-bold uppercase tracking-[0.14em]";
+/* -------------------------------------------------------------------------- */
+/* Filter chips                                                               */
+/* -------------------------------------------------------------------------- */
 
-function CityChips({
+function CityTabs({
   state,
   counts,
   onSelect,
@@ -78,7 +111,7 @@ function CityChips({
   onSelect: (id: FoodMapCityId) => void;
 }) {
   return (
-    <div role="radiogroup" aria-label="Choose a city" className="flex flex-wrap gap-2">
+    <div role="radiogroup" aria-label="Choose a city" className="fm-chiprow">
       {FOOD_MAP_CITIES.map((city) => {
         const isActive = state.city === city.id;
         return (
@@ -88,24 +121,10 @@ function CityChips({
             role="radio"
             aria-checked={isActive}
             onClick={() => onSelect(city.id)}
-            className="resume-chip min-h-touch transition-[transform,border-color,background-color,box-shadow] duration-200 ease focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-signal)] focus-visible:ring-offset-2"
-            style={{
-              borderColor: isActive
-                ? "color-mix(in srgb, var(--home-signal) 45%, var(--home-rule))"
-                : "var(--home-rule)",
-              background: isActive
-                ? "color-mix(in srgb, var(--home-signal) 18%, var(--home-paper))"
-                : "var(--home-paper-raised)",
-              color: "var(--home-ink)",
-            }}
+            className="fm-tab"
           >
             {city.name}
-            <span
-              className="ml-2 text-2xs uppercase tracking-[0.12em]"
-              style={{ color: "var(--home-ink-muted)" }}
-            >
-              {counts[city.id] ?? 0}
-            </span>
+            <span className="fm-tab-count">{counts[city.id] ?? 0}</span>
           </button>
         );
       })}
@@ -113,7 +132,7 @@ function CityChips({
   );
 }
 
-function CuratorChips({
+function CuratorStamps({
   state,
   onToggle,
 }: {
@@ -121,7 +140,7 @@ function CuratorChips({
   onToggle: (id: FoodMapCuratorId) => void;
 }) {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="fm-chiprow">
       {FOOD_MAP_CURATORS.map((curator) => {
         const isActive = state.curators.includes(curator.id);
         return (
@@ -130,22 +149,10 @@ function CuratorChips({
             type="button"
             onClick={() => onToggle(curator.id)}
             aria-pressed={isActive}
-            className="resume-chip min-h-touch inline-flex items-center gap-2 transition-[transform,border-color,background-color,box-shadow] duration-200 ease focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-signal)] focus-visible:ring-offset-2"
-            style={{
-              borderColor: isActive
-                ? `color-mix(in srgb, ${curator.accent} 55%, var(--home-rule))`
-                : "var(--home-rule)",
-              background: isActive
-                ? `color-mix(in srgb, ${curator.accent} 18%, var(--home-paper))`
-                : "var(--home-paper-raised)",
-              color: "var(--home-ink)",
-            }}
+            className="fm-stamp"
+            style={{ ["--fm-accent" as string]: curator.accent }}
           >
-            <span
-              aria-hidden="true"
-              className="inline-block h-2 w-2 rounded-full"
-              style={{ background: curator.accent }}
-            />
+            <span className="fm-stamp-dot" aria-hidden="true" />
             {curator.name}
           </button>
         );
@@ -154,7 +161,7 @@ function CuratorChips({
   );
 }
 
-function CuisineChips({
+function CuisinePills({
   cuisines,
   state,
   onToggle,
@@ -166,9 +173,8 @@ function CuisineChips({
   if (cuisines.length === 0) {
     return null;
   }
-
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="fm-chiprow">
       {cuisines.map((cuisine) => {
         const isActive = state.cuisines.includes(cuisine.id);
         return (
@@ -177,16 +183,7 @@ function CuisineChips({
             type="button"
             onClick={() => onToggle(cuisine.id)}
             aria-pressed={isActive}
-            className="resume-chip min-h-touch transition-[transform,border-color,background-color,box-shadow] duration-200 ease focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-signal)] focus-visible:ring-offset-2"
-            style={{
-              borderColor: isActive
-                ? "color-mix(in srgb, var(--home-signal) 38%, var(--home-rule))"
-                : "var(--home-rule)",
-              background: isActive
-                ? "color-mix(in srgb, var(--home-signal) 14%, var(--home-paper))"
-                : "var(--home-paper-raised)",
-              color: "var(--home-ink)",
-            }}
+            className="fm-pill"
           >
             {cuisine.label}
           </button>
@@ -196,12 +193,18 @@ function CuisineChips({
   );
 }
 
-function PlaceCard({
+/* -------------------------------------------------------------------------- */
+/* Place index                                                               */
+/* -------------------------------------------------------------------------- */
+
+function PlaceTicket({
   place,
+  index,
   isSelected,
   onSelect,
 }: {
   place: FoodMapPlace;
+  index: number;
   isSelected: boolean;
   onSelect: (id: string) => void;
 }) {
@@ -214,51 +217,51 @@ function PlaceCard({
       type="button"
       onClick={() => onSelect(place.id)}
       aria-pressed={isSelected}
-      className="home-card min-h-touch w-full rounded-[var(--radius-3xl)] p-4 text-left transition-[transform,border-color,background-color,box-shadow] duration-200 ease focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-signal)] focus-visible:ring-offset-2"
-      style={{
-        ...getPanelStyle(),
-        background: isSelected
-          ? `color-mix(in srgb, ${accent} 14%, var(--home-paper))`
-          : "color-mix(in srgb, var(--home-paper-alt) 70%, var(--home-elev-mix))",
-        borderColor: isSelected
-          ? `color-mix(in srgb, ${accent} 35%, var(--home-rule))`
-          : "var(--home-rule)",
-        boxShadow: isSelected ? "var(--shadow-md)" : "var(--shadow-sm)",
-      }}
+      className="fm-ticket"
+      style={{ ["--fm-accent" as string]: accent }}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="home-kicker mb-1">{cuisine.label}</p>
-          <p
-            className="mb-1 text-base font-semibold tracking-[-0.03em]"
-            style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
-          >
-            {place.name}
-          </p>
-          <p
-            className="mb-0 text-sm leading-relaxed"
-            style={{ color: "var(--home-ink-muted)" }}
-          >
-            {locale}
-          </p>
-        </div>
-        {place.price ? (
-          <span
-            className="resume-chip"
-            style={{
-              borderColor: "var(--home-rule)",
-              background: "var(--home-paper-raised)",
-            }}
-          >
-            {place.price}
-          </span>
-        ) : null}
-      </div>
+      <span className="fm-ticket-index" aria-hidden="true">
+        {String(index + 1).padStart(2, "0")}
+      </span>
+      <p className="fm-ticket-cuisine">{cuisine.label}</p>
+      <p className="fm-ticket-name">{place.name}</p>
+      <p className="fm-ticket-meta">
+        <span>{locale}</span>
+        {place.price ? <span className="fm-ticket-price">{place.price}</span> : null}
+      </p>
     </button>
   );
 }
 
-function PlaceDetail({
+/* -------------------------------------------------------------------------- */
+/* Rail                                                                      */
+/* -------------------------------------------------------------------------- */
+
+function CuratorPassport() {
+  return (
+    <div className="fm-passport">
+      {FOOD_MAP_CURATORS.map((curator) => (
+        <div
+          key={curator.id}
+          className="fm-passport-card"
+          style={{ ["--fm-accent" as string]: curator.accent }}
+        >
+          <p className="fm-passport-name">
+            <span
+              aria-hidden="true"
+              className="fm-stamp-dot"
+              style={{ ["--fm-accent" as string]: curator.accent }}
+            />
+            {curator.name}
+          </p>
+          <p className="fm-passport-blurb">{curator.blurb}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PlaceDossier({
   place,
   onClear,
 }: {
@@ -274,81 +277,37 @@ function PlaceDetail({
   const curatorNames = place.curators.map((id) => getFoodMapCurator(id).name);
 
   return (
-    <div className="flex flex-col gap-4">
-      <button
-        type="button"
-        onClick={onClear}
-        className="self-start min-h-touch rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] transition-[transform,border-color,background-color,color] duration-200 ease focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-signal)] focus-visible:ring-offset-2"
-        style={{
-          ...getPanelStyle(),
-          color: "var(--home-ink)",
-          fontFamily: "var(--font-home-sans)",
-        }}
-      >
-        Clear pick
+    <div className="fm-dossier" style={{ ["--fm-accent" as string]: accent }}>
+      <button type="button" onClick={onClear} className="fm-back">
+        ← Clear pick
       </button>
 
-      <div
-        className="rounded-[var(--radius-3xl)] p-5"
-        style={{
-          ...getPanelStyle(),
-          background: `color-mix(in srgb, ${accent} 12%, var(--home-paper))`,
-          borderColor: `color-mix(in srgb, ${accent} 30%, var(--home-rule))`,
-        }}
-      >
-        <p className="home-kicker mb-1">{cuisine.label}</p>
-        <h2
-          className="text-[1.35rem] font-semibold tracking-[-0.04em]"
-          style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
-        >
-          {place.name}
-        </h2>
-        <p
-          className="mb-0 mt-1 text-sm leading-relaxed"
-          style={{ color: "var(--home-ink-muted)" }}
-        >
+      <div className="fm-dossier-head" style={{ ["--fm-accent" as string]: accent }}>
+        <p className="fm-dossier-cuisine">{cuisine.label}</p>
+        <h2 className="fm-dossier-name">{place.name}</h2>
+        <p className="fm-dossier-locale">
           {locale}
           {place.price ? ` · ${place.price}` : ""}
         </p>
 
-        <div className="mt-4 grid gap-3">
-          <div className="rounded-[var(--radius-3xl)] px-4 py-3" style={getPanelStyle()}>
-            <p className="home-kicker mb-1">Order</p>
-            <p
-              className="mb-0 text-sm font-semibold tracking-[-0.02em]"
-              style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
-            >
-              {place.order}
-            </p>
+        <div className="fm-dossier-rows">
+          <div className="fm-dossier-row">
+            <p className="fm-dossier-row-label">Order</p>
+            <p className="fm-dossier-row-val">{place.order}</p>
           </div>
-          <div className="rounded-[var(--radius-3xl)] px-4 py-3" style={getPanelStyle()}>
-            <p className="home-kicker mb-1">Recommended by</p>
-            <p
-              className="mb-0 text-sm font-semibold tracking-[-0.02em]"
-              style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
-            >
-              {curatorNames.join(" · ")}
-            </p>
+          <div className="fm-dossier-row">
+            <p className="fm-dossier-row-label">Recommended by</p>
+            <p className="fm-dossier-row-val">{curatorNames.join(" · ")}</p>
           </div>
         </div>
 
-        <p
-          className="mt-4 text-sm leading-relaxed"
-          style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
-        >
-          {place.why}
-        </p>
+        <p className="fm-dossier-why">{place.why}</p>
 
         <a
           href={mapsLink(place)}
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-4 inline-flex min-h-touch items-center gap-2 self-start rounded-full px-4 py-2 text-sm font-semibold transition-[transform,border-color,background-color,color] duration-200 ease focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-signal)] focus-visible:ring-offset-2"
-          style={{
-            ...getPanelStyle(),
-            color: "var(--home-ink)",
-            fontFamily: "var(--font-home-sans)",
-          }}
+          className="fm-dossier-link"
         >
           Open in Google Maps ↗
         </a>
@@ -357,45 +316,21 @@ function PlaceDetail({
   );
 }
 
-function CuratorLegend() {
-  return (
-    <div className="flex flex-col gap-3">
-      {FOOD_MAP_CURATORS.map((curator) => (
-        <div key={curator.id} className="rounded-[var(--radius-3xl)] p-4" style={getPanelStyle()}>
-          <div className="mb-1 flex items-center gap-2">
-            <span
-              aria-hidden="true"
-              className="inline-block h-2.5 w-2.5 rounded-full"
-              style={{ background: curator.accent }}
-            />
-            <p
-              className={FILTER_LABEL_CLASS}
-              style={{ color: "var(--home-ink)" }}
-            >
-              {curator.name}
-            </p>
-          </div>
-          <p
-            className="mb-0 text-xs leading-relaxed"
-            style={{ color: "var(--home-ink-muted)" }}
-          >
-            {curator.blurb}
-          </p>
-        </div>
-      ))}
-    </div>
-  );
-}
+/* -------------------------------------------------------------------------- */
+/* Workbench                                                                  */
+/* -------------------------------------------------------------------------- */
 
 function FoodMapWorkbench({
   routeState,
   variants,
   reduceMotion,
+  isDark,
   onCommit,
 }: {
   routeState: FoodMapState;
   variants: typeof fadeIn;
   reduceMotion: boolean;
+  isDark: boolean;
   onCommit: (next: FoodMapState) => void;
 }) {
   const [searchQuery, setSearchQuery] = useState("");
@@ -431,7 +366,9 @@ function FoodMapWorkbench({
   const cityCounts = useMemo(() => countPlacesByCity(FOOD_MAP_PLACES), []);
   const cityCount = cityCounts[routeState.city] ?? 0;
 
-  const selectedPlace = routeState.pick ? getFoodMapPlaceInCity(routeState.pick, routeState.city) : undefined;
+  const selectedPlace = routeState.pick
+    ? getFoodMapPlaceInCity(routeState.pick, routeState.city)
+    : undefined;
 
   const hasFilters =
     routeState.curators.length > 0 ||
@@ -464,119 +401,93 @@ function FoodMapWorkbench({
     onCommit(resetFoodMapFilters(routeState));
   }
 
-  const activeFilterCount =
-    routeState.curators.length +
-    routeState.cuisines.length +
-    (searchQuery.trim().length > 0 ? 1 : 0);
-
   const bourdainCount = FOOD_MAP_PLACES.filter((p) =>
     p.curators.includes("bourdain")
   ).length;
 
-  const foodMapStatsCells: HomeStatsCell[] = [
-    {
-      label: "Curated stops",
-      value: FOOD_MAP_PLACES.length.toLocaleString(),
-    },
-    {
-      label: "Cities",
-      value: FOOD_MAP_CITIES.length.toLocaleString(),
-    },
-    {
-      label: "Curators",
-      value: FOOD_MAP_CURATORS.length.toLocaleString(),
-    },
-    {
-      label: `Cuisines in ${activeCity.name}`,
-      value: cityCuisines.length.toLocaleString(),
-    },
-    {
-      label: `Stops in ${activeCity.name}`,
-      value: cityCount.toLocaleString(),
-    },
-    {
-      label: "Currently visible",
-      value: visiblePlaces.length.toLocaleString(),
-      sub: `of ${cityCount}`,
-    },
-    {
-      label: "Active filters",
-      value: activeFilterCount,
-      sub: hasFilters ? "Tap reset to clear" : "None applied",
-    },
-    {
-      label: "Bourdain picks",
-      value: bourdainCount.toLocaleString(),
-      sub: "across all cities",
-    },
-  ];
-
   return (
-    <section
-      className="home-page min-h-screen"
-      aria-label="Food Map"
-      data-testid="food-map-shell"
-    >
-      <div className="home-shell home-section">
-        <motion.div
-          variants={variants}
-          initial="hidden"
-          animate="visible"
-          className="flex flex-col gap-6"
-        >
-          <div className="tool-topbar" id="food-map-main">
-            <div>
-              <p className="tool-crumbs">
-                Food Map / <strong>{activeCity.name}</strong>
-              </p>
-              <h1>Food Map</h1>
+    <section className="fm" aria-label="Food Map" data-testid="food-map-shell">
+      <div className="fm-shell">
+        <motion.div variants={variants} initial="hidden" animate="visible">
+          {/* Masthead */}
+          <header className="fm-hero" id="food-map-main">
+            <div className="fm-hero-top">
+              <div>
+                <p className="fm-kicker">A field guide · where to eat</p>
+                <h1 className="fm-title">
+                  Food <em>Map</em>
+                </h1>
+                <p className="fm-lede">
+                  The spots I actually send people to, plus the ones the late Anthony
+                  Bourdain and the crowd swear by, plotted across ten cities from Austin
+                  to Tokyo. Pick a city, filter by who is vouching for it, and pull up
+                  what to order before you go.
+                </p>
+              </div>
+
+              <div className="fm-stamp-badge" aria-hidden="true">
+                <span className="fm-stamp-small">Est. now</span>
+                <span className="fm-stamp-big">EAT HERE</span>
+                <span className="fm-stamp-small">no reservations</span>
+              </div>
             </div>
 
-            <label className="tool-search" aria-label="Filter by name or cuisine">
-              <IconSearch size={14} aria-hidden="true" />
-              <input
-                type="search"
-                placeholder="Filter by name or cuisine…"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              />
-            </label>
+            <HeroTicker />
+          </header>
+
+          {/* Search + stats */}
+          <div className="fm-ribbon">
+            <div className="fm-stat">
+              <p className="fm-stat-label">Curated stops</p>
+              <p className="fm-stat-val">{FOOD_MAP_PLACES.length}</p>
+            </div>
+            <div className="fm-stat">
+              <p className="fm-stat-label">Cities</p>
+              <p className="fm-stat-val">{FOOD_MAP_CITIES.length}</p>
+            </div>
+            <div className="fm-stat">
+              <p className="fm-stat-label">Bourdain picks</p>
+              <p className="fm-stat-val">{bourdainCount}</p>
+            </div>
+            <div className="fm-stat">
+              <p className="fm-stat-label">In {activeCity.name}</p>
+              <p className="fm-stat-val">
+                {visiblePlaces.length}
+                <em>/{cityCount}</em>
+              </p>
+            </div>
           </div>
 
-          <div className="tool-meta-chip" role="status" aria-live="polite">
-            <span className="tool-meta-chip-dot" aria-hidden="true" />
+          <div className="fm-status" role="status" aria-live="polite">
+            <span className="fm-status-dot" aria-hidden="true" />
             <span>
-              <strong>{FOOD_MAP_PLACES.length}</strong> curated stops
-            </span>
-            <span className="tool-meta-chip-divider" aria-hidden="true">
-              ·
-            </span>
-            <span>
-              <strong>{FOOD_MAP_CITIES.length}</strong> cities
-            </span>
-            <span className="tool-meta-chip-spacer" />
-            <span className="tool-meta-chip-meta">
-              Showing {visiblePlaces.length} of {cityCount} in {activeCity.name} · Reviewed {FOOD_MAP_AS_OF} · I would still verify hours before going.
+              Showing {visiblePlaces.length} of {cityCount} in {activeCity.name} ·
+              Reviewed {FOOD_MAP_AS_OF} · I would still verify hours before going.
             </span>
           </div>
 
-          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,320px)]">
-            <div className="flex flex-col gap-4">
-              <HomeStatsPanel
-                id="food-map-stats"
-                title="Food Map at a glance"
-                meta={`${visiblePlaces.length} of ${cityCount} visible in ${activeCity.name}`}
-                hideLiveDot
-                cells={foodMapStatsCells}
-                pills={[
-                  { label: "All stops", href: "/food-map" },
-                  { label: "Tokyo", href: "/food-map?city=tokyo" },
-                  { label: "Bourdain picks", href: "/food-map?curator=bourdain" },
-                  { label: "New York", href: "/food-map?city=nyc" },
-                ]}
-              />
-
-              <div className="tool-card tool-card-hero overflow-hidden p-4 sm:p-5">
+          {/* Main grid */}
+          <div className="fm-grid">
+            <div className="fm-col">
+              {/* Map */}
+              <div className="fm-mapwrap">
+                <div className="fm-mapwrap-head">
+                  <p className="fm-kicker">The map · {activeCity.name}</p>
+                  <span className="fm-map-legend" aria-hidden="true">
+                    {FOOD_MAP_CURATORS.map((c) => (
+                      <i key={c.id}>
+                        <b style={{ background: c.accent }} />
+                        {c.name.split(" ")[0]}
+                      </i>
+                    ))}
+                  </span>
+                </div>
+                <div className="fm-map-ticks" aria-hidden="true">
+                  <span />
+                  <span />
+                  <span />
+                  <span />
+                </div>
                 <FoodMapLeaflet
                   spots={filteredPlaces}
                   activeSpotId={routeState.pick}
@@ -584,94 +495,82 @@ function FoodMapWorkbench({
                   center={activeCity.center}
                   zoom={activeCity.zoom}
                   reduceMotion={reduceMotion}
+                  isDark={isDark}
                 />
               </div>
 
-              <div className="tool-card flex flex-col" style={{ gap: 14 }}>
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <p className="home-kicker mb-0">Filters</p>
+              {/* Filters */}
+              <div className="fm-panel">
+                <div className="fm-deck-head">
+                  <p className="fm-kicker">Filters</p>
                   <button
                     type="button"
                     onClick={handleResetFilters}
                     disabled={!hasFilters}
-                    className="min-h-touch rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] transition-[transform,border-color,background-color,color,box-shadow] duration-200 ease disabled:cursor-not-allowed disabled:opacity-55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-signal)] focus-visible:ring-offset-2"
-                    style={{
-                      ...getPanelStyle(),
-                      color: "var(--home-ink)",
-                      fontFamily: "var(--font-home-sans)",
-                    }}
+                    className="fm-reset"
                   >
-                    Reset filters
+                    Reset
                   </button>
                 </div>
 
-                <div className="flex flex-col gap-2">
-                  <span
-                    className={FILTER_LABEL_CLASS}
-                    style={{ color: "var(--home-ink-muted)" }}
-                  >
-                    City
-                  </span>
-                  <CityChips
-                    state={routeState}
-                    counts={cityCounts}
-                    onSelect={handleSelectCity}
-                  />
-                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 16, marginTop: 14 }}>
+                  <div className="fm-fieldset">
+                    <span className="fm-legend">City</span>
+                    <CityTabs
+                      state={routeState}
+                      counts={cityCounts}
+                      onSelect={handleSelectCity}
+                    />
+                  </div>
 
-                <div className="flex flex-col gap-2">
-                  <span
-                    className={FILTER_LABEL_CLASS}
-                    style={{ color: "var(--home-ink-muted)" }}
-                  >
-                    Curator
-                  </span>
-                  <CuratorChips state={routeState} onToggle={handleToggleCurator} />
-                </div>
+                  <div className="fm-fieldset">
+                    <span className="fm-legend">Curator</span>
+                    <CuratorStamps state={routeState} onToggle={handleToggleCurator} />
+                  </div>
 
-                <div className="flex flex-col gap-2">
-                  <span
-                    className={FILTER_LABEL_CLASS}
-                    style={{ color: "var(--home-ink-muted)" }}
-                  >
-                    Cuisine
-                  </span>
-                  <CuisineChips
-                    cuisines={cityCuisines}
-                    state={routeState}
-                    onToggle={handleToggleCuisine}
-                  />
+                  <div className="fm-fieldset">
+                    <span className="fm-legend">Cuisine</span>
+                    <CuisinePills
+                      cuisines={cityCuisines}
+                      state={routeState}
+                      onToggle={handleToggleCuisine}
+                    />
+                  </div>
                 </div>
               </div>
 
+              {/* Index */}
+              <div className="fm-index-head">
+                <h2 className="fm-index-title">The stops</h2>
+                <label className="fm-search" aria-label="Filter by name or cuisine">
+                  <IconSearch size={15} aria-hidden="true" />
+                  <input
+                    type="search"
+                    placeholder="Filter by name or cuisine…"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                  />
+                </label>
+              </div>
+
               {visiblePlaces.length === 0 ? (
-                <div className="tool-empty">
-                  <p className="text-sm font-semibold" style={{ color: "var(--home-ink)" }}>
-                    Nothing matches that combination yet.
-                  </p>
+                <div className="fm-empty">
+                  <p className="fm-empty-title">Nothing matches that combination yet.</p>
                   <p>
-                    The list intentionally stays short, so a few filters can rule it
-                    out entirely.
+                    The list intentionally stays short, so a few filters can rule it out
+                    entirely. Loosen one and it comes back.
                   </p>
-                  <button
-                    type="button"
-                    onClick={handleResetFilters}
-                    className="mt-4 min-h-touch rounded-full px-4 py-2 text-sm font-semibold transition-[transform,border-color,background-color,color] duration-200 ease focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home-signal)] focus-visible:ring-offset-2"
-                    style={{
-                      ...getPanelStyle(),
-                      color: "var(--home-ink)",
-                      fontFamily: "var(--font-home-sans)",
-                    }}
-                  >
+                  <button type="button" onClick={handleResetFilters} className="fm-reset">
                     Reset filters
                   </button>
                 </div>
               ) : (
-                <div className="grid gap-3 md:grid-cols-2">
-                  {visiblePlaces.map((place) => (
-                    <PlaceCard
+                <div className="fm-index">
+                  {visiblePlaces.map((place, i) => (
+                    <PlaceTicket
                       key={place.id}
                       place={place}
+                      index={i}
                       isSelected={routeState.pick === place.id}
                       onSelect={handleSelectPlace}
                     />
@@ -680,28 +579,21 @@ function FoodMapWorkbench({
               )}
             </div>
 
-            <aside
-              aria-label="Food map side panel"
-              className="flex flex-col gap-4 rounded-[var(--radius-3xl)] p-5 lg:sticky lg:top-24 lg:self-start"
-              style={getPanelStyle()}
-            >
+            {/* Rail */}
+            <aside aria-label="Food map side panel" className="fm-rail">
               {selectedPlace ? (
-                <PlaceDetail place={selectedPlace} onClear={handleClearPick} />
+                <PlaceDossier place={selectedPlace} onClear={handleClearPick} />
               ) : (
                 <>
-                  <p className="tool-rail-label">Curators</p>
-                  <p
-                    className="-mt-1 text-xs leading-relaxed"
-                    style={{ color: "var(--home-ink-muted)" }}
-                  >
-                    Pins are colored by who recommends them. Tap a pin or a card to
-                    see why it earns the spot.
+                  <p className="fm-kicker">The curators</p>
+                  <p className="fm-rail-lede">
+                    Pins are colored by who recommends them. Tap a pin or a stop to see
+                    what to order and why it earns the spot.
                   </p>
-                  <CuratorLegend />
+                  <CuratorPassport />
                 </>
               )}
-
-              <p className="tool-rail-foot">
+              <p className="fm-rail-foot">
                 These are the spots I actually send people to.
               </p>
             </aside>
@@ -728,6 +620,11 @@ export function FoodMapClient({ initialState }: FoodMapClientProps) {
   const shouldReduceMotion = useReducedMotion();
   const variants = shouldReduceMotion ? noMotion : fadeIn;
 
+  // Theme drives the map basemap (dark field-map vs. warm daylight). This only
+  // feeds the client-only Leaflet map, so there's no SSR markup to mismatch.
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+
   const normalizedRouteState = normalizeFoodMapState(searchParams);
   const currentQuery = searchParams.toString();
   const currentHref = currentQuery ? `${FOOD_MAP_ROUTE}?${currentQuery}` : FOOD_MAP_ROUTE;
@@ -752,9 +649,8 @@ export function FoodMapClient({ initialState }: FoodMapClientProps) {
       routeState={routeState}
       variants={variants}
       reduceMotion={Boolean(shouldReduceMotion)}
-      onCommit={(next) =>
-        router.replace(buildFoodMapHref(next), { scroll: false })
-      }
+      isDark={isDark}
+      onCommit={(next) => router.replace(buildFoodMapHref(next), { scroll: false })}
     />
   );
 }

--- a/src/app/food-map/food-map-leaflet.tsx
+++ b/src/app/food-map/food-map-leaflet.tsx
@@ -4,8 +4,8 @@ import { useEffect, useRef, useState } from "react";
 import { IconMapPin } from "@tabler/icons-react";
 import {
   loadLeaflet,
-  OSM_ATTRIBUTION,
-  OSM_TILE_URL,
+  cartoTiles,
+  type LeafletLayer,
   type LeafletLayerGroup,
   type LeafletMap,
   type LeafletMarker,
@@ -30,6 +30,8 @@ interface FoodMapLeafletProps {
   zoom: number;
   /** When true, jump instead of animating (honors prefers-reduced-motion). */
   reduceMotion?: boolean;
+  /** Drives the basemap: a moody dark field-map vs. a warm daylight one. */
+  isDark?: boolean;
 }
 
 const escapeHtml = (value: string): string =>
@@ -47,13 +49,9 @@ const escapeHtml = (value: string): string =>
 
 const pinIcon = (L: LeafletStatic, color: string, active: boolean) =>
   L.divIcon({
-    className: "food-map-pin",
-    html: `<span style="
-      display:block;width:${active ? 30 : 22}px;height:${active ? 30 : 22}px;
-      border-radius:50% 50% 50% 0;transform:rotate(-45deg);
-      background:${color};border:2px solid #fff;
-      box-shadow:0 2px 6px rgba(0,0,0,0.35);
-      ${active ? "outline:3px solid rgba(0,0,0,0.18);outline-offset:1px;" : ""}
+    className: `fm-pin-el${active ? " fm-pin-active" : ""}`,
+    html: `<span class="fm-pin-dot" style="
+      width:${active ? 30 : 22}px;height:${active ? 30 : 22}px;background:${color};
     "></span>`,
     iconSize: active ? [30, 30] : [22, 22],
     iconAnchor: active ? [15, 28] : [11, 21],
@@ -67,11 +65,13 @@ export function FoodMapLeaflet({
   center,
   zoom,
   reduceMotion = false,
+  isDark = false,
 }: FoodMapLeafletProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const leafletRef = useRef<LeafletStatic | null>(null);
   const mapRef = useRef<LeafletMap | null>(null);
   const groupRef = useRef<LeafletLayerGroup | null>(null);
+  const tileRef = useRef<LeafletLayer | null>(null);
   const markersRef = useRef<Map<string, LeafletMarker>>(new Map());
   // Tracks the last spot set we fit the viewport to, so re-styling the active
   // pin doesn't refit the bounds and fight the separate fly-to effect.
@@ -95,9 +95,11 @@ export function FoodMapLeaflet({
           center,
           zoom
         );
-        L.tileLayer(OSM_TILE_URL, { attribution: OSM_ATTRIBUTION, maxZoom: 19 }).addTo(
-          map
-        );
+        const tiles = cartoTiles(isDark);
+        tileRef.current = L.tileLayer(tiles.url, {
+          attribution: tiles.attribution,
+          maxZoom: 19,
+        }).addTo(map);
         groupRef.current = L.layerGroup().addTo(map);
         mapRef.current = map;
         setStatus("ready");
@@ -112,11 +114,27 @@ export function FoodMapLeaflet({
       mapRef.current?.remove();
       mapRef.current = null;
       groupRef.current = null;
+      tileRef.current = null;
       markers.clear();
     };
-    // Only run on mount — center/zoom changes are handled below.
+    // Only run on mount — center/zoom/theme changes are handled below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Swap the basemap when the theme flips, without tearing down the map.
+  useEffect(() => {
+    const L = leafletRef.current;
+    const map = mapRef.current;
+    if (status !== "ready" || !L || !map) return;
+    if (tileRef.current) {
+      tileRef.current.remove();
+    }
+    const tiles = cartoTiles(isDark);
+    tileRef.current = L.tileLayer(tiles.url, {
+      attribution: tiles.attribution,
+      maxZoom: 19,
+    }).addTo(map);
+  }, [isDark, status]);
 
   // Rebuild markers whenever the set of spots (or active highlight) changes.
   const spotsKey = spots.map((s) => s.id).join(",");
@@ -136,7 +154,7 @@ export function FoodMapLeaflet({
         icon: pinIcon(L, color, isActive),
       }).addTo(group);
       marker.bindPopup(
-        `<strong>${escapeHtml(spot.name)}</strong><br/><span style="color:#555">${escapeHtml(
+        `<span class="fm-popup-title">${escapeHtml(spot.name)}</span><br/><span class="fm-popup-sub">${escapeHtml(
           getFoodMapCuisine(spot.cuisine).label
         )}</span>`
       );
@@ -181,18 +199,10 @@ export function FoodMapLeaflet({
 
   if (status === "error") {
     return (
-      <div
-        className="flex min-h-[320px] flex-col items-center justify-center gap-3 rounded-[var(--radius-3xl)] p-8 text-center"
-        style={{
-          border: "1px solid var(--home-rule)",
-          background: "color-mix(in srgb, var(--home-paper) 90%, var(--home-elev-mix))",
-        }}
-        role="img"
-        aria-label="Map unavailable"
-      >
-        <IconMapPin size={28} aria-hidden="true" style={{ color: "var(--home-ink-muted)" }} />
-        <p className="max-w-xs text-sm" style={{ color: "var(--home-ink-muted)" }}>
-          The interactive map couldn&apos;t load right now. The full list of spots is
+      <div className="fm-map-fallback" role="img" aria-label="Map unavailable">
+        <IconMapPin size={28} aria-hidden="true" />
+        <p style={{ maxWidth: "22rem", margin: 0, fontSize: 13.5 }}>
+          The interactive map couldn&apos;t load right now. The full list of stops is
           still below.
         </p>
       </div>
@@ -200,27 +210,15 @@ export function FoodMapLeaflet({
   }
 
   return (
-    <div className="relative h-[420px] w-full">
+    <div style={{ position: "relative" }}>
       <div
         ref={containerRef}
-        className="h-full min-h-[320px] w-full rounded-[var(--radius-3xl)]"
-        style={{
-          border: "1px solid var(--home-rule)",
-          background: "color-mix(in srgb, var(--home-paper) 90%, var(--home-elev-mix))",
-        }}
+        className="fm-map"
         role="application"
         aria-label="Map of recommended food spots"
       />
       {status === "loading" && (
-        <div
-          className="absolute inset-0 flex items-center justify-center rounded-[var(--radius-3xl)] text-sm"
-          style={{
-            background: "color-mix(in srgb, var(--home-paper) 90%, var(--home-elev-mix))",
-            color: "var(--home-ink-muted)",
-          }}
-        >
-          Loading map…
-        </div>
+        <div className="fm-map-loading">Loading map…</div>
       )}
     </div>
   );

--- a/src/app/food-map/food-map.css
+++ b/src/app/food-map/food-map.css
@@ -1,0 +1,948 @@
+/* ==========================================================================
+   Food Map — "After Hours" field guide skin
+   --------------------------------------------------------------------------
+   This file is a deliberate, self-contained departure from the site-wide
+   editorial system (see CLAUDE.md → Styling). The food map is repurposed as a
+   late-night, printed field-guide surface: espresso + warm cream, big display
+   serif, ticket-stub cards, passport stamps, and a cinematic map. Everything
+   lives under `.fm` and defines its own local tokens so it never leaks into
+   the shared `--home-*` palette. Curator hues come straight from the data
+   (see food-map-data.ts) and are passed in as inline `--fm-accent`.
+   ========================================================================== */
+
+.fm {
+  /* ---- Local palette: warm daylight market ---- */
+  --fm-ink: #241b12;
+  --fm-ink-dim: #6b5b47;
+  --fm-ink-faint: #9c8a71;
+  --fm-paper: #f5ecdb;
+  --fm-surface: #fffaf0;
+  --fm-surface-2: #f0e5d0;
+  --fm-line: #e2d5bd;
+  --fm-line-strong: #c9b795;
+  --fm-tomato: #c14634;
+  --fm-saffron: #b9791c;
+  --fm-basil: #3d7a51;
+  --fm-signal: #d94a2f;
+  --fm-invert: #fffaf0;
+  --fm-glow: 0 0 0 rgba(0, 0, 0, 0);
+
+  /* ---- Local radii — crisper than the ticket edges around it ---- */
+  --fm-r-sm: 4px;
+  --fm-r: 8px;
+  --fm-r-lg: 14px;
+  --fm-r-pill: 999px;
+
+  --fm-shadow-sm: 0 1px 0 rgba(36, 27, 18, 0.04), 0 10px 24px -20px rgba(36, 27, 18, 0.5);
+  --fm-shadow: 0 2px 0 rgba(36, 27, 18, 0.05), 0 26px 60px -34px rgba(36, 27, 18, 0.62);
+
+  position: relative;
+  color: var(--fm-ink);
+  background: var(--fm-paper);
+  font-family: var(--font-home-sans);
+  isolation: isolate;
+  overflow: clip;
+}
+
+.dark .fm {
+  /* ---- Local palette: espresso after hours ---- */
+  --fm-ink: #f3e8d5;
+  --fm-ink-dim: #b8a586;
+  --fm-ink-faint: #8a7860;
+  --fm-paper: #120e0a;
+  --fm-surface: #1c1610;
+  --fm-surface-2: #262019;
+  --fm-line: #362c20;
+  --fm-line-strong: #4e3f2d;
+  --fm-tomato: #ef6a52;
+  --fm-saffron: #e6a537;
+  --fm-basil: #67ae76;
+  --fm-signal: #ff6a4d;
+  --fm-invert: #120e0a;
+
+  --fm-shadow-sm: 0 1px 0 rgba(0, 0, 0, 0.3), 0 12px 26px -20px rgba(0, 0, 0, 0.8);
+  --fm-shadow: 0 2px 0 rgba(0, 0, 0, 0.35), 0 30px 70px -34px rgba(0, 0, 0, 0.9);
+}
+
+/* Warm grain / lamp-glow wash behind everything. */
+.fm::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(120% 80% at 8% -6%, color-mix(in srgb, var(--fm-signal) 12%, transparent), transparent 60%),
+    radial-gradient(90% 60% at 100% 0%, color-mix(in srgb, var(--fm-saffron) 14%, transparent), transparent 55%);
+  opacity: 0.9;
+}
+
+.fm-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(20px, 4vw, 40px) clamp(16px, 4vw, 44px) 72px;
+}
+
+/* Shared label stamp — mono, letterspaced, printed. */
+.fm-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--fm-ink-dim);
+}
+.fm-kicker::before {
+  content: "";
+  width: 18px;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.6;
+}
+
+/* ==========================================================================
+   Masthead
+   ========================================================================== */
+
+.fm-hero {
+  position: relative;
+  border: 1px solid var(--fm-line);
+  border-radius: var(--fm-r-lg);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--fm-surface) 92%, transparent), var(--fm-paper));
+  box-shadow: var(--fm-shadow);
+  overflow: hidden;
+  padding: clamp(24px, 4vw, 44px);
+}
+
+/* Registration ticks in the corners — a printed-map tell. */
+.fm-hero::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border: 1px dashed color-mix(in srgb, var(--fm-line-strong) 70%, transparent);
+  border-radius: calc(var(--fm-r-lg) - 6px);
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+.fm-hero-top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  position: relative;
+  z-index: 1;
+}
+
+.fm-title {
+  margin: 14px 0 0;
+  font-family: var(--font-home-serif);
+  font-weight: 400;
+  font-size: clamp(3rem, 9vw, 6.2rem);
+  line-height: 0.86;
+  letter-spacing: -0.03em;
+  color: var(--fm-ink);
+}
+.fm-title em {
+  font-style: italic;
+  color: var(--fm-signal);
+}
+
+.fm-lede {
+  margin: 18px 0 0;
+  max-width: 56ch;
+  font-size: clamp(0.98rem, 0.4vw + 0.9rem, 1.12rem);
+  line-height: 1.7;
+  color: var(--fm-ink-dim);
+}
+
+/* Passport stamp, top-right of the masthead. */
+.fm-stamp-badge {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 108px;
+  height: 108px;
+  border-radius: var(--fm-r-pill);
+  border: 2px solid color-mix(in srgb, var(--fm-signal) 60%, var(--fm-line-strong));
+  color: color-mix(in srgb, var(--fm-signal) 78%, var(--fm-ink));
+  transform: rotate(-9deg);
+  text-align: center;
+  font-family: var(--font-mono);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background:
+    repeating-conic-gradient(from 0deg, transparent 0deg 8deg, color-mix(in srgb, var(--fm-signal) 8%, transparent) 8deg 16deg);
+  opacity: 0.92;
+}
+.fm-stamp-badge span {
+  display: block;
+}
+.fm-stamp-badge .fm-stamp-big {
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  margin-top: 2px;
+}
+.fm-stamp-badge .fm-stamp-small {
+  font-size: 8.5px;
+  margin-top: 3px;
+  opacity: 0.8;
+}
+
+/* Marquee ticker of cuisines / cities. */
+.fm-ticker {
+  position: relative;
+  z-index: 1;
+  margin-top: 26px;
+  border-top: 1px solid var(--fm-line);
+  border-bottom: 1px solid var(--fm-line);
+  padding: 0;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+  mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+}
+.fm-ticker-track {
+  display: inline-flex;
+  align-items: center;
+  gap: 22px;
+  white-space: nowrap;
+  padding: 11px 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fm-ink-dim);
+  will-change: transform;
+  animation: fm-marquee 34s linear infinite;
+}
+.fm-ticker-track span {
+  display: inline-flex;
+  align-items: center;
+  gap: 22px;
+}
+.fm-ticker-track span::after {
+  content: "◆";
+  font-size: 7px;
+  color: var(--fm-signal);
+  opacity: 0.7;
+}
+@keyframes fm-marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+/* ==========================================================================
+   Search
+   ========================================================================== */
+
+.fm-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: min(300px, 100%);
+  min-height: 44px;
+  padding: 8px 16px;
+  border-radius: var(--fm-r-pill);
+  border: 1px solid var(--fm-line-strong);
+  background: color-mix(in srgb, var(--fm-surface) 88%, var(--fm-paper));
+  color: var(--fm-ink-dim);
+  box-shadow: var(--fm-shadow-sm);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.fm-search:focus-within {
+  border-color: color-mix(in srgb, var(--fm-signal) 55%, var(--fm-line-strong));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--fm-signal) 20%, transparent);
+}
+.fm-search input {
+  all: unset;
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  color: var(--fm-ink);
+}
+.fm-search input::placeholder { color: var(--fm-ink-faint); }
+
+/* ==========================================================================
+   Stats ribbon — a torn ticket stub
+   ========================================================================== */
+
+.fm-ribbon {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  margin-top: 20px;
+  border: 1px solid var(--fm-line);
+  border-radius: var(--fm-r);
+  background: var(--fm-surface);
+  box-shadow: var(--fm-shadow-sm);
+  overflow: hidden;
+}
+@media (max-width: 720px) {
+  .fm-ribbon { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+.fm-stat {
+  position: relative;
+  padding: 16px 18px;
+  min-width: 0;
+}
+.fm-stat + .fm-stat::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 12px;
+  bottom: 12px;
+  border-left: 1px dashed var(--fm-line-strong);
+  opacity: 0.7;
+}
+@media (max-width: 720px) {
+  .fm-stat:nth-child(odd) + .fm-stat::before { border-left-style: dashed; }
+}
+.fm-stat-label {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fm-ink-faint);
+}
+.fm-stat-val {
+  margin: 6px 0 0;
+  font-family: var(--font-home-serif);
+  font-size: clamp(1.7rem, 1vw + 1.3rem, 2.2rem);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--fm-ink);
+  font-variant-numeric: tabular-nums;
+}
+.fm-stat-val em {
+  font-style: normal;
+  font-size: 0.5em;
+  color: var(--fm-ink-faint);
+  margin-left: 4px;
+}
+
+/* Live status line. */
+.fm-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 16px;
+  padding: 7px 15px;
+  border-radius: var(--fm-r-pill);
+  border: 1px solid var(--fm-line);
+  background: color-mix(in srgb, var(--fm-surface) 80%, var(--fm-paper));
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.03em;
+  color: var(--fm-ink-dim);
+}
+.fm-status strong { color: var(--fm-ink); font-weight: 600; }
+.fm-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--fm-signal);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--fm-signal) 22%, transparent);
+  animation: fm-pulse 2.4s ease-in-out infinite;
+}
+@keyframes fm-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+/* ==========================================================================
+   Layout grid
+   ========================================================================== */
+
+.fm-grid {
+  display: grid;
+  gap: 22px;
+  margin-top: 24px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 340px);
+}
+@media (max-width: 1000px) {
+  .fm-grid { grid-template-columns: minmax(0, 1fr); }
+}
+.fm-col { display: flex; flex-direction: column; gap: 20px; min-width: 0; }
+
+.fm-panel {
+  border: 1px solid var(--fm-line);
+  border-radius: var(--fm-r);
+  background: var(--fm-surface);
+  box-shadow: var(--fm-shadow-sm);
+  padding: 20px;
+}
+
+.fm-rail {
+  position: sticky;
+  top: 92px;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border: 1px solid var(--fm-line);
+  border-radius: var(--fm-r);
+  background: var(--fm-surface);
+  box-shadow: var(--fm-shadow);
+  padding: 20px;
+}
+@media (max-width: 1000px) {
+  .fm-rail { position: static; }
+}
+
+/* ==========================================================================
+   Filter deck
+   ========================================================================== */
+
+.fm-deck-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.fm-reset {
+  min-height: 44px;
+  padding: 7px 14px;
+  border-radius: var(--fm-r-pill);
+  border: 1px solid var(--fm-line-strong);
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fm-ink-dim);
+  cursor: pointer;
+  transition: color 0.18s ease, border-color 0.18s ease, background-color 0.18s ease;
+}
+.fm-reset:hover:not(:disabled) {
+  color: var(--fm-signal);
+  border-color: color-mix(in srgb, var(--fm-signal) 55%, var(--fm-line-strong));
+}
+.fm-reset:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.fm-fieldset { display: flex; flex-direction: column; gap: 10px; }
+.fm-legend {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--fm-ink-faint);
+}
+.fm-chiprow { display: flex; flex-wrap: wrap; gap: 8px; }
+
+/* City = bold destination tab. */
+.fm-tab {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  min-height: 44px;
+  padding: 9px 16px;
+  border-radius: var(--fm-r-sm);
+  border: 1px solid var(--fm-line-strong);
+  background: color-mix(in srgb, var(--fm-surface) 70%, var(--fm-paper));
+  color: var(--fm-ink);
+  font-family: var(--font-home-serif);
+  font-size: 17px;
+  letter-spacing: -0.01em;
+  cursor: pointer;
+  transition: transform 0.15s ease, border-color 0.18s ease, background-color 0.18s ease, box-shadow 0.18s ease;
+}
+.fm-tab:hover { transform: translateY(-1px); }
+.fm-tab[aria-checked="true"] {
+  border-color: transparent;
+  background: var(--fm-ink);
+  color: var(--fm-invert);
+  box-shadow: 0 6px 18px -10px color-mix(in srgb, var(--fm-ink) 80%, transparent);
+}
+.fm-tab-count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--fm-ink-faint);
+}
+.fm-tab[aria-checked="true"] .fm-tab-count {
+  color: color-mix(in srgb, var(--fm-invert) 70%, transparent);
+}
+
+/* Curator = passport stamp button. */
+.fm-stamp {
+  --fm-accent: var(--fm-signal);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 8px 14px;
+  border-radius: var(--fm-r-pill);
+  border: 1.5px solid var(--fm-line-strong);
+  background: transparent;
+  color: var(--fm-ink);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease, transform 0.15s ease;
+}
+.fm-stamp:hover { transform: translateY(-1px); }
+.fm-stamp-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--fm-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--fm-accent) 24%, transparent);
+}
+.fm-stamp[aria-pressed="true"] {
+  border-color: var(--fm-accent);
+  background: color-mix(in srgb, var(--fm-accent) 16%, transparent);
+  color: color-mix(in srgb, var(--fm-accent) 42%, var(--fm-ink));
+}
+
+/* Cuisine = printed pill. */
+.fm-pill {
+  min-height: 44px;
+  padding: 7px 13px;
+  border-radius: var(--fm-r-sm);
+  border: 1px solid var(--fm-line);
+  background: color-mix(in srgb, var(--fm-surface) 70%, var(--fm-paper));
+  color: var(--fm-ink-dim);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease;
+}
+.fm-pill:hover { color: var(--fm-ink); border-color: var(--fm-line-strong); }
+.fm-pill[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--fm-signal) 55%, var(--fm-line-strong));
+  background: color-mix(in srgb, var(--fm-signal) 14%, transparent);
+  color: color-mix(in srgb, var(--fm-signal) 45%, var(--fm-ink));
+}
+
+/* Focus ring — shared. */
+.fm :focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--fm-signal) 45%, transparent);
+}
+
+/* ==========================================================================
+   Map frame
+   ========================================================================== */
+
+.fm-mapwrap {
+  position: relative;
+  border: 1px solid var(--fm-line-strong);
+  border-radius: var(--fm-r);
+  background: var(--fm-surface-2);
+  box-shadow: var(--fm-shadow);
+  padding: 12px;
+  overflow: hidden;
+}
+.fm-mapwrap-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 2px 4px 12px;
+}
+.fm-mapwrap-head .fm-kicker { color: var(--fm-ink-dim); }
+.fm-map-legend {
+  display: inline-flex;
+  gap: 12px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fm-ink-faint);
+}
+.fm-map-legend i {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-style: normal;
+}
+.fm-map-legend b {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+/* Corner registration ticks on the map itself. */
+.fm-map-ticks {
+  position: absolute;
+  inset: 12px;
+  pointer-events: none;
+  z-index: 500;
+}
+.fm-map-ticks span {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 2px solid color-mix(in srgb, var(--fm-signal) 70%, transparent);
+}
+.fm-map-ticks span:nth-child(1) { top: 8px; left: 8px; border-right: 0; border-bottom: 0; }
+.fm-map-ticks span:nth-child(2) { top: 8px; right: 8px; border-left: 0; border-bottom: 0; }
+.fm-map-ticks span:nth-child(3) { bottom: 8px; left: 8px; border-right: 0; border-top: 0; }
+.fm-map-ticks span:nth-child(4) { bottom: 8px; right: 8px; border-left: 0; border-top: 0; }
+
+.fm-map {
+  height: clamp(360px, 52vh, 520px);
+  width: 100%;
+  border-radius: var(--fm-r-sm);
+  overflow: hidden;
+}
+.fm-map-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  height: clamp(360px, 52vh, 520px);
+  text-align: center;
+  padding: 32px;
+  color: var(--fm-ink-dim);
+}
+.fm-map-loading {
+  position: absolute;
+  inset: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--fm-r-sm);
+  background: color-mix(in srgb, var(--fm-surface-2) 88%, transparent);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fm-ink-faint);
+  z-index: 600;
+}
+
+/* Leaflet chrome, restyled to match. */
+.fm-map .leaflet-control-zoom a {
+  background: var(--fm-surface);
+  color: var(--fm-ink);
+  border-color: var(--fm-line-strong);
+}
+.fm-map .leaflet-control-attribution {
+  background: color-mix(in srgb, var(--fm-surface) 82%, transparent);
+  color: var(--fm-ink-faint);
+}
+.fm-map .leaflet-control-attribution a { color: var(--fm-ink-dim); }
+.fm-map .leaflet-popup-content-wrapper {
+  background: var(--fm-surface);
+  color: var(--fm-ink);
+  border-radius: var(--fm-r-sm);
+  border: 1px solid var(--fm-line-strong);
+  box-shadow: var(--fm-shadow);
+}
+.fm-map .leaflet-popup-tip {
+  background: var(--fm-surface);
+  border: 1px solid var(--fm-line-strong);
+}
+.fm-map .leaflet-popup-content { margin: 10px 14px; font-family: var(--font-home-sans); }
+.fm-map .fm-popup-title {
+  font-family: var(--font-home-serif);
+  font-size: 16px;
+  letter-spacing: -0.01em;
+}
+.fm-map .fm-popup-sub {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fm-ink-faint);
+}
+
+/* Custom teardrop pin — white keyline reads on both dark and light basemaps. */
+.fm-pin-el { background: transparent; border: 0; }
+.fm-pin-dot {
+  display: block;
+  border-radius: 50% 50% 50% 0;
+  transform: rotate(-45deg);
+  border: 2px solid rgba(255, 251, 240, 0.95);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.45);
+}
+.fm-pin-active .fm-pin-dot {
+  box-shadow: 0 0 0 4px rgba(255, 251, 240, 0.5), 0 4px 12px rgba(0, 0, 0, 0.55);
+  animation: fm-ping 1.8s ease-out infinite;
+}
+@keyframes fm-ping {
+  0% { box-shadow: 0 0 0 3px rgba(255, 251, 240, 0.6), 0 4px 12px rgba(0, 0, 0, 0.55); }
+  70% { box-shadow: 0 0 0 13px rgba(255, 251, 240, 0), 0 4px 12px rgba(0, 0, 0, 0.55); }
+  100% { box-shadow: 0 0 0 13px rgba(255, 251, 240, 0), 0 4px 12px rgba(0, 0, 0, 0.55); }
+}
+
+/* ==========================================================================
+   Place index — ticket stubs
+   ========================================================================== */
+
+.fm-index-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 0 2px;
+}
+.fm-index-title {
+  margin: 0;
+  font-family: var(--font-home-serif);
+  font-size: clamp(1.5rem, 1.2vw + 1.1rem, 2rem);
+  letter-spacing: -0.02em;
+  color: var(--fm-ink);
+}
+.fm-index {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+@media (max-width: 620px) {
+  .fm-index { grid-template-columns: minmax(0, 1fr); }
+}
+
+.fm-ticket {
+  --fm-accent: var(--fm-signal);
+  position: relative;
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 18px 18px 18px 20px;
+  border: 1px solid var(--fm-line);
+  border-left: 4px solid var(--fm-accent);
+  border-radius: var(--fm-r-sm);
+  background: var(--fm-surface);
+  box-shadow: var(--fm-shadow-sm);
+  cursor: pointer;
+  transition: transform 0.16s ease, border-color 0.18s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+.fm-ticket:hover { transform: translateY(-2px); box-shadow: var(--fm-shadow); }
+.fm-ticket[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--fm-accent) 10%, var(--fm-surface));
+  border-color: color-mix(in srgb, var(--fm-accent) 45%, var(--fm-line));
+  border-left-color: var(--fm-accent);
+}
+
+.fm-ticket-index {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--fm-ink-faint);
+}
+.fm-ticket-cuisine {
+  margin: 0 0 6px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--fm-accent);
+}
+.fm-ticket-name {
+  margin: 0;
+  padding-right: 28px;
+  font-family: var(--font-home-serif);
+  font-size: 1.32rem;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: var(--fm-ink);
+}
+.fm-ticket-meta {
+  margin: 8px 0 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12.5px;
+  color: var(--fm-ink-dim);
+}
+.fm-ticket-price {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: var(--fm-basil);
+  padding: 2px 7px;
+  border: 1px solid color-mix(in srgb, var(--fm-basil) 40%, var(--fm-line));
+  border-radius: var(--fm-r-sm);
+}
+
+/* Empty state. */
+.fm-empty {
+  border: 1px dashed var(--fm-line-strong);
+  border-radius: var(--fm-r);
+  background: color-mix(in srgb, var(--fm-surface) 70%, var(--fm-paper));
+  padding: 32px 24px;
+  text-align: center;
+}
+.fm-empty-title {
+  margin: 0;
+  font-family: var(--font-home-serif);
+  font-size: 1.4rem;
+  color: var(--fm-ink);
+}
+.fm-empty p { margin: 8px auto 0; max-width: 40ch; font-size: 13.5px; color: var(--fm-ink-dim); }
+.fm-empty button { margin-top: 18px; }
+
+/* ==========================================================================
+   Rail — dossier + curator passport
+   ========================================================================== */
+
+.fm-rail-lede {
+  margin: -4px 0 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--fm-ink-dim);
+}
+.fm-rail-foot {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px dashed var(--fm-line-strong);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--fm-ink-faint);
+}
+
+.fm-passport { display: flex; flex-direction: column; gap: 10px; }
+.fm-passport-card {
+  --fm-accent: var(--fm-signal);
+  position: relative;
+  padding: 14px 14px 14px 16px;
+  border: 1px solid var(--fm-line);
+  border-left: 3px solid var(--fm-accent);
+  border-radius: var(--fm-r-sm);
+  background: color-mix(in srgb, var(--fm-surface) 60%, var(--fm-paper));
+}
+.fm-passport-name {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--fm-ink);
+}
+.fm-passport-blurb {
+  margin: 6px 0 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--fm-ink-dim);
+}
+
+/* Dossier for a selected place. */
+.fm-dossier { display: flex; flex-direction: column; gap: 14px; }
+.fm-back {
+  align-self: flex-start;
+  min-height: 44px;
+  padding: 7px 14px;
+  border-radius: var(--fm-r-pill);
+  border: 1px solid var(--fm-line-strong);
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fm-ink-dim);
+  cursor: pointer;
+  transition: color 0.18s ease, border-color 0.18s ease;
+}
+.fm-back:hover { color: var(--fm-signal); border-color: color-mix(in srgb, var(--fm-signal) 55%, var(--fm-line-strong)); }
+
+.fm-dossier-head {
+  --fm-accent: var(--fm-signal);
+  padding: 16px 16px 18px;
+  border: 1px solid color-mix(in srgb, var(--fm-accent) 30%, var(--fm-line));
+  border-top: 4px solid var(--fm-accent);
+  border-radius: var(--fm-r-sm);
+  background: color-mix(in srgb, var(--fm-accent) 9%, var(--fm-surface));
+}
+.fm-dossier-cuisine {
+  margin: 0 0 6px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--fm-accent);
+}
+.fm-dossier-name {
+  margin: 0;
+  font-family: var(--font-home-serif);
+  font-size: 1.7rem;
+  line-height: 1.02;
+  letter-spacing: -0.02em;
+  color: var(--fm-ink);
+}
+.fm-dossier-locale {
+  margin: 8px 0 0;
+  font-size: 12.5px;
+  color: var(--fm-ink-dim);
+}
+
+.fm-dossier-rows { display: flex; flex-direction: column; gap: 10px; margin-top: 16px; }
+.fm-dossier-row {
+  padding: 11px 13px;
+  border: 1px solid var(--fm-line);
+  border-radius: var(--fm-r-sm);
+  background: color-mix(in srgb, var(--fm-surface) 65%, var(--fm-paper));
+}
+.fm-dossier-row-label {
+  margin: 0 0 3px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fm-ink-faint);
+}
+.fm-dossier-row-val {
+  margin: 0;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--fm-ink);
+}
+.fm-dossier-why {
+  margin: 16px 0 0;
+  font-size: 13.5px;
+  line-height: 1.7;
+  color: var(--fm-ink);
+}
+.fm-dossier-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: flex-start;
+  margin-top: 16px;
+  min-height: 44px;
+  padding: 11px 18px;
+  border-radius: var(--fm-r-pill);
+  border: 0;
+  background: var(--fm-ink);
+  color: var(--fm-invert);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.15s ease, opacity 0.18s ease;
+}
+.fm-dossier-link:hover { transform: translateY(-1px); opacity: 0.92; }
+
+/* ==========================================================================
+   Reduced motion
+   ========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  .fm-ticker-track { animation: none; transform: none; }
+  .fm-status-dot { animation: none; }
+  .fm-pin-active .fm-pin-dot { animation: none; }
+  .fm-tab:hover,
+  .fm-stamp:hover,
+  .fm-ticket:hover,
+  .fm-dossier-link:hover { transform: none; }
+}

--- a/src/app/food-map/leaflet.ts
+++ b/src/app/food-map/leaflet.ts
@@ -24,6 +24,7 @@ export interface LeafletMap {
 
 export interface LeafletLayer {
   addTo(target: LeafletMap | LeafletLayerGroup): LeafletLayer;
+  remove(): void;
 }
 
 export interface LeafletLayerGroup {
@@ -95,6 +96,17 @@ export function loadLeaflet(): Promise<LeafletStatic> {
   return cached;
 }
 
-export const OSM_TILE_URL = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
-export const OSM_ATTRIBUTION =
-  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+// CARTO basemaps give the food map its own cinematic look: a moody "dark
+// matter" field-map at night, a warm "voyager" one by day. Both are free
+// raster tiles that only require OSM + CARTO attribution.
+const CARTO_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>';
+
+export function cartoTiles(isDark: boolean): { url: string; attribution: string } {
+  return {
+    url: isDark
+      ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
+      : "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png",
+    attribution: CARTO_ATTRIBUTION,
+  };
+}


### PR DESCRIPTION
## What this does

The food map has been wearing the same shared editorial `tool-*` workbench chrome as ~20 other dashboards. This gives it a deliberate, self-contained identity of its own while keeping every bit of the existing behavior and data.

The new look is a late-night printed **field guide**:

- A warm espresso/cream palette with its own local tokens, theme-aware in both light and dark.
- A big Instrument Serif masthead ("Food *Map*"), a rotated passport stamp, and a looping cuisine/city ticker.
- A torn ticket-stub stats ribbon and a live "Showing X of Y" status line.
- Filters recast as bold destination tabs (cities), passport-stamp toggles (curators), and printed pills (cuisines).
- The place list is now a grid of numbered ticket stubs, color-keyed to the curator who vouches for the spot, with a price badge.
- Selecting a spot opens a "dossier" in the rail with the order, who recommends it, and why.
- A cinematic, theme-aware CARTO basemap (dark field-map at night, warm voyager by day) with custom glowing teardrop pins and corner registration ticks.

## How it stays clean

All styling lives under a scoped `.fm` namespace in a dedicated `src/app/food-map/food-map.css`, so it defines its own tokens and never leaks into the site-wide `--home-*` system. This is an intentional, sanctioned break from the shared styling convention for this one surface.

Preserved throughout: light/dark support, 44px minimum touch targets, `prefers-reduced-motion` (ticker, pulse, and pin animations all pause), deep-linkable URL state, the Google Maps links, and every accessibility role/label the existing tests depend on.

## Files

- `food-map.css` — new scoped design system for the surface.
- `food-map-client.tsx` — rebuilt markup/components against the new system (same state logic).
- `food-map-leaflet.tsx` + `leaflet.ts` — theme-aware CARTO basemaps, custom pins, restyled popups, and a tile swap on theme change.

## Verification

- `npx jest src/app/food-map` — 19/19 pass.
- `npx tsc --noEmit` — clean.
- `eslint` on the changed files — clean.
- `npm run build` — compiles successfully (`ƒ /food-map`).
- Screenshotted in light and dark, plus the selected-place dossier flow, via a real Chromium run against the dev server.

Note: the interactive map loads Leaflet and CARTO tiles from a CDN at runtime, which is egress-blocked in the agent sandbox, so local screenshots show the styled fallback. It renders normally in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7SVR56kV1T1nk8k2T5iUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7SVR56kV1T1nk8k2T5iUM)_