### PR TITLE
Close the two genuine gaps from the data-pipeline audit

### DIFF
--- a/.github/workflows/update-world-cup.yml
+++ b/.github/workflows/update-world-cup.yml
@@ -1,10 +1,14 @@
 name: Refresh World Cup Snapshot
 
 on:
-  # The 2026 FIFA World Cup runs June 11 through July 19. Refresh every 30 minutes
-  # across June and July to keep group standings, fixtures, and the bracket
-  # current. ESPN's site API needs no token. Outside those months there is
-  # nothing to refresh, so the schedule stays dormant.
+  # The cron only fires in June and July, the months a World Cup can run, but a
+  # coarse month gate isn't enough: with the 2026 tournament over, an unguarded
+  # schedule would still wake every 30 minutes each following June and July and
+  # commit no-op churn. The "Determine tournament window" step below reads the
+  # start and end dates out of the committed snapshot and skips the refresh
+  # entirely outside a short window around them, so the workflow self-arms when a
+  # future tournament's dates are seeded and stays dormant the rest of the time.
+  # ESPN's site API needs no token.
   schedule:
     # Staggered off :20 so it doesn't race the hourly earthquake and 6h transit
     # refreshes (which also push to main) over the same minute.
@@ -39,19 +43,52 @@ jobs:
           node-version: "20"
           cache: "npm"
 
+      - name: Determine tournament window
+        id: window
+        run: |
+          node -e "
+          const fs = require('fs');
+          const src = fs.readFileSync('src/data/worldCupSnapshot.ts', 'utf8');
+          const startMatch = src.match(/\"startDate\":\s*\"([0-9-]+)\"/);
+          const endMatch = src.match(/\"endDate\":\s*\"([0-9-]+)\"/);
+          const DAY = 24 * 60 * 60 * 1000;
+          const now = new Date();
+          // Arm two days before kickoff (pre-tournament friendlies, seeding) and
+          // stay armed three days past the final to catch late corrections, then
+          // go dormant until a future snapshot moves the dates forward.
+          const PRE_ROLL_DAYS = 2;
+          const POST_ROLL_DAYS = 3;
+          let active = true;
+          let reason = 'snapshot carried no start/end dates, defaulting to active';
+          if (startMatch && endMatch) {
+            const start = new Date(startMatch[1] + 'T00:00:00Z').getTime() - PRE_ROLL_DAYS * DAY;
+            const end = new Date(endMatch[1] + 'T23:59:59Z').getTime() + POST_ROLL_DAYS * DAY;
+            active = now.getTime() >= start && now.getTime() <= end;
+            reason = active
+              ? 'within tournament window ' + startMatch[1] + ' to ' + endMatch[1]
+              : 'outside tournament window ' + startMatch[1] + ' to ' + endMatch[1];
+          }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, 'active=' + active + '\n');
+          console.log('Tournament window active:', active, '-', reason);
+          "
+
       - name: Install dependencies
+        if: steps.window.outputs.active == 'true'
         run: npm ci --prefer-offline --no-audit --fund=false
 
       - name: Refresh World Cup snapshot
+        if: steps.window.outputs.active == 'true'
         run: npm run update:world-cup
         env:
           NODE_ENV: production
 
       - name: Verify refresh freshness
+        if: steps.window.outputs.active == 'true'
         run: npx tsx scripts/verifyDataRefresh.ts world-cup
 
       - name: Verify World Cup snapshot quality
         id: verify_quality
+        if: steps.window.outputs.active == 'true'
         run: |
           node -e "
           const fs = require('fs');
@@ -109,6 +146,7 @@ jobs:
 
       - name: Check for snapshot changes
         id: check_changes
+        if: steps.window.outputs.active == 'true'
         run: |
           if [ -z "$(git status --porcelain -- src/data/worldCupSnapshot.ts)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -135,6 +173,9 @@ jobs:
           echo "**Status:** ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
           echo "**Run Date:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.window.outputs.active }}" != "true" ]; then
+            echo "Outside the tournament window, so the refresh was skipped. The schedule re-arms when the committed snapshot's start and end dates move forward." >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [ -n "${{ steps.verify_quality.outputs.teams }}" ]; then
             echo "**Phase:** ${{ steps.verify_quality.outputs.phase }}" >> "$GITHUB_STEP_SUMMARY"
             echo "**Groups:** ${{ steps.verify_quality.outputs.groups }}" >> "$GITHUB_STEP_SUMMARY"

--- a/src/app/api/data-revisions/__tests__/route.test.ts
+++ b/src/app/api/data-revisions/__tests__/route.test.ts
@@ -54,4 +54,16 @@ describe("GET /api/data-revisions", () => {
 
     expect(entry.maxAgeSeconds).toBe(102 * 60 * 60);
   });
+
+  it("reports runtime-fetch surfaces as unavailable until a durable heartbeat exists", async () => {
+    // The test runtime is not Netlify, so the durable heartbeat store returns
+    // nothing and both request-time surfaces fall through to unavailable with a
+    // null source time rather than being omitted from the ledger.
+    for (const surface of ["news-pulse", "mba-jobs"] as const) {
+      const entry = await getLedgerEntry(surface);
+      expect(entry.source).toBe("runtime-fetch");
+      expect(entry.status).toBe("unavailable");
+      expect(entry.sourceAsOf).toBeNull();
+    }
+  });
 });

