### PR TITLE
fix: keep best ball room open after undo and make snapshot reads fail soft

### DIFF
--- a/.github/workflows/update-fantasy.yml
+++ b/.github/workflows/update-fantasy.yml
@@ -107,7 +107,19 @@ jobs:
             const scheduleTeams = Object.keys(bestBall.week17Opponents || {}).length;
             const now = Date.now();
             const generatedAgeDays = (now - Date.parse(bestBall.generatedAt || '')) / 86400000;
-            const sourceAgeLimit = [6, 7, 8].includes(new Date().getUTCMonth()) ? 4 : 14;
+            // The builder fail-softs each source to the previous snapshot's asOf,
+            // so a single upstream outage must not fail the whole job. Warn at the
+            // tight in-season bound, and only fail once a source looks abandoned.
+            const inDraftSeason = [6, 7, 8].includes(new Date().getUTCMonth());
+            const sourceWarnLimit = inDraftSeason ? 4 : 14;
+            const sourceFailLimit = inDraftSeason ? 14 : 45;
+            const checkSourceAge = (label, ageDays) => {
+              if (!Number.isFinite(ageDays) || ageDays > sourceFailLimit) {
+                failures.push('best-ball ' + label + ' source is older than ' + sourceFailLimit + ' days');
+              } else if (ageDays > sourceWarnLimit) {
+                console.log('::warning::best-ball ' + label + ' source is ' + ageDays.toFixed(1) + ' days old (warn above ' + sourceWarnLimit + ', fail above ' + sourceFailLimit + ')');
+              }
+            };
             const rankingAgeDays = (now - Date.parse(bestBall.rankingSource?.asOf || '')) / 86400000;
             const adpAgeDays = (now - Date.parse(bestBall.adpSource?.asOf || '')) / 86400000;
             const superflexAgeDays = (now - Date.parse(bestBall.superflexSource?.asOf || '')) / 86400000;
@@ -118,9 +130,9 @@ jobs:
             if (adpMatches < 150) failures.push('best-ball has ' + adpMatches + ' ADP matches (need >= 150)');
             if (scheduleTeams < 30) failures.push('best-ball has ' + scheduleTeams + ' Week 17 team mappings (need >= 30)');
             if (!Number.isFinite(generatedAgeDays) || generatedAgeDays > 10) failures.push('best-ball snapshot is older than 10 days');
