### PR TITLE
Add nine articles covering late July and August 2026

### DIFF
--- a/content/blog/2026-dutch-grand-prix-antonelli-zandvoort.mdx
+++ b/content/blog/2026-dutch-grand-prix-antonelli-zandvoort.mdx
@@ -1,0 +1,34 @@
+---
+title: "Antonelli Won Zandvoort's Farewell and Put the Title Race Back Where It Was"
+excerpt: "Kimi Antonelli came out of the summer break and won the last Dutch Grand Prix on Zandvoort's calendar, with Max Verstappen second in front of his own crowd. Russell's clean July bought him a month of hope, and one clean Antonelli weekend took most of it back."
+publishedAt: "2026-08-23"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "Dutch Grand Prix", "Zandvoort", "Kimi Antonelli", "Max Verstappen", "George Russell", "2026 F1 Season"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The driver and constructor standings, the next Grand Prix, and the race-by-race season are in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Antonelli Wins the 2026 Dutch Grand Prix"
+  description: "Kimi Antonelli won the final Dutch Grand Prix at Zandvoort ahead of Max Verstappen, stretching his championship lead over George Russell back out to 53 points."
+  keywords: ["2026 Dutch Grand Prix", "Antonelli Zandvoort win", "Verstappen home podium", "last Dutch Grand Prix Zandvoort", "2026 F1 standings", "Antonelli Russell title race"]
+---
+
+# Antonelli Won Zandvoort's Farewell and Put the Title Race Back Where It Was
+
+The summer break was supposed to be the pause that let George Russell believe again, and it lasted until about the second stint on Sunday. Kimi Antonelli won the Dutch Grand Prix from second on the grid, taking the lead with an overcut at the first stops and controlling the rest, while Max Verstappen qualified on pole for his home race and finished second in front of a crowd that treated the podium like a win. [Formula 1's official classification](https://www.formula1.com/en/results/2026/races/1292/netherlands/race-result) reads Antonelli, Verstappen, Russell, and the churn underneath it is that Antonelli's championship lead is back out to 53 points, slightly larger than it was before [Russell's win in Hungary](/writing/2026-hungarian-grand-prix-russell-clean-weekend) cut into it.
+
+This was also the last Dutch Grand Prix at Zandvoort for the foreseeable future, with the race falling off the calendar after this season, and the weekend carried that occasion in a way that shaped the race itself. The whole event was built around Verstappen, and for about forty laps he made the fairy tale look live. He held the lead from pole, managed the first stint well, and lost the race in the pit window rather than on track, when Mercedes left Antonelli out four laps longer and the tire delta at this track did the rest. Red Bull's afternoon was strategically fine and simply short of pace, which has been the truthful summary of their season, and Verstappen sending the banked final corner flat on the last lap to hold second by three tenths was the kind of goodbye the circuit deserved.
+
+For the championship, the arithmetic is straightforward and a little cruel. Antonelli moves to 247 with his seventh win of the season. Russell's podium takes him to 194, still second, with Lewis Hamilton fourth on the day and third in the standings on 183. What that means is that Russell's response since Spa, two weekends in which he won once, stood on the podium twice, and did close to nothing wrong, is worth a net of minus three points against Antonelli. When your best sustained stretch of driving loses ground to the man you are chasing, the problem is not the driving.
+
+The problem, as it has been all year, is that Antonelli at full function is the fastest thing in the sport right now, and the only force that has reliably interrupted that is his own car. That is why I would resist the conclusion that 53 points with the run-in ahead is decisive. The reliability failures that created this title race in the first place, in Barcelona, at Silverstone, in Canada, did not announce themselves in advance, and one of them landing on Antonelli in September resets the mathematics in an afternoon. Russell's job description has not changed since July. Win the weekends nothing breaks, and be close enough to collect when something does.
+
+Ferrari left Zandvoort with the quieter story, and it is starting to look like the story of their season. Hamilton and Charles Leclerc finished fourth and fifth, solid and anonymous, and the team that won two races in the early summer has now gone five weekends without seriously threatening one. Hamilton remains close enough to Russell that second in the championship is a live contest, which matters for pride and prize money, but the title conversation has narrowed back to the two Mercedes drivers and the one question that follows them everywhere.
+
+The pattern I would pull out of Zandvoort is that the break changed nothing about the season's structure. Antonelli is faster, Russell is close enough to punish failures, and the championship is a bet on which happens more often in the remaining rounds, clean weekends or broken ones. I built [Formula 1 Pulse](/formula-1) to keep that ledger as the season runs toward its end, and after this weekend the ledger says what it has said since spring, only with fewer races left to argue about it.

--- a/content/blog/2026-hungarian-grand-prix-russell-clean-weekend.mdx
+++ b/content/blog/2026-hungarian-grand-prix-russell-clean-weekend.mdx
@@ -1,0 +1,34 @@
+---
+title: "Russell Won in Hungary Because Nothing Broke, and He Needed Exactly That"
+excerpt: "George Russell took pole, led every stint that mattered, and beat Kimi Antonelli in a straight fight at the Hungaroring. One clean weekend cut the gap to 43 and moved him back ahead of Hamilton, which tells you how much of this title race has been decided by reliability."
+publishedAt: "2026-07-26"
+category: "Formula 1"
+tags: ["Formula 1", "Motorsport", "Hungarian Grand Prix", "George Russell", "Kimi Antonelli", "Lewis Hamilton", "Mercedes", "2026 F1 Season"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Formula 1 Pulse"
+  description: "The driver and constructor standings, the next Grand Prix, and the race-by-race season are in one place."
+  href: "/formula-1"
+  actionLabel: "Open the dashboard"
+seo:
+  title: "Russell Wins the 2026 Hungarian Grand Prix"
+  description: "George Russell won the 2026 Hungarian Grand Prix from pole, beating Kimi Antonelli in a straight fight to cut the championship lead to 43 points before the summer break."
+  keywords: ["2026 Hungarian Grand Prix", "Russell Hungaroring win", "Russell Antonelli championship", "Mercedes 1-2 Hungary", "2026 F1 standings", "F1 summer break 2026"]
+---
+
+# Russell Won in Hungary Because Nothing Broke, and He Needed Exactly That
+
+A week after leaving Spa in the gravel with nothing, George Russell did the only thing that keeps his championship alive. He took pole at the Hungaroring, controlled both stints, and beat Kimi Antonelli to the flag by a little over four seconds in a race where, for once, neither Mercedes had a problem. [Formula 1's official classification](https://www.formula1.com/en/results/2026/races/1291/hungary/race-result) reads Russell, Antonelli, Leclerc, and it is the first time since Austria that the order at the front was settled by pace and track position instead of by something failing.
+
+The win matters for the obvious arithmetic reason. Russell moves to 179 points, back past Lewis Hamilton into second, and the gap to Antonelli is 43 instead of the 50 it became [when Hamilton spun him out of the Belgian Grand Prix on the opening lap](/writing/2026-belgian-grand-prix-antonelli-title-lead). Antonelli's second place still moves him forward to 222, so the weekend cost him seven points rather than the twenty-five a Russell win over a broken Mercedes would have, and I think that framing is the one both drivers will privately use. Hungary stopped the bleeding without reversing anything.
+
+It also matters for a less obvious reason, which is what it says about Russell when the machinery cooperates. The list of races Russell has lost to the car this season is now long enough to be its own argument, from the battery failure while leading in Canada to the first-lap contact at Spa that he did nothing to cause. His two previous wins, in Australia and Austria, both came with an asterisk of circumstance attached in some people's minds. Hungary had no asterisk. Antonelli was quick all afternoon, got within two seconds after the second stops, and Russell answered every push without ever looking like the tires would give out first. On a track where passing is close to impossible, the pole lap on Saturday was the race, and Russell produced it under as much pressure as a qualifying session can hold.
+
+Ferrari's afternoon was quieter and probably more worrying for them than the result sheet shows. Leclerc's podium came from running third the whole way, never close enough to the Mercedes pair to interfere, and Hamilton finished fourth after starting sixth on a circuit that offered him nowhere to go. Hamilton slips to third in the standings on 171, eight behind Russell, and the pattern from [Silverstone](/writing/2026-british-grand-prix-leclerc-silverstone) and Spa has not really changed. Ferrari are close enough to collect podiums and capitalize when Mercedes stumble, and not close enough to take points off them on merit at a track that rewards raw downforce.
+
+What I find most interesting heading into the summer break is how clean the championship question has become. Antonelli leads by 43 with six wins' worth of evidence, five of them taken on merit and one inherited in Canada, that he has been the fastest driver this year. Russell has now won three times and has a car-failure ledger that explains most of the deficit. If Mercedes give both drivers a reliable second half, the gap is probably big enough and Antonelli is probably quick enough. If the failures keep coming and they land on the wrong side of the garage, 43 points is four bad Sundays, and Russell just showed what he does with a weekend where nothing breaks.
+
+The pattern I would pull out of Hungary is that this title race has two separate contests running inside it, one between the drivers and one between Mercedes and its own car, and the second one keeps deciding the first. Russell won the driver contest this weekend and it earned him seven points of ground, which is the truest measure of how large Antonelli's cushion actually is. The season goes quiet for a month now, and I built [Formula 1 Pulse](/formula-1) to hold the standings and the run-in schedule while everyone argues about what the break will change.

--- a/content/blog/building-a-best-ball-draft-room.mdx
+++ b/content/blog/building-a-best-ball-draft-room.mdx
@@ -1,0 +1,34 @@
+---
+title: "Best Ball Is a Different Game, So I Built It a Different Board"
+excerpt: "Best ball looks like redraft with the lineup decisions removed, and building tools for both taught me that resemblance is a trap. The draft is the entire season, Week 17 is the only week that pays, and a board that imports redraft logic will lose politely all summer."
+publishedAt: "2026-08-19"
+category: "Fantasy Football Analytics"
+tags: ["Best Ball", "Fantasy Football", "Underdog", "Draft Strategy", "ADP", "Week 17", "Fantasy Football 2026"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Open the Best Ball Room"
+  description: "The contest-aware best ball board, with Underdog ADP, bye coverage, and Week 17 opponents built into the draft view."
+  href: "/fantasy-football/best-ball"
+  actionLabel: "Open the board"
+seo:
+  title: "Building a Best Ball Draft Board"
+  description: "Why best ball needed its own snapshot, its own draft board, and contest presets with published economics instead of borrowed redraft logic and invented payout math."
+  keywords: ["best ball draft board", "best ball strategy 2026", "Underdog ADP", "Week 17 correlation best ball", "Best Ball Mania strategy", "best ball vs redraft"]
+---
+
+# Best Ball Is a Different Game, So I Built It a Different Board
+
+The tool is live at [the best ball room](/fantasy-football/best-ball) if you want to look before reading.
+
+After I built the [redraft rankings platform](/writing/building-a-fantasy-football-rankings-platform), best ball looked like a small extension. Same players, same scoring families, just no waivers and no lineup setting, so surely the same board with a toggle. I started building it that way, and the further I got the clearer it became that the resemblance is where the mistakes come from. Best ball is a format where the draft is the entire season. Every mistake you would normally fix on the waiver wire in October is instead permanent in August, your roster fills lineups by itself with your best scores each week, and in the big tournaments the season funnels into Week 17, where only the advancing teams are playing for the real money. A board that treats any of that as a footnote is a redraft board wearing a costume.
+
+So best ball got its own snapshot rather than a view over the redraft one, and the differences in what it carries are the argument for the split. It ships consensus rankings alongside Underdog ADP rather than a home-league market, because tournament price discovery happens in that lobby and nowhere else. It carries bye weeks as a first-class field, because in best ball a bye is a guaranteed zero you drafted on purpose, and stacking three receivers on the same bye quietly spends one of your season's weeks before kickoff. And it carries each team's Week 17 opponent, which no redraft tool bothers with, because playoff-week correlation, meaning drafting the quarterback and the opposing receiver who will be in the same building for the week that decides the tournament, is a real edge in large fields and simply is not legible from a generic schedule.
+
+The design decision I ended up most attached to is the contest presets. A best ball pick does not have a value in the abstract, and the same roster construction can be right in a tournament and wrong in a small sit-and-go, so the board makes you pick the contest first, and the contest fixes the scoring, the field shape, and the roster strategy the recommendations reason over. For Best Ball Mania, the preset's economics come from the published contest structure, since entry fees, field size, and advancement rates are all public inputs I can cite. For the formats where the lobby is variable and the economics are not published, the tool deliberately carries no payout math at all, because inventing a plausible-looking prize structure would be [the same sin I built the trade calculator to avoid](/writing/building-a-fantasy-trade-calculator), meaning false precision dressed as helpfulness. A preset either states published numbers or states that it has none.
+
+The same restraint applies to the Draft Outlook grade the board shares with the redraft tracker. It reads market price, roster shape, format fit, and bye coverage, and it tells you how your draft process compares to the room. What it does not do is estimate your fantasy points, your odds of advancing, or your payout, and it says so on the surface rather than in a footnote, because the gap between a process grade and a win-probability claim is exactly the gap where fantasy tools usually oversell themselves.
+
+What building the second board taught me is a lesson that generalizes past fantasy football. Two products can share ninety percent of their data and still deserve separate models, because the sharing that matters is in the decisions, and the decisions in best ball, from tolerating zeros, to buying correlation for one specific week, to pricing a roster against a published tournament structure, barely overlap with redraft at all. I keep the two rooms' state and logic separate in the codebase for that reason, and every time a shared abstraction has tempted me, writing down what the two games actually ask the user to decide has talked me out of it.

--- a/content/blog/building-a-draft-companion-that-cannot-click.mdx
+++ b/content/blog/building-a-draft-companion-that-cannot-click.mdx
@@ -1,0 +1,30 @@
+---
+title: "The Draft Companion I Built Cannot Touch the Draft Room, and That Is the Feature"
+excerpt: "I built a private browser side panel that keeps my draft board next to an ESPN or Underdog draft room. It records picks only when I type them, because the version that watches the room for me fails a legal test, a terms-of-service test, and an engineering test all at once."
+publishedAt: "2026-08-30"
+category: "Software Development"
+tags: ["Browser Extension", "Chrome Extension", "Fantasy Football", "Side Projects", "Web Scraping", "Engineering Judgment", "Product Decisions"]
+featured: false
+archiveBucket: "Space & Experiments"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Open the Fantasy Football Hub"
+  description: "The public rankings, tiers, and draft tools the companion panel reads from are all on the site."
+  href: "/fantasy-football"
+  actionLabel: "Open the hub"
+seo:
+  title: "A Draft Companion With No Room Access"
+  description: "Why my fantasy draft side panel records picks manually instead of scraping the draft room, and how its snapshot fallback chain keeps it honest when sources go stale."
+  keywords: ["fantasy draft companion", "chrome side panel extension", "draft assistant extension", "web scraping terms of service", "browser extension design", "fantasy draft tools"]
+---
+
+# The Draft Companion I Built Cannot Touch the Draft Room, and That Is the Feature
+
+The most recent tool in the fantasy stack is the one I cannot link you to, because it is a private Chrome and Edge extension rather than a page on this site. It is a side panel that sits next to an ESPN or Underdog draft room and keeps my draft board, tiers, roster targets, and Draft Outlook visible while the draft happens, sharing its logic with [the public rankings platform](/writing/building-a-fantasy-football-rankings-platform) so the two surfaces never disagree about a player. You record each pick in the panel by hand as it happens, and I want to write about that one design choice, because everyone who has seen the panel asks the same question. Why doesn't it just read the picks off the page?
+
+It could, mechanically. A content script watching the draft room's DOM could sync every pick with no typing, and for about a day that version was on my list. I killed it for three reasons that stack, and the stack is the point. The first is that neither provider offers a supported public interface for live draft data, and their terms restrict automated monitoring of their pages. A hobby project does not get an exemption from that because it is small or because syncing picks feels harmless, and I was not interested in building my drafting convenience on a violation. The second reason is engineering, and my QA years do the arguing here. A scraper of someone else's draft room markup is a dependency on the one thing the provider is free to change without notice, at the worst possible time, meaning draft night. The failure mode is a panel that never crashes, silently misses a pick, and then confidently recommends a player who is already rostered, and a tool that is wrong with confidence is worse than no tool. The third reason is what the permission would cost. A content script means asking for access to read the provider's pages, and every permission an extension holds is something its user has to trust and its author has to defend. The manual-entry version needs no access to any page, and I can say flatly that the panel reads nothing, clicks nothing, and submits nothing outside its own frame.
+
+So the sync is my thumb, which costs me a few seconds per pick and buys a tool whose failure modes I can enumerate. The panel treats that honesty budget the same way everywhere else. It loads rankings from the published site snapshot first, falls back to the last validated copy it saved, and falls back again to the copy bundled with the extension build, and it labels which one you are looking at, with separate dates for the ranking and market sources. When a source is stale or missing, the features that depend on it pause and say so, rather than backfilling a zero or a neutral guess, which is the same refusal discipline the [trade calculator](/writing/building-a-fantasy-trade-calculator) applies on the site. Draft state stays in local extension storage, with no account, no analytics, and no cloud sync, because a tool for one person's draft night has no business phoning anywhere.
+
+What I would generalize from this build is that the best feature decisions I have made lately are subtractive, and they get easier when you write down the failure story instead of the demo story. Auto-sync demos beautifully, and its failure story involves a terms violation, a silent data corruption, and a permission grab, all purchased to save me thirty seconds a round. Manual entry demos worse and fails boringly. I have started applying that test at work as much as in side projects, and the products I trust most, including the ones I build, are the ones where somebody visibly chose the boring failure.

--- a/content/blog/building-a-fantasy-trade-calculator.mdx
+++ b/content/blog/building-a-fantasy-trade-calculator.mdx
@@ -1,0 +1,40 @@
+---
+title: "Building a Trade Calculator That Refuses to Guess"
+excerpt: "Most fantasy trade calculators will grade any trade you type in, which is exactly the problem. Mine issues a verdict only when the data underneath it is current and reliable, and the refusal logic took longer to build than the math."
+publishedAt: "2026-08-04"
+category: "Fantasy Football Analytics"
+tags: ["Fantasy Football", "Trade Calculator", "Draft Strategy", "ADP", "Rankings", "Data Products", "Fantasy Football 2026"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Open the Trade Calculator"
+  description: "Build both sides of a preseason redraft trade and see the value ranges, the coverage grade, and the verdict when one is warranted."
+  href: "/fantasy-football/trade-calculator"
+  actionLabel: "Open the calculator"
+seo:
+  title: "Building a Fantasy Trade Calculator"
+  description: "How I built a preseason fantasy football trade calculator on replacement-relative value, blended expert consensus and ADP, and verdict logic that refuses to guess."
+  keywords: ["fantasy football trade calculator", "fantasy trade analyzer", "replacement value fantasy", "ADP trade value", "fantasy football trade evaluation", "redraft trade calculator"]
+---
+
+# Building a Trade Calculator That Refuses to Guess
+
+If you want to try the tool before reading how it works, open the [trade calculator](/fantasy-football/trade-calculator).
+
+Every August, someone in my league proposes a two-for-one about ten minutes after the draft ends, and every August the negotiation turns into dueling screenshots from trade calculators that disagree with each other. I have watched those tools long enough to notice the pattern in why they disagree. Most of them will grade absolutely anything. Type in a kicker for a first-round running back and you get a confident number. Ask in March, when the player pool the numbers were built on no longer exists, and you get a confident number. The confidence never varies, and that is the tell that the number is not measuring what it claims to measure. So when I built my own, the goal was less about a smarter valuation formula and more about a tool that knows the difference between a question it can answer and a question it cannot.
+
+## Value has to be relative to replacement, not to rank
+
+The valuation itself starts from an idea I have written about before in the context of [positional value in drafts](/writing/rb-vs-wr-draft-strategy-modeling-positional-value), which is that a player's worth in a lineup league is what he gives you above the player you could have had for free. A top-five receiver and a top-five tight end can sit near each other on an overall board and be worth very different amounts, because the drop from the fifth tight end to the replacement level at that position is a different size than the drop at receiver. So the calculator converts each side of the trade into replacement-relative value for your league's exact settings, using a starter cutoff and a depth cutoff that move with the team count, roster size, and lineup you set. The curve above the cutoff is logarithmic, because the gap between the second-ranked player and the tenth is much larger in practice than the gap between the fortieth and the forty-eighth, and a linear scale flatters mediocre players in exactly the trades where that flattery gets people fleeced.
+
+The input is two sources rather than one. Expert consensus rankings carry most of the weight, at 75 percent, because they incorporate news and judgment. Mock-draft ADP carries the rest, because it is the only reading of what the market actually believes with something at stake, and the blend shifts further toward consensus whenever the ADP sample looks thin or stale. Each side of the trade then comes out as a range instead of a point estimate, because pretending the fourteenth-ranked receiver has a value knowable to three digits is the kind of precision that makes a tool feel authoritative while making it less honest.
+
+## The verdict logic is the actual product
+
+Here is the part I care about most. The calculator only calls a trade lopsided when three things are true at once. The relative gap between the sides has to clear 15 percent, the coverage grade has to say every player involved has a reliable current-market reading, and the two value ranges cannot overlap. A gap of 5 percent or less reads as balanced no matter what, because that is well inside the noise of the inputs. Everything between those lines gets described as a lean rather than a verdict, and when the expert board is stale or a selected player has no dependable market data, the tool says so and declines to rule at all.
+
+That refusal logic took longer to design than the valuation math, and I think it is the more important half of the product. My QA background is probably showing here, because the failure mode I was designing against is the one I have seen in every domain from test dashboards to [investment research](/writing/building-an-investment-research-platform), where a tool that always produces an answer trains its users to stop asking whether the answer means anything. A trade calculator gets used in arguments. The whole reason someone opens it mid-negotiation is to borrow its authority, and a tool with borrowed authority has an obligation to know its own limits. Mine is a preseason, one-QB redraft estimator built on rankings and draft-market data. It does not know about your league's trade politics, it has no in-season projection engine, and it has no idea what a player is worth in dynasty or superflex formats, so it declines to comment on any of that rather than extrapolating.
+
+The last set of decisions was about state, and they follow the same principle of matching persistence to how the tool is used. The players you have selected persist in your browser, keyed to the season and scoring format, so a stale trade from last August cannot quietly reload into a new season's context. The league settings live in the URL instead, so when the negotiation moves to the group chat you can send the exact configured comparison rather than a screenshot. The result is a calculator that answers fewer questions than the ones it competes with, and I would argue that is precisely why its answers are worth something.

--- a/content/blog/building-a-rent-vs-buy-calculator.mdx
+++ b/content/blog/building-a-rent-vs-buy-calculator.mdx
@@ -1,0 +1,36 @@
+---
+title: "The Rent vs Buy Question Deserves a Calculator That Doesn't Pick a Side"
+excerpt: "Most rent versus buy calculators quietly favor buying by letting the down payment vanish from the renter's side of the ledger. I built one that hands the renter the same up-front cash and invests whichever side's monthly savings actually exist."
+publishedAt: "2026-08-07"
+category: "Fintech Product"
+tags: ["Fintech", "Rent vs Buy", "Personal Finance", "Housing", "Financial Modeling", "Calculators"]
+featured: false
+cluster: "Fintech Product & Pricing"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Open the Rent vs Buy Calculator"
+  description: "Compare buying and renting with the renter credited for the buyer's up-front cash and every assumption out in the open."
+  href: "/fintech-tools/rent-vs-buy"
+  actionLabel: "Open the calculator"
+seo:
+  title: "Building a Rent vs Buy Calculator"
+  description: "How I built a rent versus buy calculator that seeds the renter with the buyer's up-front cash, invests the monthly difference symmetrically, and dates its tax assumptions."
+  keywords: ["rent vs buy calculator", "rent versus buy analysis", "opportunity cost down payment", "buy or rent decision", "housing calculator", "rent vs buy math"]
+---
+
+# The Rent vs Buy Question Deserves a Calculator That Doesn't Pick a Side
+
+If you want the tool first, it lives at [rent vs buy](/fintech-tools/rent-vs-buy) under the fintech tools.
+
+The rent versus buy debate is one of those arguments where both camps have a spreadsheet and both spreadsheets are rigged, usually without their authors realizing it. The pro-buying version treats the down payment as if it costs nothing, so a couple hundred thousand dollars leaves the buyer's pocket and simply stops existing as money that could have been doing something else. The pro-renting version invests the down payment at an aggressive return and then forgets that rents rise while a fixed mortgage payment does not. I wanted a calculator I could defend to someone on either side of the argument, which meant the design constraint was symmetry rather than any particular answer.
+
+The symmetry starts with the up-front cash. In my model, whatever the buyer spends to get into the house, meaning the down payment and closing costs, gets credited to the renter as an investment portfolio on day one. That single choice changes more outcomes than any other assumption in the tool, and it is the one most calculators fudge. The renter in this comparison is a renter with the buyer's money, because that is the actual alternative a real person faces. Nobody is choosing between buying a house and setting the down payment on fire.
+
+The second symmetry is monthly. Each month, the model compares the full cost of owning, from the mortgage payment, to taxes, to insurance, to maintenance, against the full cost of renting, and invests the difference on whichever side spent less that month. Early on that is usually the renter, because rent starts below the all-in cost of a mortgage plus upkeep. Late in the comparison it often flips, because rent has been growing every year while the principal and interest payment has not moved. A calculator that only invests the renter's savings has decided the answer before you type anything, and the flip is exactly the dynamic the whole question turns on, so the model has to run it in both directions.
+
+Everything runs in nominal dollars, which was a deliberate choice I went back and forth on. Real, inflation-adjusted dollars are cleaner in theory, but nobody experiences their rent or their mortgage in real dollars, and a comparison expressed in the same units as your bank statement is one you can actually check against your life. The cost of that choice is that the growth assumptions have to carry inflation inside them, and the tool says so plainly instead of hiding it.
+
+The tax layer is where I applied a lesson from the dated capital-market assumptions in the [retirement planner](/writing/building-an-investment-research-platform), which is that any constant you hardcode about the tax code is a fact about a particular year, not a fact about the world. The SALT cap, the standard deduction, and the capital gains exclusion on a home sale all live in one defaults file with their vintage attached, because the mortgage interest deduction is worth far less than folk wisdom says whenever the standard deduction is high, and that arithmetic changes every time Congress does. Dating the assumptions does not make them permanently right. It makes them checkable, and it tells a future me exactly what to update instead of letting the tool drift quietly out of truth.
+
+What the calculator refuses to do is tell you what to do. The output is a year-by-year comparison of net worth under both paths with every assumption editable and disclosed, and a breakeven reading that shifts as you change them, and it stays educational rather than advisory on purpose. Anyone who moves the rent growth and investment return sliders a little will notice how quickly the winner flips, and I think that sensitivity is the most honest output a rent versus buy tool can produce. The decision usually gets made on the parts a model cannot hold anyway, from how long you will actually stay, to how much you value not asking a landlord's permission. What the math can do is price the financial side of the choice fairly, and fairness in this comparison turned out to be a specific engineering property, meaning the same cash, the same monthly discipline, and the same scrutiny applied to both sides of the ledger.

--- a/content/blog/building-a-score-pools-engine.mdx
+++ b/content/blog/building-a-score-pools-engine.mdx
@@ -1,0 +1,34 @@
+---
+title: "Building a Score Pool Engine That Shows Its Own Compromises"
+excerpt: "Predicting exact soccer scorelines is a losing game, but score pools don't ask you to be right. They ask you to maximize expected points under your pool's rules, and that is a problem you can actually engineer, as long as the engine admits where its calibration bends."
+publishedAt: "2026-08-11"
+category: "Sports Analytics"
+tags: ["Score Pools", "Soccer", "Football", "Prediction Models", "Dixon-Coles", "Expected Points", "Sports Analytics"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Open Score Pools"
+  description: "The scoreline distributions, the expected-points picks, and the pool leaderboard live in one tool."
+  href: "/score-pools"
+  actionLabel: "Open the tool"
+seo:
+  title: "Building a Score Pool Prediction Engine"
+  description: "How I built an exact-score pool engine on de-vigged odds, a market-calibrated Dixon-Coles model, and an expected-points optimizer that plays the pool rather than the match."
+  keywords: ["score pool predictions", "exact score prediction model", "Dixon-Coles model", "de-vig betting odds", "expected points optimizer", "soccer prediction engine"]
+---
+
+# Building a Score Pool Engine That Shows Its Own Compromises
+
+The tool this article describes lives at [score pools](/score-pools).
+
+I joined a score pool, the kind where everyone predicts exact scorelines each matchweek and collects points on a sliding scale for exact hits, correct results, and near misses. About two matchweeks in, I realized I was playing it wrong in a specific, fixable way. I was trying to predict matches, and the pool was not actually asking me to predict matches. It was asking me to maximize points under a particular scoring rule against a particular field, and those are different problems. Predicting a 2-1 might feel right, but if the scoring rule pays almost as much for the correct result and 2-1 is what everyone else picks, the pick's expected value depends on math nobody at the table is doing. That gap between the question people think they are answering and the question the game is actually asking felt like something worth building against.
+
+The engine starts from betting odds rather than from my own model of team strength, and I want to be straightforward about why. The market's prices embed more information than anything I could fit from historical results on my own time budget. But raw odds overstate every probability because the bookmaker's margin is baked in, so the first stage strips the vig to recover a probability distribution over home win, draw, and away win that actually sums to one. Skipping that step quietly inflates every downstream number, and it is the kind of error that never announces itself because the outputs still look plausible.
+
+Match odds only give you three outcomes, and a score pool needs a probability for every plausible scoreline, so the second stage expands those three numbers into a full scoreline distribution using a Dixon-Coles model. The standard version of Dixon-Coles is fitted to years of historical goals. Mine is calibrated to the market instead, meaning it searches for the attack and defense rates that reproduce the de-vigged win, draw, and loss probabilities for this specific match, then reads scoreline probabilities off that surface with the model's low-score corrections intact. What that means is the model inherits the market's opinion of the teams and only adds structure about how goals distribute, which is the part markets do not directly price. One wrinkle that cost me a rewrite is that pools score some matches on the ninety-minute result and others on the final result after extra time, and those are different distributions, so the engine carries the scoring basis through explicitly instead of assuming.
+
+The third stage is the one that plays the pool instead of the match. Given the scoreline distribution and the pool's exact scoring rule, it computes the expected points of every candidate prediction and surfaces the ones that maximize it. The answers are often unintuitive in exactly the way that convinced me the tool was worth building. A 1-1 or 2-1 prediction frequently beats the scoreline the model thinks is most likely, because those picks sit near the center of probability mass and collect partial credit from many neighbors. On top of that sits a leaderboard layer that knows the standings, because the right pick when you are protecting a lead is more conservative than the right pick when you need variance to catch someone, and late in a pool that context changes the recommendation more than the match odds do.
+
+The part of the build I would defend hardest is the diagnostics surface, which exists because every stage above involves a compromise and I did not want the tool to launder them. Calibration does not always converge cleanly, odds arrive at different times and go stale at different rates, and some inputs are hand-entered when a feed is missing. All of that shows up on the page, from as-of stamps on the odds, to labels separating sampled data from manual entries, to a residual reading of how far the calibrated model landed from the market it was aimed at. My instinct from years of QA work is that the difference between a model you can trust and a model you cannot is rarely the math, since the math is usually fine. It is whether the tool tells you when its own inputs have degraded, and a prediction engine that admits its compromises out loud is the only kind I want my name on.

--- a/content/blog/dashboards-that-read-committed-files.mdx
+++ b/content/blog/dashboards-that-read-committed-files.mdx
@@ -1,0 +1,32 @@
+---
+title: "Every Dashboard on This Site Reads a File Committed to Git, On Purpose"
+excerpt: "Fifteen-plus dashboards here share one architecture. A script fetches data on a schedule, commits a snapshot to the repository, and the pages read that file with no external calls at request time. The pattern looks primitive and removes most of the failure modes I have spent a career watching."
+publishedAt: "2026-08-15"
+category: "Software Architecture"
+tags: ["Software Architecture", "Next.js", "Data Engineering", "Reliability", "Snapshot Driven", "Dashboards", "GitHub Actions"]
+featured: false
+cluster: "Systems & Quality"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "See the pattern live"
+  title: "Browse the dashboards"
+  description: "Every data surface on the site, from sports to space to markets, runs on the committed-snapshot pattern this article describes."
+  href: "/dashboards"
+  actionLabel: "Open the index"
+seo:
+  title: "Dashboards Built on Committed Snapshots"
+  description: "Why every dashboard on this site reads a committed snapshot instead of calling an API at request time, and what that architecture buys in reliability, cost, and auditability."
+  keywords: ["snapshot driven architecture", "committed data snapshots", "dashboard architecture", "static data Next.js", "fail-soft data pipeline", "GitHub Actions data refresh"]
+---
+
+# Every Dashboard on This Site Reads a File Committed to Git, On Purpose
+
+This site has somewhere north of fifteen data dashboards, covering Formula 1, four football codes, earthquakes, launches, polling, and markets, and every one of them works the same way. A script runs on a schedule, fetches from whatever upstream source the dashboard needs, validates what came back, and commits the result to the repository as a snapshot file. The pages and API routes read that committed file and nothing else. At the moment you load the [Premier League dashboard](/writing/building-a-premier-league-dashboard) or any of [the Pulse family](/writing/building-the-pulse-dashboard-family), the site makes zero external calls on your behalf.
+
+When I describe this to engineers, the first reaction is usually that it sounds primitive, and I want to take that reaction seriously because it is half right. The fashionable architecture for a page like this is a live fetch with a caching layer, and I built things that way for years. The snapshot pattern is what I landed on after watching where dashboards actually die, and they almost never die in the rendering. They die at the integration boundary, at three in the morning, when an upstream API changes a field name, starts rate limiting, has an outage, or invalidates a key. A live-fetching page inherits every one of those failures at request time, in front of a user, and a caching layer softens the blow without changing who is standing in the blast radius. Moving the fetch to a scheduled builder moves the failure to the only place it can be handled calmly, which is a build log I read with coffee rather than a page a visitor is looking at.
+
+The property doing the most work is what I call fail-soft refresh. When a scheduled fetch fails or comes back empty, the builder keeps the previous snapshot instead of overwriting it, so the worst case for any upstream disaster is a dashboard that is a few hours stale and says so. Stale and labeled is a much better failure than down, and it is a failure mode users barely notice. I spent enough years in QA and on-call rotations to have strong feelings about this, because the pattern I kept seeing at work, at Civitech and everywhere since, is that data surfaces earn trust slowly and lose it in one blank page. A dashboard that renders something honest under every upstream condition is more trustworthy than a fresher one that sometimes renders an error, and the snapshot architecture makes the honest behavior the default rather than something each page has to remember to implement.
+
+There are two quieter benefits I did not fully anticipate. The first is that git becomes the audit log. Every data refresh is a commit with a diff, so when a number on a page looks wrong I can see exactly what changed, when it changed, and what it was before, and I can revert a bad refresh the same way I revert bad code. Debugging a data pipeline with `git log` sounds like a joke until the first time a source silently rewrites history and the diff catches it. The second is cost and abuse resistance. The site's traffic can spike to any level and the upstream sources see the same handful of scheduled requests per day, which means no rate-limit anxiety, no API keys in any request path, and no bill that scales with readers.
+
+The honest accounting is that the pattern has real limits and I run into them regularly. Snapshots make the repository heavier, staleness is a permanent condition rather than an incident, and nothing here works for data that must be personalized or truly live, which is why the tools that hold your own state, like the draft tracker, keep it in your browser instead. The pattern fits data that changes on the cadence of hours and is the same for every visitor, and I would not stretch it past that. But within that fit, I think the trade is lopsided. I gave up freshness measured in minutes and got back predictable pages, calm failure handling, an audit trail, and a hosting bill that rounds to zero, and for a site one person maintains in the margins of everything else, that is the difference between dashboards that exist and dashboards that used to work.

--- a/content/blog/how-i-run-a-draft-with-my-own-tools.mdx
+++ b/content/blog/how-i-run-a-draft-with-my-own-tools.mdx
@@ -1,0 +1,34 @@
+---
+title: "How I Actually Run a Draft Night With the Tools I Built"
+excerpt: "I built a rankings platform, a draft tracker, and a trade calculator, and draft week is the audit of whether any of it earns its place. Here is what I actually have open on the clock, what each screen is for, and the parts of drafting where I ignore my own tools on purpose."
+publishedAt: "2026-08-26"
+category: "Fantasy Football Analytics"
+tags: ["Fantasy Football", "Draft Strategy", "Draft Day", "Tiers", "ADP", "Draft Tracker", "Fantasy Football 2026"]
+featured: false
+archiveBucket: "Sports & Fantasy"
+author: "Isaac Vazquez"
+cta:
+  eyebrow: "Related tool"
+  title: "Open the Draft Tracker"
+  description: "Record picks live and watch reaches, steals, position runs, and roster coverage update as the draft happens."
+  href: "/fantasy-football/draft-tracker"
+  actionLabel: "Open the tracker"
+seo:
+  title: "Running a Draft Night With My Own Tools"
+  description: "What I actually keep open during a fantasy draft, from tier boards to live reach and steal tracking, and where I deliberately ignore my own tools on the clock."
+  keywords: ["fantasy football draft day", "draft tracker", "fantasy draft tiers", "ADP draft strategy", "fantasy football tools", "draft night process 2026"]
+---
+
+# How I Actually Run a Draft Night With the Tools I Built
+
+My main league drafts over Labor Day weekend, which means this is the week the tools on this site stop being a portfolio and start being equipment. I wrote in June about [which offseason preparation compounds and which expires](/writing/june-fantasy-football-prep-2026), and the June argument was that early work should build the machine rather than memorize answers. Draft week is when the machine runs, so I want to write down what I actually have open on the clock, because the honest version is more selective than "I use my own tools" and the places where I ignore them are as deliberate as the places where I lean on them.
+
+The screen that matters most before the draft is the tier board, and the reason is a lesson that took me embarrassingly long to internalize. Ranks create fake precision, because the difference between the eighteenth and twenty-second receiver is noise, and drafting off a flat ranked list makes you pay real draft capital to resolve distinctions the data cannot support. Tiers encode the only question that matters on the clock, which is whether the drop-off to the next name at this position is large or small. Nearly every good pick I have made in the last few years reduces to taking the last player in a tier or refusing to reach into a new one early, and [the positional math I wrote up around RB and WR value](/writing/rb-vs-wr-draft-strategy-modeling-positional-value) is what sets those tier breaks in the first place.
+
+Alongside the board I keep ADP visible, with a caveat that shaped how the platform handles it. ADP tells you what the room will let you get away with, meaning whether the player you want will still be there on the way back, and that makes it a timing tool rather than a valuation tool. But ADP is only worth reading when the matching is trustworthy, so the site matches players to market data by exact, tiered identity rather than fuzzy name matching, and when a reliable ADP source is not available it hides the ADP column entirely instead of showing something almost right. A wrong ADP is worse than none, because you will confidently wait a round on a player the actual market prices two rounds higher.
+
+During the draft itself, the tracker records every pick, and the readouts I actually look at between turns are the reaches, the steals, and the position runs. Reach and steal readings, each pick priced against the market baseline, tell me which managers are paying premiums and which positions the room is discounting, and that is information about the next two rounds, not a scoreboard. Run detection matters because runs are the one draft event where reacting fast is worth it, and the difference between noticing a tight end run on the second pick and the seventh is the difference between choosing from a tier and cleaning up after one. The roster coverage view mostly serves as a restraint, reminding me that the bench spot I want to spend on a sixth receiver still has a lineup hole behind it.
+
+Just as important is what I do not consult. The Draft Outlook grade, the room-level composite the tracker shares with the best ball board, is something I read after the draft and deliberately not during it, because a live process grade on your own draft is an invitation to draft for the grade. It measures market price and roster shape against the room, it says nothing about season outcomes, and treating it as a scoreboard on the clock would recreate exactly the false-authority problem [I built the trade calculator to refuse](/writing/building-a-fantasy-trade-calculator). The same discipline applies to any number the tools produce in a spot where my own read of the news disagrees. The snapshot knows the consensus as of its build date, and I know that the beat reporter buried a usage note this morning, so the human wins ties on freshness and the tool wins ties on arithmetic.
+
+The pattern I would pull out of a few seasons of drafting this way is that the tools earn their place by narrowing decisions rather than making them. The tier board decides what is close, ADP decides what can wait, the tracker decides what the room is doing, and the last step, the actual pick, stays a judgment call made by a person who has watched the games. Draft night is also the yearly audit of the tools themselves, because nothing exposes a data product's pretensions faster than needing it under a ninety-second clock with your own roster on the line, and the features that have survived that audit are the modest ones.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -258,4 +258,13 @@
 <url><loc>https://isaacvazquez.com/fantasy-football/mock-draft</loc><lastmod>2026-08-31T21:45:38.570Z</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacvazquez.com/fantasy-football/weekly</loc><lastmod>2026-08-31T21:45:38.570Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 <url><loc>https://isaacvazquez.com/agent-build-index</loc><lastmod>2026-08-31T15:29:08.559Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacvazquez.com/writing/2026-dutch-grand-prix-antonelli-zandvoort</loc><lastmod>2026-08-23T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacvazquez.com/writing/2026-hungarian-grand-prix-russell-clean-weekend</loc><lastmod>2026-07-26T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacvazquez.com/writing/building-a-best-ball-draft-room</loc><lastmod>2026-08-19T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacvazquez.com/writing/building-a-draft-companion-that-cannot-click</loc><lastmod>2026-08-30T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacvazquez.com/writing/building-a-fantasy-trade-calculator</loc><lastmod>2026-08-04T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacvazquez.com/writing/building-a-rent-vs-buy-calculator</loc><lastmod>2026-08-07T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacvazquez.com/writing/building-a-score-pools-engine</loc><lastmod>2026-08-11T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacvazquez.com/writing/dashboards-that-read-committed-files</loc><lastmod>2026-08-15T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+<url><loc>https://isaacvazquez.com/writing/how-i-run-a-draft-with-my-own-tools</loc><lastmod>2026-08-26T00:00:00.000Z</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 </urlset>

--- a/scripts/data/articleCoverImages.ts
+++ b/scripts/data/articleCoverImages.ts
@@ -318,4 +318,15 @@ export const ARTICLE_COVER_IMAGES: ArticleCoverImageSpec[] = [
   // Fintech Product & Pricing
   { slug: "2026-investing-setup-rates-and-risk", strategy: "editorial-card", reason: ABSTRACT_FINTECH },
   { slug: "tariff-volatility-boring-portfolio", strategy: "editorial-card", reason: ABSTRACT_FINTECH },
+
+  // August 2026 batch
+  { slug: "2026-hungarian-grand-prix-russell-clean-weekend", strategy: "wikimedia", query: "Formula 1 Hungarian Grand Prix Hungaroring", alt: "Formula 1 cars racing at the Hungaroring" },
+  { slug: "2026-dutch-grand-prix-antonelli-zandvoort", strategy: "wikimedia", query: "Formula 1 Dutch Grand Prix Zandvoort", alt: "Formula 1 cars racing at Zandvoort" },
+  { slug: "building-a-fantasy-trade-calculator", strategy: "wikimedia", query: "American football NFL game action", alt: "American football players during a game" },
+  { slug: "building-a-best-ball-draft-room", strategy: "wikimedia", query: "American football NFL stadium game", alt: "An American football game in a stadium" },
+  { slug: "how-i-run-a-draft-with-my-own-tools", strategy: "wikimedia", query: "American football NFL quarterback", alt: "An American football player during a game" },
+  { slug: "building-a-score-pools-engine", strategy: "wikimedia", query: "soccer football match stadium goal", alt: "A soccer match in a stadium" },
+  { slug: "building-a-rent-vs-buy-calculator", strategy: "editorial-card", reason: ABSTRACT_FINTECH },
+  { slug: "dashboards-that-read-committed-files", strategy: "editorial-card", reason: ABSTRACT_PRODUCT },
+  { slug: "building-a-draft-companion-that-cannot-click", strategy: "editorial-card", reason: ABSTRACT_PRODUCT },
 ];


### PR DESCRIPTION
## What this adds

Nine new posts under `content/blog/`, dated July 26 through August 30, 2026, filling the publishing gap after the July 30 automation-assistant piece:

**F1 season series** (continues the standings from the Belgian GP recap: Antonelli 204, Hamilton 159, Russell 154)
- `2026-hungarian-grand-prix-russell-clean-weekend` (Jul 26) — Russell wins, gap cut to 43
- `2026-dutch-grand-prix-antonelli-zandvoort` (Aug 23) — Antonelli's seventh win at Zandvoort's final race, gap back to 53

**Build articles for tools that never had one** (each grounded in the actual engine's documented behavior)
- `building-a-fantasy-trade-calculator` (Aug 4) — the 75/25 consensus/ADP blend and the verdict-refusal logic
- `building-a-rent-vs-buy-calculator` (Aug 7) — symmetric up-front cash and monthly-difference investing
- `building-a-score-pools-engine` (Aug 11) — de-vig, market-calibrated Dixon-Coles, EP optimizer, diagnostics
- `building-a-best-ball-draft-room` (Aug 19) — separate snapshot, contest presets, no invented economics
- `building-a-draft-companion-that-cannot-click` (Aug 30) — why provider pick sync stays disabled

**Essays**
- `dashboards-that-read-committed-files` (Aug 15) — the committed-snapshot architecture, Systems & Quality cluster
- `how-i-run-a-draft-with-my-own-tools` (Aug 26) — draft-week process piece

## Housekeeping

- Every new slug has a cover plan entry in `scripts/data/articleCoverImages.ts` (wikimedia queries for the sports pieces, editorial cards for the abstract ones). The photo fetch is egress-blocked in the agent sandbox, so `npm run update:article-images` needs to run in CI or locally per `docs/ARTICLE_IMAGE_WORKFLOW.md`.
- Taxonomy follows the one-cluster-or-one-bucket rule; voice follows `WRITING_VOICE.md`.

## Validation

- `npx jest blog-seo-content blog-taxonomy blog buildArticleCoverImages` — 61/61 passing
- `npx eslint scripts/data/articleCoverImages.ts` — clean
- Audited the new posts against the voice guide's banned-pattern list (em dashes, contrast pivots, vocabulary table) and the F1 recaps against the standings math in the existing series

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177WgrkqPzHMb7tNcNM3LyD

---
_Generated by [Claude Code](https://claude.ai/code/session_0177WgrkqPzHMb7tNcNM3LyD)_