### PR TITLE
feat(mba-tracker): application insights and a needs-attention list

### DIFF
--- a/content/changelog/2026-07-20-mba-tracker-needs-attention.mdx
+++ b/content/changelog/2026-07-20-mba-tracker-needs-attention.mdx
@@ -1,0 +1,12 @@
+---
+title: The MBA tracker now tells me what to chase
+publishedAt: "2026-07-20"
+category: Update
+summary: The application pipeline gained a needs-attention list, a conversion funnel with response and interview rates, and inline priority controls.
+tags:
+  - mba-tracker
+---
+
+For a while the [application pipeline](/mba-internship-notifications?view=applications) was quietly collecting follow-up dates and deadlines and then mostly sitting on them, which is the opposite of what a tracker is for. So I added a needs-attention list at the top of the pipeline that pulls out the follow-ups that are overdue or due today, plus the deadlines closing in on roles I have not submitted yet, and each row carries the one action I actually want in that moment, whether that is marking a follow-up done, marking a role applied, or opening it. It reads straight from the same browser-local data the rest of the tracker uses, so nothing personal leaves the page.
+
+The pipeline also reads back a little more honestly now. Instead of three raw counts it shows a small funnel from saved, to applied, to interviewing, to offer, along with the share of submitted applications that got a response or reached an interview, so I can tell whether the problem is volume or conversion. I wired priority into the cards while I was in there, since I had been able to set it in the edit dialog but not from the board, and high-priority roles now sort to the top of each column. The math behind all of it lives in a small pure module with its own tests, which is the part I trust most.

--- a/src/app/mba-internship-notifications/__tests__/mba-jobs-client.test.tsx
+++ b/src/app/mba-internship-notifications/__tests__/mba-jobs-client.test.tsx
@@ -6,6 +6,16 @@ import { MBA_COMPANIES } from "@/constants/mba-companies";
 import type { MBAJob, MBATrackedApplication } from "@/types/mba-jobs";
 import { useMBAJobs } from "@/hooks/useMBAJobs";
 import { useMBAApplications } from "@/hooks/useMBAApplications";
+import { toApplicationDateKey } from "@/lib/mba-application-insights";
+
+// A YYYY-MM-DD key `days` from today, anchored at local noon so the calendar
+// day is stable regardless of the test machine's clock or DST.
+function dayKeyOffset(days: number): string {
+  const date = new Date();
+  date.setHours(12, 0, 0, 0);
+  date.setDate(date.getDate() + days);
+  return toApplicationDateKey(date);
+}
 
 const mockPush = jest.fn();
 let currentSearchParams = new URLSearchParams();
@@ -540,5 +550,104 @@ describe("MBAJobsClient", () => {
     );
 
     expect(updateStatus).toHaveBeenCalledWith("app-1", "offer");
+  });
+
+  it("summarizes the pipeline funnel and conversion rates in the applications view", () => {
+    currentSearchParams = new URLSearchParams("view=applications");
+    const applications = [
+      buildApplication({ id: "a1", jobId: "j1", status: "saved" }),
+      buildApplication({ id: "a2", jobId: "j2", status: "applied" }),
+      buildApplication({ id: "a3", jobId: "j3", status: "applied" }),
+      buildApplication({ id: "a4", jobId: "j4", status: "interviewing" }),
+      buildApplication({ id: "a5", jobId: "j5", status: "offer" }),
+    ];
+    mockUseMBAApplications.mockReturnValue(
+      buildApplicationsHookValue({ applications, activeApplications: applications })
+    );
+
+    render(<MBAJobsClient initialState={DEFAULT_MBA_JOBS_STATE} />);
+
+    // submitted = applied(2) + interviewing(1) + offer(1) = 4; responded = 2.
+    expect(screen.getByText("Response rate")).toBeVisible();
+    expect(screen.getByText("2 of 4 heard back")).toBeVisible();
+    expect(screen.getByText("Pipeline funnel")).toBeVisible();
+    // The old ad-hoc stat cards are gone.
+    expect(screen.queryByText("Overdue follow-ups")).not.toBeInTheDocument();
+  });
+
+  it("surfaces overdue follow-ups in the needs-attention panel and clears them", () => {
+    currentSearchParams = new URLSearchParams("view=applications");
+    const updateApplication = jest.fn();
+    const application = buildApplication({
+      status: "applied",
+      followUpDate: dayKeyOffset(-3),
+      jobSnapshot: {
+        ...buildApplication().jobSnapshot,
+        companyName: "Acme",
+        title: "Strategy Manager",
+      },
+    });
+    mockUseMBAApplications.mockReturnValue(
+      buildApplicationsHookValue({
+        applications: [application],
+        activeApplications: [application],
+        updateApplication,
+      })
+    );
+
+    render(<MBAJobsClient initialState={DEFAULT_MBA_JOBS_STATE} />);
+
+    expect(screen.getByText("What to chase today.")).toBeVisible();
+    expect(screen.getByText("Follow-up overdue by 3 days")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark done" }));
+    expect(updateApplication).toHaveBeenCalledWith("app-1", { followUpDate: null });
+  });
+
+  it("marks an approaching-deadline role applied straight from the attention panel", () => {
+    currentSearchParams = new URLSearchParams("view=applications");
+    const updateStatus = jest.fn();
+    const application = buildApplication({
+      status: "saved",
+      deadline: dayKeyOffset(2),
+    });
+    mockUseMBAApplications.mockReturnValue(
+      buildApplicationsHookValue({
+        applications: [application],
+        activeApplications: [application],
+        updateStatus,
+      })
+    );
+
+    render(<MBAJobsClient initialState={DEFAULT_MBA_JOBS_STATE} />);
+
+    expect(screen.getByText("Deadline in 2 days")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark applied" }));
+    expect(updateStatus).toHaveBeenCalledWith("app-1", "applied");
+  });
+
+  it("shows an all-caught-up state and changes priority inline from a card", () => {
+    currentSearchParams = new URLSearchParams("view=applications");
+    const updatePriority = jest.fn();
+    const application = buildApplication({ status: "applied", priority: "medium" });
+    mockUseMBAApplications.mockReturnValue(
+      buildApplicationsHookValue({
+        applications: [application],
+        activeApplications: [application],
+        updatePriority,
+      })
+    );
+
+    render(<MBAJobsClient initialState={DEFAULT_MBA_JOBS_STATE} />);
+
+    // No follow-ups or deadlines are pending, so the panel reassures instead.
+    expect(screen.getByText(/You.re all caught up\./)).toBeVisible();
+
+    fireEvent.change(
+      screen.getByLabelText("Priority for MBA Product Intern"),
+      { target: { value: "high" } }
+    );
+    expect(updatePriority).toHaveBeenCalledWith("app-1", "high");
   });
 });

