### PR TITLE
Soccer: token-gated request-time refresh for PL and La Liga

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,7 @@ npm run dev
 
 - Prefer Node 20 locally to match GitHub Actions.
 - `npm run update:investments` also requires `.venv/bin/python3`.
-- `npm run update:football`, `npm run update:premier-league`, and `npm run update:la-liga` use `FOOTBALL_DATA_API_TOKEN` only when rebuilding checked-in football snapshots.
+- `npm run update:football`, `npm run update:premier-league`, and `npm run update:la-liga` use `FOOTBALL_DATA_API_TOKEN` only when rebuilding checked-in football snapshots. The same token is optional at runtime: when set in the deploy environment, the Premier League and La Liga summary APIs refresh standings and fixtures at request time (5-minute in-memory TTL) and fall back to the committed snapshots; without it they serve the committed snapshots only.
 - `npm run update:mlb`, `npm run update:nba`, `npm run update:nfl`, `npm run update:golf`, and `npm run update:world-cup` use public sports data sources and do not require auth tokens.
 - `npm run update:bay-area-transit` uses BART's public legacy API with the published demo key baked into the builder; no token setup required.
 - `npm run update:tech-startups` processes a hand-maintained seed inside `scripts/buildTechStartupSnapshot.ts`; there is no live source to poll.

--- a/SNAPSHOT_DRIVEN_DASHBOARDS.md
+++ b/SNAPSHOT_DRIVEN_DASHBOARDS.md
@@ -149,8 +149,8 @@ by BART abbr, world-cup `/teams/[teamId]` by team slug.
 
 | Route(s) | Snapshot | Builder / `npm run` | Workflow | Upstream source | Cadence |
 |---|---|---|---|---|---|
-| `/premier-league` | `src/data/premierLeagueSnapshot.ts` | `buildPremierLeagueSnapshot.ts` · `update:premier-league` / `update:football` | `update-premier-league.yml` | football-data.org (token) | daily 06:15 UTC, Aug–May |
-| `/la-liga` | `src/data/laLigaSnapshot.ts` | `updateLaLigaSnapshot.ts` · `update:la-liga` / `update:football` | `update-la-liga.yml` | football-data.org (token) | daily 06:30 UTC, Aug–May |
+| `/premier-league` | `src/data/premierLeagueSnapshot.ts` | `buildPremierLeagueSnapshot.ts` · `update:premier-league` / `update:football` | `update-premier-league.yml` | football-data.org (token; the summary API also refreshes standings/fixtures at request time when the token is set) | daily 06:15 UTC, Aug–May |
+| `/la-liga` | `src/data/laLigaSnapshot.ts` | `updateLaLigaSnapshot.ts` · `update:la-liga` / `update:football` | `update-la-liga.yml` | football-data.org (token; the summary API also refreshes standings/fixtures at request time when the token is set) | daily 06:30 UTC, Aug–May |
 | `/nfl` | `src/data/nflSnapshot.ts` | `updateNflSnapshot.ts` · `update:nfl` | `update-nfl.yml` | NFLverse CSVs | Tue 10:35 UTC, Sep–Feb |
 | `/mlb` | `src/data/mlbSnapshot.ts` | `updateMlbSnapshot.ts` · `update:mlb` | `update-mlb.yml` | MLB Stats API | daily 10:05 UTC, Mar–Nov |
 | `/nba` | `src/data/nbaSnapshot.ts` | `updateNbaSnapshot.ts` · `update:nba` | `update-nba.yml` | ESPN NBA | daily 10:20 UTC, mid-Oct–Jun |

--- a/docs/DATA_UPDATE_OPERATIONS.md
+++ b/docs/DATA_UPDATE_OPERATIONS.md
@@ -26,8 +26,8 @@ request time, with the committed artifact retained as the last-good fallback.
 | Fantasy football | `update:fantasy` | `buildFantasyPositionData.ts` → `buildFantasyAdpData.ts` → `buildFantasySnapshots.ts` | FantasyPros cheatsheets + FF Calculator ADP | `public/data/fantasy/{ppr,half_ppr,standard}.json`, `src/data/fantasy*.generated.ts` | `update-fantasy.yml` | daily July through September; weekly otherwise |
 | Investments | `update:investments` | `fetch_investments_data.py` (needs `.venv`) → `buildInvestmentsSnapshots.ts` | `defeatbeta-api` (Python) | `public/data/investments/index.json` + `{SYMBOL}/snapshot.json` | `update-investments.yml` | weekdays 22:15 UTC |
 | Football (both) | `update:football` | `updateFootballSnapshots.ts` | football-data.org *(token)* | `src/data/premierLeagueSnapshot.ts` + `laLigaSnapshot.ts` | none *(full run is manual ~weekly)* | manual |
-| Premier League | `update:premier-league` | `buildPremierLeagueSnapshot.ts` | football-data.org *(token)* | `src/data/premierLeagueSnapshot.ts` | `update-premier-league.yml` | every 4h, August through May |
-| La Liga | `update:la-liga` | `updateLaLigaSnapshot.ts` | football-data.org *(token)* | `src/data/laLigaSnapshot.ts` | `update-la-liga.yml` | every 4h, August through May |
+| Premier League | `update:premier-league` | `buildPremierLeagueSnapshot.ts` | football-data.org *(token; the summary API also refreshes standings/fixtures at request time when the token is set)* | `src/data/premierLeagueSnapshot.ts` | `update-premier-league.yml` | every 4h, August through May |
+| La Liga | `update:la-liga` | `updateLaLigaSnapshot.ts` | football-data.org *(token; the summary API also refreshes standings/fixtures at request time when the token is set)* | `src/data/laLigaSnapshot.ts` | `update-la-liga.yml` | every 4h, August through May |
 | NFL | `update:nfl` | `updateNflSnapshot.ts` | NFLverse CSVs | `src/data/nflSnapshot.ts` | `update-nfl.yml` | Tue 10:35 UTC, September through February |
 | MLB | `update:mlb` | `updateMlbSnapshot.ts` | MLB Stats API | `src/data/mlbSnapshot.ts` | `update-mlb.yml` | every 4h, March through November |
 | NBA | `update:nba` | `updateNbaSnapshot.ts` | ESPN NBA | `src/data/nbaSnapshot.ts` | `update-nba.yml` | every 4h, mid-October through June |
