### PR TITLE
Earthquake: live-first serving, daily fallback snapshot

### DIFF
--- a/.github/workflows/update-earthquake.yml
+++ b/.github/workflows/update-earthquake.yml
@@ -1,11 +1,13 @@
 name: Refresh Earthquake Snapshot
 
 on:
-  # Hourly pass. USGS feeds update every minute, but an hourly snapshot keeps the
-  # dashboard current without spending runner minutes constantly. The USGS public
+  # Daily fallback refresh. The summary API fetches USGS live at request time
+  # (getEarthquakeSummary preferLive), so the committed snapshot only matters as
+  # the cold-start / outage fallback — a daily pass keeps that seed warm without
+  # the hourly commit churn the dashboard no longer needs. The USGS public
   # GeoJSON feeds need no token.
   schedule:
-    - cron: "20 * * * *"
+    - cron: "20 6 * * *"
   workflow_dispatch:
 
 # Don't stack a manual dispatch on top of a scheduled run.
@@ -137,7 +139,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Status:** ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
           echo "**Run Date:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Schedule:** Hourly at :20 UTC" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Schedule:** Daily at 06:20 UTC (fallback seed; the API serves live USGS)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ -n "${{ steps.verify_quality.outputs.recent }}" ]; then
             echo "**Recent (24h):** ${{ steps.verify_quality.outputs.recent }}" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,7 +441,7 @@ Current behavior:
 - `update-world-cup.yml` runs every 30 minutes during June and July
 - `update-score-pools.yml` runs every six hours, requires both live provider tokens, and rejects provider-empty or stale live-league output
 - `update-bay-area-transit.yml` runs on manual dispatch and every six hours year-round, then commits `src/data/bayAreaTransitSnapshot.ts` when it changes
-- `update-earthquake.yml` runs on manual dispatch and hourly (minute 20), then commits `src/data/earthquakeSnapshot.ts` when it changes
+- `update-earthquake.yml` runs on manual dispatch and daily at 06:20 UTC, then commits `src/data/earthquakeSnapshot.ts` when it changes — a fallback-seed refresh only, since the summary API fetches USGS live at request time
 - `update-polling.yml` runs every six hours and refreshes the VoteHub-backed polling snapshot
 - `audit-curated-data.yml` checks review dates, verification flags, and structural integrity across Frontier Models, Tech Startups, AI Dev Tools, Museum Log, Travel Deals, and Food Map every Monday
 - The tech startup tracker has no workflow by design — its dataset is editorially curated, so refreshes happen by editing the seed and running `npm run update:tech-startups` locally

--- a/SNAPSHOT_DRIVEN_DASHBOARDS.md
+++ b/SNAPSHOT_DRIVEN_DASHBOARDS.md
@@ -103,7 +103,7 @@ Usage is `commit-and-push-snapshot.sh <commit-message> <pathspec...>`. The scrip
    jitter.
 
 The retry loop exists because `main` moves constantly — many snapshot bots
-(earthquake hourly, world cup, transit, etc.) push to the same branch and collide.
+(world cup every 30 minutes in-tournament, transit, etc.) push to the same branch and collide.
 A refresh commit only touches its own snapshot files, so a rebase never truly
 conflicts; the failure mode is just losing the race repeatedly. The script bails
 (exit 1) only on a **genuine rebase conflict** (it aborts the rebase) or after
@@ -159,7 +159,7 @@ by BART abbr, world-cup `/teams/[teamId]` by team slug.
 | `/world-cup-2026` | `src/data/worldCupSnapshot.ts` | `buildWorldCupSnapshot.ts` · `update:world-cup` | `update-world-cup.yml` | ESPN `soccer/fifa.world` | every 6h, Jun–Jul |
 | `/score-pools` (+ `/tracker`, `/settings`) | `src/data/scorePoolsSnapshot.ts` | `buildScorePoolsSnapshot.ts` · `update:score-pools` | `update-score-pools.yml` | The Odds API + API-Football (tokens optional) + manual/CSV | every 6h |
 | `/bay-area-transit` | `src/data/bayAreaTransitSnapshot.ts` | `buildBayAreaTransitSnapshot.ts` · `update:bay-area-transit` | `update-bay-area-transit.yml` | BART public API (demo key) | every 6h, year-round |