--- a/src/app/mba-internship-notifications/mba-jobs-client.tsx
+++ b/src/app/mba-internship-notifications/mba-jobs-client.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type ReactNode,
 } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -15,8 +16,12 @@ import {
   Bell,
   BellOff,
   BriefcaseBusiness,
+  CalendarClock,
   CalendarDays,
+  CheckCircle2,
+  ChevronRight,
   CircleAlert,
+  Clock,
   Download,
   Edit3,
   ExternalLink,
@@ -48,10 +53,21 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ChevronDown } from "lucide-react";
 import {
+  MBA_APPLICATION_PRIORITIES,
   MBA_APPLICATION_PRIORITY_LABELS,
   MBA_APPLICATION_STATUSES,
   MBA_APPLICATION_STATUS_LABELS,
 } from "@/lib/mba-applications";
+import {
+  describeAttentionItem,
+  getApplicationAttentionItems,
+  isFollowUpAttention,
+  sortApplicationsForColumn,
+  summarizeApplicationPipeline,
+  type MBAApplicationInsights,
+  type MBAAttentionItem,
+  type MBAAttentionKind,
+} from "@/lib/mba-application-insights";
 import { useMBAApplications } from "@/hooks/useMBAApplications";
 import { useMBAJobs } from "@/hooks/useMBAJobs";
 import { MBA_COMPANIES, MBA_COMPANY_MAP } from "@/constants/mba-companies";
@@ -208,6 +224,29 @@ const ACTIVE_APPLICATION_STATUSES: MBAApplicationStatus[] = [
   "offer",
   "rejected",
 ];