@@ -70,7 +70,7 @@ in Netlify Blobs so cold starts do not erase their fallback.
 
 | Need | Used by |
 |------|---------|
-| `FOOTBALL_DATA_API_TOKEN` | `update:football`, `update:premier-league`, `update:la-liga` (only when rebuilding) |
+| `FOOTBALL_DATA_API_TOKEN` | `update:football`, `update:premier-league`, `update:la-liga` (only when rebuilding). Optional at runtime: when set in the deploy environment, the Premier League and La Liga summary APIs also refresh standings and fixtures at request time (5-minute in-memory TTL, committed snapshots as fallback) |
 | `THE_ODDS_API_KEY` (required in the scheduled workflow) | `update:score-pools` |
 | `API_FOOTBALL_KEY` (required in the scheduled workflow) | `update:score-pools` |
 | `GITHUB_TOKEN` / `GH_TOKEN` (optional, higher rate limit) | `update:github-trending` |
@@ -85,7 +85,10 @@ in Netlify Blobs so cold starts do not erase their fallback.
   providers. Earthquake and BART make separate request-time refreshes and keep
   those snapshots as fallbacks.
 - Premier League and La Liga refresh through their dedicated daily workflows;
-  NFL refreshes through `update-nfl.yml` (or a manual run).
+  NFL refreshes through `update-nfl.yml` (or a manual run). When
+  `FOOTBALL_DATA_API_TOKEN` is set at runtime, the PL and La Liga summary APIs
+  additionally refresh standings and fixtures at request time and fall back to
+  the committed snapshots.
 - `update:football` (the ~16-min full refresh, including per-team fixtures and
   form) remains an explicit local task, not a build step.
 - `publish-data.yml` coalesces successful refresh workflows, triggers the

--- a/src/app/api/la-liga/summary/__tests__/route.test.ts
+++ b/src/app/api/la-liga/summary/__tests__/route.test.ts
@@ -84,6 +84,9 @@ describe("GET /api/la-liga/summary", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=300, stale-while-revalidate=900"
     );
