### PR TITLE
Fix invalid ProfilePage dateModified datetime flagged by Search Console

### DIFF
--- a/src/lib/__tests__/ai-seo.test.ts
+++ b/src/lib/__tests__/ai-seo.test.ts
@@ -122,10 +122,19 @@ describe("AI SEO structured-data generators", () => {
       lastReviewed: "2026-05-01",
     }) as Record<string, unknown>;
 
-    expect(schema.dateModified).toBe("2026-05-01");
+    expect(schema.dateModified).toBe("2026-05-01T00:00:00Z");
     expect((schema.mainEntity as Record<string, unknown>)["@type"]).toBe(
       "Person"
     );
+  });
+
+  it("passes a full ISO datetime reviewed date through unchanged", () => {
+    const schema = generateProfilePageSchema({
+      person: { name: "Isaac Vazquez" },
+      lastReviewed: "2026-05-01T14:30:00-07:00",
+    }) as Record<string, unknown>;
+
+    expect(schema.dateModified).toBe("2026-05-01T14:30:00-07:00");
   });
 });
 

--- a/src/lib/ai-seo.ts
+++ b/src/lib/ai-seo.ts
@@ -640,6 +640,13 @@ export function generateBreadcrumbSchema(items: BreadcrumbItem[]) {
 /**
  * Generates ProfilePage schema for about/resume pages
  */
+
+// Google's ProfilePage rich result validates dateModified as a DateTime, so a
+// bare YYYY-MM-DD gets expanded to midnight UTC rather than passed through.
+function toProfileDateTime(value: string): string {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00Z` : value;
+}
+
 export function generateProfilePageSchema(data: {
   person: PersonSchemaData;
   url?: string;
@@ -655,7 +662,9 @@ export function generateProfilePageSchema(data: {
     description:
       data.description ||
       `Professional profile of ${data.person.name || siteConfig.name}`,
-    ...(data.lastReviewed && { dateModified: data.lastReviewed }),
+    ...(data.lastReviewed && {
+      dateModified: toProfileDateTime(data.lastReviewed),
+    }),
     mainEntity: generateEnhancedPersonSchema(data.person),
   };
 }


### PR DESCRIPTION
## Summary
Google Search Console flagged the site with a Profile page structured data issue, "Invalid datetime value for dateModified." The only page emitting ProfilePage schema is /about, and it serves `dateModified: "2026-07-16"`. That is a valid schema.org Date, but Google's ProfilePage rich result validates the field as a DateTime (ISO 8601 with a time component), so the bare date fails its check.

## Changes
- `generateProfilePageSchema` now expands a date-only `lastReviewed` (YYYY-MM-DD) to midnight UTC (`T00:00:00Z`) before emitting `dateModified`; full datetimes pass through unchanged.
- Updated the existing test to the new expected output and added a pass-through test for full ISO datetimes.

## Testing
- `npx jest src/lib/__tests__/ai-seo.test.ts src/lib/__tests__/seo-integrity.test.ts` (23 passed)
- `npx tsc --noEmit` clean