-| `/earthquake-pulse` | `src/data/earthquakeSnapshot.ts` | `buildEarthquakeSnapshot.ts` · `update:earthquake` | `update-earthquake.yml` | USGS GeoJSON feeds | hourly (min 20) |
+| `/earthquake-pulse` | `src/data/earthquakeSnapshot.ts` | `buildEarthquakeSnapshot.ts` · `update:earthquake` | `update-earthquake.yml` | USGS GeoJSON feeds | daily 06:20 UTC (fallback seed; the API serves live USGS at request time) |
 | `/github-trending-pulse` | `src/data/githubTrendingSnapshot.ts` | `buildGitHubTrendingSnapshot.ts` · `update:github-trending` | `update-github-trending.yml` | GitHub Search API | daily 07:45 UTC |
 | `/spacex-mission-control` | `src/data/spacexSnapshot.generated.json` (+ image manifest) | `buildSpaceXSnapshot.ts` · `update:spacex` | `update-spacex.yml` | Launch Library / SpaceDevs | daily 09:25 + 21:25 UTC |
 | `/tech-startup-tracker` | `src/data/techStartupSnapshot.ts` | `buildTechStartupSnapshot.ts` · `update:tech-startups` | none (curated) | hand-maintained seed | manual |

--- a/docs/DATA_UPDATE_OPERATIONS.md
+++ b/docs/DATA_UPDATE_OPERATIONS.md
@@ -36,7 +36,7 @@ request time, with the committed artifact retained as the last-good fallback.
 | World Cup 2026 | `update:world-cup` | `buildWorldCupSnapshot.ts` | ESPN `soccer/fifa.world` | `src/data/worldCupSnapshot.ts` | `update-world-cup.yml` | every 30m, June through July |
 | Score pools | `update:score-pools` | `buildScorePoolsSnapshot.ts` | The Odds API + API-Football *(tokens required for live leagues)* + manual/CSV | `src/data/scorePoolsSnapshot.ts` | `update-score-pools.yml` | every 6h |
 | Bay Area Transit | `update:bay-area-transit` | `buildBayAreaTransitSnapshot.ts` | BART public API *(demo key)* | `src/data/bayAreaTransitSnapshot.ts` | `update-bay-area-transit.yml` | every 6h, year-round |
-| Earthquake Pulse | `update:earthquake` | `buildEarthquakeSnapshot.ts` | USGS GeoJSON feeds | `src/data/earthquakeSnapshot.ts` | `update-earthquake.yml` | hourly (min 20) |
+| Earthquake Pulse | `update:earthquake` | `buildEarthquakeSnapshot.ts` | USGS GeoJSON feeds | `src/data/earthquakeSnapshot.ts` | `update-earthquake.yml` | daily 06:20 UTC (fallback seed; the API serves live USGS) |
 | GitHub Trending | `update:github-trending` | `buildGitHubTrendingSnapshot.ts` | GitHub Search API *(`GITHUB_TOKEN` optional)* | `src/data/githubTrendingSnapshot.ts` | `update-github-trending.yml` | daily 07:45 UTC |
 | SpaceX data | `update:spacex` *(alias `update:spacex-data`)* | `buildSpaceXSnapshot.ts` | Launch Library / SpaceDevs | `src/data/spacexSnapshot.generated.json` | `update-spacex.yml` | daily 09:25 + 21:25 UTC |
 | SpaceX images | `update:spacex-images` | `buildSpaceXImageSnapshots.ts` | launch image assets | `src/data/spacexImageManifest.generated.json`, `public/data/spacex/*` | `update-spacex.yml` | daily 09:25 + 21:25 UTC |
@@ -124,7 +124,7 @@ commits, then pushes to `HEAD:main` with a retry loop (default 8 attempts;
 override via `SNAPSHOT_PUSH_ATTEMPTS`). On each push rejection it
 `git fetch origin main` and `git rebase --autostash origin/main`, then retries
 with capped exponential backoff plus jitter, which absorbs the contention from
