### PR TITLE
Strengthen personal search entity signals

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -49,6 +49,7 @@ export default function AboutPage() {
                   "@type": "CollegeOrUniversity",
                   name: profile.education[0].name,
                   description: profile.education[0].description,
+                  url: profile.education[0].url,
                 },
               ],
               alumniOf: [profile.education[1]],

--- a/src/components/__tests__/StructuredData.test.tsx
+++ b/src/components/__tests__/StructuredData.test.tsx
@@ -71,6 +71,18 @@ describe("StructuredData", () => {
     expect(schema["@id"]).toBe(
       "https://isaacvazquez.com/about#person"
     );
+    expect(schema).toEqual(
+      expect.objectContaining({
+        name: "Isaac Vazquez",
+        givenName: "Isaac",
+        familyName: "Vazquez",
+        alternateName: ["@isaacvazquez", "IsaacAVazquez"],
+        image: "https://isaacvazquez.com/images/headshot-home.webp",
+      })
+    );
+    expect(schema.disambiguatingDescription).toContain(
+      "UC Berkeley Haas MBA candidate"
+    );
     expect(schema.worksFor).toEqual(
       expect.objectContaining({ name: "Haas@Work" })
     );
@@ -109,6 +121,7 @@ describe("StructuredData", () => {
         name: "Florida State University",
         description:
           "Bachelor of Arts - Political Science and International Affairs",
+        url: "https://www.fsu.edu/",
       },
     ]);
   });

--- a/src/lib/__tests__/ai-seo.test.ts
+++ b/src/lib/__tests__/ai-seo.test.ts
@@ -74,6 +74,35 @@ describe("AI SEO structured-data generators", () => {
       "https://isaacvazquez.com/about#person"
     );
     expect(schema.url).toBe("https://isaacvazquez.com/about");
+    expect(schema.givenName).toBe("Isaac");
+    expect(schema.familyName).toBe("Vazquez");
+    expect(schema.alternateName).toEqual([
+      "@isaacvazquez",
+      "IsaacAVazquez",
+    ]);
+  });
+
+  it("keeps education organizations free of role timing fields", () => {
+    const schema = generateEnhancedPersonSchema({
+      alumniOf: [
+        {
+          "@type": "CollegeOrUniversity",
+          name: "Florida State University",
+          startDate: "2014",
+          endDate: "2018",
+        },
+      ],
+    }) as Record<string, unknown>;
+
+    expect(schema.alumniOf).toEqual([
+      {
+        "@type": "CollegeOrUniversity",
+        name: "Florida State University",
+        description: undefined,
+      },
+    ]);
+    expect(JSON.stringify(schema)).not.toContain('"startDate"');
+    expect(JSON.stringify(schema)).not.toContain('"endDate"');
   });
 
   it("gives each breadcrumb trail a page-specific id", () => {

--- a/src/lib/ai-seo.ts
+++ b/src/lib/ai-seo.ts
@@ -14,6 +14,7 @@ import { buildPersonEntity, siteConfig } from "./seo";
 
 export interface PersonSchemaData {
   name?: string;
+  alternateName?: string | string[];
   jobTitle?: string;
   description?: string;
   url?: string;
@@ -206,7 +207,9 @@ export function generateEnhancedPersonSchema(data: PersonSchemaData) {
 
   if (data.name) {
     schema.name = data.name;
-    schema.alternateName = data.name;
+  }
+  if (data.alternateName) {
+    schema.alternateName = data.alternateName;
   }
   if (data.description) {
     schema.description = data.description;
@@ -270,8 +273,6 @@ export function generateEnhancedPersonSchema(data: PersonSchemaData) {
       description: edu.description,
       ...(edu.address && { address: edu.address }),
       ...(edu.url && { url: edu.url }),
-      ...(edu.startDate && { startDate: edu.startDate }),
-      ...(edu.endDate && { endDate: edu.endDate }),
     }));
   }
 

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,9 +1,14 @@
 export const profile = {
   name: "Isaac Vazquez",
+  givenName: "Isaac",
+  familyName: "Vazquez",
+  alternateNames: ["@isaacvazquez", "IsaacAVazquez"],
   shortTitle: "Product Manager",
   fullTitle: "Product Manager & UC Berkeley Haas MBA Candidate",
   description:
     "Product manager with a QA-to-product background and 6+ years across SaaS, analytics, and civic tech. Builds AI workflow, fintech, and decision-support products.",
+  disambiguatingDescription:
+    "Product manager and UC Berkeley Haas MBA candidate based in Berkeley, California, with six years across civic technology, QA, analytics, and SaaS.",
   shortDescription:
     "UC Berkeley Haas MBA candidate with a background in QA, analytics, and product work across SaaS, civic tech, and fintech-style tools.",
   location: {
@@ -56,6 +61,7 @@ export const profile = {
       "@type": "CollegeOrUniversity" as const,
       name: "UC Berkeley Haas School of Business",
       description: "MBA Candidate (Class of 2027)",
+      url: "https://haas.berkeley.edu/",
       degree: "Master of Business Administration",
       startDate: "2025-08",
       endDate: "2027-05",
@@ -64,6 +70,7 @@ export const profile = {
       "@type": "CollegeOrUniversity" as const,
       name: "Florida State University",
       description: "Bachelor of Arts - Political Science and International Affairs",
+      url: "https://www.fsu.edu/",
       degree: "Bachelor of Arts",
       endDate: "2018",
     },

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -351,10 +351,14 @@ export function buildPersonEntity(): Record<string, unknown> {
     "@type": "Person",
     "@id": personSchemaId,
     name: siteConfig.name,
+    givenName: profile.givenName,
+    familyName: profile.familyName,
+    alternateName: profile.alternateNames,
     jobTitle: profile.fullTitle,
     description: siteConfig.description,
+    disambiguatingDescription: profile.disambiguatingDescription,
     url: personCanonicalUrl,
-    image: absoluteUrl(siteConfig.ogImage),
+    image: absoluteUrl("/images/headshot-home.webp"),
     sameAs: profileSameAs,
     address: {
       "@type": "PostalAddress",
@@ -366,12 +370,14 @@ export function buildPersonEntity(): Record<string, unknown> {
       "@type": "CollegeOrUniversity",
       name: currentEducation.name,
       description: currentEducation.description,
+      url: currentEducation.url,
     },
     alumniOf: [
       {
         "@type": "CollegeOrUniversity",
         name: completedEducation.name,
         description: completedEducation.description,
+        url: completedEducation.url,
       },
     ],
     worksFor: {


### PR DESCRIPTION
## What changed

This tightens the canonical Person and ProfilePage schema around the searches that identify Isaac by name, role, school, and technical background.

The Person entity now separates the given and family names, connects the established public handles, uses the actual headshot, includes a plain disambiguation description, and links the Berkeley Haas and Florida State education entities to their official sites. The enhanced schema generator no longer repeats the full name as an alternate name or puts role timing fields on education organizations.

## Why

Live search results already connect the site with Isaac Vazquez, product management, Berkeley Haas, LinkedIn, Haas@Work, and the résumé, but the structured Person record had a few avoidable ambiguities. These changes make the entity easier to distinguish from other people with the same name while keeping the visible page copy unchanged.

## Validation

- Production build passed
- TypeScript passed
- ESLint passed
- 24 targeted schema tests passed
- Generated homepage and About-page JSON-LD inspected successfully
- Diff checks passed