### PR TITLE
Frontier models: daily live fact check (Blobs refresh lane pilot)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,7 @@ Confirm live API routes from `src/app/api/**/route.ts`. Current routes:
 - `/api/bay-area-transit/summary` and `/api/bay-area-transit/stations/[stationId]`
 - `/api/earthquake-pulse/summary`
 - `/api/fantasy-data`
+- `/api/frontier-models/summary`
 - `/api/golf/summary` and `/api/golf/players/[playerId]`
 - `/api/investments/index`, `/api/investments/quotes`, `/api/investments/data/[symbol]`
 - `/api/la-liga/summary` and `/api/la-liga/teams/[teamId]`
@@ -444,6 +445,7 @@ Current behavior:
 - `update-earthquake.yml` runs on manual dispatch and hourly (minute 20), then commits `src/data/earthquakeSnapshot.ts` when it changes
 - `update-polling.yml` runs every six hours and refreshes the VoteHub-backed polling snapshot
 - `audit-curated-data.yml` checks review dates, verification flags, and structural integrity across Frontier Models, Tech Startups, AI Dev Tools, Museum Log, Travel Deals, and Food Map every Monday
+- `netlify/functions/refresh-frontier-models.ts` is a Netlify scheduled function (daily 07:30 UTC, no GitHub Action) that fact-checks the frontier-models seed against models.dev and OpenRouter, writes the result to the `dashboard-snapshots` Netlify Blobs store, and purges the `frontier-models` CDN cache tag; the committed seed stays the fallback
 - The tech startup tracker has no workflow by design — its dataset is editorially curated, so refreshes happen by editing the seed and running `npm run update:tech-startups` locally
 - All 16 snapshot `update-*.yml` workflows commit and push through the shared `scripts/ci/commit-and-push-snapshot.sh` helper (usage: `commit-and-push-snapshot.sh <commit-message> <pathspec...>`). It regenerates and stages sitemap freshness metadata with the snapshot, sets the `github-actions[bot]` identity, exits cleanly on a no-op refresh, and pushes to `HEAD:main` with a fetch/`rebase --autostash` retry loop (default 8 attempts, `SNAPSHOT_PUSH_ATTEMPTS` override) plus capped exponential backoff to absorb concurrent snapshot-bot pushes. Behavior is asserted by `.github/workflows/__tests__/snapshot-workflows.test.ts` and `update-investments.test.ts`.
 - `publish-data.yml` coalesces successful refreshes, triggers the Netlify build hook when production is behind, and verifies the full `/api/data-revisions` ledger before closing publication incidents

--- a/SNAPSHOT_DRIVEN_DASHBOARDS.md
+++ b/SNAPSHOT_DRIVEN_DASHBOARDS.md
@@ -163,12 +163,49 @@ by BART abbr, world-cup `/teams/[teamId]` by team slug.
 | `/github-trending-pulse` | `src/data/githubTrendingSnapshot.ts` | `buildGitHubTrendingSnapshot.ts` · `update:github-trending` | `update-github-trending.yml` | GitHub Search API | daily 07:45 UTC |
 | `/spacex-mission-control` | `src/data/spacexSnapshot.generated.json` (+ image manifest) | `buildSpaceXSnapshot.ts` · `update:spacex` | `update-spacex.yml` | Launch Library / SpaceDevs | daily 09:25 + 21:25 UTC |
 | `/tech-startup-tracker` | `src/data/techStartupSnapshot.ts` | `buildTechStartupSnapshot.ts` · `update:tech-startups` | none (curated) | hand-maintained seed | manual |
-| `/frontier-models` | `src/data/frontierModelsSnapshot.ts` | `buildFrontierModelsSnapshot.ts` · `update:frontier-models` | none (curated) | `scripts/data/frontierModels.source.ts` | manual |
+| `/frontier-models` | `src/data/frontierModelsSnapshot.ts` (seed) + `dashboard-snapshots` blob | `buildFrontierModelsSnapshot.ts` · `update:frontier-models` (seed) | `netlify/functions/refresh-frontier-models.ts` (scheduled function, not an Action) | curated seed + models.dev/OpenRouter fact check | seed manual; facts daily 07:30 UTC |
 
 **Curated surfaces** (`tech-startup-tracker`, `frontier-models`) have no Action
 because there's no live source to poll — figures are approximate, tagged with an
 `asOf` date and a `verified: false` flag, and disclosed on-page. Refresh by
-editing the seed and re-running the builder.
+editing the seed and re-running the builder. Frontier-models additionally runs
+the blob-backed fact check described below; the curated seed and editorial
+notes remain the source of truth for what is listed.
+
+---
+
+## The blob-backed refresh lane (pilot: frontier-models)
+
+The git-commit pipeline above couples data freshness to deploys: every refresh
+is a bot commit, and production only advances when `publish-data.yml` fires the
+build hook. For surfaces whose data can refresh without review, there is a
+second lane that skips both:
+
+1. A **Netlify scheduled function** (`netlify/functions/refresh-frontier-models.ts`,
+   in-code `config.schedule`, 30s execution cap) fetches the upstream sources.
+2. It writes the refreshed snapshot to the **`dashboard-snapshots` Netlify
+   Blobs store** via `src/lib/snapshotBlobStore.ts` (strong consistency,
+   `{ savedAt, value }` envelope). Reads are fail-soft and return `null`
+   off-Netlify or on any store error; **writes throw**, so a broken refresh is
+   a failed function run in the Netlify logs, never silent stasis.
+3. It purges the surface's **CDN cache tag** (`purgeCache({ tags })`), so API
+   responses flip to the fresh data immediately instead of aging out.
+4. The accessor (`src/lib/frontierModelsSnapshot.ts`) reads **blob first with
+   the committed seed as fallback**, behind a short in-memory TTL. A blob
+   older than its max age is ignored — a dead refresh function must not keep
+   stamping old facts as fresh — and local dev and tests always serve the seed.
+
+The committed seed keeps every property the git lane had (reviewable diffs,
+local dev, cold-start data); the blob only carries the freshness. Failure at
+any step leaves the previous blob or the seed serving.
+
+For frontier-models specifically the refresh is a **fact check, not a rewrite**:
+the curated catalog decides which models are listed and every editorial note,
+while models.dev + OpenRouter (both keyless) refresh pricing, context windows,
+output limits, and cutoffs. Matching is exact-normalized-name per provider,
+never fuzzy (the fantasy ADP rule), and each model carries a `liveCheck`
+outcome (`confirmed` / `updated` / `curated-only`) surfaced in the on-page
+disclosure line.
 
 **Related but not this pattern:**
 - `/polling-aggregator` reads a committed `src/data/pollingSnapshot.ts` with **no

--- a/docs/DATA_UPDATE_OPERATIONS.md
+++ b/docs/DATA_UPDATE_OPERATIONS.md
@@ -41,7 +41,7 @@ request time, with the committed artifact retained as the last-good fallback.
 | SpaceX data | `update:spacex` *(alias `update:spacex-data`)* | `buildSpaceXSnapshot.ts` | Launch Library / SpaceDevs | `src/data/spacexSnapshot.generated.json` | `update-spacex.yml` | daily 09:25 + 21:25 UTC |
 | SpaceX images | `update:spacex-images` | `buildSpaceXImageSnapshots.ts` | launch image assets | `src/data/spacexImageManifest.generated.json`, `public/data/spacex/*` | `update-spacex.yml` | daily 09:25 + 21:25 UTC |
 | Tech startups | `update:tech-startups` | `buildTechStartupSnapshot.ts` | curated seed *(in script)* | `src/data/techStartupSnapshot.ts` | none *(curated)* | manual |