--- a/src/app/api/data-revisions/route.ts
+++ b/src/app/api/data-revisions/route.ts
@@ -42,6 +42,10 @@ import {
 } from "@/lib/dataRevision";
 import { getSpaceXSnapshot } from "@/lib/spacexSnapshot";
 import { hasLiveScorePoolsData } from "@/lib/scorePoolsSnapshot";
+import {
+  readRuntimeSurfaceHeartbeat,
+  type RuntimeSurfaceHeartbeat,
+} from "@/lib/runtimeSurfaceHeartbeat";
 import fantasySnapshot from "../../../../public/data/fantasy/ppr.json";
 import investmentsIndex from "../../../../public/data/investments/index.json";
 
@@ -52,6 +56,10 @@ export async function GET() {
   const now = Date.now();
   const nowDate = new Date(now);
   const spacexSnapshot = getSpaceXSnapshot();
+  const [newsPulseHeartbeat, mbaJobsHeartbeat] = await Promise.all([
+    readRuntimeSurfaceHeartbeat("news-pulse"),
+    readRuntimeSurfaceHeartbeat("mba-jobs"),
+  ]);
   const entry = (
     surface: DataSurfaceId,
     payload: unknown,
@@ -67,6 +75,30 @@ export async function GET() {
       source: policy.source,
       now,
       status,
+    });
+  };
+  // Request-time surfaces carry no committed artifact. Their source time and
+  // condition come from the durable heartbeat each route writes on refresh. A
+  // missing heartbeat (no successful fetch yet, or running off-Netlify) falls
+  // through to "unavailable" via the null sourceAsOf. A non-fresh heartbeat
+  // status is passed through so a currently-failing source reads as such even
+  // when the last good data is still within the age target.
+  const runtimeEntry = (
+    surface: DataSurfaceId,
+    heartbeat: RuntimeSurfaceHeartbeat | null
+  ) => {
+    const policy = getDataFreshnessPolicy(surface, nowDate);
+    return createDataRevisionEntry({
+      surface,
+      payload: heartbeat ?? { surface },
+      sourceAsOf: heartbeat?.fetchedAt ?? null,
+      maxAgeMs: policy.maxAgeMs,
+      source: policy.source,
+      now,
+      status:
+        heartbeat && heartbeat.status !== "fresh"
+          ? heartbeat.status
+          : undefined,
     });
   };
   const entries = [
@@ -148,6 +180,8 @@ export async function GET() {
       pollingSnapshot,
       pollingSnapshot.sourceAsOf ?? pollingSnapshot.generatedAt
     ),
+    runtimeEntry("news-pulse", newsPulseHeartbeat),
+    runtimeEntry("mba-jobs", mbaJobsHeartbeat),
   ];
 
   return NextResponse.json(

--- a/src/app/api/mba-jobs/route.ts
+++ b/src/app/api/mba-jobs/route.ts
@@ -20,6 +20,8 @@ import {
   rateLimitResponse,
 } from "@/lib/rateLimit";
 import { readDurableJson, writeDurableJson } from "@/lib/durableJsonCache";
+import type { DataDeliveryStatus } from "@/lib/dataRevision";
+import { recordRuntimeSurfaceHeartbeat } from "@/lib/runtimeSurfaceHeartbeat";
 
 const TIMEOUT_MS = 8_000;
 const MAX_SNIPPET_LENGTH = 220;
@@ -1036,22 +1038,39 @@ function getOrFetchJobs(
 
     const settle = async (result: JobsFetchResult): Promise<JobsFetchResult> => {
       let served = result;
+      let status: DataDeliveryStatus;
 
       if (!result.isError && !result.isDegraded) {
         setBoundedCacheValue(lastGoodJobs, cacheKey, result);
         await writeDurableJson(getDurableJobsKey(cacheKey), result);
+        status = "fresh";
       } else if (result.isError) {
         const good = lastGoodJobs.get(cacheKey);
-        if (good) served = buildStaleJobsResult(good, result);
+        if (good) {
+          served = buildStaleJobsResult(good, result);
+          status = "stale-fallback";
+        } else {
+          status = "unavailable";
+        }
       } else {
         // Degraded: some boards answered, some failed. Never promote this to
         // lastGoodJobs, but do backfill the failed boards from it.
         const good = lastGoodJobs.get(cacheKey);
         if (good) served = mergeLastGoodIntoDegraded(good, result);
+        status = "degraded";
       }
 
       entry.value = served;
       entry.completedAt = Date.now();
+      // Stamp the revision-ledger heartbeat with the served condition. A total
+      // outage with no last-good (unavailable) served nothing, so it's skipped
+      // and the last known-good heartbeat stands.
+      if (status !== "unavailable") {
+        await recordRuntimeSurfaceHeartbeat("mba-jobs", {
+          fetchedAt: served.body.fetchedAt,
+          status,
+        });
+      }
       return served;
     };
 

--- a/src/app/api/news-pulse/route.ts
+++ b/src/app/api/news-pulse/route.ts
@@ -3,6 +3,7 @@ import { parseNewsFeed } from "@/lib/news-pulse-feed-parser";
 import { NEWS_FEEDS, type NewsFeedId } from "@/lib/news-pulse-sources";
 import type { NewsArticle } from "@/lib/news-pulse-utils";
 import { readDurableJson, writeDurableJson } from "@/lib/durableJsonCache";
+import { recordRuntimeSurfaceHeartbeat } from "@/lib/runtimeSurfaceHeartbeat";
 
 const CACHE_CONTROL_HEADER = "public, s-maxage=300, stale-while-revalidate=600";
 const ERROR_CACHE_CONTROL_HEADER = "no-store";
@@ -258,7 +259,17 @@ function getOrFetch(key: string): Promise<FeedFetchResult> {
     };
 
     try {
-      return settle(await fetchAllFeeds());
+      const result = settle(await fetchAllFeeds());
+      // Stamp the revision-ledger heartbeat with the served condition. A total
+      // outage (unavailable) served nothing, so it's skipped and the last
+      // known-good heartbeat stands.
+      if (result.body.dataStatus !== "unavailable") {
+        await recordRuntimeSurfaceHeartbeat("news-pulse", {
+          fetchedAt: result.body.fetchedAt,
+          status: result.body.dataStatus,
+        });
+      }
+      return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : "unknown error";
       return settle({

--- a/src/lib/__tests__/runtimeSurfaceHeartbeat.test.ts
+++ b/src/lib/__tests__/runtimeSurfaceHeartbeat.test.ts
@@ -1,0 +1,50 @@
+import { readDurableJson, writeDurableJson } from "@/lib/durableJsonCache";
+import {
+  readRuntimeSurfaceHeartbeat,
+  recordRuntimeSurfaceHeartbeat,
+} from "@/lib/runtimeSurfaceHeartbeat";
+
+jest.mock("@/lib/durableJsonCache", () => ({
+  readDurableJson: jest.fn(),
+  writeDurableJson: jest.fn(),
+}));
+
+const mockRead = readDurableJson as jest.Mock;
+const mockWrite = writeDurableJson as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("runtimeSurfaceHeartbeat", () => {
+  it("writes a heartbeat under a fixed per-surface key", async () => {
+    const heartbeat = {
+      fetchedAt: "2026-07-20T00:00:00.000Z",
+      status: "fresh" as const,
+    };
+    await recordRuntimeSurfaceHeartbeat("news-pulse", heartbeat);
+
+    expect(mockWrite).toHaveBeenCalledWith("heartbeat/news-pulse", heartbeat);
+  });
+
+  it("never overwrites the last known-good heartbeat with an unavailable one", async () => {
+    await recordRuntimeSurfaceHeartbeat("mba-jobs", {
+      fetchedAt: "2026-07-20T00:00:00.000Z",
+      status: "unavailable",
+    });
+
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("reads the heartbeat for a surface by its fixed key", async () => {
+    mockRead.mockResolvedValue({ fetchedAt: "2026-07-20", status: "degraded" });
+
+    const heartbeat = await readRuntimeSurfaceHeartbeat("mba-jobs");
+
+    expect(mockRead).toHaveBeenCalledWith(
+      "heartbeat/mba-jobs",
+      expect.any(Number)
+    );
+    expect(heartbeat).toEqual({ fetchedAt: "2026-07-20", status: "degraded" });
+  });
+});

--- a/src/lib/dataFreshnessPolicy.ts
+++ b/src/lib/dataFreshnessPolicy.ts
@@ -23,10 +23,12 @@ export type DataSurfaceId =
   | "museum-log"
   | "travel-deals"
   | "food-map"
-  | "polling";
+  | "polling"
+  | "news-pulse"
+  | "mba-jobs";
 
 interface DataFreshnessPolicy {
-  source: "git-snapshot" | "curated-snapshot";
+  source: "git-snapshot" | "curated-snapshot" | "runtime-fetch";
   maxAgeMs: (now: Date) => number;
 }
 
@@ -94,6 +96,12 @@ const POLICIES: Record<DataSurfaceId, DataFreshnessPolicy> = {
   "travel-deals": { source: "curated-snapshot", maxAgeMs: () => 30 * DAY_MS },
   "food-map": { source: "curated-snapshot", maxAgeMs: () => 90 * DAY_MS },
   polling: { source: "git-snapshot", maxAgeMs: () => 21 * DAY_MS },
+  // Request-time surfaces. "Source age" is the last refresh that served usable
+  // data, read from the durable heartbeat. Targets are generous because these
+  // only refresh when the route is actually hit, so a quiet stretch shouldn't
+  // read as a broken pipeline. News headlines move faster than job boards.
+  "news-pulse": { source: "runtime-fetch", maxAgeMs: () => 6 * HOUR_MS },
+  "mba-jobs": { source: "runtime-fetch", maxAgeMs: () => 30 * HOUR_MS },
 };
 
 export const DATA_SURFACE_IDS = Object.freeze(

--- a/src/lib/runtimeSurfaceHeartbeat.ts
+++ b/src/lib/runtimeSurfaceHeartbeat.ts
@@ -1,0 +1,49 @@
+import type { DataDeliveryStatus } from "@/lib/dataRevision";
+import { readDurableJson, writeDurableJson } from "@/lib/durableJsonCache";
+
+// News Pulse and MBA jobs fetch at request time and keep their last-good data in
+// per-instance in-memory Maps backed by the durable Netlify Blobs cache. Those
+// durable values are keyed for the route's own fallback needs (per feed, per
+// query hash), so they're awkward for the revision ledger to read. Instead each
+// runtime surface writes a single fixed-key "heartbeat" on every refresh that
+// served usable data: when it last had good data and in what condition. The
+// ledger reads those heartbeats to place these surfaces alongside the committed
+// snapshots without reaching into each route's private keying.
+
+export type RuntimeSurfaceId = "news-pulse" | "mba-jobs";
+
+export interface RuntimeSurfaceHeartbeat {
+  // ISO timestamp of the last refresh that served usable data. For a
+  // stale-fallback serve this is the last *successful* fetch, not the failed
+  // attempt, so ledger age reflects true data age.
+  fetchedAt: string;
+  status: DataDeliveryStatus;
+}
+
+// Read generously — the freshness verdict is the ledger's job via the surface's
+// dataFreshnessPolicy, not this max-age. This only discards a heartbeat so old
+// it's certainly not the live pipeline's state.
+const HEARTBEAT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+function heartbeatKey(surface: RuntimeSurfaceId): string {
+  return `heartbeat/${surface}`;
+}
+
+export async function recordRuntimeSurfaceHeartbeat(
+  surface: RuntimeSurfaceId,
+  heartbeat: RuntimeSurfaceHeartbeat
+): Promise<void> {
+  // A total outage that served nothing must not overwrite the last known-good
+  // heartbeat; callers should skip recording in that case, but guard here too.
+  if (heartbeat.status === "unavailable") return;
+  await writeDurableJson(heartbeatKey(surface), heartbeat);
+}
+
+export async function readRuntimeSurfaceHeartbeat(
+  surface: RuntimeSurfaceId
+): Promise<RuntimeSurfaceHeartbeat | null> {
+  return readDurableJson<RuntimeSurfaceHeartbeat>(
+    heartbeatKey(surface),
+    HEARTBEAT_MAX_AGE_MS
+  );
+}


### PR DESCRIPTION
The July 19 data-pipeline audit flagged a list of open items, but nearly all of them shipped on the 20th. Working through each one, exactly two were genuinely still missing. This closes both.

## What this changes

**World Cup refresh goes dormant outside its tournament window.** The refresh cron only fires in June and July, but with the 2026 tournament over it would still wake every 30 minutes each following June and July and commit no-op churn. A new guard step reads `startDate`/`endDate` out of the committed snapshot and skips the refresh outside a short window around them (two days before kickoff through three days after the final), so it self-arms whenever a future tournament's dates are seeded and stays dormant otherwise. No hardcoded year.

**News Pulse and MBA jobs are now in the `/api/data-revisions` ledger.** Their last-good durability already existed via the Netlify Blobs `durableJsonCache`, but they were absent from the revision ledger because their data is request-time and per-query rather than a committed snapshot. Each route now writes a fixed-key refresh heartbeat (`heartbeat/news-pulse`, `heartbeat/mba-jobs`) on every refresh that served usable data, and the ledger reads those to place both surfaces alongside the committed snapshots with real source-time and status. A total outage never overwrites the last known-good heartbeat, and a non-fresh heartbeat status is passed through so a currently-failing source reads as such.

## Not done, on purpose

- The polling reframe was dropped: polling is already a live VoteHub pipeline, not sample data, so relabeling it as illustrative would be wrong.
- No five-tool export/import feature: corruption recovery is already universal across the browser-persisted tools, so a JSON backup is a convenience rather than the data-wipe fix the audit implied.

## Verification

`tsc --noEmit`, eslint, and the affected Jest suites all pass (77 tests), including new coverage for the heartbeat module and the two new ledger entries.