### PR TITLE
API tier: durable Netlify CDN caching on success responses

### DIFF
--- a/src/app/api/news-pulse/route.ts
+++ b/src/app/api/news-pulse/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { buildCdnCacheHeaders } from "@/lib/apiCacheHeaders";
 import { parseNewsFeed } from "@/lib/news-pulse-feed-parser";
 import { NEWS_FEEDS, type NewsFeedId } from "@/lib/news-pulse-sources";
 import type { NewsArticle } from "@/lib/news-pulse-utils";
@@ -295,11 +296,10 @@ export async function GET() {
 
   return NextResponse.json(result.body, {
     status: result.status,
-    headers: {
-      "Cache-Control": result.isError || result.isStale
-        ? ERROR_CACHE_CONTROL_HEADER
-        : CACHE_CONTROL_HEADER,
-    },
+    headers:
+      result.isError || result.isStale
+        ? { "Cache-Control": ERROR_CACHE_CONTROL_HEADER }
+        : buildCdnCacheHeaders(CACHE_CONTROL_HEADER),
   });
 }
 

--- a/src/lib/__tests__/apiCacheHeaders.test.ts
+++ b/src/lib/__tests__/apiCacheHeaders.test.ts
@@ -1,0 +1,57 @@
+import {
+  buildCdnCacheHeaders,
+  buildDurableCdnCacheControl,
+  buildQueryCacheHeaders,
+} from "@/lib/apiCacheHeaders";
+
+describe("buildDurableCdnCacheControl", () => {
+  it("derives a durable s-maxage header from max-age plus SWR", () => {
+    expect(
+      buildDurableCdnCacheControl(
+        "public, max-age=300, stale-while-revalidate=900"
+      )
+    ).toBe("public, durable, s-maxage=300, stale-while-revalidate=900");
+  });
+
+  it("prefers an explicit s-maxage over max-age", () => {
+    expect(
+      buildDurableCdnCacheControl(
+        "public, max-age=60, s-maxage=1800, stale-while-revalidate=3600"
+      )
+    ).toBe("public, durable, s-maxage=1800, stale-while-revalidate=3600");
+  });
+
+  it("returns null for non-cacheable values so error paths gain no CDN header", () => {
+    expect(buildDurableCdnCacheControl("no-store")).toBeNull();
+    expect(buildDurableCdnCacheControl("private, max-age=60")).toBeNull();
+    expect(buildDurableCdnCacheControl("public")).toBeNull();
+  });
+});
+
+describe("buildCdnCacheHeaders", () => {
+  it("emits both headers for cacheable values", () => {
+    expect(buildCdnCacheHeaders("public, max-age=60")).toEqual({
+      "Cache-Control": "public, max-age=60",
+      "Netlify-CDN-Cache-Control": "public, durable, s-maxage=60",
+    });
+  });
+
+  it("emits only Cache-Control for no-store", () => {
+    expect(buildCdnCacheHeaders("no-store")).toEqual({
+      "Cache-Control": "no-store",
+    });
+  });
+});
+
+describe("buildQueryCacheHeaders", () => {
+  it("keeps the query cache-key opt-in alongside the durable header", () => {
+    expect(
+      buildQueryCacheHeaders("public, max-age=30, stale-while-revalidate=60")
+    ).toEqual({
+      "Cache-Control": "public, max-age=30, stale-while-revalidate=60",
+      "Netlify-CDN-Cache-Control":
+        "public, durable, s-maxage=30, stale-while-revalidate=60",
+      "Netlify-Vary": "query",
+    });
+  });
+});

--- a/src/lib/__tests__/snapshotResponse.test.ts
+++ b/src/lib/__tests__/snapshotResponse.test.ts
@@ -10,9 +10,25 @@ describe("createSnapshotResponseHeaders", () => {
     });
 
     expect(headers["Cache-Control"]).toBe("public, max-age=60");
+    expect(headers["Netlify-CDN-Cache-Control"]).toBe(
+      "public, durable, s-maxage=60"
+    );
     expect(headers["X-Data-Revision"]).toHaveLength(64);
     expect(headers["X-Data-Status"]).toBe("fresh");
     expect(headers["X-Data-Source-As-Of"]).toBeDefined();
     expect(headers.ETag).toBe(`"${headers["X-Data-Revision"]}"`);
+  });
+
+  it("mirrors stale-while-revalidate into the durable CDN header", () => {
+    const headers = createSnapshotResponseHeaders({
+      surface: "golf",
+      payload: { players: 70 },
+      sourceAsOf: new Date().toISOString(),
+      cacheControl: "public, max-age=300, stale-while-revalidate=900",
+    });
+
+    expect(headers["Netlify-CDN-Cache-Control"]).toBe(
+      "public, durable, s-maxage=300, stale-while-revalidate=900"
+    );
   });
 });