-| Frontier models | `update:frontier-models` | `buildFrontierModelsSnapshot.ts` | `scripts/data/frontierModels.source.ts` | `src/data/frontierModelsSnapshot.ts` | none *(curated)* | manual |
+| Frontier models | `update:frontier-models` *(seed)* | `buildFrontierModelsSnapshot.ts` + `netlify/functions/refresh-frontier-models.ts` | `scripts/data/frontierModels.source.ts` + models.dev/OpenRouter fact check | `src/data/frontierModelsSnapshot.ts` *(seed)* + `dashboard-snapshots` blob | Netlify scheduled function *(no Action)* | seed manual; facts daily 07:30 UTC |
 | AI dev tools | none | hand-authored catalog | official product and repository sources | `src/app/ai-dev-tools/ai-dev-tools-data.ts` | `audit-curated-data.yml` | weekly review |
 | Museum log | none | hand-authored catalog | museum websites and curator notes | `src/data/museumSnapshot.ts` | `audit-curated-data.yml` | weekly review |
 | Travel deals | none | hand-authored estimates | editorial fare bands and tactics | `src/data/travelDealsSnapshot.ts` | `audit-curated-data.yml` | weekly review |
@@ -63,6 +63,13 @@ source and licensing ledger is `INVESTMENTS_DATA_SOURCES.md`.
 News Pulse remains API-backed at request time and has no committed snapshot. Its
 last good per-feed data, and the MBA jobs route's last good result, are persisted
 in Netlify Blobs so cold starts do not erase their fallback.
+
+Frontier models pilots the blob-backed refresh lane: a daily Netlify scheduled
+function fact-checks the curated seed against models.dev and OpenRouter, writes
+the result to the `dashboard-snapshots` blob store, and purges the surface's
+CDN cache tag. No commit and no rebuild is involved; the committed seed stays
+the fallback and the editorial source of truth. See the lane description in
+`../SNAPSHOT_DRIVEN_DASHBOARDS.md`.
 
 ---
 

--- a/netlify/functions/__tests__/refresh-frontier-models.test.ts
+++ b/netlify/functions/__tests__/refresh-frontier-models.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@netlify/functions", () => ({
+  purgeCache: jest.fn(),
+}));
+
+jest.mock("../../../src/lib/frontierModelsLive", () => ({
+  FRONTIER_MODELS_BLOB_KEY: "frontier-models",
+  fetchLiveModelFacts: jest.fn(),
+  applyLiveModelFacts: jest.fn(),
+}));
+
+jest.mock("../../../src/lib/snapshotBlobStore", () => ({
+  writeSnapshotBlob: jest.fn(),
+}));
+
+import { purgeCache } from "@netlify/functions";
+import {
+  applyLiveModelFacts,
+  fetchLiveModelFacts,
+} from "../../../src/lib/frontierModelsLive";
+import { writeSnapshotBlob } from "../../../src/lib/snapshotBlobStore";
+import handler, { config } from "../refresh-frontier-models";
+
+const mockPurge = purgeCache as jest.Mock;
+const mockFetchFacts = fetchLiveModelFacts as jest.Mock;
+const mockApply = applyLiveModelFacts as jest.Mock;
+const mockWrite = writeSnapshotBlob as jest.Mock;
+
+const refreshedSnapshot = {
+  models: [{ id: "m" }],
+  liveFacts: {
+    checkedAt: "2026-07-20T07:30:00.000Z",
+    sources: ["models.dev", "openrouter"],
+    updated: 1,
+    confirmed: 2,
+    curatedOnly: 3,
+  },
+};
+
+describe("refresh-frontier-models scheduled function", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchFacts.mockResolvedValue({ fetchedAt: "now", byProvider: {} });
+    mockApply.mockReturnValue(refreshedSnapshot);
+    mockWrite.mockResolvedValue(undefined);
+    mockPurge.mockResolvedValue(undefined);
+  });
+
+  it("runs on a daily schedule", () => {
+    expect(config.schedule).toBe("30 7 * * *");
+  });
+
+  it("writes the refreshed snapshot to the blob store, then purges the tag", async () => {
+    const response = await handler();
+    const body = await response.json();
+
+    expect(mockWrite).toHaveBeenCalledWith(
+      "frontier-models",
+      refreshedSnapshot
+    );
+    expect(mockPurge).toHaveBeenCalledWith({ tags: ["frontier-models"] });
+    expect(body.ok).toBe(true);
+    expect(body.liveFacts.updated).toBe(1);
+  });
+
+  it("does not write when the upstream fetch fails", async () => {
+    mockFetchFacts.mockRejectedValue(new Error("degraded catalog"));
+
+    await expect(handler()).rejects.toThrow("degraded catalog");
+    expect(mockWrite).not.toHaveBeenCalled();
+    expect(mockPurge).not.toHaveBeenCalled();
+  });
+
+  it("propagates write failures so the run shows as failed", async () => {
+    mockWrite.mockRejectedValue(new Error("store down"));
+
+    await expect(handler()).rejects.toThrow("store down");
+    expect(mockPurge).not.toHaveBeenCalled();
+  });
+
+  it("still succeeds when only the purge fails", async () => {
+    mockPurge.mockRejectedValue(new Error("purge api down"));
+
+    const response = await handler();
+    const body = await response.json();
+
+    expect(body.ok).toBe(true);
+    expect(mockWrite).toHaveBeenCalled();
+  });
+});