-many snapshot bots (earthquake hourly, world cup, transit, etc.) pushing to
+many snapshot bots (world cup in-tournament, transit, etc.) pushing to
 `main` concurrently. It bails (exit 1) only on a genuine rebase conflict or after
 exhausting every attempt. Usage is asserted by
 `.github/workflows/__tests__/snapshot-workflows.test.ts` (and the investments

--- a/src/lib/__tests__/earthquakeSnapshot.test.ts
+++ b/src/lib/__tests__/earthquakeSnapshot.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@/lib/earthquakeData", () => ({
+  buildEarthquakeSnapshotData: jest.fn(),
+}));
+
+import { earthquakeSnapshot } from "@/data/earthquakeSnapshot";
+import { buildEarthquakeSnapshotData } from "@/lib/earthquakeData";
+import {
+  getEarthquakeSummary,
+  resetEarthquakeLiveCacheForTests,
+} from "@/lib/earthquakeSnapshot";
+import type { EarthquakeSummary } from "@/types/earthquake";
+
+const mockBuild = buildEarthquakeSnapshotData as jest.MockedFunction<
+  typeof buildEarthquakeSnapshotData
+>;
+
+function liveSummary(generatedAt: string): EarthquakeSummary {
+  return {
+    ...earthquakeSnapshot.summary,
+    generatedAt,
+  };
+}
+
+describe("getEarthquakeSummary", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetEarthquakeLiveCacheForTests();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns the committed snapshot without fetching when preferLive is off", async () => {
+    const summary = await getEarthquakeSummary();
+
+    expect(summary).toBe(earthquakeSnapshot.summary);
+    expect(mockBuild).not.toHaveBeenCalled();
+  });
+
+  it("collapses concurrent live requests into a single USGS fetch", async () => {
+    let resolveBuild: (value: { summary: EarthquakeSummary }) => void;
+    mockBuild.mockReturnValue(
+      new Promise((resolve) => {
+        resolveBuild = resolve;
+      }) as ReturnType<typeof buildEarthquakeSnapshotData>
+    );
+
+    const first = getEarthquakeSummary({ preferLive: true });
+    const second = getEarthquakeSummary({ preferLive: true });
+    resolveBuild!({ summary: liveSummary("2026-07-20T10:00:00.000Z") });
+
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(mockBuild).toHaveBeenCalledTimes(1);
+    expect(a.generatedAt).toBe("2026-07-20T10:00:00.000Z");
+    expect(b).toBe(a);
+  });
+
+  it("serves the cached live summary until the TTL lapses, then refetches", async () => {
+    jest.useFakeTimers();
+    mockBuild.mockResolvedValue({
+      summary: liveSummary("2026-07-20T10:00:00.000Z"),
+    } as Awaited<ReturnType<typeof buildEarthquakeSnapshotData>>);
+
+    await getEarthquakeSummary({ preferLive: true });
+    await getEarthquakeSummary({ preferLive: true });
+    expect(mockBuild).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(61_000);
+    await getEarthquakeSummary({ preferLive: true });
+    expect(mockBuild).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the committed snapshot on failure without negative-caching", async () => {
+    mockBuild.mockRejectedValueOnce(new Error("USGS unavailable"));
+
+    const fallback = await getEarthquakeSummary({ preferLive: true });
+    expect(fallback).toBe(earthquakeSnapshot.summary);
+
+    mockBuild.mockResolvedValueOnce({
+      summary: liveSummary("2026-07-20T11:00:00.000Z"),
+    } as Awaited<ReturnType<typeof buildEarthquakeSnapshotData>>);
+
+    const recovered = await getEarthquakeSummary({ preferLive: true });
+    expect(recovered.generatedAt).toBe("2026-07-20T11:00:00.000Z");
+    expect(mockBuild).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/dataFreshnessPolicy.ts
+++ b/src/lib/dataFreshnessPolicy.ts
@@ -47,7 +47,9 @@ function inMonthRange(now: Date, start: number, end: number): boolean {
 }
 
 const POLICIES: Record<DataSurfaceId, DataFreshnessPolicy> = {
-  earthquake: { source: "git-snapshot", maxAgeMs: () => 2 * HOUR_MS },
+  // The summary API serves live USGS data at request time; the committed
+  // artifact is only the cold-start fallback, refreshed daily (06:20 UTC).
+  earthquake: { source: "git-snapshot", maxAgeMs: () => 26 * HOUR_MS },
   "bay-area-transit": { source: "git-snapshot", maxAgeMs: () => 8 * HOUR_MS },
   "formula-1": {
     source: "git-snapshot",

--- a/src/lib/earthquakeSnapshot.ts
+++ b/src/lib/earthquakeSnapshot.ts
@@ -59,20 +59,49 @@ interface EarthquakeSummaryOptions {
   preferLive?: boolean;
 }
 
+// Every CDN miss used to trigger a fresh three-feed USGS fetch. A short
+// in-memory TTL plus a single-flight promise (mirroring
+// bayAreaTransitSnapshot) collapses concurrent misses into one upstream call
+// per instance. The TTL matches the route's max-age=60 so this cache and the
+// CDN expire together.
+const LIVE_CACHE_TTL_MS = 60_000;
+let liveSummaryCache: { summary: EarthquakeSummary; expiresAt: number } | null =
+  null;
+let liveSummaryInflight: Promise<EarthquakeSummary> | null = null;
+
+export function resetEarthquakeLiveCacheForTests(): void {
+  liveSummaryCache = null;
+  liveSummaryInflight = null;
+}
+
 export async function getEarthquakeSummary(
   options: EarthquakeSummaryOptions = {}
 ): Promise<EarthquakeSummary> {
-  if (options.preferLive) {
-    try {
-      return (await buildEarthquakeSnapshotData()).summary;
-    } catch {
-      // The committed snapshot is the last-known-good fallback when USGS is
-      // unavailable. Its generatedAt timestamp keeps the fallback explicit in
-      // response headers and the UI instead of making old data look current.
-    }
-  }
+  if (!options.preferLive) return earthquakeSnapshot.summary;
 
-  return earthquakeSnapshot.summary;
+  if (liveSummaryCache && liveSummaryCache.expiresAt > Date.now()) {
+    return liveSummaryCache.summary;
+  }
+  if (liveSummaryInflight) return liveSummaryInflight;
+
+  liveSummaryInflight = buildEarthquakeSnapshotData()
+    .then((snapshot) => {
+      liveSummaryCache = {
+        summary: snapshot.summary,
+        expiresAt: Date.now() + LIVE_CACHE_TTL_MS,
+      };
+      return snapshot.summary;
+    })
+    // The committed snapshot is the last-known-good fallback when USGS is
+    // unavailable. Its generatedAt timestamp keeps the fallback explicit in
+    // response headers and the UI instead of making old data look current.
+    // Failures are not negative-cached, so the next miss retries USGS.
+    .catch(() => earthquakeSnapshot.summary)
+    .finally(() => {
+      liveSummaryInflight = null;
+    });
+
+  return liveSummaryInflight;
 }
 
 export async function getQuakeEvent(quakeId: string): Promise<QuakeEvent> {


### PR DESCRIPTION
## What

The earthquake dashboard already serves live USGS data at request time (`getEarthquakeSummary({ preferLive: true })`), which makes the hourly snapshot commits mostly churn. This PR completes the live-first posture:

- **Single-flight TTL cache on the live path.** Every CDN miss used to trigger a fresh three-feed USGS fetch. `getEarthquakeSummary` now mirrors the `bayAreaTransitSnapshot` pattern: a 60s in-memory cache (matching the route's `max-age=60`) plus an in-flight promise so concurrent misses collapse into one upstream call. Failures still fall back to the committed snapshot and are not negative-cached.
- **Hourly cron → daily fallback refresh.** `update-earthquake.yml` now runs once a day at 06:20 UTC. The committed snapshot only matters as the cold-start / outage fallback, so a daily pass keeps that seed warm without ~24 automated commits a day (earthquake was the noisiest snapshot bot).
- **Freshness policy 2h → 26h** to match the new fallback-seed role, with a comment explaining why.
- Docs updated (`SNAPSHOT_DRIVEN_DASHBOARDS.md`, `docs/DATA_UPDATE_OPERATIONS.md`, `AGENTS.md`).

## Why

First step of the live-data migration plan: where an upstream tolerates request-time fetching (USGS updates every minute, no limits), serve live and demote the committed snapshot to a fallback seed. This removes the single largest source of automated commit noise on `main`.

## Tests

- New `src/lib/__tests__/earthquakeSnapshot.test.ts`: single-flight coalescing, TTL expiry, failure fallback without negative-caching, snapshot-only path.
- Existing earthquake route, freshness-policy, verifyDataRefresh, and snapshot-workflow suites all green (26 tests).