### PR TITLE
MLB: request-time live scoreboard with snapshot fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ Confirm live API routes from `src/app/api/**/route.ts`. Current routes:
 - `/api/stocks`
 - `/api/world-cup/summary` and `/api/world-cup/teams/[teamId]`
 
-The dashboard APIs read committed snapshot files; they do not call external services at request time.
+Most dashboard APIs read committed snapshot files at request time. The exceptions that call external services at request time are the earthquake-pulse, bay-area-transit, news-pulse, mba-jobs, investments quotes, and MLB summary routes; each keeps the committed snapshot (or cached data) as its fallback.
 
 ---
 

--- a/SNAPSHOT_DRIVEN_DASHBOARDS.md
+++ b/SNAPSHOT_DRIVEN_DASHBOARDS.md
@@ -152,7 +152,7 @@ by BART abbr, world-cup `/teams/[teamId]` by team slug.
 | `/premier-league` | `src/data/premierLeagueSnapshot.ts` | `buildPremierLeagueSnapshot.ts` · `update:premier-league` / `update:football` | `update-premier-league.yml` | football-data.org (token) | daily 06:15 UTC, Aug–May |
 | `/la-liga` | `src/data/laLigaSnapshot.ts` | `updateLaLigaSnapshot.ts` · `update:la-liga` / `update:football` | `update-la-liga.yml` | football-data.org (token) | daily 06:30 UTC, Aug–May |
 | `/nfl` | `src/data/nflSnapshot.ts` | `updateNflSnapshot.ts` · `update:nfl` | `update-nfl.yml` | NFLverse CSVs | Tue 10:35 UTC, Sep–Feb |
-| `/mlb` | `src/data/mlbSnapshot.ts` | `updateMlbSnapshot.ts` · `update:mlb` | `update-mlb.yml` | MLB Stats API | daily 10:05 UTC, Mar–Nov |
+| `/mlb` | `src/data/mlbSnapshot.ts` | `updateMlbSnapshot.ts` · `update:mlb` | `update-mlb.yml` | MLB Stats API | daily 10:05 UTC, Mar–Nov (fallback seed; the API serves live statsapi at request time) |
 | `/nba` | `src/data/nbaSnapshot.ts` | `updateNbaSnapshot.ts` · `update:nba` | `update-nba.yml` | ESPN NBA | daily 10:20 UTC, mid-Oct–Jun |
 | `/golf` | `src/data/golfSnapshot.ts` | `buildGolfSnapshot.ts` · `update:golf` | `update-golf.yml` | ESPN golf | daily 08:40 UTC |
 | `/formula-1`, `/fantasy-formula-1` | `src/data/formula1Snapshot.ts` | `buildFormula1Snapshot.ts` · `update:formula-1` | `update-formula-1.yml` | OpenF1 | daily 08:10 UTC |

--- a/docs/DATA_UPDATE_OPERATIONS.md
+++ b/docs/DATA_UPDATE_OPERATIONS.md
@@ -14,8 +14,9 @@ architecture or the per-workflow prose:
 The `update:*` commands write committed TypeScript or JSON artifacts. A failed
 or empty fetch keeps the previous snapshot, and every scheduled job now checks
 the artifact timestamp against one shared freshness policy before it can
-commit. Earthquake and BART APIs also refresh their time-sensitive data at
-request time, with the committed artifact retained as the last-good fallback.
+commit. Earthquake, BART, and MLB APIs also refresh their time-sensitive data
+at request time, with the committed artifact retained as the last-good
+fallback.
 
 ---
 
@@ -29,7 +30,7 @@ request time, with the committed artifact retained as the last-good fallback.
 | Premier League | `update:premier-league` | `buildPremierLeagueSnapshot.ts` | football-data.org *(token)* | `src/data/premierLeagueSnapshot.ts` | `update-premier-league.yml` | every 4h, August through May |
 | La Liga | `update:la-liga` | `updateLaLigaSnapshot.ts` | football-data.org *(token)* | `src/data/laLigaSnapshot.ts` | `update-la-liga.yml` | every 4h, August through May |
 | NFL | `update:nfl` | `updateNflSnapshot.ts` | NFLverse CSVs | `src/data/nflSnapshot.ts` | `update-nfl.yml` | Tue 10:35 UTC, September through February |