--- a/src/lib/apiCacheHeaders.ts
+++ b/src/lib/apiCacheHeaders.ts
@@ -3,13 +3,51 @@ export const NO_STORE_HEADERS = {
 } as const;
 
 /**
+ * Derives the Netlify CDN companion for a success Cache-Control value.
+ * `durable` opts the response into Netlify's shared, region-independent cache
+ * so concurrent CDN misses across nodes collapse into one function
+ * invocation, and the durable cache is invalidated automatically on deploys,
+ * so snapshot-backed routes never outlive their data. Returns null for
+ * non-cacheable values (no-store/private/no TTL) so error paths never gain a
+ * CDN header.
+ */
+export function buildDurableCdnCacheControl(
+  cacheControl: string
+): string | null {
+  if (/no-store|private/i.test(cacheControl)) return null;
+  const sMaxAge = cacheControl.match(/(?:^|[,\s])s-maxage=(\d+)/i)?.[1];
+  const maxAge = cacheControl.match(/(?:^|[,\s])max-age=(\d+)/i)?.[1];
+  const ttl = sMaxAge ?? maxAge;
+  if (!ttl) return null;
+  const swr = cacheControl.match(
+    /(?:^|[,\s])stale-while-revalidate=(\d+)/i
+  )?.[1];
+  const parts = ["public", "durable", `s-maxage=${ttl}`];
+  if (swr) parts.push(`stale-while-revalidate=${swr}`);
+  return parts.join(", ");
+}
+
+/** Cache-Control plus its durable Netlify CDN companion when cacheable. */
+export function buildCdnCacheHeaders(
+  cacheControl: string
+): Record<string, string> {
+  const cdnCacheControl = buildDurableCdnCacheControl(cacheControl);
+  return {
+    "Cache-Control": cacheControl,
+    ...(cdnCacheControl
+      ? { "Netlify-CDN-Cache-Control": cdnCacheControl }
+      : {}),
+  };
+}
+
+/**
  * Netlify does not include the public query string in its default cache key
  * for Next.js route handlers. Query-dependent responses must opt in so one
  * request cannot populate the edge cache for every parameter combination.
  */
 export function buildQueryCacheHeaders(cacheControl: string) {
   return {
-    "Cache-Control": cacheControl,
+    ...buildCdnCacheHeaders(cacheControl),
     "Netlify-Vary": "query",
   } as const;
 }

--- a/src/lib/snapshotResponse.ts
+++ b/src/lib/snapshotResponse.ts
@@ -1,3 +1,4 @@
+import { buildCdnCacheHeaders } from "@/lib/apiCacheHeaders";
 import {
   createDataResponseHeaders,
   createDataRevisionEntry,
@@ -36,7 +37,7 @@ export function createSnapshotResponseHeaders({
   });
 
   return {
-    "Cache-Control": cacheControl,
+    ...buildCdnCacheHeaders(cacheControl),
     ...createDataResponseHeaders(revision),
   };
 }


### PR DESCRIPTION
## What

Every dashboard API route already returns `Cache-Control: public, max-age=…, stale-while-revalidate=…` on success and `no-store` on errors. This PR adds the Netlify-specific companion header so those successes also land in Netlify's **durable cache** (shared, region-independent):

- New `buildDurableCdnCacheControl` / `buildCdnCacheHeaders` in `src/lib/apiCacheHeaders.ts` derive `Netlify-CDN-Cache-Control: public, durable, s-maxage=<ttl>[, stale-while-revalidate=<swr>]` from the existing Cache-Control string, returning nothing for `no-store`/`private`/TTL-less values so error paths never gain a CDN header.
- `createSnapshotResponseHeaders` (used by all 27 snapshot/live dashboard routes) and `buildQueryCacheHeaders` (query-keyed routes, keeps `Netlify-Vary: query`) now emit both headers.
- `/api/news-pulse` success path opts in too; its error/stale paths keep their existing headers.

## Why

Without `durable`, each Netlify CDN node caches independently, so a burst of geographically spread traffic still fans out to one function invocation per node — and for the request-time surfaces (earthquake, transit, news-pulse) that means parallel upstream fetches. With `durable`, concurrent misses collapse into one invocation. Netlify invalidates the durable cache on deploys, so snapshot-backed routes can't outlive their data. Browsers keep the smaller `max-age`; the CDN gets `s-maxage`.

The HTML/page tier is unaffected: `src/proxy.ts` still sets `Netlify-CDN-Cache-Control: no-store` for pages, and its matcher excludes `/api/`.

## Tests

New `apiCacheHeaders.test.ts` (derivation, s-maxage precedence, no-store/private guard, query variant) + extended `snapshotResponse.test.ts`. Full API route test sweep: 33 suites / 166 tests green.