### PR TITLE
E2E: stop hardcoding draft-tracker top picks

### DIFF
--- a/e2e/fantasy-football.spec.ts
+++ b/e2e/fantasy-football.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
 async function getReadyFantasyShell(page: Page) {
@@ -265,11 +267,24 @@ test.describe("Fantasy football rankings", () => {
 
 test.describe("Fantasy football draft tracker", () => {
   test("loads the correct board for every scoring format", async ({ page }) => {
+    // The expected first pick is read from the same committed snapshot the
+    // board renders, not hardcoded — scheduled data refreshes reorder the
+    // rankings and a name literal goes stale within days.
     const scoringFormats = [
-      { label: "PPR", topPlayer: "Ja'Marr Chase" },
-      { label: "Half PPR", topPlayer: "Bijan Robinson" },
-      { label: "Standard", topPlayer: "Jahmyr Gibbs" },
-    ] as const;
+      { label: "PPR", file: "ppr" },
+      { label: "Half PPR", file: "half_ppr" },
+      { label: "Standard", file: "standard" },
+    ].map((scoring) => {
+      const snapshot = JSON.parse(
+        readFileSync(
+          path.join(process.cwd(), "public", "data", "fantasy", `${scoring.file}.json`),
+          "utf8"
+        )
+      ) as { overall: Array<{ name: string }> };
+      const topPlayer = snapshot.overall[0]?.name;
+      expect(topPlayer, `${scoring.label} snapshot has an overall board`).toBeTruthy();
+      return { label: scoring.label, topPlayer: topPlayer! };
+    });
 
     await page.goto("/fantasy-football/draft-tracker");
     await waitForDraftTrackerHydration(page);


### PR DESCRIPTION
## What

The draft-tracker E2E spec hardcoded the expected first pick per scoring format ("Ja'Marr Chase" / "Bijan Robinson" / "Jahmyr Gibbs"). Today's scheduled fantasy snapshot refresh moved the Standard board's top pick to Bijan Robinson, and shard 1 of the E2E matrix went red on every branch, including a docs-only merge to main.

The spec now reads the expected top player from the same committed snapshot the board renders (`public/data/fantasy/<format>.json`, `overall[0].name`), so scheduled data refreshes can't break it again. Same failure class and fix shape as the SpaceX E2E repair in PR #279.

## Not caused by the migration batch

Verified before fixing: the identical failure appears on main's own post-merge CI for PR #333 (docs-only), and the fantasy data refresh commit landed independently of the batch.

## Tests

The repaired test passes locally against the dev server with the current (drifted) data: 1 passed. It still asserts a real value — the snapshot must have a non-empty overall board, and the rendered first pick must match it.