-            if (!Number.isFinite(rankingAgeDays) || rankingAgeDays > sourceAgeLimit) failures.push('best-ball rankings source is older than ' + sourceAgeLimit + ' days');
-            if (!Number.isFinite(adpAgeDays) || adpAgeDays > sourceAgeLimit) failures.push('best-ball ADP source is older than ' + sourceAgeLimit + ' days');
-            if (!Number.isFinite(superflexAgeDays) || superflexAgeDays > sourceAgeLimit) failures.push('best-ball Superflex source is older than ' + sourceAgeLimit + ' days');
+            checkSourceAge('rankings', rankingAgeDays);
+            checkSourceAge('ADP', adpAgeDays);
+            checkSourceAge('Superflex', superflexAgeDays);
             if (!String(bestBall.scheduleSource?.url || '').includes('dates=' + bestBall.season)) failures.push('best-ball Week 17 schedule does not match snapshot season');
           } catch (err) {
             failures.push('best-ball failed to parse: ' + err.message);

--- a/scripts/buildFantasySnapshots.ts
+++ b/scripts/buildFantasySnapshots.ts
@@ -60,8 +60,9 @@ export async function buildFantasySnapshots(
   };
 
   // Finish every build and serialization before creating directories or staging
-  // files. A failure in any format therefore leaves the complete published set
-  // and its shared revision untouched.
+  // files, so a failure in any format leaves the published set and its shared
+  // revision untouched. This covers the build and serialization phase only —
+  // see the rename loop below for what the publish phase actually guarantees.
   const serializedSnapshots = SCORING_FORMATS.map((scoring) => ({
     scoring,
     contents: `${JSON.stringify(buildSnapshot(scoring), null, 2)}\n`,
@@ -92,8 +93,12 @@ export async function buildFantasySnapshots(
       await writeFile(output.tempPath, output.contents, "utf8");
     }
 
-    // The revision is the publication marker consumed by clients and deploy
-    // checks, so it moves only after all three scoring files are in place.
+    // These renames are sequential, so a failure partway through can leave one
+    // scoring file new and the others stale. There is no cross-file atomic
+    // rename, so the revision marker is the guard instead: it moves only after
+    // all three succeed, and consumers key on it, so a partial set is never
+    // announced as published. The catch below removes leftover temp files; it
+    // cannot un-rename, and it does not need to.
     for (const output of snapshotOutputs) {
       await rename(output.tempPath, output.targetPath);
     }

--- a/src/app/fantasy-football/best-ball/draft-tracker/draft-tracker-client.tsx
+++ b/src/app/fantasy-football/best-ball/draft-tracker/draft-tracker-client.tsx
@@ -373,7 +373,10 @@ function BestBallDraftRoom({
     ]
   );
 
-  const showSetup = draft.state.picks.length === 0 && !roomStarted;
+  // `restoredWithPicks` keeps a reloaded room open after the user undoes back
+  // to zero picks, instead of dropping them onto the slot picker.
+  const showSetup =
+    draft.state.picks.length === 0 && !roomStarted && !draft.restoredWithPicks;
 
   if (!draft.isLoaded) {
     return (

--- a/src/app/fantasy-football/best-ball/draft-tracker/use-best-ball-draft.ts
+++ b/src/app/fantasy-football/best-ball/draft-tracker/use-best-ball-draft.ts
@@ -31,6 +31,10 @@ export function useBestBallDraft({
     createBestBallDraftState(season, rules, initialSlot)
   );
   const [loadedKey, setLoadedKey] = useState<string | null>(null);
+  // A restored draft puts the user in the room without them clicking through
+  // setup. The room must stay open even if they then undo back to zero picks,
+  // otherwise undoing the last pick ejects them to the slot picker.
+  const [restoredWithPicks, setRestoredWithPicks] = useState(false);
   const [persistenceError, setPersistenceError] = useState<string | null>(null);
   const [restoreNotice, setRestoreNotice] = useState<string | null>(null);
 
@@ -60,6 +64,7 @@ export function useBestBallDraft({
     }
     // The key identifies a different contest-specific room and should replace the prior room in memory.
     setState(nextState);
+    setRestoredWithPicks(nextState.picks.length > 0);
     setLoadedKey(storageKey);
   }, [initialSlot, rules, season, storageKey]);
 
@@ -111,6 +116,7 @@ export function useBestBallDraft({
   return {
     state,
     isLoaded: loadedKey === storageKey,
+    restoredWithPicks,
     persistenceError,
     restoreNotice,
     currentPick,

--- a/src/hooks/useFantasySnapshot.ts
+++ b/src/hooks/useFantasySnapshot.ts
@@ -49,7 +49,9 @@ function cacheNormalizedFantasySnapshot(
   scoring: FantasyRouteScoring,
   snapshot: FantasySnapshot | unknown
 ): FantasySnapshot {
-  const normalizedSnapshot = normalizeFantasySnapshot(snapshot, scoring);
+  const normalizedSnapshot = normalizeFantasySnapshot(snapshot, scoring, {
+    lenient: true,
+  });
   snapshotCache.set(getFantasySnapshotCacheKey(scoring), normalizedSnapshot);
   return normalizedSnapshot;
 }
@@ -126,6 +128,10 @@ async function loadFantasySnapshot(scoring: FantasyRouteScoring): Promise<Fantas
   // a missing snapshot file during a botched deploy — fall back to the API
   // route, which reads the same files server-side and so should agree on shape.
   // Only surface a user-visible error when both paths fail.
+  // The API fallback is worth attempting even when normalization fails: the
+  // static file may be a stale copy of a different scoring format while the
+  // API returns the correct one. Row-level defects no longer reach here at
+  // all, since the normalizer runs lenient and drops those rows instead.
   const request = fetchStaticFantasySnapshot(scoring)
     .then((rawSnapshot) => cacheNormalizedFantasySnapshot(scoring, rawSnapshot))
     .catch(async (staticError) => {

--- a/src/lib/__tests__/fantasy.test.ts
+++ b/src/lib/__tests__/fantasy.test.ts
@@ -144,6 +144,21 @@ describe("fantasy snapshot normalization", () => {
     expect(() => normalizeFantasySnapshot(wrongSlice, "ppr")).toThrow(/RB.*position WR/i);
   });
 
+  it("drops only the unusable rows in lenient mode instead of blanking the board", () => {
+    const snapshot = buildRuntimeSnapshot();
+    snapshot.overall = [
+      { ...VALID_RUNTIME_PLAYER, id: "keep-1", name: "Keeper One" },
+      { ...VALID_RUNTIME_PLAYER, id: "drop-1", name: "Bad Rank", averageRank: 0 },
+      { ...VALID_RUNTIME_PLAYER, id: "keep-2", name: "Keeper Two" },
+    ];
+
+    // Strict is the default and still refuses the whole snapshot.
+    expect(() => normalizeFantasySnapshot(snapshot, "ppr")).toThrow(/averageRank/i);
+
+    const lenient = normalizeFantasySnapshot(snapshot, "ppr", { lenient: true });
+    expect(lenient.overall.map((player) => player.id)).toEqual(["keep-1", "keep-2"]);
+  });
+
   it("allows actual RB, WR, and TE positions in the FLEX slice", () => {
     const snapshot = buildRuntimeSnapshot();
     snapshot.positions = {

--- a/src/lib/bestBallSource.ts
+++ b/src/lib/bestBallSource.ts
@@ -120,6 +120,13 @@ export function parseBestBallAdpPayload(
   const entries: FantasyAdpEntry[] = [];
   const timestamps: Array<string | null> = [];
 
+  // The request pins ranker, week, and season but not format, so the expected
+  // format is an assumption about the provider's default. Skip an off-contract
+  // row the same way an unusable one is skipped rather than aborting the whole
+  // refresh over it; if nothing matches, the contract really did change and the
+  // empty-result check below fails loudly.
+  let offContractRows = 0;
+
   for (const raw of payload as RawBestBallAdpPlayer[]) {
     if (
       finiteNumber(raw?.season) !== expected.season ||
@@ -127,9 +134,8 @@ export function parseBestBallAdpPayload(
       raw?.format !== expected.format ||
       raw?.rankerSlug !== expected.ranker
     ) {
-      throw new Error(
-        "Best ball ADP source returned a row outside the requested season, week, format, or ranker."
-      );
+      offContractRows += 1;
+      continue;
     }
 
     const name = typeof raw?.player?.name === "string" ? raw.player.name.trim() : "";
@@ -151,7 +157,11 @@ export function parseBestBallAdpPayload(
   }
 
   if (entries.length === 0) {
-    throw new Error("Best ball ADP source returned no usable players.");
+    throw new Error(
+      offContractRows > 0
+        ? `Best ball ADP source returned ${offContractRows} row(s), all outside the requested season, week, format, or ranker.`
+        : "Best ball ADP source returned no usable players."
+    );
   }
 
   return {

--- a/src/lib/fantasy.ts
+++ b/src/lib/fantasy.ts
@@ -1,4 +1,5 @@
 import { Player, Position, ScoringFormat } from "@/types";
+import { logger } from "@/lib/logger";
 
 export const FANTASY_ROUTE_POSITIONS = [
   "overall",
@@ -404,67 +405,86 @@ export function publishFantasyPlayer(player: Player): Player {
   return publishedPlayer as Player;
 }
 
+/**
+ * Strict mode throws on the first unusable row, which is what the builder and
+ * the snapshot tests want, since bad data should never get published. Lenient
+ * mode drops the row and keeps the rest, which is what the running site wants,
+ * since one malformed player must not blank a whole scoring format's board.
+ */
 function toPlayerArray(
   raw: unknown,
-  slice: FantasySnapshotPosition | "OVERALL"
+  slice: FantasySnapshotPosition | "OVERALL",
+  lenient: boolean,
+  dropped: string[]
 ): Player[] {
   if (!Array.isArray(raw)) {
     return [];
   }
 
   const seenPlayerIds = new Set<string>();
-  return raw.map((rawPlayer, index) => {
+  const players: Player[] = [];
+
+  const reject = (message: string): void => {
+    if (!lenient) throw new Error(message);
+    dropped.push(message);
+  };
+
+  for (const [index, rawPlayer] of raw.entries()) {
     if (!rawPlayer || typeof rawPlayer !== "object" || Array.isArray(rawPlayer)) {
-      throw new Error(`Fantasy snapshot ${slice} player ${index + 1} is not an object.`);
+      reject(`Fantasy snapshot ${slice} player ${index + 1} is not an object.`);
+      continue;
     }
 
     const player = rawPlayer as Record<string, unknown>;
-    for (const field of ["id", "name", "team"] as const) {
-      if (typeof player[field] !== "string" || player[field].trim().length === 0) {
-        throw new Error(
-          `Fantasy snapshot ${slice} player ${index + 1} has an invalid ${field}.`
-        );
-      }
+    const badField = (["id", "name", "team"] as const).find(
+      (field) => typeof player[field] !== "string" || player[field].trim().length === 0
+    );
+    if (badField) {
+      reject(`Fantasy snapshot ${slice} player ${index + 1} has an invalid ${badField}.`);
+      continue;
     }
 
     const position = player.position;
     if (!FANTASY_ACTUAL_POSITIONS.includes(position as FantasyActualPosition)) {
-      throw new Error(
-        `Fantasy snapshot ${slice} player ${String(player.id)} has an invalid position.`
-      );
+      reject(`Fantasy snapshot ${slice} player ${String(player.id)} has an invalid position.`);
+      continue;
     }
     if (
       (slice === "FLEX" &&
         !FANTASY_FLEX_POSITIONS.includes(position as (typeof FANTASY_FLEX_POSITIONS)[number])) ||
       (slice !== "OVERALL" && slice !== "FLEX" && position !== slice)
     ) {
-      throw new Error(
+      reject(
         `Fantasy snapshot ${slice} player ${String(player.id)} has position ${String(position)}.`
       );
+      continue;
     }
 
     if (!isFiniteNumber(player.averageRank) || player.averageRank <= 0) {
-      throw new Error(
-        `Fantasy snapshot ${slice} player ${String(player.id)} has an invalid averageRank.`
-      );
+      reject(`Fantasy snapshot ${slice} player ${String(player.id)} has an invalid averageRank.`);
+      continue;
     }
     if (
       player.standardDeviation !== undefined &&
       (!isFiniteNumber(player.standardDeviation) || player.standardDeviation < 0)
     ) {
-      throw new Error(
+      reject(
         `Fantasy snapshot ${slice} player ${String(player.id)} has an invalid standardDeviation.`
       );
+      continue;
     }
 
     const playerId = player.id as string;
     if (seenPlayerIds.has(playerId)) {
-      throw new Error(`Fantasy snapshot ${slice} contains duplicate player id ${playerId}.`);
+      reject(`Fantasy snapshot ${slice} contains duplicate player id ${playerId}.`);
+      continue;
     }
     seenPlayerIds.add(playerId);
 
-    return publishFantasyPlayer(player as unknown as Player);
-  });
+    players.push(publishFantasyPlayer(player as unknown as Player));
+  }
+
+  return players;
 }
 
 function getFantasySliceSupport(
@@ -610,10 +630,19 @@ function normalizeRawSliceMetadata(
   };
 }
 
+/**
+ * `lenient` drops unusable player rows instead of throwing. Runtime readers
+ * pass it so a single bad row degrades one player rather than the whole board;
+ * the builder and the snapshot tests leave it off so bad data fails loudly
+ * before it is ever published.
+ */
 export function normalizeFantasySnapshot(
   rawSnapshot: unknown,
-  scoring: FantasyRouteScoring
+  scoring: FantasyRouteScoring,
+  options: { lenient?: boolean } = {}
 ): FantasySnapshot {
+  const lenient = options.lenient === true;
+  const dropped: string[] = [];
   const input =
     rawSnapshot && typeof rawSnapshot === "object"
       ? (rawSnapshot as RawFantasySnapshot)
@@ -628,16 +657,23 @@ export function normalizeFantasySnapshot(
       ? (input.sliceMetadata as Partial<Record<FantasyRoutePosition, RawFantasySnapshotSliceMetadata>>)
       : {};
 
-  const overallPlayers = toPlayerArray(input.overall, "OVERALL");
+  const overallPlayers = toPlayerArray(input.overall, "OVERALL", lenient, dropped);
   const positions: Record<FantasySnapshotPosition, Player[]> = {
-    QB: toPlayerArray(rawPositions.QB, "QB"),
-    RB: toPlayerArray(rawPositions.RB, "RB"),
-    WR: toPlayerArray(rawPositions.WR, "WR"),
-    TE: toPlayerArray(rawPositions.TE, "TE"),
-    FLEX: toPlayerArray(rawPositions.FLEX, "FLEX"),
-    K: toPlayerArray(rawPositions.K, "K"),
-    DST: toPlayerArray(rawPositions.DST, "DST"),
+    QB: toPlayerArray(rawPositions.QB, "QB", lenient, dropped),
+    RB: toPlayerArray(rawPositions.RB, "RB", lenient, dropped),
+    WR: toPlayerArray(rawPositions.WR, "WR", lenient, dropped),
+    TE: toPlayerArray(rawPositions.TE, "TE", lenient, dropped),
+    FLEX: toPlayerArray(rawPositions.FLEX, "FLEX", lenient, dropped),
+    K: toPlayerArray(rawPositions.K, "K", lenient, dropped),
+    DST: toPlayerArray(rawPositions.DST, "DST", lenient, dropped),
   };
+
+  if (dropped.length > 0) {
+    logger.warn(
+      `Fantasy snapshot ${scoring} dropped ${dropped.length} unusable player row(s)`,
+      dropped.slice(0, 10)
+    );
+  }
 
   const publishedPlayerCount =
     overallPlayers.length +

--- a/src/lib/fantasySnapshotServer.ts
+++ b/src/lib/fantasySnapshotServer.ts
@@ -26,7 +26,11 @@ export async function loadFantasySnapshot(scoring: FantasyRouteScoring): Promise
 
   const snapshotPath = getFantasySnapshotPath(scoring);
   const fileContents = await readFile(snapshotPath, "utf8");
-  const data = normalizeFantasySnapshot(JSON.parse(fileContents), scoring);
+  // Lenient at runtime: a bad row should cost one player, not the whole board.
+  // The builder and the snapshot tests validate strictly before publishing.
+  const data = normalizeFantasySnapshot(JSON.parse(fileContents), scoring, {
+    lenient: true,
+  });
   snapshotCache.set(scoring, { data, expiresAt: Date.now() + SNAPSHOT_TTL_MS });
   return data;
 }


### PR DESCRIPTION
Fixes the failing E2E test that landed with #387, plus four of the five open review findings.

## The undo bug

`persists a BBM room and persists an undo after reload` was failing for a reason the assertion hid. The text was not wrong — it was gone.

A restored draft opens the room without anyone clicking through setup, so `roomStarted` stayed `false` after a reload. `showSetup` is `picks.length === 0 && !roomStarted`, so undoing the last pick flipped the whole room back to the slot picker and the counter stopped existing. Hence "element(s) not found" rather than a wrong number.

The restore path now reports `restoredWithPicks`, and the room stays open. Latching it inside `useBestBallDraft` rather than in a client effect keeps `react-hooks/set-state-in-effect` clean.

## Review findings

**Fail-soft snapshot reads.** `normalizeFantasySnapshot` takes `{ lenient }`. The server accessor and client hook pass it, so an unusable row is dropped and logged rather than blanking a scoring format's board — restoring the fail-soft convention in `CLAUDE.md`. The builder and snapshot tests keep the strict default, so the ~6 existing `.toThrow()` assertions still hold and bad data still fails before publishing. New test covers the lenient path.

**ADP contract rows.** `parseBestBallAdpPayload` skips an off-contract row like every other unusable row instead of aborting. The request pins ranker/week/season but never `format`, so the expected format is an assumption about the provider's default; one stray row should not cost the refresh. It still throws when no row qualifies.

**CI staleness.** Source age warns at the tight in-season bound and fails only at 14/45 days. The builder fail-softs each source to the previous `asOf`, so a single upstream outage no longer fails the scheduled job and opens an issue.

**Publish atomicity.** Comments in `buildFantasySnapshots.ts` now state the guarantee that actually holds. There is no cross-file atomic rename; the revision marker moving last is what keeps a partial set unpublished.

## Deliberately not changed

The fifth finding claimed the API fallback is pointless when static normalization fails, because the API reads the same files through the same normalizer. A test disproves it — `falls back to a valid API snapshot when the static snapshot fails normalization` covers a stale static file carrying the wrong `scoringFormat` while the API returns the correct payload. I implemented the change, the test caught it, and I reverted. Lenient mode removes the row-level case the finding was really about.

## Verification

`tsc --noEmit` clean, `eslint src` clean (0 errors, 0 warnings), **278 suites / 1918 tests**, **20/20 fantasy E2E** including the previously failing one, `npm run build` exit 0.