-| MLB | `update:mlb` | `updateMlbSnapshot.ts` | MLB Stats API | `src/data/mlbSnapshot.ts` | `update-mlb.yml` | every 4h, March through November |
+| MLB | `update:mlb` | `updateMlbSnapshot.ts` | MLB Stats API | `src/data/mlbSnapshot.ts` | `update-mlb.yml` | every 4h, March through November (fallback seed; the API serves live statsapi at request time) |
 | NBA | `update:nba` | `updateNbaSnapshot.ts` | ESPN NBA | `src/data/nbaSnapshot.ts` | `update-nba.yml` | every 4h, mid-October through June |
 | Golf | `update:golf` | `buildGolfSnapshot.ts` | ESPN golf | `src/data/golfSnapshot.ts` | `update-golf.yml` | every 3h Thursday through Sunday; daily otherwise |
 | Formula 1 | `update:formula-1` | `buildFormula1Snapshot.ts` | OpenF1 | `src/data/formula1Snapshot.ts` | `update-formula-1.yml` | every 3h Thursday through Sunday; daily otherwise |
@@ -82,8 +83,8 @@ in Netlify Blobs so cold starts do not erase their fallback.
 ## Build and refresh boundary
 
 - Production builds consume committed snapshots and never call external data
-  providers. Earthquake and BART make separate request-time refreshes and keep
-  those snapshots as fallbacks.
+  providers. Earthquake, BART, and MLB make separate request-time refreshes
+  and keep those snapshots as fallbacks.
 - Premier League and La Liga refresh through their dedicated daily workflows;
   NFL refreshes through `update-nfl.yml` (or a manual run).
 - `update:football` (the ~16-min full refresh, including per-team fixtures and

--- a/src/app/api/mlb/summary/__tests__/route.test.ts
+++ b/src/app/api/mlb/summary/__tests__/route.test.ts
@@ -88,8 +88,12 @@ describe("GET /api/mlb/summary", () => {
     expect(body.standings[0].shortName).toBe("Yankees");
     expect(body.teams[0].abbreviation).toBe("NYY");
     expect(response.headers.get("Cache-Control")).toBe(
-      "public, max-age=300, stale-while-revalidate=900"
+      "public, max-age=60, stale-while-revalidate=300"
     );
+    expect(response.headers.get("X-Data-Source")).toBe(
+      "statsapi-runtime-with-snapshot-fallback"
+    );
+    expect(mockGetMlbSummarySnapshot).toHaveBeenCalledWith({ preferLive: true });
   });
 
   it("returns a stable empty payload when the snapshot is unavailable", async () => {

--- a/src/app/api/mlb/summary/route.ts
+++ b/src/app/api/mlb/summary/route.ts
@@ -6,7 +6,7 @@ import {
 import { logger } from "@/lib/logger";
 import { createSnapshotResponseHeaders } from "@/lib/snapshotResponse";
 
-const SUCCESS_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=900";
+const SUCCESS_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
 // Errors (4xx/5xx) must NOT be cached by the CDN — otherwise a transient
 // upstream failure poisons the cache for the full success TTL.
 const ERROR_CACHE_HEADERS = {
@@ -15,13 +15,14 @@ const ERROR_CACHE_HEADERS = {
 
 export async function GET() {
   try {
-    const summary = await getMlbSummarySnapshot();
+    const summary = await getMlbSummarySnapshot({ preferLive: true });
     return NextResponse.json(summary, {
       headers: createSnapshotResponseHeaders({
         surface: "mlb",
         payload: summary,
         sourceAsOf: summary.updatedAt,
         cacheControl: SUCCESS_CACHE_CONTROL,
+        source: "statsapi-runtime-with-snapshot-fallback",
       }),
     });
   } catch (error) {

--- a/src/lib/__tests__/mlbData.test.ts
+++ b/src/lib/__tests__/mlbData.test.ts
@@ -2,12 +2,14 @@
  * @jest-environment node
  */
 import {
+  buildMlbLiveSummaryData,
   getCurrentSeason,
   getMlbSummary,
   getMlbTeamSnapshot,
   isValidMlbTeamId,
   createEmptyMlbSnapshot,
 } from "../mlbData";
+import type { MlbGame, MlbSummarySnapshot, MlbTeamOption } from "@/types/mlb";
 
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
@@ -839,6 +841,268 @@ describe("getMlbTeamSnapshot", () => {
 
     await expect(getMlbTeamSnapshot("147")).rejects.toMatchObject({
       status: 404,
+    });
+  });
+});
+
+// ---- Live summary builder --------------------------------------------------
+
+function isoDate(daysFromToday: number): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + daysFromToday);
+  return date.toISOString().slice(0, 10);
+}
+
+function isoDateTime(daysFromToday: number, time = "T20:00:00Z"): string {
+  return `${isoDate(daysFromToday)}${time}`;
+}
+
+const LIVE_TEAMS: MlbTeamOption[] = [
+  {
+    id: "147",
+    name: "New York Yankees",
+    shortName: "Yankees",
+    abbreviation: "NYY",
+    league: "AL",
+    division: "AL East",
+    venue: "Yankee Stadium",
+    logo: "https://www.mlbstatic.com/team-logos/147.svg",
+  },
+  {
+    id: "111",
+    name: "Boston Red Sox",
+    shortName: "Red Sox",
+    abbreviation: "BOS",
+    league: "AL",
+    division: "AL East",
+    venue: "Fenway Park",
+    logo: "https://www.mlbstatic.com/team-logos/111.svg",
+  },
+];
+
+function committedGame(
+  id: string,
+  utcDate: string,
+  status: string,
+  score: MlbGame["score"] = { winner: null, home: null, away: null }
+): MlbGame {
+  return {
+    id,
+    utcDate,
+    status,
+    matchday: null,
+    stage: "R",
+    homeTeam: {
+      id: "147",
+      name: "New York Yankees",
+      shortName: "Yankees",
+      abbreviation: "NYY",
+      crest: "https://www.mlbstatic.com/team-logos/147.svg",
+    },
+    awayTeam: {
+      id: "111",
+      name: "Boston Red Sox",
+      shortName: "Red Sox",
+      abbreviation: "BOS",
+      crest: "https://www.mlbstatic.com/team-logos/111.svg",
+    },
+    score,
+  };
+}
+
+function liveFallbackSummary(): MlbSummarySnapshot {
+  return {
+    season: "2026",
+    updatedAt: isoDate(-1),
+    sourceLabel: "MLB Stats API",
+    sourceUrls: { standings: "standings", schedule: "schedule", leaders: "leaders" },
+    teams: LIVE_TEAMS,
+    standings: [],
+    recentGames: [
+      committedGame("900001", isoDateTime(-3), "FINISHED", {
+        winner: "HOME_TEAM",
+        home: 4,
+        away: 1,
+      }),
+    ],
+    upcomingGames: [
+      committedGame("900101", isoDateTime(0), "Scheduled"),
+      committedGame("900103", isoDateTime(0, "T17:00:00Z"), "Scheduled"),
+      committedGame("900102", isoDateTime(1), "Scheduled"),
+    ],
+    hittingLeaders: { homeRuns: [], runsBattedIn: [], battingAverage: [] },
+    pitchingLeaders: { earnedRunAverage: [], wins: [], strikeouts: [] },
+  };
+}
+
+function rawScheduleGame(
+  gamePk: number,
+  gameDate: string,
+  abstractGameState: string,
+  detailedState: string,
+  homeScore: number | null = null,
+  awayScore: number | null = null
+) {
+  return {
+    gamePk,
+    gameDate,
+    gameType: "R",
+    status: { abstractGameState, detailedState },
+    teams: {
+      home: {
+        team: { id: 147, name: "New York Yankees", abbreviation: "NYY" },
+        score: homeScore,
+        isWinner: null,
+      },
+      away: {
+        team: { id: 111, name: "Boston Red Sox", abbreviation: "BOS" },
+        score: awayScore,
+        isWinner: null,
+      },
+    },
+  };
+}
+
+function makeLiveScheduleRouter(
+  yesterdayResponse: () => Response,
+  todayResponse: () => Response
+) {
+  return async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (!url.includes("/schedule?")) {
+      throw new Error(`Unexpected fetch URL in test: ${url}`);
+    }
+    const startMatch = url.match(/startDate=([^&]+)/);
+    const start = startMatch ? startMatch[1] : "";
+    if (start < isoDate(0)) return yesterdayResponse();
+    return todayResponse();
+  };
+}
+
+describe("buildMlbLiveSummaryData", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("merges yesterday's finals and today's scoreboard into the committed summary", async () => {
+    jest.spyOn(global, "fetch").mockImplementation(
+      makeLiveScheduleRouter(
+        () =>
+          jsonResponse({
+            dates: [
+              {
+                date: isoDate(-1),
+                games: [
+                  rawScheduleGame(900050, isoDateTime(-1), "Final", "Final", 3, 2),
+                ],
+              },
+            ],
+          }),
+        () =>
+          jsonResponse({
+            dates: [
+              {
+                date: isoDate(0),
+                games: [
+                  rawScheduleGame(
+                    900101,
+                    isoDateTime(0),
+                    "Live",
+                    "In Progress",
+                    2,
+                    1
+                  ),
+                  rawScheduleGame(
+                    900103,
+                    isoDateTime(0, "T17:00:00Z"),
+                    "Final",
+                    "Final",
+                    6,
+                    5
+                  ),
+                ],
+              },
+            ],
+          })
+      ) as unknown as typeof fetch
+    );
+
+    const fallback = liveFallbackSummary();
+    const summary = await buildMlbLiveSummaryData(fallback);
+
+    // Today's in-progress game replaces its committed entry with live score
+    // and state; the now-finished game leaves the upcoming list.
+    expect(summary.upcomingGames.map((g) => g.id)).toEqual(["900101", "900102"]);
+    const liveGame = summary.upcomingGames[0];
+    expect(liveGame.status).toBe("In Progress");
+    expect(liveGame.score).toEqual({ winner: null, home: 2, away: 1 });
+    // Known-team enrichment still applies to live games.
+    expect(liveGame.homeTeam.shortName).toBe("Yankees");
+
+    // Finals from both windows merge ahead of the committed recents, newest first.
+    expect(summary.recentGames.map((g) => g.id)).toEqual([
+      "900103",
+      "900050",
+      "900001",
+    ]);
+    expect(summary.recentGames[0].score).toEqual({
+      winner: "HOME_TEAM",
+      home: 6,
+      away: 5,
+    });
+
+    // Non-time-sensitive sections stay committed; the stamp refreshes.
+    expect(summary.standings).toBe(fallback.standings);
+    expect(summary.hittingLeaders).toBe(fallback.hittingLeaders);
+    expect(summary.teams).toBe(fallback.teams);
+    expect(summary.updatedAt).toBe(isoDate(0));
+  });
+
+  it("keeps the committed games for a window whose fetch fails", async () => {
+    jest.spyOn(global, "fetch").mockImplementation(
+      makeLiveScheduleRouter(
+        () => jsonResponse({}, 404),
+        () =>
+          jsonResponse({
+            dates: [
+              {
+                date: isoDate(0),
+                games: [
+                  rawScheduleGame(
+                    900103,
+                    isoDateTime(0, "T17:00:00Z"),
+                    "Final",
+                    "Final",
+                    6,
+                    5
+                  ),
+                ],
+              },
+            ],
+          })
+      ) as unknown as typeof fetch
+    );
+
+    const fallback = liveFallbackSummary();
+    const summary = await buildMlbLiveSummaryData(fallback);
+
+    // Yesterday's window failed, so only today's final joins the committed recents.
+    expect(summary.recentGames.map((g) => g.id)).toEqual(["900103", "900001"]);
+    expect(summary.upcomingGames.map((g) => g.id)).toEqual(["900101", "900102"]);
+  });
+
+  it("throws when every live schedule window fails so callers can fall back wholesale", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementation(
+        makeLiveScheduleRouter(
+          () => jsonResponse({}, 404),
+          () => jsonResponse({}, 404)
+        ) as unknown as typeof fetch
+      );
+
+    await expect(buildMlbLiveSummaryData(liveFallbackSummary())).rejects.toMatchObject({
+      status: 503,
     });
   });
 });

--- a/src/lib/__tests__/mlbSnapshot.test.ts
+++ b/src/lib/__tests__/mlbSnapshot.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@/data/mlbSnapshot", () => ({
+  mlbSnapshot: {
+    season: "2026",
+    updatedAt: "2026-07-19",
+    sourceLabel: "MLB Stats API",
+    sourceUrls: { standings: "standings", schedule: "schedule", leaders: "leaders" },
+    teams: [],
+    standings: [],
+    recentGames: [],
+    upcomingGames: [],
+    hittingLeaders: { homeRuns: [], runsBattedIn: [], battingAverage: [] },
+    pitchingLeaders: { earnedRunAverage: [], wins: [], strikeouts: [] },
+    teamSnapshots: {},
+  },
+}));
+
+jest.mock("@/lib/mlbData", () => ({
+  buildMlbLiveSummaryData: jest.fn(),
+}));
+
+import { getMlbSummarySnapshot, resetMlbLiveCacheForTests } from "../mlbSnapshot";
+import { buildMlbLiveSummaryData } from "@/lib/mlbData";
+import type { MlbSummarySnapshot } from "@/types/mlb";
+
+const mockBuildLive = buildMlbLiveSummaryData as jest.MockedFunction<
+  typeof buildMlbLiveSummaryData
+>;
+
+function liveSummaryFixture(): MlbSummarySnapshot {
+  return {
+    season: "2026",
+    updatedAt: "2026-07-20",
+    sourceLabel: "MLB Stats API",
+    sourceUrls: { standings: "standings", schedule: "schedule", leaders: "leaders" },
+    teams: [],
+    standings: [],
+    recentGames: [
+      {
+        id: "776001",
+        utcDate: "2026-07-19T23:10:00Z",
+        status: "FINISHED",
+        matchday: null,
+        stage: "R",
+        homeTeam: {
+          id: "147",
+          name: "New York Yankees",
+          shortName: "Yankees",
+          abbreviation: "NYY",
+          crest: null,
+        },
+        awayTeam: {
+          id: "111",
+          name: "Boston Red Sox",
+          shortName: "Red Sox",
+          abbreviation: "BOS",
+          crest: null,
+        },
+        score: { winner: "HOME_TEAM", home: 5, away: 2 },
+      },
+    ],
+    upcomingGames: [],
+    hittingLeaders: { homeRuns: [], runsBattedIn: [], battingAverage: [] },
+    pitchingLeaders: { earnedRunAverage: [], wins: [], strikeouts: [] },
+  };
+}
+
+describe("getMlbSummarySnapshot", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMlbLiveCacheForTests();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns the committed summary without calling the live builder by default", async () => {
+    const summary = await getMlbSummarySnapshot();
+
+    expect(summary.updatedAt).toBe("2026-07-19");
+    expect("teamSnapshots" in summary).toBe(false);
+    expect(mockBuildLive).not.toHaveBeenCalled();
+  });
+
+  it("serves the live summary from the TTL cache on repeat calls", async () => {
+    jest.useFakeTimers();
+    mockBuildLive.mockResolvedValue(liveSummaryFixture());
+
+    const first = await getMlbSummarySnapshot({ preferLive: true });
+    jest.advanceTimersByTime(59_000);
+    const second = await getMlbSummarySnapshot({ preferLive: true });
+
+    expect(first.updatedAt).toBe("2026-07-20");
+    expect(second).toBe(first);
+    expect(mockBuildLive).toHaveBeenCalledTimes(1);
+    // The builder receives the committed summary (minus team snapshots) as
+    // its fallback seed.
+    const fallbackArg = mockBuildLive.mock.calls[0][0];
+    expect(fallbackArg.updatedAt).toBe("2026-07-19");
+    expect("teamSnapshots" in fallbackArg).toBe(false);
+  });
+
+  it("rebuilds the live summary after the TTL expires", async () => {
+    jest.useFakeTimers();
+    mockBuildLive.mockResolvedValue(liveSummaryFixture());
+
+    await getMlbSummarySnapshot({ preferLive: true });
+    jest.advanceTimersByTime(60_001);
+    await getMlbSummarySnapshot({ preferLive: true });
+
+    expect(mockBuildLive).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent live requests into a single in-flight build", async () => {
+    let resolveBuild: (summary: MlbSummarySnapshot) => void = () => undefined;
+    mockBuildLive.mockImplementation(
+      () =>
+        new Promise<MlbSummarySnapshot>((resolve) => {
+          resolveBuild = resolve;
+        })
+    );
+
+    const firstPromise = getMlbSummarySnapshot({ preferLive: true });
+    const secondPromise = getMlbSummarySnapshot({ preferLive: true });
+    resolveBuild(liveSummaryFixture());
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+    expect(mockBuildLive).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+    expect(first.updatedAt).toBe("2026-07-20");
+  });
+
+  it("falls back to the committed summary on failure without caching the failure", async () => {
+    mockBuildLive.mockRejectedValueOnce(new Error("statsapi unavailable"));
+
+    const fallback = await getMlbSummarySnapshot({ preferLive: true });
+    expect(fallback.updatedAt).toBe("2026-07-19");
+
+    // The failure must not be cached: the next call retries the live build.
+    mockBuildLive.mockResolvedValueOnce(liveSummaryFixture());
+    const live = await getMlbSummarySnapshot({ preferLive: true });
+
+    expect(live.updatedAt).toBe("2026-07-20");
+    expect(mockBuildLive).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/mlbData.ts
+++ b/src/lib/mlbData.ts
@@ -10,6 +10,7 @@ import type {
   MlbPitchingLeaders,
   MlbSnapshot,
   MlbStandingsRow,
+  MlbSummarySnapshot,
   MlbTeamOption,
   MlbTeamProfile,
   MlbTeamSnapshot,
@@ -572,6 +573,107 @@ export async function getMlbSummary(): Promise<{
     hittingLeaders: { homeRuns, runsBattedIn, battingAverage },
     pitchingLeaders: { earnedRunAverage, wins, strikeouts },
     generatedAt: new Date().toISOString(),
+  };
+}
+
+// Live schedule windows are fetched at request time, so they bypass the
+// framework fetch cache; the accessor's in-memory TTL cache bounds call volume.
+const LIVE_SCHEDULE_REVALIDATE_SECONDS = 0;
+
+function fetchLiveScheduleWindow(
+  startOffsetDays: number,
+  endOffsetDays: number
+): Promise<StatsApiScheduleResponse> {
+  return fetchStatsApiJson<StatsApiScheduleResponse>(
+    `/schedule?${buildQueryString({
+      sportId: SPORT_ID,
+      startDate: dateOffsetIso(startOffsetDays),
+      endDate: dateOffsetIso(endOffsetDays),
+    })}`,
+    LIVE_SCHEDULE_REVALIDATE_SECONDS
+  );
+}
+
+function collectScheduleGames(
+  response: StatsApiScheduleResponse,
+  teamLookup: Map<string, MlbTeamOption>
+): MlbGame[] {
+  const games: MlbGame[] = [];
+  for (const date of response.dates ?? []) {
+    for (const raw of date.games ?? []) {
+      const game = normalizeGame(raw, teamLookup);
+      if (game) games.push(game);
+    }
+  }
+  return games;
+}
+
+/**
+ * Request-time refresh of only the time-sensitive summary sections: yesterday's
+ * finals and today's scoreboard (live scores and game states). Standings,
+ * leaders, and the team list always come from the committed snapshot passed in
+ * as the fallback. Each schedule window falls back to the committed games when
+ * its fetch fails; the builder throws only when both windows fail so the
+ * accessor can fall back to the committed summary wholesale. Two upstream
+ * calls per refresh, mirroring buildBayAreaTransitLiveSnapshotData.
+ */
+export async function buildMlbLiveSummaryData(
+  fallback: MlbSummarySnapshot
+): Promise<MlbSummarySnapshot> {
+  const teamLookup = new Map(fallback.teams.map((team) => [team.id, team]));
+
+  const [yesterdayResult, todayResult] = await Promise.allSettled([
+    fetchLiveScheduleWindow(-1, -1),
+    fetchLiveScheduleWindow(0, 0),
+  ]);
+
+  if (yesterdayResult.status === "rejected" && todayResult.status === "rejected") {
+    throw createMlbDataError("Every MLB live schedule window was unavailable.", 503);
+  }
+
+  const freshFinished: MlbGame[] = [];
+  let upcomingGames = fallback.upcomingGames;
+
+  if (yesterdayResult.status === "fulfilled") {
+    for (const game of collectScheduleGames(yesterdayResult.value, teamLookup)) {
+      if (game.status === "FINISHED") freshFinished.push(game);
+    }
+  }
+
+  if (todayResult.status === "fulfilled") {
+    const todayGames = collectScheduleGames(todayResult.value, teamLookup);
+    const todayIds = new Set(todayGames.map((game) => game.id));
+    const pending = todayGames.filter((game) => game.status !== "FINISHED");
+    for (const game of todayGames) {
+      if (game.status === "FINISHED") freshFinished.push(game);
+    }
+    // Fresh pending games replace their committed entries so live scores and
+    // game states stay current. Committed entries for today's now-finished
+    // games drop out here and re-enter through recentGames instead.
+    upcomingGames = [
+      ...pending,
+      ...fallback.upcomingGames.filter((game) => !todayIds.has(game.id)),
+    ]
+      .sort((a, b) => new Date(a.utcDate).getTime() - new Date(b.utcDate).getTime())
+      .slice(0, UPCOMING_GAME_LIMIT);
+  }
+
+  let recentGames = fallback.recentGames;
+  if (freshFinished.length > 0) {
+    const freshIds = new Set(freshFinished.map((game) => game.id));
+    recentGames = [
+      ...freshFinished,
+      ...fallback.recentGames.filter((game) => !freshIds.has(game.id)),
+    ]
+      .sort((a, b) => new Date(b.utcDate).getTime() - new Date(a.utcDate).getTime())
+      .slice(0, RECENT_GAME_LIMIT);
+  }
+
+  return {
+    ...fallback,
+    updatedAt: new Date().toISOString().slice(0, 10),
+    recentGames,
+    upcomingGames,
   };
 }
 

--- a/src/lib/mlbSnapshot.ts
+++ b/src/lib/mlbSnapshot.ts
@@ -1,4 +1,5 @@
 import { mlbSnapshot } from "@/data/mlbSnapshot";
+import { buildMlbLiveSummaryData } from "@/lib/mlbData";
 import type { MlbSummarySnapshot, MlbTeamSnapshot } from "@/types/mlb";
 
 const SUMMARY_GAME_LIMIT = 10;
@@ -77,8 +78,46 @@ export function isValidMlbTeamId(teamId: string): boolean {
   return MLB_TEAM_ID_PATTERN.test(teamId) && teamId in mlbSnapshot.teamSnapshots;
 }
 
-export async function getMlbSummarySnapshot(): Promise<MlbSummarySnapshot> {
-  return clampMlbSummarySnapshot(mlbSnapshot);
+interface MlbSummaryOptions {
+  preferLive?: boolean;
+}
+
+const LIVE_CACHE_TTL_MS = 60_000;
+let liveSummaryCache:
+  | { summary: MlbSummarySnapshot; expiresAt: number }
+  | null = null;
+let liveSummaryInflight: Promise<MlbSummarySnapshot> | null = null;
+
+export function resetMlbLiveCacheForTests(): void {
+  liveSummaryCache = null;
+  liveSummaryInflight = null;
+}
+
+export async function getMlbSummarySnapshot(
+  options: MlbSummaryOptions = {}
+): Promise<MlbSummarySnapshot> {
+  if (!options.preferLive) return clampMlbSummarySnapshot(mlbSnapshot);
+  if (liveSummaryCache && liveSummaryCache.expiresAt > Date.now()) {
+    return liveSummaryCache.summary;
+  }
+  if (liveSummaryInflight) return liveSummaryInflight;
+
+  liveSummaryInflight = buildMlbLiveSummaryData(clampMlbSummarySnapshot(mlbSnapshot))
+    .then((summary) => {
+      liveSummaryCache = {
+        summary,
+        expiresAt: Date.now() + LIVE_CACHE_TTL_MS,
+      };
+      return summary;
+    })
+    // The committed snapshot is the last-known-good fallback when statsapi is
+    // unavailable. Failures are never cached, so the next request retries.
+    .catch(() => clampMlbSummarySnapshot(mlbSnapshot))
+    .finally(() => {
+      liveSummaryInflight = null;
+    });
+
+  return liveSummaryInflight;
 }
 
 export async function getMlbTeamSnapshot(teamId: string): Promise<MlbTeamSnapshot> {


### PR DESCRIPTION
## What

`/api/mlb/summary` now serves live MLB data at request time. A new `buildMlbLiveSummaryData` in `src/lib/mlbData.ts` fetches only the time-sensitive sections from statsapi.mlb.com (yesterday's finals and today's scoreboard, two schedule calls per refresh) and merges them into a copy of the committed snapshot's summary, so live scores and game states stay current while standings, leaders, and the team list remain committed. The summary accessor in `src/lib/mlbSnapshot.ts` gains a `{ preferLive: true }` option that mirrors the Bay Area Transit accessor exactly: a 60s in-memory TTL cache plus a single-flight inflight promise, with any failure falling back to the committed snapshot and never being cached. The route's success cache header drops to `public, max-age=60, stale-while-revalidate=300` (errors stay `no-store`) and the data source header now reports `statsapi-runtime-with-snapshot-fallback`.

## Why

The MLB dashboard was limited to the 4h committed snapshot cadence, which is stale for in-progress games. The transit and earthquake surfaces already refresh their time-sensitive data at request time with the committed artifact as the last-good fallback, and this brings MLB in line with that pattern. The 60s TTL and single-flight coalescing bound statsapi calls to at most two upstream requests per minute per instance regardless of traffic. statsapi.mlb.com is free and requires no key; the interface is unofficial and MLBAM data remains subject to its copyright notice, which is why the committed snapshot fallback and source labeling stay intact. `update-mlb.yml` and the teams route are untouched; the 4h workflow now refreshes the fallback seed.

## Tests

New `src/lib/__tests__/mlbSnapshot.test.ts` covers the accessor: committed path bypasses the builder, TTL cache serves repeats, fake-timer TTL expiry rebuilds, concurrent requests coalesce into one build, and a failed build falls back to the committed summary without negative caching. New `buildMlbLiveSummaryData` cases in `src/lib/__tests__/mlbData.test.ts` cover the merge of yesterday's finals and today's live scoreboard, per-window fallback when one fetch fails, and a wholesale throw when both fail. The route test asserts the new cache header, source header, and `preferLive` call. All four suites pass (25 tests), plus a clean `tsc --noEmit` and eslint on touched files.