+    // The route opts into the token-gated request-time refresh; without a
+    // configured token the accessor still serves the committed snapshot.
+    expect(mockGetLaLigaSummarySnapshot).toHaveBeenCalledWith({ preferLive: true });
   });
 
   it("returns a stable empty payload when the snapshot is unavailable", async () => {

--- a/src/app/api/la-liga/summary/route.ts
+++ b/src/app/api/la-liga/summary/route.ts
@@ -15,7 +15,10 @@ const ERROR_CACHE_HEADERS = {
 
 export async function GET() {
   try {
-    const summary = await getLaLigaSummarySnapshot();
+    // preferLive is a no-op unless FOOTBALL_DATA_API_TOKEN is configured; the
+    // accessor then refreshes standings and fixtures at request time behind a
+    // 5-minute in-memory cache, with the committed snapshot as fallback.
+    const summary = await getLaLigaSummarySnapshot({ preferLive: true });
     return NextResponse.json(summary, {
       headers: createSnapshotResponseHeaders({
         surface: "la-liga",

--- a/src/app/api/premier-league/summary/__tests__/route.test.ts
+++ b/src/app/api/premier-league/summary/__tests__/route.test.ts
@@ -57,6 +57,9 @@ describe("GET /api/premier-league/summary", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=300, stale-while-revalidate=900"
     );
+    // The route opts into the token-gated request-time refresh; without a
+    // configured token the accessor still serves the committed snapshot.
+    expect(mockGetPremierLeagueSummary).toHaveBeenCalledWith({ preferLive: true });
   });
 
   it("returns a stable empty payload when the snapshot is unavailable", async () => {

--- a/src/app/api/premier-league/summary/route.ts
+++ b/src/app/api/premier-league/summary/route.ts
@@ -15,7 +15,10 @@ const ERROR_CACHE_HEADERS = {
 
 export async function GET() {
   try {
-    const summary = await getPremierLeagueSummary();
+    // preferLive is a no-op unless FOOTBALL_DATA_API_TOKEN is configured; the
+    // accessor then refreshes standings and fixtures at request time behind a
+    // 5-minute in-memory cache, with the committed snapshot as fallback.
+    const summary = await getPremierLeagueSummary({ preferLive: true });
 
     return NextResponse.json(summary, {
       headers: createSnapshotResponseHeaders({

--- a/src/lib/__tests__/laLigaSnapshot.test.ts
+++ b/src/lib/__tests__/laLigaSnapshot.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @jest-environment node
+ */
+import { laLigaSnapshot } from "@/data/laLigaSnapshot";
+import {
+  getLaLigaSummarySnapshot,
+  resetLaLigaLiveSummaryCacheForTests,
+} from "../laLigaSnapshot";
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const REAL_MADRID = { id: 86, name: "Real Madrid CF", shortName: "Real Madrid", tla: "RMA", crest: null };
+const BARCELONA = { id: 81, name: "FC Barcelona", shortName: "Barcelona", tla: "FCB", crest: null };
+
+function liveStandingsPayload() {
+  return {
+    competition: { code: "PD", name: "Primera Division" },
+    season: { startDate: "2025-08-15", endDate: "2026-05-24", currentMatchday: 38 },
+    standings: [
+      {
+        type: "TOTAL",
+        table: [
+          { position: 1, playedGames: 38, won: 29, draw: 5, lost: 4, points: 92, goalsFor: 95, goalsAgainst: 28, goalDifference: 67, team: BARCELONA },
+          { position: 2, playedGames: 38, won: 27, draw: 7, lost: 4, points: 88, goalsFor: 84, goalsAgainst: 30, goalDifference: 54, team: REAL_MADRID },
+        ],
+      },
+    ],
+  };
+}
+
+function liveFinishedPayload() {
+  return {
+    matches: [
+      {
+        id: 80001,
+        utcDate: "2026-05-24T19:00:00Z",
+        status: "FINISHED",
+        matchday: 38,
+        stage: "REGULAR_SEASON",
+        homeTeam: BARCELONA,
+        awayTeam: REAL_MADRID,
+        score: { winner: "DRAW", fullTime: { home: 2, away: 2 } },
+      },
+    ],
+  };
+}
+
+function liveScheduledPayload() {
+  return {
+    matches: [
+      {
+        id: 80002,
+        utcDate: "2026-08-23T19:00:00Z",
+        status: "SCHEDULED",
+        matchday: 1,
+        stage: "REGULAR_SEASON",
+        homeTeam: REAL_MADRID,
+        awayTeam: BARCELONA,
+        score: { winner: null, fullTime: { home: null, away: null } },
+      },
+    ],
+  };
+}
+
+function routeLiveFetch(url: string): Response {
+  if (url.includes("/standings")) return jsonResponse(liveStandingsPayload());
+  if (url.includes("/matches")) {
+    if (url.includes("status=FINISHED")) return jsonResponse(liveFinishedPayload());
+    if (url.includes("status=SCHEDULED")) return jsonResponse(liveScheduledPayload());
+  }
+  throw new Error(`Unexpected fetch URL in test: ${url}`);
+}
+
+describe("getLaLigaSummarySnapshot accessor", () => {
+  let previousToken: string | undefined;
+
+  beforeAll(() => {
+    previousToken = process.env.FOOTBALL_DATA_API_TOKEN;
+  });
+
+  beforeEach(() => {
+    resetLaLigaLiveSummaryCacheForTests();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    if (previousToken === undefined) {
+      delete process.env.FOOTBALL_DATA_API_TOKEN;
+    } else {
+      process.env.FOOTBALL_DATA_API_TOKEN = previousToken;
+    }
+  });
+
+  describe("without a configured token", () => {
+    beforeEach(() => {
+      delete process.env.FOOTBALL_DATA_API_TOKEN;
+    });
+
+    it("returns the committed snapshot and never fetches, even with preferLive", async () => {
+      const fetchSpy = jest.spyOn(global, "fetch");
+
+      const committed = await getLaLigaSummarySnapshot();
+      const preferLive = await getLaLigaSummarySnapshot({ preferLive: true });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      // Byte-for-byte identical to the token-less default path.
+      expect(JSON.stringify(preferLive)).toBe(JSON.stringify(committed));
+      expect(preferLive.clubs).toEqual(laLigaSnapshot.clubs);
+      expect(preferLive.updatedAt).toBe(laLigaSnapshot.updatedAt);
+    });
+  });
+
+  describe("with a configured token", () => {
+    beforeEach(() => {
+      process.env.FOOTBALL_DATA_API_TOKEN = "test-token";
+    });
+
+    it("merges live standings and fixtures over the committed snapshot", async () => {
+      const fetchSpy = jest
+        .spyOn(global, "fetch")
+        .mockImplementation((input: Parameters<typeof fetch>[0]) =>
+          Promise.resolve(routeLiveFetch(String(input)))
+        );
+
+      const summary = await getLaLigaSummarySnapshot({ preferLive: true });
+
+      // Exactly three upstream requests: standings, finished, scheduled.
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      const urls = fetchSpy.mock.calls.map((call) => String(call[0]));
+      expect(urls.every((url) => url.includes("/competitions/PD/"))).toBe(true);
+
+      // Live sections replace the committed values.
+      expect(summary.clubs.map((club) => club.code)).toEqual(["FCB", "RMA"]);
+      expect(summary.clubs[0].points).toBe(92);
+      expect(summary.matchday).toBe(38);
+      expect(summary.season).toBe("2025/26");
+      expect(summary.recentFixtures.map((f) => f.id)).toEqual(["80001"]);
+      expect(summary.upcomingFixtures.map((f) => f.id)).toEqual(["80002"]);
+
+      // Untouched sections keep the committed snapshot values.
+      expect(summary.scorers).toEqual(laLigaSnapshot.scorers);
+      expect(summary.teams).toEqual(laLigaSnapshot.teams);
+      expect(summary.sourceLabel).toBe(laLigaSnapshot.sourceLabel);
+    });
+
+    it("single-flights concurrent requests and re-fetches only after the TTL", async () => {
+      let now = 1_800_000_000_000;
+      jest.spyOn(Date, "now").mockImplementation(() => now);
+      const fetchSpy = jest
+        .spyOn(global, "fetch")
+        .mockImplementation((input: Parameters<typeof fetch>[0]) =>
+          Promise.resolve(routeLiveFetch(String(input)))
+        );
+
+      const [first, second] = await Promise.all([
+        getLaLigaSummarySnapshot({ preferLive: true }),
+        getLaLigaSummarySnapshot({ preferLive: true }),
+      ]);
+
+      // One flight (3 requests) serves both concurrent callers.
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(second.clubs).toEqual(first.clubs);
+
+      // Within the TTL the cache serves without fetching.
+      await getLaLigaSummarySnapshot({ preferLive: true });
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+      // Past the TTL a new flight runs.
+      now += 5 * 60 * 1000 + 1;
+      await getLaLigaSummarySnapshot({ preferLive: true });
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
+    });
+
+    it("falls back to the committed snapshot on total failure without negative-caching", async () => {
+      // 404 is a non-retried client error, so each section fails after one call.
+      const fetchSpy = jest
+        .spyOn(global, "fetch")
+        .mockImplementation(() => Promise.resolve(jsonResponse({}, 404)));
+
+      const committed = await getLaLigaSummarySnapshot();
+      const fallback = await getLaLigaSummarySnapshot({ preferLive: true });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(JSON.stringify(fallback)).toBe(JSON.stringify(committed));
+
+      // The failure was not cached: the next request retries the live path.
+      fetchSpy.mockImplementation((input: Parameters<typeof fetch>[0]) =>
+        Promise.resolve(routeLiveFetch(String(input)))
+      );
+      const refreshed = await getLaLigaSummarySnapshot({ preferLive: true });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
+      expect(refreshed.clubs.map((club) => club.code)).toEqual(["FCB", "RMA"]);
+    });
+
+    it("keeps the committed section when a single section fails", async () => {
+      jest.spyOn(global, "fetch").mockImplementation((input: Parameters<typeof fetch>[0]) => {
+        const url = String(input);
+        if (url.includes("/standings")) return Promise.resolve(jsonResponse({}, 404));
+        return Promise.resolve(routeLiveFetch(url));
+      });
+
+      const summary = await getLaLigaSummarySnapshot({ preferLive: true });
+
+      expect(summary.clubs).toEqual(laLigaSnapshot.clubs);
+      expect(summary.matchday).toBe(laLigaSnapshot.matchday);
+      expect(summary.recentFixtures.map((f) => f.id)).toEqual(["80001"]);
+      expect(summary.upcomingFixtures.map((f) => f.id)).toEqual(["80002"]);
+    });
+  });
+});

--- a/src/lib/__tests__/premierLeagueSnapshot.test.ts
+++ b/src/lib/__tests__/premierLeagueSnapshot.test.ts
@@ -1,0 +1,273 @@
+/**
+ * @jest-environment node
+ */
+import { premierLeagueSnapshot } from "@/data/premierLeagueSnapshot";
+import {
+  getPremierLeagueSummary,
+  resetPremierLeagueLiveSummaryCacheForTests,
+} from "../premierLeagueSnapshot";
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const ARSENAL = { id: 57, name: "Arsenal FC", shortName: "Arsenal", tla: "ARS", crest: null };
+const CHELSEA = { id: 61, name: "Chelsea FC", shortName: "Chelsea", tla: "CHE", crest: null };
+
+function liveStandingsPayload() {
+  return {
+    area: { name: "England" },
+    competition: {
+      code: "PL",
+      name: "Premier League",
+      emblem: null,
+      area: { name: "England" },
+    },
+    season: {
+      startDate: "2025-08-15",
+      endDate: "2026-05-24",
+      currentMatchday: 38,
+      winner: null,
+    },
+    standings: [
+      {
+        type: "TOTAL",
+        table: [
+          { position: 1, playedGames: 38, won: 28, draw: 6, lost: 4, points: 90, goalsFor: 88, goalsAgainst: 30, goalDifference: 58, team: CHELSEA },
+          { position: 2, playedGames: 38, won: 26, draw: 7, lost: 5, points: 85, goalsFor: 80, goalsAgainst: 32, goalDifference: 48, team: ARSENAL },
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * Off-season placeholder: the season pointer has rolled forward but no games
+ * are played, which must never replace the committed table.
+ */
+function rolledOverStandingsPayload() {
+  return {
+    area: { name: "England" },
+    competition: { code: "PL", name: "Premier League", emblem: null, area: { name: "England" } },
+    season: { startDate: "2026-08-21", endDate: "2027-05-30", currentMatchday: 1, winner: null },
+    standings: [
+      {
+        type: "TOTAL",
+        table: [
+          { position: 1, playedGames: 0, won: 0, draw: 0, lost: 0, points: 0, goalsFor: 0, goalsAgainst: 0, goalDifference: 0, team: ARSENAL },
+          { position: 2, playedGames: 0, won: 0, draw: 0, lost: 0, points: 0, goalsFor: 0, goalsAgainst: 0, goalDifference: 0, team: CHELSEA },
+        ],
+      },
+    ],
+  };
+}
+
+function liveFinishedPayload() {
+  return {
+    matches: [
+      {
+        id: 90001,
+        utcDate: "2026-05-24T15:00:00Z",
+        status: "FINISHED",
+        matchday: 38,
+        stage: "REGULAR_SEASON",
+        homeTeam: ARSENAL,
+        awayTeam: CHELSEA,
+        score: { winner: "HOME_TEAM", fullTime: { home: 2, away: 1 } },
+      },
+    ],
+  };
+}
+
+function liveScheduledPayload() {
+  return {
+    matches: [
+      {
+        id: 90002,
+        utcDate: "2026-08-22T15:00:00Z",
+        status: "SCHEDULED",
+        matchday: 1,
+        stage: "REGULAR_SEASON",
+        homeTeam: CHELSEA,
+        awayTeam: ARSENAL,
+        score: { winner: null, fullTime: { home: null, away: null } },
+      },
+    ],
+  };
+}
+
+function routeLiveFetch(url: string): Response {
+  if (url.includes("/standings")) return jsonResponse(liveStandingsPayload());
+  if (url.includes("/matches")) {
+    if (url.includes("status=FINISHED")) return jsonResponse(liveFinishedPayload());
+    if (url.includes("status=SCHEDULED")) return jsonResponse(liveScheduledPayload());
+  }
+  throw new Error(`Unexpected fetch URL in test: ${url}`);
+}
+
+describe("getPremierLeagueSummary accessor", () => {
+  let previousToken: string | undefined;
+
+  beforeAll(() => {
+    previousToken = process.env.FOOTBALL_DATA_API_TOKEN;
+  });
+
+  beforeEach(() => {
+    resetPremierLeagueLiveSummaryCacheForTests();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    if (previousToken === undefined) {
+      delete process.env.FOOTBALL_DATA_API_TOKEN;
+    } else {
+      process.env.FOOTBALL_DATA_API_TOKEN = previousToken;
+    }
+  });
+
+  describe("without a configured token", () => {
+    beforeEach(() => {
+      delete process.env.FOOTBALL_DATA_API_TOKEN;
+    });
+
+    it("returns the committed snapshot and never fetches, even with preferLive", async () => {
+      const fetchSpy = jest.spyOn(global, "fetch");
+
+      const committed = await getPremierLeagueSummary();
+      const preferLive = await getPremierLeagueSummary({ preferLive: true });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      // Byte-for-byte identical to the token-less default path.
+      expect(JSON.stringify(preferLive)).toBe(JSON.stringify(committed));
+      expect(preferLive.standings).toEqual(premierLeagueSnapshot.summary.standings);
+    });
+
+    it("treats a whitespace-only token as absent", async () => {
+      process.env.FOOTBALL_DATA_API_TOKEN = "   ";
+      const fetchSpy = jest.spyOn(global, "fetch");
+
+      const summary = await getPremierLeagueSummary({ preferLive: true });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(summary.standings).toEqual(premierLeagueSnapshot.summary.standings);
+    });
+  });
+
+  describe("with a configured token", () => {
+    beforeEach(() => {
+      process.env.FOOTBALL_DATA_API_TOKEN = "test-token";
+    });
+
+    it("merges live standings and fixtures over the committed snapshot", async () => {
+      const fetchSpy = jest
+        .spyOn(global, "fetch")
+        .mockImplementation((input: Parameters<typeof fetch>[0]) =>
+          Promise.resolve(routeLiveFetch(String(input)))
+        );
+
+      const summary = await getPremierLeagueSummary({ preferLive: true });
+
+      // Exactly three upstream requests: standings, finished, scheduled.
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      const urls = fetchSpy.mock.calls.map((call) => String(call[0]));
+      expect(urls.every((url) => url.includes("/competitions/PL/"))).toBe(true);
+
+      // Live sections replace the committed values.
+      expect(summary.standings.map((row) => row.team.id)).toEqual(["61", "57"]);
+      expect(summary.standings[0].points).toBe(90);
+      expect(summary.competition?.currentMatchday).toBe(38);
+      expect(summary.recentFixtures.map((f) => f.id)).toEqual(["90001"]);
+      expect(summary.upcomingFixtures.map((f) => f.id)).toEqual(["90002"]);
+
+      // Untouched sections keep the committed snapshot values.
+      expect(summary.scorers).toEqual(premierLeagueSnapshot.summary.scorers);
+      expect(summary.teams).toEqual(premierLeagueSnapshot.summary.teams);
+    });
+
+    it("single-flights concurrent requests and re-fetches only after the TTL", async () => {
+      let now = 1_800_000_000_000;
+      jest.spyOn(Date, "now").mockImplementation(() => now);
+      const fetchSpy = jest
+        .spyOn(global, "fetch")
+        .mockImplementation((input: Parameters<typeof fetch>[0]) =>
+          Promise.resolve(routeLiveFetch(String(input)))
+        );
+
+      const [first, second] = await Promise.all([
+        getPremierLeagueSummary({ preferLive: true }),
+        getPremierLeagueSummary({ preferLive: true }),
+      ]);
+
+      // One flight (3 requests) serves both concurrent callers.
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(second.standings).toEqual(first.standings);
+
+      // Within the TTL the cache serves without fetching.
+      await getPremierLeagueSummary({ preferLive: true });
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+      // Past the TTL a new flight runs.
+      now += 5 * 60 * 1000 + 1;
+      await getPremierLeagueSummary({ preferLive: true });
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
+    });
+
+    it("falls back to the committed snapshot on total failure without negative-caching", async () => {
+      // 404 is a non-retried client error, so each section fails after one call.
+      const fetchSpy = jest
+        .spyOn(global, "fetch")
+        .mockImplementation(() => Promise.resolve(jsonResponse({}, 404)));
+
+      const committed = await getPremierLeagueSummary();
+      const fallback = await getPremierLeagueSummary({ preferLive: true });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(JSON.stringify(fallback)).toBe(JSON.stringify(committed));
+
+      // The failure was not cached: the next request retries the live path.
+      fetchSpy.mockImplementation((input: Parameters<typeof fetch>[0]) =>
+        Promise.resolve(routeLiveFetch(String(input)))
+      );
+      const refreshed = await getPremierLeagueSummary({ preferLive: true });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
+      expect(refreshed.standings.map((row) => row.team.id)).toEqual(["61", "57"]);
+    });
+
+    it("keeps the committed section when a single section fails", async () => {
+      jest.spyOn(global, "fetch").mockImplementation((input: Parameters<typeof fetch>[0]) => {
+        const url = String(input);
+        if (url.includes("/standings")) return Promise.resolve(jsonResponse({}, 404));
+        return Promise.resolve(routeLiveFetch(url));
+      });
+
+      const summary = await getPremierLeagueSummary({ preferLive: true });
+
+      expect(summary.standings).toEqual(premierLeagueSnapshot.summary.standings);
+      expect(summary.recentFixtures.map((f) => f.id)).toEqual(["90001"]);
+      expect(summary.upcomingFixtures.map((f) => f.id)).toEqual(["90002"]);
+    });
+
+    it("keeps the committed table when live standings are a zeroed rolled-over placeholder", async () => {
+      jest.spyOn(global, "fetch").mockImplementation((input: Parameters<typeof fetch>[0]) => {
+        const url = String(input);
+        if (url.includes("/standings")) {
+          return Promise.resolve(jsonResponse(rolledOverStandingsPayload()));
+        }
+        return Promise.resolve(routeLiveFetch(url));
+      });
+
+      const summary = await getPremierLeagueSummary({ preferLive: true });
+
+      expect(summary.standings).toEqual(premierLeagueSnapshot.summary.standings);
+      expect(summary.competition).toEqual(premierLeagueSnapshot.summary.competition);
+      expect(summary.recentFixtures.map((f) => f.id)).toEqual(["90001"]);
+    });
+  });
+});

--- a/src/lib/laLigaData.ts
+++ b/src/lib/laLigaData.ts
@@ -8,6 +8,7 @@ import type {
   LaLigaLeader,
   LaLigaMatchdayGoals,
   LaLigaSnapshot,
+  LaLigaSummarySnapshot,
   LaLigaTeamOption,
   LaLigaTeamProfile,
   LaLigaTeamSnapshot,
@@ -547,6 +548,92 @@ export async function getLaLigaSummary(options?: { season?: number }): Promise<{
     teams,
     generatedAt: new Date().toISOString(),
   };
+}
+
+/**
+ * Request-time refresh used by the summary accessor when a football-data.org
+ * token is configured. Only the standings (clubs plus the season label and
+ * matchday from the same response) and the recent/upcoming fixture lists are
+ * refreshed (3 upstream requests); every other section keeps the committed
+ * snapshot's value. A section that fails, comes back empty, or reflects the
+ * rolled-over-but-unstarted season keeps the committed value. If no section
+ * refreshes, this throws so the caller falls back to the committed snapshot
+ * wholesale without caching the failure.
+ */
+export async function buildLaLigaLiveSummary(
+  baseSummary: LaLigaSummarySnapshot
+): Promise<LaLigaSummarySnapshot> {
+  const [standingsResult, recentResult, upcomingResult] = await Promise.allSettled([
+    fetchFootballDataJson<FootballDataCompetitionStandingsResponse>(
+      `/competitions/${LA_LIGA_CODE}/standings`,
+      SUMMARY_REVALIDATE_SECONDS
+    ),
+    fetchFootballDataJson<FootballDataMatchesResponse>(
+      `/competitions/${LA_LIGA_CODE}/matches?${buildQueryString({ status: "FINISHED", limit: RECENT_FIXTURE_LIMIT })}`,
+      SUMMARY_REVALIDATE_SECONDS
+    ),
+    fetchFootballDataJson<FootballDataMatchesResponse>(
+      `/competitions/${LA_LIGA_CODE}/matches?${buildQueryString({ status: "SCHEDULED", limit: UPCOMING_FIXTURE_LIMIT })}`,
+      SUMMARY_REVALIDATE_SECONDS
+    ),
+  ]);
+
+  const summary: LaLigaSummarySnapshot = { ...baseSummary };
+  let refreshedSections = 0;
+
+  if (standingsResult.status === "fulfilled") {
+    const standingsGroup =
+      standingsResult.value.standings?.find((g) => g?.type === "TOTAL") ??
+      standingsResult.value.standings?.[0] ??
+      null;
+    const clubs = (standingsGroup?.table ?? [])
+      .map((row) => normalizeStandingRow(row))
+      .filter((c): c is LaLigaClub => c !== null);
+
+    // A zeroed rolled-over table (season pointer advanced, no games played)
+    // would wipe the dashboard, so the committed table is kept instead.
+    if (clubs.length > 0 && !seasonNotStarted(standingsResult.value.season, clubs)) {
+      summary.clubs = clubs;
+      summary.season = buildSeasonLabel(
+        standingsResult.value.season?.startDate,
+        standingsResult.value.season?.endDate
+      );
+      summary.matchday = standingsResult.value.season?.currentMatchday ?? summary.matchday;
+      refreshedSections += 1;
+    }
+  }
+
+  if (recentResult.status === "fulfilled") {
+    const recentFixtures = (recentResult.value.matches ?? [])
+      .map((m) => normalizeFixture(m))
+      .filter((f): f is LaLigaFixture => f !== null)
+      .sort((a, b) => new Date(b.utcDate).getTime() - new Date(a.utcDate).getTime())
+      .slice(0, RECENT_FIXTURE_LIMIT);
+
+    if (recentFixtures.length > 0) {
+      summary.recentFixtures = recentFixtures;
+      refreshedSections += 1;
+    }
+  }
+
+  if (upcomingResult.status === "fulfilled") {
+    const upcomingFixtures = (upcomingResult.value.matches ?? [])
+      .map((m) => normalizeFixture(m))
+      .filter((f): f is LaLigaFixture => f !== null)
+      .sort((a, b) => new Date(a.utcDate).getTime() - new Date(b.utcDate).getTime())
+      .slice(0, UPCOMING_FIXTURE_LIMIT);
+
+    if (upcomingFixtures.length > 0) {
+      summary.upcomingFixtures = upcomingFixtures;
+      refreshedSections += 1;
+    }
+  }
+
+  if (refreshedSections === 0) {
+    throw createLaLigaDataError("La Liga live refresh produced no usable sections.", 503);
+  }
+
+  return { ...summary, updatedAt: new Date().toISOString().slice(0, 10) };
 }
 
 export async function getLaLigaTeamSnapshot(teamId: string): Promise<LaLigaTeamSnapshot> {

--- a/src/lib/laLigaSnapshot.ts
+++ b/src/lib/laLigaSnapshot.ts
@@ -1,4 +1,5 @@
 import { laLigaSnapshot } from "@/data/laLigaSnapshot";
+import { buildLaLigaLiveSummary } from "@/lib/laLigaData";
 import type { LaLigaSummarySnapshot, LaLigaTeamSnapshot } from "@/types/la-liga";
 
 const SUMMARY_FIXTURE_LIMIT = 8;
@@ -16,8 +17,14 @@ function limitFixtures<T>(fixtures: T[], limit: number): T[] {
   return fixtures.slice(0, limit);
 }
 
-function clampLaLigaSummarySnapshot(snapshot: typeof laLigaSnapshot): LaLigaSummarySnapshot {
-  const { teamSnapshots: _teamSnapshots, ...summarySnapshot } = snapshot;
+function committedLaLigaSummarySnapshot(): LaLigaSummarySnapshot {
+  const { teamSnapshots: _teamSnapshots, ...summarySnapshot } = laLigaSnapshot;
+  return summarySnapshot;
+}
+
+function clampLaLigaSummarySnapshot(
+  summarySnapshot: LaLigaSummarySnapshot
+): LaLigaSummarySnapshot {
   return {
     ...summarySnapshot,
     recentFixtures: limitFixtures(summarySnapshot.recentFixtures, SUMMARY_FIXTURE_LIMIT),
@@ -85,8 +92,66 @@ export function isValidLaLigaTeamId(teamId: string): boolean {
   return LA_LIGA_TEAM_ID_PATTERN.test(teamId) && teamId in laLigaSnapshot.teamSnapshots;
 }
 
-export async function getLaLigaSummarySnapshot(): Promise<LaLigaSummarySnapshot> {
-  return clampLaLigaSummarySnapshot(laLigaSnapshot);
+interface LaLigaSummaryOptions {
+  preferLive?: boolean;
+}
+
+// Request-time live refresh (football-data.org) is double-gated: the caller
+// must ask for it (`preferLive`) and FOOTBALL_DATA_API_TOKEN must be set in
+// the environment. The token is read per call, so an un-configured deploy
+// never fetches and keeps returning the committed snapshot unchanged. The
+// live path mirrors the bay-area-transit accessor: a 5-minute in-memory TTL
+// plus a single-flight guard, which bounds upstream traffic to roughly one
+// 3-request refresh per 5 minutes per instance, well inside the
+// football-data.org free tier of 10 requests per minute.
+const LIVE_SUMMARY_TTL_MS = 5 * 60 * 1000;
+let liveSummaryCache:
+  | { summary: LaLigaSummarySnapshot; expiresAt: number }
+  | null = null;
+let liveSummaryInflight: Promise<LaLigaSummarySnapshot> | null = null;
+
+export function resetLaLigaLiveSummaryCacheForTests(): void {
+  liveSummaryCache = null;
+  liveSummaryInflight = null;
+}
+
+function hasFootballDataToken(): boolean {
+  return Boolean(process.env.FOOTBALL_DATA_API_TOKEN?.trim());
+}
+
+async function getLaLigaSummarySource(
+  options: LaLigaSummaryOptions
+): Promise<LaLigaSummarySnapshot> {
+  if (!options.preferLive || !hasFootballDataToken()) {
+    return committedLaLigaSummarySnapshot();
+  }
+  if (liveSummaryCache && liveSummaryCache.expiresAt > Date.now()) {
+    return liveSummaryCache.summary;
+  }
+  if (liveSummaryInflight) return liveSummaryInflight;
+
+  liveSummaryInflight = buildLaLigaLiveSummary(committedLaLigaSummarySnapshot())
+    .then((summary) => {
+      liveSummaryCache = {
+        summary,
+        expiresAt: Date.now() + LIVE_SUMMARY_TTL_MS,
+      };
+      return summary;
+    })
+    // A failed refresh serves the committed snapshot and is NOT cached, so
+    // the next request retries the live path.
+    .catch(() => committedLaLigaSummarySnapshot())
+    .finally(() => {
+      liveSummaryInflight = null;
+    });
+
+  return liveSummaryInflight;
+}
+
+export async function getLaLigaSummarySnapshot(
+  options: LaLigaSummaryOptions = {}
+): Promise<LaLigaSummarySnapshot> {
+  return clampLaLigaSummarySnapshot(await getLaLigaSummarySource(options));
 }
 
 export async function getLaLigaTeamSnapshot(teamId: string): Promise<LaLigaTeamSnapshot> {

--- a/src/lib/premierLeagueData.ts
+++ b/src/lib/premierLeagueData.ts
@@ -666,6 +666,96 @@ export async function getPremierLeagueSummary(
   };
 }
 
+/**
+ * Request-time refresh used by the summary accessor when a football-data.org
+ * token is configured. Only the standings and the recent/upcoming fixture
+ * lists are refreshed (3 upstream requests); every other section keeps the
+ * committed snapshot's value. A section that fails, comes back empty, or
+ * reflects the rolled-over-but-unstarted season keeps the committed value.
+ * If no section refreshes, this throws so the caller falls back to the
+ * committed snapshot wholesale without caching the failure.
+ */
+export async function buildPremierLeagueLiveSummary(
+  baseSummary: PremierLeagueSummary
+): Promise<PremierLeagueSummary> {
+  const [standingsResult, recentResult, upcomingResult] = await Promise.allSettled([
+    fetchFootballDataJson<FootballDataCompetitionStandingsResponse>(
+      `/competitions/${PREMIER_LEAGUE_CODE}/standings`,
+      SUMMARY_REVALIDATE_SECONDS
+    ),
+    fetchFootballDataJson<FootballDataMatchesResponse>(
+      `/competitions/${PREMIER_LEAGUE_CODE}/matches?${buildQueryString({
+        status: "FINISHED",
+        limit: RECENT_FIXTURE_LIMIT,
+      })}`,
+      SUMMARY_REVALIDATE_SECONDS
+    ),
+    fetchFootballDataJson<FootballDataMatchesResponse>(
+      `/competitions/${PREMIER_LEAGUE_CODE}/matches?${buildQueryString({
+        status: "SCHEDULED",
+        limit: UPCOMING_FIXTURE_LIMIT,
+      })}`,
+      SUMMARY_REVALIDATE_SECONDS
+    ),
+  ]);
+
+  const summary: PremierLeagueSummary = { ...baseSummary };
+  let refreshedSections = 0;
+
+  if (standingsResult.status === "fulfilled") {
+    const standingsGroup =
+      standingsResult.value.standings?.find((group) => group?.type === "TOTAL") ??
+      standingsResult.value.standings?.[0] ??
+      null;
+    const standings = (standingsGroup?.table ?? [])
+      .map((row) => normalizeStandingRow(row))
+      .filter((row): row is PremierLeagueStandingRow => row !== null);
+
+    // A zeroed rolled-over table (season pointer advanced, no games played)
+    // would wipe the dashboard, so the committed table is kept instead.
+    if (standings.length > 0 && !seasonNotStarted(standingsResult.value.season, standings)) {
+      summary.standings = standings;
+      summary.competition = buildCompetitionMeta(standingsResult.value);
+      refreshedSections += 1;
+    }
+  }
+
+  if (recentResult.status === "fulfilled") {
+    const recentFixtures = (recentResult.value.matches ?? [])
+      .map((match) => normalizeFixture(match))
+      .filter((match): match is PremierLeagueFixture => match !== null)
+      .sort(sortFixturesDescending)
+      .slice(0, RECENT_FIXTURE_LIMIT);
+
+    if (recentFixtures.length > 0) {
+      summary.recentFixtures = recentFixtures;
+      refreshedSections += 1;
+    }
+  }
+
+  if (upcomingResult.status === "fulfilled") {
+    const upcomingFixtures = (upcomingResult.value.matches ?? [])
+      .map((match) => normalizeFixture(match))
+      .filter((match): match is PremierLeagueFixture => match !== null)
+      .sort(sortFixturesAscending)
+      .slice(0, UPCOMING_FIXTURE_LIMIT);
+
+    if (upcomingFixtures.length > 0) {
+      summary.upcomingFixtures = upcomingFixtures;
+      refreshedSections += 1;
+    }
+  }
+
+  if (refreshedSections === 0) {
+    throw createPremierLeagueDataError(
+      "Premier League live refresh produced no usable sections.",
+      503
+    );
+  }
+
+  return { ...summary, generatedAt: new Date().toISOString() };
+}
+
 export async function getPremierLeagueTeamSnapshot(
   teamId: string
 ): Promise<PremierLeagueTeamSnapshot> {

--- a/src/lib/premierLeagueSnapshot.ts
+++ b/src/lib/premierLeagueSnapshot.ts
@@ -1,4 +1,5 @@
 import { premierLeagueSnapshot } from "@/data/premierLeagueSnapshot";
+import { buildPremierLeagueLiveSummary } from "@/lib/premierLeagueData";
 import type {
   PremierLeagueSummary,
   PremierLeagueTeamSnapshot,
@@ -86,8 +87,66 @@ export function isValidPremierLeagueTeamId(teamId: string): boolean {
   return PL_TEAM_ID_PATTERN.test(teamId) && teamId in premierLeagueSnapshot.teamSnapshots;
 }
 
-export async function getPremierLeagueSummary(): Promise<PremierLeagueSummary> {
-  return clampPremierLeagueSummary(premierLeagueSnapshot.summary);
+interface PremierLeagueSummaryOptions {
+  preferLive?: boolean;
+}
+
+// Request-time live refresh (football-data.org) is double-gated: the caller
+// must ask for it (`preferLive`) and FOOTBALL_DATA_API_TOKEN must be set in
+// the environment. The token is read per call, so an un-configured deploy
+// never fetches and keeps returning the committed snapshot unchanged. The
+// live path mirrors the bay-area-transit accessor: a 5-minute in-memory TTL
+// plus a single-flight guard, which bounds upstream traffic to roughly one
+// 3-request refresh per 5 minutes per instance, well inside the
+// football-data.org free tier of 10 requests per minute.
+const LIVE_SUMMARY_TTL_MS = 5 * 60 * 1000;
+let liveSummaryCache:
+  | { summary: PremierLeagueSummary; expiresAt: number }
+  | null = null;
+let liveSummaryInflight: Promise<PremierLeagueSummary> | null = null;
+
+export function resetPremierLeagueLiveSummaryCacheForTests(): void {
+  liveSummaryCache = null;
+  liveSummaryInflight = null;
+}
+
+function hasFootballDataToken(): boolean {
+  return Boolean(process.env.FOOTBALL_DATA_API_TOKEN?.trim());
+}
+
+async function getPremierLeagueSummarySource(
+  options: PremierLeagueSummaryOptions
+): Promise<PremierLeagueSummary> {
+  if (!options.preferLive || !hasFootballDataToken()) {
+    return premierLeagueSnapshot.summary;
+  }
+  if (liveSummaryCache && liveSummaryCache.expiresAt > Date.now()) {
+    return liveSummaryCache.summary;
+  }
+  if (liveSummaryInflight) return liveSummaryInflight;
+
+  liveSummaryInflight = buildPremierLeagueLiveSummary(premierLeagueSnapshot.summary)
+    .then((summary) => {
+      liveSummaryCache = {
+        summary,
+        expiresAt: Date.now() + LIVE_SUMMARY_TTL_MS,
+      };
+      return summary;
+    })
+    // A failed refresh serves the committed snapshot and is NOT cached, so
+    // the next request retries the live path.
+    .catch(() => premierLeagueSnapshot.summary)
+    .finally(() => {
+      liveSummaryInflight = null;
+    });
+
+  return liveSummaryInflight;
+}
+
+export async function getPremierLeagueSummary(
+  options: PremierLeagueSummaryOptions = {}
+): Promise<PremierLeagueSummary> {
+  return clampPremierLeagueSummary(await getPremierLeagueSummarySource(options));
 }
 
 export async function getPremierLeagueTeamSnapshot(


### PR DESCRIPTION
## What

Adds an optional request-time refresh to the Premier League and La Liga summary APIs, gated on `FOOTBALL_DATA_API_TOKEN` being set in the runtime environment.

- New `buildPremierLeagueLiveSummary` / `buildLaLigaLiveSummary` in the existing `src/lib` data modules refresh standings and the recent/upcoming fixture lists (3 upstream requests per league) from api.football-data.org v4, reusing the exact transform logic the snapshot builders already use. A section that fails, comes back empty, or reflects the rolled-over-but-unstarted season keeps the committed value; if nothing refreshes, the whole call falls back to the committed snapshot.
- The accessor libs (`src/lib/premierLeagueSnapshot.ts`, `src/lib/laLigaSnapshot.ts`) gain a `preferLive` option that mirrors the bay-area-transit pattern: token read at call time, 5-minute in-memory TTL, single-flight guard, committed-snapshot fallback that is never negative-cached, plus a reset-for-tests export.
- The two summary routes pass `{ preferLive: true }`. Success cache headers, error `no-store` behavior, teams routes, pages, and the update workflows are untouched.
- Docs: token row and PL/La Liga rows in `docs/DATA_UPDATE_OPERATIONS.md`, the PL/La Liga rows in `SNAPSHOT_DRIVEN_DASHBOARDS.md`, and the `FOOTBALL_DATA_API_TOKEN` local-setup bullet in `AGENTS.md`.

## Why

The committed snapshots refresh on a scheduled cadence, so standings and fixtures can lag by hours during matchdays. With a token configured, the summary APIs now serve data at most about 5 minutes old while keeping the committed snapshots as a full fallback. With no token configured, behavior is byte-for-byte identical to today: zero fetches, committed snapshot only, so local dev, tests, and un-configured deploys are unaffected.

## Tests

- New accessor suites `src/lib/__tests__/premierLeagueSnapshot.test.ts` and `laLigaSnapshot.test.ts` cover: no token means committed snapshot and zero fetches (including whitespace-only token); token means live standings/fixtures merged over committed sections; single-flight plus 5-minute TTL (3 fetches per flight, cache hit inside the TTL, refetch after); total failure falls back wholesale without negative-caching; per-section failure and the zeroed rolled-over-standings placeholder keep the committed values.
- Route tests updated to assert the summary routes opt into `preferLive`.
- `npx jest src/lib/__tests__/footballSnapshot.test.ts src/lib/__tests__/premierLeagueSnapshot.test.ts src/lib/__tests__/laLigaSnapshot.test.ts src/lib/__tests__/premierLeagueData.test.ts src/lib/__tests__/laLigaData.test.ts src/app/api/premier-league src/app/api/la-liga src/app/la-liga --silent`: 11 suites, 60 tests, all green. `tsc --noEmit` and `eslint` on touched files: clean.

## Follow-up (human)

Set `FOOTBALL_DATA_API_TOKEN` in the Netlify environment to activate the live path. The 5-minute TTL plus single-flight bounds upstream traffic to roughly one 3-request refresh per league per 5 minutes per instance, well inside the free tier's 10 requests/minute. Free-tier football-data feeds stay delayed, so no UI copy was changed and nothing is framed as "live".