+
+// Progression stages shown in the pipeline funnel (outcome branches like
+// "rejected" are reported separately rather than as a funnel step).
+const APPLICATION_FUNNEL_STAGES: {
+  key: keyof MBAApplicationInsights["funnel"];
+  label: string;
+}[] = [
+  { key: "saved", label: "Saved" },
+  { key: "applied", label: "Applied" },
+  { key: "interviewing", label: "Interview" },
+  { key: "offer", label: "Offer" },
+];
+
+const ATTENTION_KIND_ACCENTS: Record<MBAAttentionKind, string> = {
+  "follow-up-overdue": "var(--home-negative)",
+  "deadline-passed": "var(--home-negative)",
+  "follow-up-today": "var(--home-signal)",
+  "deadline-soon": "var(--home-warning)",
+};
+
+function formatRate(value: number | null): string {
+  return value === null ? "—" : `${Math.round(value * 100)}%`;
+}
 
 function getReadableAccentColor(accent: string): string {
   return `color-mix(in srgb, var(--home-ink) 76%, ${accent} 24%)`;
@@ -1342,15 +1381,292 @@ function CompanyFilterStrip({
   );
 }
 
+function InsightTile({
+  label,
+  value,
+  sub,
+  tone = "default",
+}: {
+  label: string;
+  value: ReactNode;
+  sub?: string;
+  tone?: "default" | "good";
+}) {
+  const valueColor =
+    tone === "good"
+      ? "color-mix(in srgb, var(--home-positive) 60%, var(--home-ink))"
+      : "var(--home-ink)";
+  return (
+    <div
+      className="rounded-[var(--radius-3xl)] border p-4"
+      style={{ borderColor: "var(--home-rule)" }}
+    >
+      <p className="home-meta mb-0">{label}</p>
+      <p
+        className="mb-0 mt-2 text-2xl font-semibold tabular-nums"
+        style={{ color: valueColor }}
+      >
+        {value}
+      </p>
+      {sub && <p className="home-note-copy mb-0 mt-1 text-xs">{sub}</p>}
+    </div>
+  );
+}
+
+function PipelineInsights({ insights }: { insights: MBAApplicationInsights }) {
+  const { funnel, submitted } = insights;
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <InsightTile
+          label="Active"
+          value={insights.total}
+          sub="In play right now"
+          tone={insights.total > 0 ? "good" : "default"}
+        />
+        <InsightTile label="Submitted" value={submitted} sub="Applied or further" />
+        <InsightTile
+          label="Response rate"
+          value={formatRate(insights.responseRate)}
+          sub={
+            submitted > 0
+              ? `${insights.responded} of ${submitted} heard back`
+              : "No submissions yet"
+          }
+        />
+        <InsightTile
+          label="Interview rate"
+          value={formatRate(insights.interviewRate)}
+          sub={
+            submitted > 0
+              ? `${insights.interviews} reached interview`
+              : "No submissions yet"
+          }
+        />
+      </div>
+
+      <div
+        className="rounded-[var(--radius-3xl)] border p-4"
+        style={{
+          borderColor: "var(--home-rule)",
+          background: "color-mix(in srgb, var(--home-paper-alt) 58%, var(--home-elev-mix))",
+        }}
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="home-meta mb-0">Pipeline funnel</p>
+          <p
+            className="mb-0 text-xs"
+            style={{ color: "var(--home-ink-muted)", fontFamily: CHIP_FONT_FAMILY }}
+          >
+            {funnel.rejected} rejected · {insights.archived} archived
+          </p>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {APPLICATION_FUNNEL_STAGES.map((stage, index) => (
+            <div key={stage.key} className="flex items-center gap-2">
+              <div
+                className="min-w-[5.25rem] rounded-[var(--radius-2xl)] border px-3 py-2"
+                style={{ borderColor: "var(--home-rule)", background: "var(--home-paper)" }}
+              >
+                <p
+                  className="mb-0 text-lg font-semibold tabular-nums"
+                  style={{ color: "var(--home-ink)", fontFamily: CHIP_FONT_FAMILY }}
+                >
+                  {funnel[stage.key]}
+                </p>
+                <p className="home-meta mb-0">{stage.label}</p>
+              </div>
+              {index < APPLICATION_FUNNEL_STAGES.length - 1 && (
+                <ChevronRight
+                  className="h-4 w-4 shrink-0"
+                  style={{ color: "var(--home-ink-muted)" }}
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+          ))}
+        </div>
+        <p className="home-note-copy mb-0 mt-3 text-xs">
+          Rates are the share of submitted applications (applied or further) that reached each
+          stage, computed from your browser-local pipeline.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function AttentionRow({
+  item,
+  onEdit,
+  onMarkApplied,
+  onClearFollowUp,
+}: {
+  item: MBAAttentionItem;
+  onEdit: (application: MBATrackedApplication) => void;
+  onMarkApplied: (id: string) => void;
+  onClearFollowUp: (id: string) => void;
+}) {
+  const { application } = item;
+  const accent = ATTENTION_KIND_ACCENTS[item.kind];
+  const isFollowUp = isFollowUpAttention(item.kind);
+  const Icon = isFollowUp ? Clock : CalendarClock;
+
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-[var(--radius-3xl)] border p-4 sm:flex-row sm:items-center sm:justify-between"
+      style={{
+        borderColor: `color-mix(in srgb, ${accent} 30%, var(--home-rule))`,
+        background: `color-mix(in srgb, ${accent} 8%, var(--home-paper))`,
+      }}
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        <span
+          className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full"
+          style={{
+            background: `color-mix(in srgb, ${accent} 18%, var(--home-paper))`,
+            color: getReadableAccentColor(accent),
+          }}
+          aria-hidden="true"
+        >
+          <Icon className="h-4 w-4" />
+        </span>
+        <div className="min-w-0">
+          <p className="home-meta mb-0">{application.jobSnapshot.companyName}</p>
+          <p
+            className="mb-0 mt-1 text-sm font-semibold"
+            style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
+          >
+            {application.jobSnapshot.title}
+          </p>
+          <p
+            className="mb-0 mt-1 text-xs font-semibold"
+            style={{ color: getReadableAccentColor(accent), fontFamily: CHIP_FONT_FAMILY }}
+          >
+            {describeAttentionItem(item)}
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        {isFollowUp ? (
+          <button
+            type="button"
+            onClick={() => onClearFollowUp(application.id)}
+            className="home-button home-button-secondary text-sm"
+          >
+            <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+            Mark done
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onMarkApplied(application.id)}
+            className="home-button home-button-secondary text-sm"
+          >
+            <BriefcaseBusiness className="h-3.5 w-3.5" aria-hidden="true" />
+            Mark applied
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => onEdit(application)}
+          className="home-button home-button-secondary text-sm"
+        >
+          <Edit3 className="h-3.5 w-3.5" aria-hidden="true" />
+          Edit
+        </button>
+        {application.jobSnapshot.applyUrl && (
+          <CardActionLink
+            href={application.jobSnapshot.applyUrl}
+            label="Open"
+            ariaLabel={`Open ${application.jobSnapshot.title} at ${application.jobSnapshot.companyName}`}
+            trailingIcon
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function NeedsAttentionPanel({
+  items,
+  hasApplications,
+  onEdit,
+  onMarkApplied,
+  onClearFollowUp,
+}: {
+  items: MBAAttentionItem[];
+  hasApplications: boolean;
+  onEdit: (application: MBATrackedApplication) => void;
+  onMarkApplied: (id: string) => void;
+  onClearFollowUp: (id: string) => void;
+}) {
+  // Nothing to nudge about until the pipeline has at least one application.
+  if (!hasApplications) return null;
+
+  return (
+    <section className="space-y-4" aria-labelledby="mba-attention-heading">
+      <SectionLead
+        kicker="Needs attention"
+        title="What to chase today."
+        description="Overdue and same-day follow-ups plus deadlines closing on roles you have not submitted yet, pulled straight from your tracked pipeline."
+        id="mba-attention-heading"
+      />
+      <div className="section-panel">
+        {items.length === 0 ? (
+          <div className="flex items-center gap-3">
+            <span
+              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full"
+              style={{
+                background: "color-mix(in srgb, var(--home-positive) 16%, var(--home-paper))",
+                color: "color-mix(in srgb, var(--home-positive) 60%, var(--home-ink))",
+              }}
+              aria-hidden="true"
+            >
+              <CheckCircle2 className="h-5 w-5" />
+            </span>
+            <div>
+              <p
+                className="mb-0 text-sm font-semibold"
+                style={{ color: "var(--home-ink)", fontFamily: "var(--font-home-sans)" }}
+              >
+                You&rsquo;re all caught up.
+              </p>
+              <p className="home-note-copy mb-0 mt-1 text-sm">
+                No follow-ups or deadlines need action right now. Add a follow-up date when you
+                apply and it will surface here on the day.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {items.map((item) => (
+              <li key={`${item.application.id}-${item.kind}`}>
+                <AttentionRow
+                  item={item}
+                  onEdit={onEdit}
+                  onMarkApplied={onMarkApplied}
+                  onClearFollowUp={onClearFollowUp}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
 function ApplicationCard({
   application,
   onStatusChange,
+  onPriorityChange,
   onEdit,
   onArchive,
   onRemove,
 }: {
   application: MBATrackedApplication;
   onStatusChange: (status: MBAApplicationStatus) => void;
+  onPriorityChange: (priority: MBAApplicationPriority) => void;
   onEdit: () => void;
   onArchive: () => void;
   onRemove: () => void;
@@ -1421,6 +1737,21 @@ function ApplicationCard({
             </option>
           ))}
         </select>
+        <select
+          value={application.priority}
+          onChange={(event) =>
+            onPriorityChange(event.target.value as MBAApplicationPriority)
+          }
+          className="min-h-[44px] rounded-full border px-3 py-2 text-sm"
+          style={applicationInputStyle}
+          aria-label={`Priority for ${application.jobSnapshot.title}`}
+        >
+          {MBA_APPLICATION_PRIORITIES.map((priority) => (
+            <option key={priority} value={priority}>
+              {MBA_APPLICATION_PRIORITY_LABELS[priority]} priority
+            </option>
+          ))}
+        </select>
         <button type="button" onClick={onEdit} className="home-button home-button-secondary text-sm">
           <Edit3 className="h-3.5 w-3.5" aria-hidden="true" />
           Edit
@@ -1458,9 +1789,11 @@ function ApplicationCard({
 
 function ApplicationPipeline({
   applications,
+  insights,
   onCreate,
   onEdit,
   onStatusChange,
+  onPriorityChange,
   onArchive,
   onRemove,
   onExportJson,
@@ -1468,9 +1801,11 @@ function ApplicationPipeline({
   onImport,
 }: {
   applications: MBATrackedApplication[];
+  insights: MBAApplicationInsights;
   onCreate: () => void;
   onEdit: (application: MBATrackedApplication) => void;
   onStatusChange: (id: string, status: MBAApplicationStatus) => void;
+  onPriorityChange: (id: string, priority: MBAApplicationPriority) => void;
   onArchive: (id: string) => void;
   onRemove: (id: string) => void;
   onExportJson: () => void;
@@ -1481,7 +1816,6 @@ function ApplicationPipeline({
   const [statusFilter, setStatusFilter] = useState<MBAApplicationStatus | "all">("all");
   const [importMessage, setImportMessage] = useState<string | null>(null);
   const importInputRef = useRef<HTMLInputElement | null>(null);
-  const today = getTodayDateKey();
 
   const filteredApplications = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
@@ -1503,19 +1837,6 @@ function ApplicationPipeline({
     });
   }, [applications, query, statusFilter]);
 
-  const overdueCount = applications.filter(
-    (application) =>
-      application.status !== "archived" &&
-      application.followUpDate !== null &&
-      application.followUpDate < today
-  ).length;
-  const todayCount = applications.filter(
-    (application) =>
-      application.status !== "archived" && application.followUpDate === today
-  ).length;
-  const activeCount = applications.filter(
-    (application) => application.status !== "archived"
-  ).length;
   const statusesToShow =
     statusFilter === "all" ? ACTIVE_APPLICATION_STATUSES : [statusFilter];
 
@@ -1545,26 +1866,7 @@ function ApplicationPipeline({
         id="mba-application-pipeline-heading"
       />
       <div className="section-panel space-y-6">
-        <div className="grid gap-3 md:grid-cols-3">
-          <div className="rounded-[var(--radius-3xl)] border p-4" style={{ borderColor: "var(--home-rule)" }}>
-            <p className="home-meta mb-0">Active applications</p>
-            <p className="mb-0 mt-2 text-2xl font-semibold tabular-nums" style={{ color: "var(--home-ink)" }}>
-              {activeCount}
-            </p>
-          </div>
-          <div className="rounded-[var(--radius-3xl)] border p-4" style={{ borderColor: "var(--home-rule)" }}>
-            <p className="home-meta mb-0">Due today</p>
-            <p className="mb-0 mt-2 text-2xl font-semibold tabular-nums" style={{ color: "var(--home-ink)" }}>
-              {todayCount}
-            </p>
-          </div>
-          <div className="rounded-[var(--radius-3xl)] border p-4" style={{ borderColor: "var(--home-rule)" }}>
-            <p className="home-meta mb-0">Overdue follow-ups</p>
-            <p className="mb-0 mt-2 text-2xl font-semibold tabular-nums" style={{ color: "var(--home-ink)" }}>
-              {overdueCount}
-            </p>
-          </div>
-        </div>
+        <PipelineInsights insights={insights} />
 
         <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px] xl:min-w-[34rem]">
@@ -1653,8 +1955,10 @@ function ApplicationPipeline({
         ) : (
           <div className="grid gap-4 xl:grid-cols-5">
             {statusesToShow.map((status) => {
-              const statusApplications = filteredApplications.filter(
-                (application) => application.status === status
+              const statusApplications = sortApplicationsForColumn(
+                filteredApplications.filter(
+                  (application) => application.status === status
+                )
               );
               return (
                 <div key={status} className="space-y-3">
@@ -1685,6 +1989,9 @@ function ApplicationPipeline({
                         application={application}
                         onStatusChange={(nextStatus) =>
                           onStatusChange(application.id, nextStatus)
+                        }
+                        onPriorityChange={(nextPriority) =>
+                          onPriorityChange(application.id, nextPriority)
                         }
                         onEdit={() => onEdit(application)}
                         onArchive={() => onArchive(application.id)}
@@ -1838,12 +2145,22 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
     addManualApplication,
     updateApplication,
     updateStatus,
+    updatePriority,
     archiveApplication,
     removeApplication,
     importApplications,
     exportJson,
     exportCsv,
   } = useMBAApplications();
+  const applicationTodayKey = getTodayDateKey();
+  const applicationInsights = useMemo(
+    () => summarizeApplicationPipeline(applications, applicationTodayKey),
+    [applications, applicationTodayKey]
+  );
+  const attentionItems = useMemo(
+    () => getApplicationAttentionItems(applications, applicationTodayKey),
+    [applications, applicationTodayKey]
+  );
   const activeFilters = hasActiveFilters(uiState);
   const effectiveState = useMemo(
     () => ({ ...uiState, q: deferredQuery, location: deferredLocation }),
@@ -2058,6 +2375,10 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
     trackJob(job, status);
   }
 
+  function handleClearFollowUp(id: string) {
+    updateApplication(id, { followUpDate: null });
+  }
+
   function handleExportJson() {
     downloadTextFile(
       `mba-applications-${getTodayDateKey()}.json`,
@@ -2270,17 +2591,28 @@ export function MBAJobsClient({ initialState }: MBAJobsClientProps) {
           <SourceHealthPanel sourceStatuses={sourceStatuses} isLoading={isLoading} />
 
           {uiState.view === "applications" ? (
-            <ApplicationPipeline
-              applications={applications}
-              onCreate={() => openApplicationDialog(null)}
-              onEdit={openApplicationDialog}
-              onStatusChange={updateStatus}
-              onArchive={archiveApplication}
-              onRemove={removeApplication}
-              onExportJson={handleExportJson}
-              onExportCsv={handleExportCsv}
-              onImport={importApplications}
-            />
+            <>
+              <NeedsAttentionPanel
+                items={attentionItems}
+                hasApplications={applications.length > 0}
+                onEdit={openApplicationDialog}
+                onMarkApplied={(id) => updateStatus(id, "applied")}
+                onClearFollowUp={handleClearFollowUp}
+              />
+              <ApplicationPipeline
+                applications={applications}
+                insights={applicationInsights}
+                onCreate={() => openApplicationDialog(null)}
+                onEdit={openApplicationDialog}
+                onStatusChange={updateStatus}
+                onPriorityChange={updatePriority}
+                onArchive={archiveApplication}
+                onRemove={removeApplication}
+                onExportJson={handleExportJson}
+                onExportCsv={handleExportCsv}
+                onImport={importApplications}
+              />
+            </>
           ) : (
             <>
           {fetchErrors.length > 0 && !isLoading && (

--- a/src/lib/__tests__/mba-application-insights.test.ts
+++ b/src/lib/__tests__/mba-application-insights.test.ts
@@ -1,0 +1,315 @@
+import {
+  describeAttentionItem,
+  diffInDays,
+  getApplicationAttentionItems,
+  sortApplicationsForColumn,
+  summarizeApplicationPipeline,
+  toApplicationDateKey,
+} from "../mba-application-insights";
+import type {
+  MBAApplicationPriority,
+  MBAApplicationStatus,
+  MBATrackedApplication,
+} from "@/types/mba-jobs";
+
+const TODAY = "2026-07-20";
+
+let idCounter = 0;
+
+function buildApplication(
+  overrides: {
+    status?: MBAApplicationStatus;
+    priority?: MBAApplicationPriority;
+    followUpDate?: string | null;
+    deadline?: string | null;
+    updatedAt?: string;
+    companyName?: string;
+    title?: string;
+  } = {}
+): MBATrackedApplication {
+  idCounter += 1;
+  const company = overrides.companyName ?? `Company ${idCounter}`;
+  return {
+    id: `app-${idCounter}`,
+    jobId: `job-${idCounter}`,
+    jobSnapshot: {
+      id: `job-${idCounter}`,
+      companyId: "stripe",
+      companyName: company,
+      title: overrides.title ?? "Product Manager",
+      location: "Remote",
+      department: "Product",
+      applyUrl: "https://example.com/apply",
+      postedAt: "2026-07-01T00:00:00.000Z",
+      atsType: "greenhouse",
+      category: "fintech",
+      snippet: null,
+      roleType: "full-time",
+      roleFamilies: ["product"],
+      capturedAt: "2026-07-01T00:00:00.000Z",
+      source: "live-feed",
+    },
+    status: overrides.status ?? "saved",
+    priority: overrides.priority ?? "medium",
+    notes: "",
+    contact: "",
+    sourceUrl: "https://example.com/apply",
+    followUpDate: overrides.followUpDate ?? null,
+    deadline: overrides.deadline ?? null,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-07-10T00:00:00.000Z",
+    appliedAt: null,
+    archivedAt: null,
+  };
+}
+
+describe("date-key helpers", () => {
+  it("formats a date in the local calendar day", () => {
+    expect(toApplicationDateKey(new Date(2026, 6, 5))).toBe("2026-07-05");
+  });
+
+  it("counts whole days between keys and rejects malformed input", () => {
+    expect(diffInDays(TODAY, "2026-07-23")).toBe(3);
+    expect(diffInDays(TODAY, "2026-07-17")).toBe(-3);
+    expect(diffInDays(TODAY, TODAY)).toBe(0);
+    expect(diffInDays(TODAY, "not-a-date")).toBeNull();
+  });
+});
+
+describe("summarizeApplicationPipeline", () => {
+  it("builds funnel counts and stage-conversion rates from active applications", () => {
+    const applications = [
+      buildApplication({ status: "saved" }),
+      buildApplication({ status: "saved" }),
+      buildApplication({ status: "applied" }),
+      buildApplication({ status: "applied" }),
+      buildApplication({ status: "applied" }),
+      buildApplication({ status: "interviewing" }),
+      buildApplication({ status: "interviewing" }),
+      buildApplication({ status: "offer" }),
+      buildApplication({ status: "rejected" }),
+      buildApplication({ status: "archived" }),
+    ];
+
+    const insights = summarizeApplicationPipeline(applications, TODAY);
+
+    expect(insights.total).toBe(9);
+    expect(insights.archived).toBe(1);
+    expect(insights.funnel).toEqual({
+      saved: 2,
+      applied: 3,
+      interviewing: 2,
+      offer: 1,
+      rejected: 1,
+    });
+    expect(insights.submitted).toBe(7);
+    expect(insights.responded).toBe(4);
+    expect(insights.interviews).toBe(3);
+    expect(insights.offers).toBe(1);
+    expect(insights.responseRate).toBeCloseTo(4 / 7);
+    expect(insights.interviewRate).toBeCloseTo(3 / 7);
+    expect(insights.offerRate).toBeCloseTo(1 / 7);
+  });
+
+  it("returns null rates when nothing has been submitted yet", () => {
+    const insights = summarizeApplicationPipeline(
+      [buildApplication({ status: "saved" }), buildApplication({ status: "saved" })],
+      TODAY
+    );
+
+    expect(insights.submitted).toBe(0);
+    expect(insights.responseRate).toBeNull();
+    expect(insights.interviewRate).toBeNull();
+    expect(insights.offerRate).toBeNull();
+  });
+
+  it("buckets follow-ups and only counts deadlines for un-submitted roles", () => {
+    const applications = [
+      buildApplication({ followUpDate: "2026-07-17" }), // overdue
+      buildApplication({ followUpDate: TODAY }), // due today
+      buildApplication({ followUpDate: "2026-07-24" }), // upcoming (within window)
+      buildApplication({ followUpDate: "2026-09-01" }), // beyond window, ignored
+      buildApplication({ status: "saved", deadline: "2026-07-18" }), // passed
+      buildApplication({ status: "saved", deadline: TODAY }), // due today
+      buildApplication({ status: "saved", deadline: "2026-07-25" }), // upcoming
+      buildApplication({ status: "applied", deadline: "2026-07-18" }), // submitted, ignored
+    ];
+
+    const insights = summarizeApplicationPipeline(applications, TODAY);
+
+    expect(insights.followUps).toEqual({ overdue: 1, dueToday: 1, upcoming: 1 });
+    expect(insights.deadlines).toEqual({ overdue: 1, dueToday: 1, upcoming: 1 });
+  });
+});
+
+describe("getApplicationAttentionItems", () => {
+  it("surfaces overdue and due-today follow-ups but not future ones", () => {
+    const overdue = buildApplication({ followUpDate: "2026-07-15", companyName: "Overdue Co" });
+    const today = buildApplication({ followUpDate: TODAY, companyName: "Today Co" });
+    const future = buildApplication({ followUpDate: "2026-07-25", companyName: "Future Co" });
+
+    const items = getApplicationAttentionItems([future, today, overdue], TODAY);
+
+    expect(items.map((item) => item.application.jobSnapshot.companyName)).toEqual([
+      "Overdue Co",
+      "Today Co",
+    ]);
+    expect(items[0].kind).toBe("follow-up-overdue");
+    expect(items[0].daysFromToday).toBe(-5);
+    expect(items[1].kind).toBe("follow-up-today");
+  });
+
+  it("treats deadlines as actionable only while a role is un-submitted", () => {
+    const savedSoon = buildApplication({
+      status: "saved",
+      deadline: "2026-07-22",
+      companyName: "Saved Co",
+    });
+    const appliedPassed = buildApplication({
+      status: "applied",
+      deadline: "2026-07-01",
+      companyName: "Applied Co",
+    });
+
+    const items = getApplicationAttentionItems([savedSoon, appliedPassed], TODAY);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].application.jobSnapshot.companyName).toBe("Saved Co");
+    expect(items[0].kind).toBe("deadline-soon");
+  });
+
+  it("surfaces each application once under its most urgent signal", () => {
+    const both = buildApplication({
+      status: "saved",
+      followUpDate: "2026-07-16", // overdue follow-up (most urgent)
+      deadline: "2026-07-22", // also a soon deadline
+      companyName: "Both Co",
+    });
+
+    const items = getApplicationAttentionItems([both], TODAY);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].kind).toBe("follow-up-overdue");
+  });
+
+  it("orders by urgency, then by imminence, then by priority", () => {
+    const followUpOverdue = buildApplication({
+      followUpDate: "2026-07-19",
+      companyName: "FollowUp Co",
+    });
+    const deadlinePassed = buildApplication({
+      status: "saved",
+      deadline: "2026-07-10",
+      companyName: "Deadline Co",
+    });
+    const soonLowPriority = buildApplication({
+      status: "saved",
+      deadline: "2026-07-21",
+      priority: "low",
+      companyName: "Soon Low",
+    });
+    const soonHighPriority = buildApplication({
+      status: "saved",
+      deadline: "2026-07-21",
+      priority: "high",
+      companyName: "Soon High",
+    });
+
+    const items = getApplicationAttentionItems(
+      [soonLowPriority, soonHighPriority, deadlinePassed, followUpOverdue],
+      TODAY
+    );
+
+    expect(items.map((item) => item.kind)).toEqual([
+      "follow-up-overdue",
+      "deadline-passed",
+      "deadline-soon",
+      "deadline-soon",
+    ]);
+    // Same-kind, same-date ties break toward higher priority first.
+    expect(items[2].application.jobSnapshot.companyName).toBe("Soon High");
+    expect(items[3].application.jobSnapshot.companyName).toBe("Soon Low");
+  });
+
+  it("ignores archived applications and malformed dates", () => {
+    const archived = buildApplication({ status: "archived", followUpDate: "2026-07-01" });
+    const malformed = buildApplication({ followUpDate: "07/20/2026" });
+
+    expect(getApplicationAttentionItems([archived, malformed], TODAY)).toEqual([]);
+  });
+});
+
+describe("describeAttentionItem", () => {
+  it("renders human-readable summaries with singular and plural days", () => {
+    const base = buildApplication();
+    expect(
+      describeAttentionItem({
+        application: base,
+        kind: "follow-up-overdue",
+        dateKey: "2026-07-17",
+        daysFromToday: -3,
+      })
+    ).toBe("Follow-up overdue by 3 days");
+    expect(
+      describeAttentionItem({
+        application: base,
+        kind: "deadline-passed",
+        dateKey: "2026-07-19",
+        daysFromToday: -1,
+      })
+    ).toBe("Deadline passed 1 day ago");
+    expect(
+      describeAttentionItem({
+        application: base,
+        kind: "deadline-soon",
+        dateKey: TODAY,
+        daysFromToday: 0,
+      })
+    ).toBe("Deadline today");
+    expect(
+      describeAttentionItem({
+        application: base,
+        kind: "follow-up-today",
+        dateKey: TODAY,
+        daysFromToday: 0,
+      })
+    ).toBe("Follow-up due today");
+  });
+});
+
+describe("sortApplicationsForColumn", () => {
+  it("orders by priority, then most recently updated, without mutating input", () => {
+    const lowRecent = buildApplication({
+      priority: "low",
+      updatedAt: "2026-07-19T00:00:00.000Z",
+      companyName: "Low Recent",
+    });
+    const highOld = buildApplication({
+      priority: "high",
+      updatedAt: "2026-07-02T00:00:00.000Z",
+      companyName: "High Old",
+    });
+    const mediumRecent = buildApplication({
+      priority: "medium",
+      updatedAt: "2026-07-18T00:00:00.000Z",
+      companyName: "Medium Recent",
+    });
+    const highRecent = buildApplication({
+      priority: "high",
+      updatedAt: "2026-07-15T00:00:00.000Z",
+      companyName: "High Recent",
+    });
+
+    const input = [lowRecent, highOld, mediumRecent, highRecent];
+    const sorted = sortApplicationsForColumn(input);
+
+    expect(sorted.map((item) => item.jobSnapshot.companyName)).toEqual([
+      "High Recent",
+      "High Old",
+      "Medium Recent",
+      "Low Recent",
+    ]);
+    // Original array order is preserved.
+    expect(input[0]).toBe(lowRecent);
+  });
+});

--- a/src/lib/mba-application-insights.ts
+++ b/src/lib/mba-application-insights.ts
@@ -1,0 +1,332 @@
+// ---------------------------------------------------------------------------
+// MBA application insights — a pure, framework-free engine over the tracked
+// application pipeline.
+//
+// The tracker already collects statuses, priorities, follow-up dates, and
+// deadlines, but until now it only surfaced three raw counts. This module
+// turns that same browser-local data into two useful readings: a pipeline
+// summary (funnel counts plus stage-conversion rates) and a prioritized
+// "needs attention" list (overdue follow-ups, follow-ups due today, and
+// approaching or missed application deadlines).
+//
+// Everything here is a pure function of the applications array plus a
+// `todayKey` (a YYYY-MM-DD string), so it is easy to unit test and it never
+// touches storage, the network, or `Date.now()` behind the caller's back.
+// ---------------------------------------------------------------------------
+
+import type {
+  MBAApplicationPriority,
+  MBAApplicationStatus,
+  MBATrackedApplication,
+} from "@/types/mba-jobs";
+
+const DAY_MS = 86_400_000;
+
+// How far ahead a follow-up or deadline counts as "upcoming" rather than a
+// distant future date the user does not need to act on yet.
+export const MBA_ATTENTION_WINDOW_DAYS = 7;
+
+// ── Date-key helpers ───────────────────────────────────────────────────────
+
+/**
+ * Local-calendar day key (YYYY-MM-DD) for a date. Matches the format the
+ * tracker stores follow-up dates and deadlines in and that `<input type="date">`
+ * produces, so comparisons stay in the user's own calendar day.
+ */
+export function toApplicationDateKey(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function parseDateKey(key: string): number | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(key)) return null;
+  const ms = Date.parse(`${key}T00:00:00.000Z`);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Whole calendar days from `fromKey` to `toKey` (positive when `toKey` is in
+ * the future). Both keys are read at UTC midnight so the difference is a clean
+ * day count with no DST drift. Returns null when either key is malformed.
+ */
+export function diffInDays(fromKey: string, toKey: string): number | null {
+  const from = parseDateKey(fromKey);
+  const to = parseDateKey(toKey);
+  if (from === null || to === null) return null;
+  return Math.round((to - from) / DAY_MS);
+}
+
+// ── Ordering helpers ───────────────────────────────────────────────────────
+
+const PRIORITY_RANK: Record<MBAApplicationPriority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+/**
+ * Order applications within a status column: highest priority first, then the
+ * most recently touched. Returns a new array; the input is not mutated.
+ */
+export function sortApplicationsForColumn(
+  applications: MBATrackedApplication[]
+): MBATrackedApplication[] {
+  return [...applications].sort((left, right) => {
+    const priorityDiff = PRIORITY_RANK[left.priority] - PRIORITY_RANK[right.priority];
+    if (priorityDiff !== 0) return priorityDiff;
+    return new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime();
+  });
+}
+
+// ── Pipeline summary ───────────────────────────────────────────────────────
+
+export interface MBAApplicationFunnel {
+  saved: number;
+  applied: number;
+  interviewing: number;
+  offer: number;
+  rejected: number;
+}
+
+export interface MBAApplicationBucketCounts {
+  // For deadlines, `overdue` means the deadline has already passed.
+  overdue: number;
+  dueToday: number;
+  upcoming: number;
+}
+
+export interface MBAApplicationInsights {
+  // Non-archived applications only; archived ones are counted separately.
+  total: number;
+  archived: number;
+  funnel: MBAApplicationFunnel;
+  // Reached "applied" or beyond (applied + interviewing + offer + rejected).
+  submitted: number;
+  // Heard back either way (interviewing + offer + rejected).
+  responded: number;
+  // Reached at least the interview stage (interviewing + offer).
+  interviews: number;
+  offers: number;
+  // Shares of `submitted`; null when nothing has been submitted yet so the UI
+  // can show a dash instead of a misleading 0%.
+  responseRate: number | null;
+  interviewRate: number | null;
+  offerRate: number | null;
+  followUps: MBAApplicationBucketCounts;
+  deadlines: MBAApplicationBucketCounts;
+  // Applications with at least one actionable follow-up/deadline signal.
+  attentionCount: number;
+}
+
+const EMPTY_FUNNEL: MBAApplicationFunnel = {
+  saved: 0,
+  applied: 0,
+  interviewing: 0,
+  offer: 0,
+  rejected: 0,
+};
+
+function isActive(application: MBATrackedApplication): boolean {
+  return application.status !== "archived";
+}
+
+function rate(part: number, whole: number): number | null {
+  return whole > 0 ? part / whole : null;
+}
+
+/**
+ * Summarize the tracked pipeline into funnel counts, stage-conversion rates,
+ * and follow-up/deadline bucket counts. Archived applications are excluded
+ * from the funnel and rates (they have been set aside) but reported as a
+ * separate `archived` total.
+ */
+export function summarizeApplicationPipeline(
+  applications: MBATrackedApplication[],
+  todayKey: string
+): MBAApplicationInsights {
+  const funnel: MBAApplicationFunnel = { ...EMPTY_FUNNEL };
+  const followUps: MBAApplicationBucketCounts = { overdue: 0, dueToday: 0, upcoming: 0 };
+  const deadlines: MBAApplicationBucketCounts = { overdue: 0, dueToday: 0, upcoming: 0 };
+  let archived = 0;
+  let active = 0;
+
+  for (const application of applications) {
+    if (!isActive(application)) {
+      archived += 1;
+      continue;
+    }
+    active += 1;
+    if (application.status in funnel) {
+      funnel[application.status as keyof MBAApplicationFunnel] += 1;
+    }
+
+    if (application.followUpDate) {
+      const diff = diffInDays(todayKey, application.followUpDate);
+      if (diff !== null) {
+        if (diff < 0) followUps.overdue += 1;
+        else if (diff === 0) followUps.dueToday += 1;
+        else if (diff <= MBA_ATTENTION_WINDOW_DAYS) followUps.upcoming += 1;
+      }
+    }
+
+    // Deadlines only matter while a role is still un-submitted ("saved").
+    if (application.status === "saved" && application.deadline) {
+      const diff = diffInDays(todayKey, application.deadline);
+      if (diff !== null) {
+        if (diff < 0) deadlines.overdue += 1;
+        else if (diff === 0) deadlines.dueToday += 1;
+        else if (diff <= MBA_ATTENTION_WINDOW_DAYS) deadlines.upcoming += 1;
+      }
+    }
+  }
+
+  const submitted = funnel.applied + funnel.interviewing + funnel.offer + funnel.rejected;
+  const responded = funnel.interviewing + funnel.offer + funnel.rejected;
+  const interviews = funnel.interviewing + funnel.offer;
+  const offers = funnel.offer;
+
+  return {
+    total: active,
+    archived,
+    funnel,
+    submitted,
+    responded,
+    interviews,
+    offers,
+    responseRate: rate(responded, submitted),
+    interviewRate: rate(interviews, submitted),
+    offerRate: rate(offers, submitted),
+    followUps,
+    deadlines,
+    attentionCount: getApplicationAttentionItems(applications, todayKey).length,
+  };
+}
+
+// ── Needs-attention list ───────────────────────────────────────────────────
+
+export type MBAAttentionKind =
+  | "follow-up-overdue"
+  | "follow-up-today"
+  | "deadline-passed"
+  | "deadline-soon";
+
+export interface MBAAttentionItem {
+  application: MBATrackedApplication;
+  kind: MBAAttentionKind;
+  // The follow-up date or deadline that triggered this item.
+  dateKey: string;
+  // Whole days from today: negative = past, 0 = today, positive = upcoming.
+  daysFromToday: number;
+}
+
+// Lower rank = more urgent. A single application surfaces once, under its most
+// urgent signal.
+const ATTENTION_RANK: Record<MBAAttentionKind, number> = {
+  "follow-up-overdue": 0,
+  "deadline-passed": 1,
+  "follow-up-today": 2,
+  "deadline-soon": 3,
+};
+
+export const MBA_ATTENTION_KIND_LABELS: Record<MBAAttentionKind, string> = {
+  "follow-up-overdue": "Follow-up overdue",
+  "follow-up-today": "Follow-up today",
+  "deadline-passed": "Deadline passed",
+  "deadline-soon": "Deadline soon",
+};
+
+function getAttentionForApplication(
+  application: MBATrackedApplication,
+  todayKey: string
+): MBAAttentionItem | null {
+  if (!isActive(application)) return null;
+
+  const candidates: MBAAttentionItem[] = [];
+
+  if (application.followUpDate) {
+    const diff = diffInDays(todayKey, application.followUpDate);
+    if (diff !== null && diff <= 0) {
+      candidates.push({
+        application,
+        kind: diff < 0 ? "follow-up-overdue" : "follow-up-today",
+        dateKey: application.followUpDate,
+        daysFromToday: diff,
+      });
+    }
+  }
+
+  // A deadline is only actionable while the role is still un-submitted.
+  if (application.status === "saved" && application.deadline) {
+    const diff = diffInDays(todayKey, application.deadline);
+    if (diff !== null && diff <= MBA_ATTENTION_WINDOW_DAYS) {
+      candidates.push({
+        application,
+        kind: diff < 0 ? "deadline-passed" : "deadline-soon",
+        dateKey: application.deadline,
+        daysFromToday: diff,
+      });
+    }
+  }
+
+  if (candidates.length === 0) return null;
+  return candidates.reduce((best, candidate) =>
+    ATTENTION_RANK[candidate.kind] < ATTENTION_RANK[best.kind] ? candidate : best
+  );
+}
+
+/**
+ * Build the prioritized list of applications that need action now: overdue
+ * follow-ups, follow-ups due today, and deadlines that are approaching (within
+ * {@link MBA_ATTENTION_WINDOW_DAYS}) or already passed on un-submitted roles.
+ *
+ * Ordered most urgent first — by signal kind, then by how overdue/imminent the
+ * date is, then by the application's priority.
+ */
+export function getApplicationAttentionItems(
+  applications: MBATrackedApplication[],
+  todayKey: string
+): MBAAttentionItem[] {
+  const items = applications
+    .map((application) => getAttentionForApplication(application, todayKey))
+    .filter((item): item is MBAAttentionItem => item !== null);
+
+  return items.sort((left, right) => {
+    const kindDiff = ATTENTION_RANK[left.kind] - ATTENTION_RANK[right.kind];
+    if (kindDiff !== 0) return kindDiff;
+    if (left.daysFromToday !== right.daysFromToday) {
+      return left.daysFromToday - right.daysFromToday;
+    }
+    const priorityDiff =
+      PRIORITY_RANK[left.application.priority] - PRIORITY_RANK[right.application.priority];
+    if (priorityDiff !== 0) return priorityDiff;
+    return left.application.jobSnapshot.companyName.localeCompare(
+      right.application.jobSnapshot.companyName
+    );
+  });
+}
+
+/** Human-readable summary of an attention item, e.g. "Follow-up overdue by 3 days". */
+export function describeAttentionItem(item: MBAAttentionItem): string {
+  const days = Math.abs(item.daysFromToday);
+  const dayLabel = days === 1 ? "1 day" : `${days} days`;
+  switch (item.kind) {
+    case "follow-up-overdue":
+      return `Follow-up overdue by ${dayLabel}`;
+    case "follow-up-today":
+      return "Follow-up due today";
+    case "deadline-passed":
+      return `Deadline passed ${dayLabel} ago`;
+    case "deadline-soon":
+      return item.daysFromToday === 0 ? "Deadline today" : `Deadline in ${dayLabel}`;
+  }
+}
+
+/** Whether an attention item is a follow-up signal (vs. a deadline signal). */
+export function isFollowUpAttention(kind: MBAAttentionKind): boolean {
+  return kind === "follow-up-overdue" || kind === "follow-up-today";
+}
+
+// Re-exported for callers that want to keep status keys in one place.
+export type { MBAApplicationStatus };


### PR DESCRIPTION
## What and why

The application pipeline on `/mba-internship-notifications` was collecting follow-up dates, deadlines, and priorities, but it only surfaced three raw counts and never acted on any of it. That is the opposite of what a tracker is for. This turns the same browser-local data into two more useful readings and wires up a control that was defined in the hook but never used.

## Changes

- **New pure insights engine** (`src/lib/mba-application-insights.ts`): pipeline funnel counts, response/interview/offer rates over submitted applications, follow-up and deadline buckets, a prioritized attention list (one signal per application, most urgent first), and a priority-aware column sort. It is a pure function of the applications array plus a `todayKey`, matching the repo's pure-engine pattern (retirement / draft / score-pools), and is fully unit tested.
- **Needs-attention panel**: turns overdue and same-day follow-ups, plus deadlines that are approaching or already passed on un-submitted roles, into actionable rows (mark done, mark applied, edit, open). Shows an all-caught-up state when nothing is pending, and stays hidden until the pipeline has at least one application.
- **Pipeline insights block**: replaces the three ad-hoc stat cards with an engine-driven funnel (saved → applied → interviewing → offer), response and interview rates, and a short disclosure of how the rates are defined. Rates read `—` until something is submitted rather than a misleading 0%.
- **Inline priority + column sort**: `updatePriority` was already exposed by `useMBAApplications` but nothing used it, so priority could only be changed in the edit dialog. Application cards now have an inline priority select, and high-priority roles sort to the top of each status column.

Everything stays browser-local; no personal application data is sent to the server, and the snapshot-driven feed side of the tracker is untouched.

## Testing

- `mba-application-insights.test.ts` (new): 12 tests covering funnel/rate math, follow-up and deadline bucketing, attention ordering and gating (deadlines only for un-submitted roles, one item per application), malformed-date handling, and the column sort.
- `mba-jobs-client.test.tsx`: 4 new integration tests rendering the real client for the funnel/rates readout, the overdue-follow-up flow (mark done clears the follow-up), the approaching-deadline flow (mark applied), and inline priority changes plus the all-caught-up state.
- Full suite for the tracker green (53 tests across 8 suites), `tsc --noEmit` clean, `eslint` clean.
- Verified in a real browser (dev server + Playwright): light desktop and dark mobile, no horizontal overflow at 390px, correct funnel/rate math, and correct attention ordering, accent colors, and actions.

Two unrelated suites (`sitemap-consistency`, `blog-seo-content`) fail on `main` as well because of a `lastmod` timestamp drift; they are not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TfME83M29DdJSDEMvmRmn

---
_Generated by [Claude Code](https://claude.ai/code/session_017TfME83M29DdJSDEMvmRmn)_