--- a/netlify/functions/refresh-frontier-models.ts
+++ b/netlify/functions/refresh-frontier-models.ts
@@ -1,0 +1,46 @@
+import type { Config } from "@netlify/functions";
+import { purgeCache } from "@netlify/functions";
+import { frontierModelsSnapshot } from "../../src/data/frontierModelsSnapshot";
+import {
+  applyLiveModelFacts,
+  fetchLiveModelFacts,
+  FRONTIER_MODELS_BLOB_KEY,
+} from "../../src/lib/frontierModelsLive";
+import { writeSnapshotBlob } from "../../src/lib/snapshotBlobStore";
+
+// Daily fact check for the frontier-models catalog — the pilot for the
+// blob-backed refresh lane. It fetches the keyless models.dev and OpenRouter
+// catalogs, applies the checkable facts onto the committed curated seed
+// (editorial notes untouched), writes the result to the dashboard-snapshots
+// blob store, and purges the surface's CDN cache tag. No git commit, no
+// rebuild. Failures leave the previous blob (or the committed seed) serving:
+// fetchLiveModelFacts throws on degraded upstream payloads, and
+// writeSnapshotBlob throws rather than no-ops, so a broken refresh shows up
+// as a failed function run in the Netlify logs instead of silent stasis.
+export default async () => {
+  const catalog = await fetchLiveModelFacts();
+  const next = applyLiveModelFacts(frontierModelsSnapshot, catalog);
+  await writeSnapshotBlob(FRONTIER_MODELS_BLOB_KEY, next);
+
+  try {
+    await purgeCache({ tags: [FRONTIER_MODELS_BLOB_KEY] });
+  } catch (error) {
+    // Purge is an optimization; CDN entries age out via s-maxage regardless.
+    console.warn("frontier-models cache tag purge failed:", error);
+  }
+
+  console.log(
+    `frontier-models facts refreshed: ${next.liveFacts?.updated ?? 0} updated, ` +
+      `${next.liveFacts?.confirmed ?? 0} confirmed, ` +
+      `${next.liveFacts?.curatedOnly ?? 0} curated-only.`
+  );
+
+  return new Response(JSON.stringify({ ok: true, liveFacts: next.liveFacts }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+export const config: Config = {
+  // Daily at 07:30 UTC, staggered off the GitHub Actions snapshot crons.
+  schedule: "30 7 * * *",
+};

--- a/src/app/api/frontier-models/summary/__tests__/route.test.ts
+++ b/src/app/api/frontier-models/summary/__tests__/route.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@/lib/frontierModelsSnapshot", () => ({
+  getFrontierModelsSnapshot: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+import { GET } from "../route";
+import { getFrontierModelsSnapshot } from "@/lib/frontierModelsSnapshot";
+import { logger } from "@/lib/logger";
+
+const mockGetSnapshot = getFrontierModelsSnapshot as jest.MockedFunction<
+  typeof getFrontierModelsSnapshot
+>;
+const mockLoggerError = logger.error as jest.MockedFunction<
+  typeof logger.error
+>;
+
+function makeSnapshot(withLiveFacts: boolean) {
+  return {
+    generatedAt: "2026-07-20T07:30:00.000Z",
+    asOf: "2026-07-20",
+    verified: false,
+    sourceLabel: "Curated by Isaac Vazquez",
+    models: [
+      {
+        id: "anthropic-claude-opus-4-8",
+        provider: "anthropic" as const,
+        providerLabel: "Anthropic",
+        name: "Claude Opus 4.8",
+        releaseDate: "2026-06-01",
+        knowledgeCutoff: "2026-01",
+        contextWindow: 200000,
+        maxOutputTokens: 64000,
+        inputPricePerMTokens: 15,
+        outputPricePerMTokens: 75,
+        priceTier: "premium" as const,
+        modalities: ["text" as const],
+        reasoning: true,
+        editorialNote: "Note.",
+        docsUrl: null,
+      },
+    ],
+    providers: [{ id: "anthropic" as const, label: "Anthropic", count: 1 }],
+    priceTiers: [{ id: "premium" as const, label: "Premium", count: 1 }],
+    ...(withLiveFacts
+      ? {
+          liveFacts: {
+            checkedAt: "2026-07-20T07:30:00.000Z",
+            sources: ["models.dev", "openrouter"],
+            updated: 1,
+            confirmed: 0,
+            curatedOnly: 0,
+          },
+        }
+      : {}),
+  };
+}
+
+describe("GET /api/frontier-models/summary", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the snapshot with cache headers and the surface cache tag", async () => {
+    mockGetSnapshot.mockResolvedValue(makeSnapshot(true));
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.models).toHaveLength(1);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=300, stale-while-revalidate=3600"
+    );
+    expect(response.headers.get("Netlify-Cache-Tag")).toBe("frontier-models");
+    expect(response.headers.get("X-Data-Source")).toBe(
+      "curated-with-daily-fact-check"
+    );
+    expect(response.headers.get("X-Data-Revision")).toMatch(/^[a-f0-9]{64}$/);
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("labels the curated seed when no fact check has run", async () => {
+    mockGetSnapshot.mockResolvedValue(makeSnapshot(false));
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Data-Source")).toBe("curated-seed");
+  });
+
+  it("returns a logged, uncached 500 on failure", async () => {
+    mockGetSnapshot.mockRejectedValue(new Error("boom"));
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("boom");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/frontier-models/summary/route.ts
+++ b/src/app/api/frontier-models/summary/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { getFrontierModelsSnapshot } from "@/lib/frontierModelsSnapshot";
+import { logger } from "@/lib/logger";
+import { createSnapshotResponseHeaders } from "@/lib/snapshotResponse";
+
+const SUCCESS_CACHE_CONTROL =
+  "public, max-age=300, stale-while-revalidate=3600";
+// Errors (4xx/5xx) must NOT be cached by the CDN — otherwise a transient
+// failure poisons the cache for the full success TTL.
+const ERROR_CACHE_HEADERS = {
+  "Cache-Control": "no-store",
+};
+
+export async function GET() {
+  try {
+    const snapshot = await getFrontierModelsSnapshot();
+
+    return NextResponse.json(snapshot, {
+      headers: {
+        ...createSnapshotResponseHeaders({
+          surface: "frontier-models",
+          payload: snapshot,
+          sourceAsOf: snapshot.liveFacts?.checkedAt ?? snapshot.generatedAt,
+          cacheControl: SUCCESS_CACHE_CONTROL,
+          source: snapshot.liveFacts
+            ? "curated-with-daily-fact-check"
+            : "curated-seed",
+        }),
+        // Lets the scheduled refresh purge exactly this surface's CDN entries
+        // right after writing a fresh blob.
+        "Netlify-Cache-Tag": "frontier-models",
+      },
+    });
+  } catch (error) {
+    const err = error as Error & { status?: number };
+
+    if ((err.status ?? 500) >= 500) {
+      logger.error("Frontier models summary API error", error);
+    }
+
+    return NextResponse.json(
+      { error: err.message || "Unable to load the frontier models snapshot" },
+      {
+        status: err.status ?? 500,
+        headers: ERROR_CACHE_HEADERS,
+      }
+    );
+  }
+}

--- a/src/app/frontier-models/frontier-models-client.tsx
+++ b/src/app/frontier-models/frontier-models-client.tsx
@@ -214,6 +214,9 @@ export function FrontierModelsClient({
         <p className="text-xs uppercase tracking-[0.18em] text-[var(--home-ink-muted)]">
           Curated by Isaac · Data as of {snapshot.asOf ?? snapshot.generatedAt.slice(0, 10)} · Updated {updatedAt}
           {!snapshot.verified ? " · Independent review pending" : ""}
+          {snapshot.liveFacts
+            ? ` · Facts auto-checked ${snapshot.liveFacts.checkedAt.slice(0, 10)} against ${snapshot.liveFacts.sources.join(" + ")}`
+            : ""}
         </p>
       </header>
 

--- a/src/lib/__tests__/frontierModelsLive.test.ts
+++ b/src/lib/__tests__/frontierModelsLive.test.ts
@@ -1,0 +1,255 @@
+/**
+ * @jest-environment node
+ */
+import { buildFrontierModelsSnapshot } from "@/lib/frontierModels";
+import {
+  applyLiveModelFacts,
+  fetchLiveModelFacts,
+  normalizeModelName,
+  type LiveFactsCatalog,
+} from "@/lib/frontierModelsLive";
+
+describe("normalizeModelName", () => {
+  it("collapses names to a conservative comparison key", () => {
+    expect(normalizeModelName("Claude Opus 4.8")).toBe("claudeopus48");
+    expect(normalizeModelName("claude-opus-4.8")).toBe("claudeopus48");
+    expect(normalizeModelName("GPT-5.6")).toBe("gpt56");
+    // Distinct versions stay distinct — no substring matching anywhere.
+    expect(normalizeModelName("GPT-5")).not.toBe(normalizeModelName("GPT-5.6"));
+  });
+});
+
+function makeModelsDevPayload() {
+  return {
+    anthropic: {
+      models: {
+        "claude-opus-4.8": {
+          name: "Claude Opus 4.8",
+          reasoning: true,
+          knowledge: "2026-02",
+          release_date: "2026-06-01",
+          modalities: { input: ["text", "image"] },
+          cost: { input: 18, output: 90 },
+          limit: { context: 300000, output: 64000 },
+        },
+      },
+    },
+    openai: { models: {} },
+    google: { models: {} },
+    mistral: { models: {} },
+    deepseek: { models: {} },
+    xai: { models: {} },
+  };
+}
+
+function makeOpenRouterPayload() {
+  const filler = Array.from({ length: 60 }, (_, index) => ({
+    id: `other/model-${index}`,
+    name: `Other: Model ${index}`,
+    context_length: 8192,
+    pricing: { prompt: "0.000001", completion: "0.000002" },
+  }));
+  return {
+    data: [
+      ...filler,
+      {
+        id: "anthropic/claude-opus-4.8",
+        name: "Anthropic: Claude Opus 4.8",
+        context_length: 200000,
+        pricing: { prompt: "0.000015", completion: "0.000075" },
+        top_provider: { max_completion_tokens: 32000 },
+        architecture: { input_modalities: ["text", "image"] },
+        supported_parameters: ["reasoning"],
+      },
+      {
+        id: "x-ai/grok-4.5",
+        name: "xAI: Grok 4.5",
+        context_length: 500000,
+        pricing: { prompt: "0.000002", completion: "0.000006" },
+        top_provider: { max_completion_tokens: 32000 },
+        architecture: { input_modalities: ["text", "image"] },
+        supported_parameters: [],
+      },
+    ],
+  };
+}
+
+describe("fetchLiveModelFacts", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockCatalogFetch(
+    modelsDev: unknown = makeModelsDevPayload(),
+    openRouter: unknown = makeOpenRouterPayload()
+  ) {
+    return jest
+      .spyOn(global, "fetch")
+      .mockImplementation((input: unknown) => {
+        const url = String(input);
+        const payload = url.includes("models.dev") ? modelsDev : openRouter;
+        return Promise.resolve(
+          new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        );
+      });
+  }
+
+  it("merges both catalogs with models.dev taking precedence", async () => {
+    mockCatalogFetch();
+
+    const catalog = await fetchLiveModelFacts(new Date("2026-07-20T07:30:00Z"));
+
+    // models.dev entry wins for Opus even though OpenRouter also lists it.
+    const opus = catalog.byProvider.anthropic?.claudeopus48;
+    expect(opus?.source).toBe("models.dev");
+    expect(opus?.contextWindow).toBe(300000);
+    expect(opus?.inputPricePerMTokens).toBe(18);
+    expect(opus?.knowledgeCutoff).toBe("2026-02");
+
+    // OpenRouter fills providers models.dev did not cover, with per-token
+    // string pricing converted to per-million.
+    const grok = catalog.byProvider.xai?.grok45;
+    expect(grok?.source).toBe("openrouter");
+    expect(grok?.contextWindow).toBe(500000);
+    expect(grok?.inputPricePerMTokens).toBeCloseTo(2);
+    expect(grok?.outputPricePerMTokens).toBeCloseTo(6);
+  });
+
+  it("throws on an implausibly small models.dev payload", async () => {
+    mockCatalogFetch({ anthropic: { models: {} } });
+
+    await expect(fetchLiveModelFacts()).rejects.toThrow(/few providers/);
+  });
+
+  it("throws on an implausibly small OpenRouter payload", async () => {
+    mockCatalogFetch(makeModelsDevPayload(), { data: [{ id: "a/b" }] });
+
+    await expect(fetchLiveModelFacts()).rejects.toThrow(/few models/);
+  });
+});
+
+describe("applyLiveModelFacts", () => {
+  const providerLabels = {
+    anthropic: "Anthropic",
+    openai: "OpenAI",
+    google: "Google",
+    meta: "Meta",
+    xai: "xAI",
+    deepseek: "DeepSeek",
+    mistral: "Mistral",
+  } as const;
+
+  const snapshot = buildFrontierModelsSnapshot(
+    [
+      {
+        id: "anthropic-claude-opus-4-8",
+        provider: "anthropic",
+        name: "Claude Opus 4.8",
+        releaseDate: "2026-06-01",
+        knowledgeCutoff: "2026-01",
+        contextWindow: 200000,
+        maxOutputTokens: 64000,
+        inputPricePerMTokens: 15,
+        outputPricePerMTokens: 75,
+        modalities: ["text", "vision"],
+        reasoning: true,
+        editorialNote: "Kept verbatim.",
+        docsUrl: "https://docs.anthropic.com",
+      },
+      {
+        id: "xai-grok-4-5",
+        provider: "xai",
+        name: "Grok 4.5",
+        releaseDate: "2026-07-01",
+        knowledgeCutoff: "2026-02",
+        contextWindow: 500000,
+        maxOutputTokens: 32000,
+        inputPricePerMTokens: 2,
+        outputPricePerMTokens: 6,
+        modalities: ["text", "vision"],
+        reasoning: true,
+        editorialNote: "Also kept verbatim.",
+        docsUrl: "https://docs.x.ai",
+      },
+      {
+        id: "mistral-nowhere",
+        provider: "mistral",
+        name: "Nowhere Large",
+        releaseDate: "2026-05-01",
+        knowledgeCutoff: null,
+        contextWindow: 128000,
+        maxOutputTokens: 16000,
+        inputPricePerMTokens: 1,
+        outputPricePerMTokens: 3,
+        modalities: ["text"],
+        reasoning: false,
+        editorialNote: "No catalog knows this one.",
+        docsUrl: null,
+      },
+    ],
+    providerLabels,
+    "2026-07-20T00:00:00.000Z",
+    "Curated by Isaac Vazquez",
+    "2026-07-20",
+    false
+  );
+
+  const catalog: LiveFactsCatalog = {
+    fetchedAt: "2026-07-20T07:30:00.000Z",
+    byProvider: {
+      anthropic: {
+        claudeopus48: {
+          source: "models.dev",
+          contextWindow: 300000,
+          inputPricePerMTokens: 18,
+          outputPricePerMTokens: 90,
+          knowledgeCutoff: "2026-02",
+        },
+      },
+      xai: {
+        grok45: {
+          source: "openrouter",
+          contextWindow: 500000,
+          maxOutputTokens: 32000,
+          inputPricePerMTokens: 2,
+          outputPricePerMTokens: 6,
+        },
+      },
+    },
+  };
+
+  it("updates facts, preserves curation, and stamps per-model outcomes", () => {
+    const next = applyLiveModelFacts(snapshot, catalog);
+
+    const opus = next.models.find((model) => model.id.includes("opus"));
+    expect(opus?.contextWindow).toBe(300000);
+    expect(opus?.inputPricePerMTokens).toBe(18);
+    expect(opus?.editorialNote).toBe("Kept verbatim.");
+    expect(opus?.liveCheck?.status).toBe("updated");
+    // Price tier recomputed from the corrected pricing.
+    expect(opus?.priceTier).toBe("premium");
+
+    const grok = next.models.find((model) => model.id.includes("grok"));
+    expect(grok?.liveCheck?.status).toBe("confirmed");
+
+    const unmatched = next.models.find((model) => model.id.includes("nowhere"));
+    expect(unmatched?.liveCheck?.status).toBe("curated-only");
+    expect(unmatched?.contextWindow).toBe(128000);
+
+    expect(next.liveFacts).toEqual({
+      checkedAt: "2026-07-20T07:30:00.000Z",
+      sources: ["models.dev", "openrouter"],
+      updated: 1,
+      confirmed: 1,
+      curatedOnly: 1,
+    });
+
+    // Curated review provenance is untouched by the automated check.
+    expect(next.asOf).toBe("2026-07-20");
+    expect(next.verified).toBe(false);
+    expect(next.sourceLabel).toBe("Curated by Isaac Vazquez");
+  });
+});

--- a/src/lib/__tests__/frontierModelsSnapshot.test.ts
+++ b/src/lib/__tests__/frontierModelsSnapshot.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@/lib/snapshotBlobStore", () => ({
+  readSnapshotBlob: jest.fn(),
+}));
+
+import { frontierModelsSnapshot } from "@/data/frontierModelsSnapshot";
+import {
+  getFrontierModelsSnapshot,
+  resetFrontierModelsCacheForTests,
+} from "@/lib/frontierModelsSnapshot";
+import { readSnapshotBlob } from "@/lib/snapshotBlobStore";
+import type { FrontierModelsSnapshot } from "@/types/frontierModels";
+
+const mockRead = readSnapshotBlob as jest.MockedFunction<
+  typeof readSnapshotBlob
+>;
+
+function blobSnapshot(): FrontierModelsSnapshot {
+  return {
+    ...frontierModelsSnapshot,
+    generatedAt: "2026-07-20T07:30:00.000Z",
+    liveFacts: {
+      checkedAt: "2026-07-20T07:30:00.000Z",
+      sources: ["models.dev", "openrouter"],
+      updated: 2,
+      confirmed: 10,
+      curatedOnly: 1,
+    },
+  };
+}
+
+describe("getFrontierModelsSnapshot", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetFrontierModelsCacheForTests();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("serves the blob-backed snapshot when the daily refresh has written one", async () => {
+    const fromBlob = blobSnapshot();
+    mockRead.mockResolvedValue({
+      value: fromBlob,
+      savedAt: fromBlob.generatedAt,
+    });
+
+    const snapshot = await getFrontierModelsSnapshot();
+
+    expect(snapshot.liveFacts?.updated).toBe(2);
+    expect(mockRead).toHaveBeenCalledWith(
+      "frontier-models",
+      3 * 24 * 60 * 60 * 1000
+    );
+  });
+
+  it("falls back to the committed seed when no blob exists", async () => {
+    mockRead.mockResolvedValue(null);
+
+    const snapshot = await getFrontierModelsSnapshot();
+
+    expect(snapshot).toBe(frontierModelsSnapshot);
+  });
+
+  it("refuses a blob with no models", async () => {
+    mockRead.mockResolvedValue({
+      value: { ...blobSnapshot(), models: [] },
+      savedAt: "2026-07-20T07:30:00.000Z",
+    });
+
+    const snapshot = await getFrontierModelsSnapshot();
+
+    expect(snapshot).toBe(frontierModelsSnapshot);
+  });
+
+  it("falls back to the committed seed when the blob read rejects", async () => {
+    mockRead.mockRejectedValue(new Error("store down"));
+
+    const snapshot = await getFrontierModelsSnapshot();
+
+    expect(snapshot).toBe(frontierModelsSnapshot);
+  });
+
+  it("caches the result for the TTL, then re-reads", async () => {
+    jest.useFakeTimers();
+    mockRead.mockResolvedValue(null);
+
+    await getFrontierModelsSnapshot();
+    await getFrontierModelsSnapshot();
+    expect(mockRead).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(5 * 60 * 1000 + 1000);
+    await getFrontierModelsSnapshot();
+    expect(mockRead).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/__tests__/snapshotBlobStore.test.ts
+++ b/src/lib/__tests__/snapshotBlobStore.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@netlify/blobs", () => ({
+  getStore: jest.fn(),
+}));
+
+import { getStore } from "@netlify/blobs";
+import {
+  readSnapshotBlob,
+  writeSnapshotBlob,
+} from "@/lib/snapshotBlobStore";
+
+const mockGetStore = getStore as jest.Mock;
+
+function withNetlifyRuntime() {
+  process.env.NETLIFY = "true";
+}
+
+const originalNetlify = process.env.NETLIFY;
+const originalLocal = process.env.NETLIFY_LOCAL;
+
+afterEach(() => {
+  jest.clearAllMocks();
+  if (originalNetlify === undefined) delete process.env.NETLIFY;
+  else process.env.NETLIFY = originalNetlify;
+  if (originalLocal === undefined) delete process.env.NETLIFY_LOCAL;
+  else process.env.NETLIFY_LOCAL = originalLocal;
+});
+
+describe("snapshotBlobStore outside Netlify", () => {
+  beforeEach(() => {
+    delete process.env.NETLIFY;
+    delete process.env.NETLIFY_LOCAL;
+  });
+
+  it("reads null so callers fall back to the committed seed", async () => {
+    await expect(readSnapshotBlob("frontier-models", 1_000)).resolves.toBeNull();
+    expect(mockGetStore).not.toHaveBeenCalled();
+  });
+
+  it("throws on write so refresh functions cannot silently no-op", async () => {
+    await expect(
+      writeSnapshotBlob("frontier-models", { ok: true })
+    ).rejects.toThrow(/Netlify runtime/);
+  });
+});
+
+describe("snapshotBlobStore on Netlify", () => {
+  beforeEach(withNetlifyRuntime);
+
+  it("returns the envelope value and savedAt within max age", async () => {
+    const savedAt = new Date().toISOString();
+    mockGetStore.mockReturnValue({
+      get: jest.fn().mockResolvedValue({ savedAt, value: { models: [1] } }),
+    });
+
+    const read = await readSnapshotBlob<{ models: number[] }>(
+      "frontier-models",
+      60_000
+    );
+
+    expect(read).toEqual({ value: { models: [1] }, savedAt });
+    expect(mockGetStore).toHaveBeenCalledWith({
+      name: "dashboard-snapshots",
+      consistency: "strong",
+    });
+  });
+
+  it("treats an over-age envelope as missing", async () => {
+    const savedAt = new Date(Date.now() - 10 * 60_000).toISOString();
+    mockGetStore.mockReturnValue({
+      get: jest.fn().mockResolvedValue({ savedAt, value: { models: [1] } }),
+    });
+
+    await expect(
+      readSnapshotBlob("frontier-models", 60_000)
+    ).resolves.toBeNull();
+  });
+
+  it("swallows read errors", async () => {
+    mockGetStore.mockReturnValue({
+      get: jest.fn().mockRejectedValue(new Error("store down")),
+    });
+
+    await expect(
+      readSnapshotBlob("frontier-models", 60_000)
+    ).resolves.toBeNull();
+  });
+
+  it("writes an envelope and propagates write failures", async () => {
+    const setJSON = jest.fn().mockResolvedValue(undefined);
+    mockGetStore.mockReturnValue({ setJSON });
+
+    await writeSnapshotBlob("frontier-models", { models: [1] });
+    expect(setJSON).toHaveBeenCalledWith(
+      "frontier-models",
+      expect.objectContaining({
+        savedAt: expect.any(String),
+        value: { models: [1] },
+      })
+    );
+
+    setJSON.mockRejectedValueOnce(new Error("write refused"));
+    await expect(
+      writeSnapshotBlob("frontier-models", { models: [2] })
+    ).rejects.toThrow("write refused");
+  });
+});

--- a/src/lib/frontierModelsLive.ts
+++ b/src/lib/frontierModelsLive.ts
@@ -1,0 +1,365 @@
+import type {
+  FrontierModel,
+  FrontierModelsSnapshot,
+  FrontierModality,
+  FrontierProvider,
+} from "@/types/frontierModels";
+// Relative import (not "@/lib/…") so the Netlify scheduled function can
+// bundle this module without Next's tsconfig path alias.
+import {
+  buildFrontierModelsSnapshot,
+  type FrontierSourceModel,
+} from "./frontierModels";
+
+/** Blob key the scheduled refresh writes and the accessor reads. */
+export const FRONTIER_MODELS_BLOB_KEY = "frontier-models";
+
+/**
+ * Live fact-checking layer for the frontier-models catalog.
+ *
+ * The curated seed stays the source of truth for WHICH models are listed and
+ * for every editorial note. This module refreshes the checkable facts
+ * (pricing, context window, output limit, knowledge cutoff, release date)
+ * against two keyless public catalogs — models.dev's api.json and
+ * OpenRouter's /api/v1/models — and stamps each model with the outcome.
+ *
+ * Matching is deliberately conservative, mirroring the fantasy ADP rule of
+ * "tiered exact matching, never fuzzy": a curated model only picks up live
+ * facts when its normalized name matches a catalog entry for the same
+ * provider exactly. Anything else stays curated-only rather than risking a
+ * wrong-model overwrite.
+ */
+
+const MODELS_DEV_URL = "https://models.dev/api.json";
+const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
+const FETCH_TIMEOUT_MS = 15_000;
+
+// Refuse to merge against an implausibly small catalog — a degraded upstream
+// response must not strip live confirmations from every model.
+const MIN_MODELS_DEV_PROVIDERS = 5;
+const MIN_OPENROUTER_MODELS = 50;
+
+export interface LiveModelFacts {
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  inputPricePerMTokens?: number;
+  outputPricePerMTokens?: number;
+  knowledgeCutoff?: string;
+  releaseDate?: string;
+  reasoning?: boolean;
+  modalities?: FrontierModality[];
+  source: "models.dev" | "openrouter";
+}
+
+export interface LiveFactsCatalog {
+  fetchedAt: string;
+  /** provider id → normalized model name → facts */
+  byProvider: Partial<
+    Record<FrontierProvider, Record<string, LiveModelFacts>>
+  >;
+}
+
+/** "Claude Opus 4.8" / "claude-opus-4.8" / "Claude Opus 4·8" → "claudeopus48" */
+export function normalizeModelName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+const OPENROUTER_PROVIDER_PREFIXES: Record<string, FrontierProvider> = {
+  anthropic: "anthropic",
+  openai: "openai",
+  google: "google",
+  "meta-llama": "meta",
+  "x-ai": "xai",
+  deepseek: "deepseek",
+  mistralai: "mistral",
+};
+
+const MODELS_DEV_PROVIDER_IDS: Record<string, FrontierProvider> = {
+  anthropic: "anthropic",
+  openai: "openai",
+  google: "google",
+  meta: "meta",
+  xai: "xai",
+  deepseek: "deepseek",
+  mistral: "mistral",
+};
+
+function toFiniteNumber(value: unknown): number | undefined {
+  const parsed = typeof value === "string" ? Number(value) : value;
+  return typeof parsed === "number" && Number.isFinite(parsed) && parsed >= 0
+    ? parsed
+    : undefined;
+}
+
+function toModalities(input: unknown): FrontierModality[] | undefined {
+  if (!Array.isArray(input)) return undefined;
+  const mapped = new Set<FrontierModality>();
+  for (const raw of input) {
+    if (typeof raw !== "string") continue;
+    const value = raw.toLowerCase();
+    if (value === "text") mapped.add("text");
+    if (value === "image" || value === "vision") mapped.add("vision");
+    if (value === "audio") mapped.add("audio");
+  }
+  return mapped.size > 0 ? Array.from(mapped) : undefined;
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}: ${url}`);
+  }
+  return response.json();
+}
+
+interface ModelsDevModel {
+  name?: string;
+  reasoning?: boolean;
+  knowledge?: string;
+  release_date?: string;
+  modalities?: { input?: string[] };
+  cost?: { input?: number; output?: number };
+  limit?: { context?: number; output?: number };
+}
+
+function parseModelsDev(payload: unknown): LiveFactsCatalog["byProvider"] {
+  const byProvider: LiveFactsCatalog["byProvider"] = {};
+  if (!payload || typeof payload !== "object") {
+    throw new Error("models.dev payload is not an object.");
+  }
+  const providers = Object.entries(payload as Record<string, unknown>).filter(
+    ([id]) => id in MODELS_DEV_PROVIDER_IDS
+  );
+  if (
+    Object.keys(payload as Record<string, unknown>).length <
+    MIN_MODELS_DEV_PROVIDERS
+  ) {
+    throw new Error("models.dev payload has implausibly few providers.");
+  }
+
+  for (const [providerId, entry] of providers) {
+    const provider = MODELS_DEV_PROVIDER_IDS[providerId];
+    const models =
+      entry && typeof entry === "object"
+        ? ((entry as { models?: Record<string, ModelsDevModel> }).models ?? {})
+        : {};
+    for (const model of Object.values(models)) {
+      if (!model?.name) continue;
+      const key = normalizeModelName(model.name);
+      if (!key) continue;
+      const facts: LiveModelFacts = { source: "models.dev" };
+      const context = toFiniteNumber(model.limit?.context);
+      const output = toFiniteNumber(model.limit?.output);
+      const inputCost = toFiniteNumber(model.cost?.input);
+      const outputCost = toFiniteNumber(model.cost?.output);
+      if (context) facts.contextWindow = context;
+      if (output) facts.maxOutputTokens = output;
+      if (inputCost !== undefined) facts.inputPricePerMTokens = inputCost;
+      if (outputCost !== undefined) facts.outputPricePerMTokens = outputCost;
+      if (typeof model.knowledge === "string" && model.knowledge) {
+        facts.knowledgeCutoff = model.knowledge;
+      }
+      if (typeof model.release_date === "string" && model.release_date) {
+        facts.releaseDate = model.release_date;
+      }
+      if (typeof model.reasoning === "boolean") {
+        facts.reasoning = model.reasoning;
+      }
+      const modalities = toModalities(model.modalities?.input);
+      if (modalities) facts.modalities = modalities;
+
+      byProvider[provider] = byProvider[provider] ?? {};
+      byProvider[provider]![key] = facts;
+    }
+  }
+  return byProvider;
+}
+
+interface OpenRouterModel {
+  id?: string;
+  name?: string;
+  context_length?: number;
+  pricing?: { prompt?: string; completion?: string };
+  top_provider?: { max_completion_tokens?: number | null };
+  architecture?: { input_modalities?: string[] };
+  supported_parameters?: string[];
+}
+
+function parseOpenRouter(payload: unknown): LiveFactsCatalog["byProvider"] {
+  const byProvider: LiveFactsCatalog["byProvider"] = {};
+  const models = (payload as { data?: OpenRouterModel[] })?.data;
+  if (!Array.isArray(models)) {
+    throw new Error("OpenRouter payload has no data array.");
+  }
+  if (models.length < MIN_OPENROUTER_MODELS) {
+    throw new Error("OpenRouter payload has implausibly few models.");
+  }
+
+  for (const model of models) {
+    const idPrefix = model.id?.split("/")[0] ?? "";
+    const provider = OPENROUTER_PROVIDER_PREFIXES[idPrefix];
+    if (!provider || !model.name) continue;
+    // OpenRouter names read "Anthropic: Claude Opus 4.8" — drop the vendor
+    // prefix before normalizing so it matches the curated display name.
+    const bareName = model.name.includes(":")
+      ? model.name.slice(model.name.indexOf(":") + 1)
+      : model.name;
+    const key = normalizeModelName(bareName);
+    if (!key) continue;
+
+    const facts: LiveModelFacts = { source: "openrouter" };
+    const context = toFiniteNumber(model.context_length);
+    const output = toFiniteNumber(model.top_provider?.max_completion_tokens);
+    // OpenRouter pricing is USD per single token, as strings.
+    const prompt = toFiniteNumber(model.pricing?.prompt);
+    const completion = toFiniteNumber(model.pricing?.completion);
+    if (context) facts.contextWindow = context;
+    if (output) facts.maxOutputTokens = output;
+    // Per-token strings times 1e6 accumulate float noise (0.0000002 becomes
+    // 0.19999999999999998 per million) — round to six decimals.
+    if (prompt !== undefined) {
+      facts.inputPricePerMTokens = Number((prompt * 1_000_000).toFixed(6));
+    }
+    if (completion !== undefined) {
+      facts.outputPricePerMTokens = Number(
+        (completion * 1_000_000).toFixed(6)
+      );
+    }
+    if (Array.isArray(model.supported_parameters)) {
+      facts.reasoning = model.supported_parameters.includes("reasoning");
+    }
+    const modalities = toModalities(model.architecture?.input_modalities);
+    if (modalities) facts.modalities = modalities;
+
+    byProvider[provider] = byProvider[provider] ?? {};
+    // models.dev wins when both catalogs know a model (richer metadata);
+    // OpenRouter only fills gaps, so don't overwrite an existing entry here.
+    if (!byProvider[provider]![key]) {
+      byProvider[provider]![key] = facts;
+    }
+  }
+  return byProvider;
+}
+
+export async function fetchLiveModelFacts(
+  now = new Date()
+): Promise<LiveFactsCatalog> {
+  const [modelsDevPayload, openRouterPayload] = await Promise.all([
+    fetchJson(MODELS_DEV_URL),
+    fetchJson(OPENROUTER_MODELS_URL),
+  ]);
+
+  const fromModelsDev = parseModelsDev(modelsDevPayload);
+  const fromOpenRouter = parseOpenRouter(openRouterPayload);
+
+  const byProvider: LiveFactsCatalog["byProvider"] = { ...fromModelsDev };
+  for (const [provider, models] of Object.entries(fromOpenRouter)) {
+    const key = provider as FrontierProvider;
+    byProvider[key] = { ...models, ...byProvider[key] };
+  }
+
+  return { fetchedAt: now.toISOString(), byProvider };
+}
+
+const CHECKED_FACT_KEYS = [
+  "contextWindow",
+  "maxOutputTokens",
+  "inputPricePerMTokens",
+  "outputPricePerMTokens",
+] as const;
+
+/**
+ * Applies live facts onto the curated snapshot, returning a rebuilt snapshot
+ * (price tiers and provider/tier summaries recomputed) where every model
+ * carries a liveCheck outcome. Editorial fields are never touched.
+ */
+export function applyLiveModelFacts(
+  snapshot: FrontierModelsSnapshot,
+  catalog: LiveFactsCatalog
+): FrontierModelsSnapshot {
+  const providerLabels = {} as Record<FrontierProvider, string>;
+  for (const model of snapshot.models) {
+    providerLabels[model.provider] = model.providerLabel;
+  }
+
+  let updated = 0;
+  let confirmed = 0;
+  let curatedOnly = 0;
+
+  const source: FrontierSourceModel[] = snapshot.models.map((model) => {
+    const facts =
+      catalog.byProvider[model.provider]?.[normalizeModelName(model.name)];
+    const {
+      priceTier: _priceTier,
+      providerLabel: _providerLabel,
+      ...curated
+    } = model;
+
+    if (!facts) {
+      curatedOnly += 1;
+      return {
+        ...curated,
+        liveCheck: {
+          status: "curated-only" as const,
+          checkedAt: catalog.fetchedAt,
+          source: null,
+        },
+      };
+    }
+
+    const next = { ...curated };
+    if (facts.contextWindow) next.contextWindow = facts.contextWindow;
+    if (facts.maxOutputTokens) next.maxOutputTokens = facts.maxOutputTokens;
+    if (facts.inputPricePerMTokens !== undefined) {
+      next.inputPricePerMTokens = facts.inputPricePerMTokens;
+    }
+    if (facts.outputPricePerMTokens !== undefined) {
+      next.outputPricePerMTokens = facts.outputPricePerMTokens;
+    }
+    if (facts.knowledgeCutoff) next.knowledgeCutoff = facts.knowledgeCutoff;
+    if (facts.releaseDate) next.releaseDate = facts.releaseDate;
+    if (facts.reasoning !== undefined) next.reasoning = facts.reasoning;
+    if (facts.modalities) next.modalities = facts.modalities;
+
+    const changed = CHECKED_FACT_KEYS.some(
+      (key) => (next[key] ?? null) !== (model[key] ?? null)
+    );
+    if (changed) {
+      updated += 1;
+    } else {
+      confirmed += 1;
+    }
+
+    return {
+      ...next,
+      liveCheck: {
+        status: changed ? ("updated" as const) : ("confirmed" as const),
+        checkedAt: catalog.fetchedAt,
+        source: facts.source,
+      },
+    };
+  });
+
+  const rebuilt = buildFrontierModelsSnapshot(
+    source,
+    providerLabels,
+    catalog.fetchedAt,
+    snapshot.sourceLabel,
+    snapshot.asOf,
+    snapshot.verified
+  );
+
+  return {
+    ...rebuilt,
+    liveFacts: {
+      checkedAt: catalog.fetchedAt,
+      sources: ["models.dev", "openrouter"],
+      updated,
+      confirmed,
+      curatedOnly,
+    },
+  };
+}

--- a/src/lib/frontierModelsSnapshot.ts
+++ b/src/lib/frontierModelsSnapshot.ts
@@ -1,6 +1,45 @@
 import { frontierModelsSnapshot } from "@/data/frontierModelsSnapshot";
+import { FRONTIER_MODELS_BLOB_KEY } from "@/lib/frontierModelsLive";
+import { readSnapshotBlob } from "@/lib/snapshotBlobStore";
 import type { FrontierModelsSnapshot } from "@/types/frontierModels";
 
+// Serve the blob written by the daily scheduled refresh for up to three
+// days. Past that, the committed curated seed is the more honest source —
+// a silently dead refresh function must not keep stamping old facts as
+// freshly checked.
+const BLOB_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+// One blob read per instance per window; the CDN caches the route on top.
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+let cache: { snapshot: FrontierModelsSnapshot; expiresAt: number } | null =
+  null;
+let inflight: Promise<FrontierModelsSnapshot> | null = null;
+
+export function resetFrontierModelsCacheForTests(): void {
+  cache = null;
+  inflight = null;
+}
+
 export async function getFrontierModelsSnapshot(): Promise<FrontierModelsSnapshot> {
-  return frontierModelsSnapshot;
+  if (cache && cache.expiresAt > Date.now()) return cache.snapshot;
+  if (inflight) return inflight;
+
+  inflight = readSnapshotBlob<FrontierModelsSnapshot>(
+    FRONTIER_MODELS_BLOB_KEY,
+    BLOB_MAX_AGE_MS
+  )
+    .then((blob) => {
+      // A malformed or empty blob must never blank the catalog.
+      const snapshot = blob?.value?.models?.length
+        ? blob.value
+        : frontierModelsSnapshot;
+      cache = { snapshot, expiresAt: Date.now() + CACHE_TTL_MS };
+      return snapshot;
+    })
+    .catch(() => frontierModelsSnapshot)
+    .finally(() => {
+      inflight = null;
+    });
+
+  return inflight;
 }

--- a/src/lib/snapshotBlobStore.ts
+++ b/src/lib/snapshotBlobStore.ts
@@ -1,0 +1,72 @@
+import { getStore } from "@netlify/blobs";
+
+/**
+ * Blob-backed snapshot store — the git-free refresh lane.
+ *
+ * Where `durableJsonCache` persists request-time last-good state, this store
+ * holds full dashboard snapshots written by scheduled refresh functions
+ * (see netlify/functions/refresh-frontier-models.mts). Serving code reads the
+ * blob first and falls back to the committed seed snapshot, so a surface can
+ * refresh daily without a git commit or a site rebuild.
+ *
+ * Contract:
+ * - Reads are fail-soft: off-Netlify (local dev, jest, CI builds) and on any
+ *   store error they return null, and the caller serves the committed seed.
+ * - Writes THROW on failure. They only run inside scheduled refresh
+ *   functions, which must fail loudly so a broken refresh is visible in the
+ *   function logs instead of silently freezing the surface.
+ * - Strong consistency, so a read right after the scheduled write sees it.
+ */
+const STORE_NAME = "dashboard-snapshots";
+
+interface SnapshotEnvelope<T> {
+  savedAt: string;
+  value: T;
+}
+
+function hasNetlifyRuntime(): boolean {
+  return process.env.NETLIFY === "true" || process.env.NETLIFY_LOCAL === "true";
+}
+
+export interface SnapshotBlobRead<T> {
+  value: T;
+  savedAt: string;
+}
+
+export async function readSnapshotBlob<T>(
+  key: string,
+  maxAgeMs: number
+): Promise<SnapshotBlobRead<T> | null> {
+  if (!hasNetlifyRuntime()) return null;
+
+  try {
+    const envelope = (await getStore({
+      name: STORE_NAME,
+      consistency: "strong",
+    }).get(key, { type: "json" })) as SnapshotEnvelope<T> | null;
+    if (!envelope?.savedAt) return null;
+    const savedAt = Date.parse(envelope.savedAt);
+    if (!Number.isFinite(savedAt) || Date.now() - savedAt > maxAgeMs) {
+      return null;
+    }
+    return { value: envelope.value, savedAt: envelope.savedAt };
+  } catch {
+    return null;
+  }
+}
+
+export async function writeSnapshotBlob<T>(
+  key: string,
+  value: T
+): Promise<void> {
+  if (!hasNetlifyRuntime()) {
+    throw new Error(
+      "writeSnapshotBlob requires the Netlify runtime; refresh functions must not silently no-op."
+    );
+  }
+
+  await getStore({ name: STORE_NAME, consistency: "strong" }).setJSON(key, {
+    savedAt: new Date().toISOString(),
+    value,
+  } satisfies SnapshotEnvelope<T>);
+}

--- a/src/types/frontierModels.ts
+++ b/src/types/frontierModels.ts
@@ -13,6 +13,19 @@ export type FrontierPriceTier = "budget" | "standard" | "premium";
 
 export type FrontierView = "list" | "chart";
 
+/**
+ * Outcome of the daily automated fact check against models.dev and
+ * OpenRouter. "confirmed" means the checkable numbers matched the curated
+ * entry, "updated" means the live catalogs corrected them, and
+ * "curated-only" means no catalog entry matched, so the curated facts stand
+ * unchecked.
+ */
+export interface FrontierModelLiveCheck {
+  status: "confirmed" | "updated" | "curated-only";
+  checkedAt: string;
+  source: "models.dev" | "openrouter" | null;
+}
+
 export interface FrontierModel {
   id: string;
   provider: FrontierProvider;
@@ -29,6 +42,7 @@ export interface FrontierModel {
   reasoning: boolean;
   editorialNote: string;
   docsUrl: string | null;
+  liveCheck?: FrontierModelLiveCheck;
 }
 
 export interface FrontierModelProviderSummary {
@@ -53,6 +67,14 @@ export interface FrontierModelsSnapshot {
   models: FrontierModel[];
   providers: FrontierModelProviderSummary[];
   priceTiers: FrontierModelPriceTierSummary[];
+  /** Present when the daily automated fact check has run (blob-served data). */
+  liveFacts?: {
+    checkedAt: string;
+    sources: string[];
+    updated: number;
+    confirmed: number;
+    curatedOnly: number;
+  };
 }
 
 export type FrontierProviderFilter = FrontierProvider | "all";


### PR DESCRIPTION
## What

The frontier-models catalog was hand-curated with no live source, which is how it went 67 days stale earlier this year (audit item). This PR gives it a daily automated fact check and, in the process, pilots the git-free refresh lane the migration plan proposed:

- **`src/lib/frontierModelsLive.ts`** fetches two keyless catalogs (models.dev `api.json`, OpenRouter `/api/v1/models`) and applies the checkable facts (pricing, context window, output limit, cutoff, release date, modalities) onto the curated seed. Matching is exact-normalized-name per provider, never fuzzy (the fantasy ADP rule). Every model gets a `liveCheck` outcome: `confirmed`, `updated`, or `curated-only`. Editorial notes and the curated model list are never touched. Degraded upstream payloads (too few providers/models) throw rather than merge.
- **`src/lib/snapshotBlobStore.ts`** (new, generic): the `dashboard-snapshots` Netlify Blobs store. Fail-soft reads (null off-Netlify or on store errors, so local dev/tests/CI always serve the committed seed); writes throw so a broken refresh is a visible failed function run.
- **`netlify/functions/refresh-frontier-models.ts`**: scheduled function (daily 07:30 UTC, in-code cron) that fetches, merges, writes the blob, and purges the `frontier-models` CDN cache tag. No git commit, no rebuild, no deploy.
- **Accessor** now reads blob-first (3-day max age, then the seed wins again so a dead refresh can't stamp old facts as fresh) behind a 5-minute in-memory TTL with single-flight.
- **New `/api/frontier-models/summary`** route with standard snapshot headers plus `Netlify-Cache-Tag: frontier-models` so the purge bites.
- On-page disclosure line now appends "Facts auto-checked <date> against models.dev + openrouter" when blob data is serving. The curated `asOf`/`verified` review framing stays.

## Verified end to end

Both live endpoints probed and parsed today; a real dry run against the committed seed found genuine drift the check will now catch daily: 6 of 9 entries updated (Claude Sonnet 5 is now 1M context at $2/$10, Opus 4.8 at $5/$25 with 1M context, Haiku 4.5 output limit 64K, corrected Llama pricing), 1 confirmed, 2 curated-only (Gemini 3.1 Pro, DeepSeek V4 — absent from both catalogs, facts stand unchecked and are labeled as such).

## Why this shape

This is the pilot for moving snapshot refreshes off the git-commit + rebuild pipeline: scheduled function → Blobs → cache-tag purge, with the committed seed keeping reviewable diffs, local dev, and cold-start behavior. The pattern doc gained a "blob-backed refresh lane" section (`SNAPSHOT_DRIVEN_DASHBOARDS.md`) for the next surfaces.

## Tests

30 tests across 7 suites: blob store contract (env gating, envelope, max-age, loud writes), catalog parsing/merging (models.dev precedence, per-token price conversion + float rounding, degraded-payload guards), conservative matching + fact application (editorial preservation, price-tier recompute, outcome counts), accessor blob-first/fallback/TTL, API route headers + cache tag, scheduled function orchestration (write-then-purge, no write on fetch failure, purge failure tolerated). `tsc --noEmit` clean.